### PR TITLE
Numeric scalars

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/snippet/package.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/snippet/package.scala
@@ -3,7 +3,10 @@
 
 package lucuma.odb.graphql
 import cats.syntax.all._
-import edu.gemini.grackle.{Cursor, Predicate, Result, Value}
+import edu.gemini.grackle.Cursor
+import edu.gemini.grackle.Predicate
+import edu.gemini.grackle.Result
+import edu.gemini.grackle.Value
 import edu.gemini.grackle.sql.FailedJoin
 import eu.timepit.refined.types.string
 import io.circe.Json


### PR DESCRIPTION
I'm not sure this is a good idea, am happy to close the PR w/o merge, but wanted to raise it for discussion (again).  The issue is that our API uses various numeric custom scalars.  For example, `Long`, `BigDecimal` and even `PosBigDecimal`, etc.  At the moment in `lucuma-odb`, these will require specifying the value as a quoted string:

```
"fooLong": "1"
```

whereas an `Int` must not be quoted (I think):

```
"fooInt": 1
```

It seems like it's going to be confusing for the user to know when to quote numeric values and when not to.  On the other hand, if we make the changes in this PR then this will be accepted:

```
"fooLong": 1
```

this will fail

```
"fooLong": 2147483648
```

but this would work

```
"fooLong": "2147483648"
```

So, still confusing when to use quotes. :-/ 
