### PR TITLE
WIP on target-env

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,9 +59,6 @@ lazy val service = project
       "com.github.vertical-blank" % "sql-formatter" % "2.0.3",
     ),
     reStart / envVars += "PORT" -> "8082",
-    reStartArgs       += "-skip-migration",
-    scalacOptions    ++= Seq(
-      "-explain"
-    )
+    reStartArgs       += "-skip-migration"
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -59,6 +59,9 @@ lazy val service = project
       "com.github.vertical-blank" % "sql-formatter" % "2.0.3",
     ),
     reStart / envVars += "PORT" -> "8082",
-    reStartArgs       += "-skip-migration"
+    reStartArgs       += "-skip-migration",
+    scalacOptions    ++= Seq(
+      "-explain"
+    )
   )
 

--- a/modules/service/src/main/resources/db/migration/V0030__observations.sql
+++ b/modules/service/src/main/resources/db/migration/V0030__observations.sql
@@ -102,8 +102,8 @@ create table t_observation (
   c_active_status    e_obs_active_status not null    default 'active',
 
   -- target environment
-  c_explicit_ra      d_angle_µas         null default null,
-  c_explicit_dec     d_angle_µas         null default null,
+  c_explicit_ra      d_angle_µas         null        default null,
+  c_explicit_dec     d_angle_µas         null        default null,
 
   -- both explicit coordinates are defined or neither are defined
   constraint explicit_base_neither_or_both

--- a/modules/service/src/main/resources/db/migration/V0070__targets.sql
+++ b/modules/service/src/main/resources/db/migration/V0070__targets.sql
@@ -87,8 +87,9 @@ create table t_target (
   ),
 
   -- source profile is just a blob. we'll see how this works
-  c_source_profile jsonb not null
+  c_source_profile jsonb not null,
 
+  unique (c_program_id, c_target_id)
 );
 
 

--- a/modules/service/src/main/resources/db/migration/V0080_asterism.sql
+++ b/modules/service/src/main/resources/db/migration/V0080_asterism.sql
@@ -1,0 +1,15 @@
+
+-- A join table for observations and science (asterism) targets.  Since you
+-- cannot simply join any observation with any target (they must reference the
+-- same program), it includes a shared program id column.
+create table t_asterism_target (
+
+  c_program_id     d_program_id     not null,
+  c_observation_id d_observation_id not null,
+  c_target_id      d_target_id      not null,
+
+  foreign key (c_program_id, c_observation_id) references t_observation(c_program_id, c_observation_id),
+  foreign key (c_program_id, c_target_id)      references t_target(c_program_id, c_target_id),
+  constraint t_asterism_target_pkey primary key (c_program_id, c_observation_id, c_target_id)
+
+)

--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -2470,10 +2470,7 @@ input UpdateObservationsInput {
   SET: ObservationPropertiesInput!
 
   # Filters the observations to be updated according to those that match the given constraints.
-  # WHERE: WhereObservation
-
-  # Temporary -- to be replaced with WhereObservation matching
-  WHERE: [ObservationId!]
+  WHERE: WhereObservation
 
   # Caps the number of results returned to the given value (if additional observations match the WHERE clause they will be updated but not returned).
   LIMIT: NonNegInt

--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4234,10 +4234,7 @@ type Observation {
   plannedTime: PlannedTimeSummary!
 
   # The program that contains this observation
-  program(
-    # Set to true to include deleted values
-    includeDeleted: Boolean! = false
-  ): Program!
+  program: Program!
 
   # The observation's target(s)
   targetEnvironment: TargetEnvironment!

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -61,6 +61,7 @@ object OdbMapping {
           new SkunkMapping[F](database, monitor)
             with SnippetMapping[F]
             with ComputeMapping[F]
+            with MappingExtras[F]
             with MutationCompanionOps[F] {
 
           val schema = unsafeLoadSchema("OdbSchema.graphql") |+| enums
@@ -73,8 +74,9 @@ object OdbMapping {
               UserSnippet(this),
               ProgramSnippet(this, database, user, topics),
               AllocationSnippet(this, database, user),
+              SharedTargetSnippet(this),
               ObservationSnippet(this, database, user),
-              TargetSnippet(this, database, user),
+              TargetSnippet(this, database, user)
             ).reduce
 
           val typeMappings = snippet.typeMappings

--- a/modules/service/src/main/scala/lucuma/odb/graphql/snippet/ObservationSnippet.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/snippet/ObservationSnippet.scala
@@ -147,31 +147,6 @@ object ObservationSnippet {
         }
       }
 
-    // TODO: probably delete
-//    val updateObservationsOneByOne: Mutation =
-//      Mutation.simple { (child, env) =>
-//        env.getR[UpdateObservationsInput]("input").flatTraverse { input =>
-//          pool.use { svc =>
-//
-//            val updateResults: F[List[(Observation.Id, UpdateResult[Observation.Id])]] =
-//              input.WHERE.toList.flatten.traverse { oid =>
-//                svc.updateObservation(oid, input.SET).tupleLeft(oid)
-//              }
-//
-//            updateResults.map { lst =>
-//              lst.foldLeft(List.empty[Observation.Id].rightIor[String].toIorNes) {
-//                case (ior, (_, UpdateResult.NothingToBeDone)) => ior.addLeft(NonEmptySet.one("No updates specified."))
-//                case (ior, (oid, UpdateResult.NoSuchObject )) => ior.addLeft(NonEmptySet.one(s"Observation $oid does not exist or is not editable by user ${user.id}."))
-//                case (ior, (_,   UpdateResult.Success(oid) )) => ior.addRight(List(oid))
-//              }.bimap(
-//                ms  => NonEmptyChain.fromNonEmptyList(ms.toNonEmptyList.map(m => Problem(m))),
-//                oids => observationListNoFiltering(oids, child))
-//            }
-//          }
-//        }
-//      }
-
-    // TODO: This seems closer to what we want than the one-by-one approach above?
     val updateObservations: Mutation =
       Mutation.simple { (child, env) =>
         env.getR[UpdateObservationsInput]("input").flatTraverse { input =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/snippet/ObservationSnippet.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/snippet/ObservationSnippet.scala
@@ -210,7 +210,9 @@ object ObservationSnippet {
             pool.use { svc =>
               svc
                 .updateObservations(input.SET, which)
-                .as(Filter(filterPredicate, child))
+                .map { lst =>
+                  Filter(Predicates.inObservationIds(lst), child)
+                }
             }
           }
         }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/snippet/SharedTargetSnippet.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/snippet/SharedTargetSnippet.scala
@@ -1,0 +1,102 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package snippet
+
+import edu.gemini.grackle.skunk.SkunkMapping
+import lucuma.core.math.{Declination, RightAscension}
+import lucuma.odb.graphql.util.{MappingExtras, SnippetMapping}
+import lucuma.odb.util.Codecs.{declination, observation_id, right_ascension, target_id}
+
+object SharedTargetSnippet {
+
+  def apply[F[_]](
+    m: SnippetMapping[F] with MappingExtras[F] with SkunkMapping[F]
+  ): m.Snippet = {
+
+    import m.ColumnRef
+    import m.FieldRef
+    import m.ObjectMapping
+    import m.PrefixedMapping
+    import m.Snippet
+    import m.SqlField
+    import m.TableDef
+    import m.TypeMapping
+    import m.col
+    import m.schema
+
+    val RightAscensionType = schema.ref("RightAscension")
+    val DeclinationType    = schema.ref("Declination")
+
+    object ObservationView extends TableDef("v_observation") {
+      object TargetEnvironment {
+        object Coordinates {
+          val SyntheticId: ColumnRef = col("c_explicit_base_id",  observation_id.embedded)
+          val Ra: ColumnRef          = col("c_explicit_ra",       right_ascension.embedded)
+          val Dec: ColumnRef         = col("c_explicit_dec",      declination.embedded)
+        }
+      }
+    }
+
+    object TargetView extends TableDef("v_target") {
+      object Sidereal {
+        val SyntheticId: ColumnRef = col("c_sidereal_id", target_id.embedded)
+        val Ra: ColumnRef          = col("c_sid_ra",      right_ascension.embedded)
+        val Dec: ColumnRef         = col("c_sid_dec",     declination.embedded)
+      }
+    }
+
+    def rightAscensionMapping(
+      idColumn:    ColumnRef,
+      valueColumn: ColumnRef
+    ): ObjectMapping =
+      ObjectMapping(
+        tpe = RightAscensionType,
+        fieldMappings = List(
+          SqlField("synthetic_id", idColumn, key = true, hidden = true),
+          SqlField("value", valueColumn, hidden = true),
+          FieldRef[RightAscension]("value").as("hms", RightAscension.fromStringHMS.reverseGet),
+          FieldRef[RightAscension]("value").as("hours", c => BigDecimal(c.toHourAngle.toDoubleHours)),
+          FieldRef[RightAscension]("value").as("degrees", c => BigDecimal(c.toAngle.toDoubleDegrees)),
+          FieldRef[RightAscension]("value").as("microarcseconds", _.toAngle.toMicroarcseconds),
+        )
+      )
+
+    def declinationMapping(
+      idColumn:    ColumnRef,
+      valueColumn: ColumnRef
+    ): ObjectMapping =
+      ObjectMapping(
+        tpe = DeclinationType,
+        fieldMappings = List(
+          SqlField("synthetic_id", idColumn, key = true, hidden = true),
+          SqlField("value", valueColumn, hidden = true),
+          FieldRef[Declination]("value").as("dms", Declination.fromStringSignedDMS.reverseGet),
+          FieldRef[Declination]("value").as("degrees", c => BigDecimal(c.toAngle.toDoubleDegrees)),
+          FieldRef[Declination]("value").as("microarcseconds", _.toAngle.toMicroarcseconds),
+        )
+      )
+
+    val typeMappings: List[TypeMapping] =
+      List(
+        PrefixedMapping(
+          tpe = RightAscensionType,
+          mappings = List(
+            List("explicitBase", "ra") -> rightAscensionMapping(ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Ra),
+            List("sidereal",     "ra") -> rightAscensionMapping(TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Ra)
+          )
+        ),
+        PrefixedMapping(
+          tpe = DeclinationType,
+          mappings = List(
+            List("explicitBase", "dec") -> declinationMapping(ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Dec),
+            List("sidereal",     "dec") -> declinationMapping(TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Dec)
+          )
+        )
+      )
+
+    Snippet(typeMappings)
+  }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/snippet/SharedTargetSnippet.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/snippet/SharedTargetSnippet.scala
@@ -88,15 +88,15 @@ object SharedTargetSnippet {
         PrefixedMapping(
           tpe = RightAscensionType,
           mappings = List(
-            List("explicitBase", "ra") -> rightAscensionMapping(ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Ra),
-            List("sidereal",     "ra") -> rightAscensionMapping(TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Ra)
+            List("observation", "explicitBase", "ra") -> rightAscensionMapping(ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Ra),
+            List("target",      "sidereal",     "ra") -> rightAscensionMapping(TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Ra)
           )
         ),
         PrefixedMapping(
           tpe = DeclinationType,
           mappings = List(
-            List("explicitBase", "dec") -> declinationMapping(ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Dec),
-            List("sidereal",     "dec") -> declinationMapping(TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Dec)
+            List("observation", "explicitBase", "dec") -> declinationMapping(ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Dec),
+            List("target",      "sidereal",     "dec") -> declinationMapping(TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Dec)
           )
         )
       )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/snippet/SharedTargetSnippet.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/snippet/SharedTargetSnippet.scala
@@ -5,9 +5,14 @@ package lucuma.odb.graphql
 package snippet
 
 import edu.gemini.grackle.skunk.SkunkMapping
-import lucuma.core.math.{Declination, RightAscension}
-import lucuma.odb.graphql.util.{MappingExtras, SnippetMapping}
-import lucuma.odb.util.Codecs.{declination, observation_id, right_ascension, target_id}
+import lucuma.core.math.Declination
+import lucuma.core.math.RightAscension
+import lucuma.odb.graphql.util.MappingExtras
+import lucuma.odb.graphql.util.SnippetMapping
+import lucuma.odb.util.Codecs.declination
+import lucuma.odb.util.Codecs.observation_id
+import lucuma.odb.util.Codecs.right_ascension
+import lucuma.odb.util.Codecs.target_id
 
 object SharedTargetSnippet {
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/snippet/TargetSnippet.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/snippet/TargetSnippet.scala
@@ -82,8 +82,8 @@ object TargetSnippet {
       sessionPool.map(TargetService.fromSession(_, user))
 
     object TargetView extends TableDef("v_target") {
-      val Id            = col("c_program_id", program_id)
-      val TargetId      = col("c_target_id", target_id)
+      val ProgramId     = col("c_program_id", program_id)
+      val Id            = col("c_target_id", target_id)
       val Name          = col("c_name", text_nonempty)
       val Existence     = col("c_existence", existence)
       val SourceProfile = col("c_source_profile", jsonb)
@@ -129,8 +129,8 @@ object TargetSnippet {
       def includeDeleted(b: Boolean): Predicate =
         if (b) True else Eql(UniquePath(List("existence")), Const[Existence](Existence.Present))
 
-      def hasTargetId(oid: Target.Id): Predicate =
-        Eql(UniquePath(List("id")), Const(oid))
+      def hasTargetId(tid: Target.Id): Predicate =
+        Eql(UniquePath(List("id")), Const(tid))
 
     }
 
@@ -166,7 +166,7 @@ object TargetSnippet {
           SqlField("id", TargetView.Id, key = true),
           SqlField("existence", TargetView.Existence),
           SqlField("name", TargetView.Name),
-          SqlObject("program", Join(TargetView.Id, ProgramTable.Id)),
+          SqlObject("program", Join(TargetView.ProgramId, ProgramTable.Id)),
           SqlJson("sourceProfile", TargetView.SourceProfile),
           SqlObject("sidereal"),
           SqlObject("nonsidereal"),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/snippet/input/UpdateObservationsInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/snippet/input/UpdateObservationsInput.scala
@@ -5,15 +5,16 @@ package lucuma.odb.graphql
 package snippet
 package input
 
-import cats.syntax.parallel._
+import cats.syntax.parallel.*
+import edu.gemini.grackle.Predicate
 import eu.timepit.refined.types.numeric.NonNegInt
 import lucuma.core.model.Observation
-import lucuma.odb.graphql.util.Bindings._
+import lucuma.odb.graphql.util.Bindings.*
 
 final case class UpdateObservationsInput(
   SET:            ObservationPropertiesInput,
-  WHERE:          Option[List[Observation.Id]], // temporary, replace with WHERE clause
-  LIMIT:          Option[NonNegInt] ,
+  WHERE:          Option[Predicate],
+  LIMIT:          Option[NonNegInt],
   includeDeleted: Option[Boolean]
 )
 
@@ -23,7 +24,7 @@ object UpdateObservationsInput {
     ObjectFieldsBinding.rmap {
       case List(
         ObservationPropertiesInput.EditBinding("SET", rSET),
-        ObservationIdBinding.List.Option("WHERE", rWHERE),
+        WhereObservation.Binding.Option("WHERE", rWHERE),
         NonNegIntBinding.Option("LIMIT", rLIMIT),
         BooleanBinding.Option("includeDeleted", rIncludeDeleted)
       ) =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/util/MappingExtras.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/util/MappingExtras.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.util
+
+import edu.gemini.grackle.Mapping
+import io.circe.Encoder
+
+import scala.reflect.ClassTag
+
+trait MappingExtras[F[_]] extends Mapping[F] {
+
+  object FieldRef {
+    def apply[A](underlyingField: String): Partial[A] =
+      new Partial[A](underlyingField)
+
+    class Partial[A](underlyingField: String) {
+      def as[B: Encoder](field: String, f: A => B)(implicit ev: ClassTag[A]): CursorField[B] =
+        CursorField(field, _.field(underlyingField, None).flatMap(_.as[A].map(f)), List(underlyingField))
+    }
+  }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -43,12 +43,6 @@ trait ObservationService[F[_]] {
     SET:         ObservationPropertiesInput,
   ): F[CreateResult]
 
-  // TODO: probably delete
-//  def updateObservation(
-//    observationId: Observation.Id,
-//    SET:           ObservationPropertiesInput
-//  ): F[UpdateResult[Observation.Id]]
-
   def updateObservations(
     WHERE: List[Observation.Id],
     SET:   ObservationPropertiesInput
@@ -71,9 +65,6 @@ object ObservationService {
   ): ObservationService[F] =
     new ObservationService[F] {
 
-//      def fail[A](msg: String): F[A] =
-//        MonadCancelThrow[F].raiseError(new RuntimeException(msg))
-
       override def createObservation(
         programId:   Program.Id,
         SET:         ObservationPropertiesInput,
@@ -95,23 +86,6 @@ object ObservationService {
             }
           }
         }
-
-      // TODO: probably delete
-//      override def updateObservation(
-//        observationId: Observation.Id,
-//        SET:           ObservationPropertiesInput
-//      ): F[UpdateResult[Observation.Id]] =
-//        Trace[F].span("updateObservation") {
-//          Statements.updateObservation(observationId, SET.subtitle, SET.existence, SET.status, SET.activeStatus, SET.constraintSet, user) match {
-//            case None     => UpdateResult.NothingToBeDone.pure[F].widen
-//            case Some(af) =>
-//              session.prepare(af.fragment.command).use(_.execute(af.argument)).flatMap {
-//                case Completion.Update(0) => UpdateResult.NoSuchObject.pure[F].widen
-//                case Completion.Update(1) => UpdateResult.Success(observationId).pure[F].widen
-//                case other                => fail(s"Expected `Update(0)` or `Update(1)`, found $other")
-//              }
-//          }
-//        }
 
       override def updateObservations(
         WHERE: List[Observation.Id],
@@ -228,87 +202,6 @@ object ObservationService {
           ${hour_angle_range_value.opt},
           ${hour_angle_range_value.opt}
       """
-
-    // TODO: Probably delete
-//    def updateObservation(
-//      observationId: Observation.Id,
-//      subtitle:      Nullable[NonEmptyString],
-//      ex:            Option[Existence],
-//      status:        Option[ObsStatus],
-//      activeState:   Option[ObsActiveStatus],
-//      constraintSet: Option[ConstraintSet],
-//      user:          User
-//    ): Option[AppliedFragment] = {
-//
-//      val base = void"update t_observation o set "
-//
-//      val upExistence = sql"c_existence = $existence"
-//      val upSubtitle  = sql"c_subtitle = ${text_nonempty.opt}"
-//      val upStatus    = sql"c_status = $obs_status"
-//      val upActive    = sql"c_active_status = $obs_active_status"
-//
-//      val upCloud     = sql"c_cloud_extinction = $cloud_extinction"
-//      val upImage     = sql"c_image_quality = $image_quality"
-//      val upSky       = sql"c_sky_background = $sky_background"
-//      val upWater     = sql"c_water_vapor = $water_vapor"
-//
-//      val ups: List[AppliedFragment] =
-//        List(
-//          ex.map(upExistence),
-//          subtitle match {
-//            case Nullable.Null  => Some(upSubtitle(None))
-//            case Absent         => None
-//            case NonNull(value) => Some(upSubtitle(Some(value)))
-//          },
-//          status.map(upStatus),
-//          activeState.map(upActive),
-//          constraintSet.toList.flatMap { cs =>
-//            List(
-//              upCloud(cs.cloudExtinction),
-//              upImage(cs.imageQuality),
-//              upSky(cs.skyBackground),
-//              upWater(cs.waterVapor)
-//            )
-//          }
-//        ).flatten
-//
-//      NonEmptyList.fromList(ups).map { nel =>
-//        val up = nel.intercalate(void", ")
-//
-//        import lucuma.core.model.Access._
-//
-//        val where = user.role.access match {
-//
-//          case Service | Admin | Staff =>
-//            sql"""
-//              where o.c_observation_id = $observation_id
-//            """.apply(observationId)
-//
-//          case Ngo => ??? // TODO
-//
-//          case Guest | Pi =>
-//            sql"""
-//              from t_program p
-//              where o.c_observation_id = $observation_id
-//              and o.c_program_id = p.c_program_id
-//              and (
-//                p.c_pi_user_id = $user_id
-//                or
-//                exists(
-//                  select u.c_role
-//                  from   t_program_user u
-//                  where  u.c_program_id = o.c_program_id
-//                  and    u.c_user_id    = $user_id
-//                  and    u.c_role       = 'coi'
-//                )
-//              )
-//            """.apply(observationId ~ user.id ~ user.id)
-//        }
-//
-//        base |+| up |+| where
-//
-//      }
-//    }
 
     def updateObservations(
       WHERE:         List[Observation.Id],

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -5,8 +5,9 @@ package lucuma.odb.service
 
 import cats.data.NonEmptyList
 import cats.effect.Sync
-import cats.syntax.all._
-import eu.timepit.refined.types.numeric.PosBigDecimal
+import cats.syntax.all.*
+import edu.gemini.grackle.Predicate
+import eu.timepit.refined.types.numeric.{NonNegInt, PosBigDecimal}
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
@@ -18,7 +19,7 @@ import lucuma.core.model.GuestRole
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.ServiceRole
-import lucuma.core.model.StandardRole._
+import lucuma.core.model.StandardRole.*
 import lucuma.core.model.User
 import lucuma.odb.data.Existence
 import lucuma.odb.data.Nullable
@@ -30,10 +31,10 @@ import lucuma.odb.data.Tag
 import lucuma.odb.data.UpdateResult
 import lucuma.odb.graphql.snippet.input.ConstraintSetInput
 import lucuma.odb.graphql.snippet.input.ObservationPropertiesInput
-import lucuma.odb.util.Codecs._
+import lucuma.odb.util.Codecs.*
 import natchez.Trace
-import skunk._
-import skunk.implicits._
+import skunk.*
+import skunk.implicits.*
 
 trait ObservationService[F[_]] {
   import ObservationService._
@@ -44,9 +45,9 @@ trait ObservationService[F[_]] {
   ): F[CreateResult]
 
   def updateObservations(
-    WHERE: List[Observation.Id],
-    SET:   ObservationPropertiesInput
-  ): F[UpdateResult[List[Observation.Id]]]
+    SET:   ObservationPropertiesInput,
+    which: AppliedFragment
+  ): F[Unit]
 
 }
 
@@ -88,22 +89,12 @@ object ObservationService {
         }
 
       override def updateObservations(
-        WHERE: List[Observation.Id],
-        SET:   ObservationPropertiesInput
-      ): F[UpdateResult[List[Observation.Id]]] =
-        Trace[F].span("updateObservations") {
-          Statements.updateObservations(WHERE, SET.subtitle, SET.existence, SET.status, SET.activeStatus, SET.constraintSet, user) match {
-            case None     =>
-              UpdateResult.NothingToBeDone.pure[F].widen
-            case Some(af) =>
-              session.prepare(af.fragment.query(observation_id)).use { pq =>
-                pq.stream(af.argument, chunkSize = 1024).compile.toList.map {
-                  case Nil  => UpdateResult.NoSuchObject
-                  case oids => UpdateResult.Success(oids)
-                }
-              }
-          }
-        }
+        SET:   ObservationPropertiesInput,
+        which: AppliedFragment
+      ): F[Unit] =
+        Statements.updateObservations(SET, which).traverse { af =>
+          session.prepare(af.fragment.command).use(_.execute(af.argument))
+        }.void
 
     }
 
@@ -203,39 +194,28 @@ object ObservationService {
           ${hour_angle_range_value.opt}
       """
 
-    def updateObservations(
-      WHERE:         List[Observation.Id],
-      subtitle:      Nullable[NonEmptyString],
-      ex:            Option[Existence],
-      status:        Option[ObsStatus],
-      activeState:   Option[ObsActiveStatus],
-      constraintSet: Option[ConstraintSet],
-      user:          User
-    ): Option[AppliedFragment] = {
-
-      val base = void"update t_observation o set "
-
+    def updates(SET: ObservationPropertiesInput): Option[NonEmptyList[AppliedFragment]] = {
       val upExistence = sql"c_existence = $existence"
-      val upSubtitle  = sql"c_subtitle = ${text_nonempty.opt}"
-      val upStatus    = sql"c_status = $obs_status"
-      val upActive    = sql"c_active_status = $obs_active_status"
+      val upSubtitle = sql"c_subtitle = ${text_nonempty.opt}"
+      val upStatus = sql"c_status = $obs_status"
+      val upActive = sql"c_active_status = $obs_active_status"
 
-      val upCloud     = sql"c_cloud_extinction = $cloud_extinction"
-      val upImage     = sql"c_image_quality = $image_quality"
-      val upSky       = sql"c_sky_background = $sky_background"
-      val upWater     = sql"c_water_vapor = $water_vapor"
+      val upCloud = sql"c_cloud_extinction = $cloud_extinction"
+      val upImage = sql"c_image_quality = $image_quality"
+      val upSky = sql"c_sky_background = $sky_background"
+      val upWater = sql"c_water_vapor = $water_vapor"
 
       val ups: List[AppliedFragment] =
         List(
-          ex.map(upExistence),
-          subtitle match {
+          SET.existence.map(upExistence),
+          SET.subtitle match {
             case Nullable.Null  => Some(upSubtitle(None))
             case Absent         => None
             case NonNull(value) => Some(upSubtitle(Some(value)))
           },
-          status.map(upStatus),
-          activeState.map(upActive),
-          constraintSet.toList.flatMap { cs =>
+          SET.status.map(upStatus),
+          SET.activeStatus.map(upActive),
+          SET.constraintSet.toList.flatMap { cs =>
             List(
               upCloud(cs.cloudExtinction),
               upImage(cs.imageQuality),
@@ -245,49 +225,18 @@ object ObservationService {
           }
         ).flatten
 
-      for {
-        _   <- WHERE.headOption
-        nel <- NonEmptyList.fromList(ups)
-      } yield {
-        val up = nel.intercalate(void", ")
-
-        import lucuma.core.model.Access._
-
-        val where = user.role.access match {
-
-          case Service | Admin | Staff =>
-            sql"""
-              where o.c_observation_id in ( ${observation_id.list(WHERE)} )
-            """.apply(WHERE)
-
-          case Ngo => ??? // TODO
-
-          case Guest | Pi =>
-            sql"""
-              from t_program p
-              where o.c_observation_id in ( ${observation_id.list(WHERE.size)} )
-              and o.c_program_id = p.c_program_id
-              and (
-                p.c_pi_user_id = $user_id
-                or
-                exists(
-                  select u.c_role
-                  from   t_program_user u
-                  where  u.c_program_id = o.c_program_id
-                  and    u.c_user_id    = $user_id
-                  and    u.c_role       = 'coi'
-                )
-              )
-            """.apply(WHERE ~ user.id ~ user.id)
-        }
-
-        val returning: AppliedFragment =
-          void"RETURNING o.c_observation_id"
-
-        base |+| up |+| where |+| returning
-
-      }
+      NonEmptyList.fromList(ups)
     }
+
+    def updateObservations(
+      SET:   ObservationPropertiesInput,
+      which: AppliedFragment
+    ): Option[AppliedFragment] =
+      updates(SET).map { us =>
+        void"UPDATE t_observation " |+|
+        void"SET " |+| us.intercalate(void", ") |+| void" " |+|
+        void"WHERE t_observation.c_observation_id IN (" |+| which |+| void")"
+      }
 
   }
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -92,11 +92,11 @@ object ObservationService {
         SET:   ObservationPropertiesInput,
         which: AppliedFragment
       ): F[List[Observation.Id]] =
-        Statements.updateObservations(SET, which).traverse { af =>
+        Statements.updateObservations(SET, which).toList.flatTraverse { af =>
           session.prepare(af.fragment.query(observation_id)).use { pq =>
             pq.stream(af.argument, chunkSize = 1024).compile.toList
           }
-        }.map(_.toList.flatten)
+        }
 
     }
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -7,7 +7,8 @@ import cats.data.NonEmptyList
 import cats.effect.Sync
 import cats.syntax.all.*
 import edu.gemini.grackle.Predicate
-import eu.timepit.refined.types.numeric.{NonNegInt, PosBigDecimal}
+import eu.timepit.refined.types.numeric.NonNegInt
+import eu.timepit.refined.types.numeric.PosBigDecimal
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality


### PR DESCRIPTION
This is kind of a mishmash of progress on observations, but I think I'd like to get it in before working on creating/updating target environments.  I believe the way that observations are updated needs to be changed to take into account the target observation's existing state.

Here's a summary of what is included in this PR

1. Target environment explicit base in observation
2. Link table for observations/targets (asterisms)
3. Remove extraneous `includeDeleted` flag from observation -> program lookup
4. Shared RA/Dec mapping (for asterism explicit base + sidereal targets)
5. Target ID mapping bug fix
6. WHERE clause in observation update