### PR TITLE
WIP: fetchable enum instances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ val jwtVersion                 = "5.0.0"
 val logbackVersion             = "1.2.11"
 val log4catsVersion            = "2.4.0"
 val lucumaGraphQLRoutesVersion = "0.5.2"
+val lucumaCoreVersion          = "0.51.0"
 val munitVersion               = "0.7.29"
 val munitCatsEffectVersion     = "1.0.7"
 val natchezHttp4sVersion       = "0.3.2"
@@ -63,3 +64,12 @@ lazy val service = project
     reStartArgs       += "-skip-migration"
   )
 
+lazy val enums = project
+  .in(file("modules/enums"))
+  .settings(
+    name := "lucuma-odb-enums",
+    libraryDependencies ++= Seq(
+      "edu.gemini" %% "lucuma-core" % lucumaCoreVersion,
+      "edu.gemini" %% "clue-core"   % clueVersion,
+    )
+  )

--- a/modules/enums/src/main/scala/EnumeratedQuery.scala
+++ b/modules/enums/src/main/scala/EnumeratedQuery.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.enums
+
+import cats.data.NonEmptyList
+import clue.GraphQLOperation
+import io.circe.Decoder
+import lucuma.core.util.Enumerated
+
+/** A GraphQL operation that fetches a list of `A` and turns it into an `Enumerated[A]`. */
+abstract class EnumeratedQuery[A](tag: A => String) extends GraphQLOperation[Nothing] {
+
+  given ElemDecoder: Decoder[A]
+
+  type Variables = Unit
+  type Data = Enumerated[A]
+
+  val varEncoder  = implicitly
+  val dataDecoder = Decoder[NonEmptyList[A]].map(Enumerated.fromNEL(_).withTag(tag))
+
+}
+

--- a/modules/enums/src/main/scala/Enums.scala
+++ b/modules/enums/src/main/scala/Enums.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.enums
+
+import cats.Functor
+import cats.syntax.all._
+import clue.TransactionalClient
+import lucuma.core.model.Partner
+import lucuma.core.util.Enumerated
+
+case class Enums(
+  partner: Enumerated[Partner]
+  // ...
+)
+
+object Enums {
+
+  def fetch[F[_]: Functor](client: TransactionalClient[F, Nothing]): F[Enums] =
+    (client.request(PartnerQuery).apply).map(apply(_))
+
+}
+
+given (using es: Enums): Enumerated[Partner] = es.partner
+// ...

--- a/modules/enums/src/main/scala/partner.scala
+++ b/modules/enums/src/main/scala/partner.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.enums
+
+import lucuma.core.model.Partner
+
+object PartnerQuery extends EnumeratedQuery[Partner](_.tag) {
+
+    val document =
+      """
+        query {
+          partnerMeta {
+            tag
+            shortName
+            longName
+            active
+          }
+        }
+      """
+
+    val ElemDecoder = hc =>
+      for {
+        tag <- hc.downField("tag").as[String]
+        nam <- hc.downField("name").as[String]
+        shn <- hc.downField("shortName").as[String]
+        act <- hc.downField("active").as[Boolean]
+      } yield ??? // TODO: Partner(tag, tag, nam, shn, act)
+
+  }
+


### PR DESCRIPTION
The idea here is that on init an app would fetch an `Enums` (a collection of `Enumerated` instances) and then pass it implicitly. Then `(using Enums)` would make all its member instances available.

In order to make this real we need to remove the corresponding instances from `core`. I suggest we let Explore switch over from tmp-api before introducing this. For now the lookup tables and enumerated instances are consistent so it should be fine.