### PR TITLE
Target Environment Explicit Base

### DIFF
--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -204,8 +204,8 @@ input ConstraintSetInput {
 
 # Absolute coordinates relative base epoch
 input CoordinatesInput {
-  ra: RightAscensionInput!
-  dec: DeclinationInput!
+  ra: RightAscensionInput
+  dec: DeclinationInput
 }
 
 # Observation creation parameters
@@ -1569,7 +1569,6 @@ input LargeProgramInput {
 
 # A line flux value with integrated units
 input LineFluxIntegratedInput {
-  value: PosBigDecimal!
   units: LineFluxIntegratedUnits!
 }
 

--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -1569,6 +1569,7 @@ input LargeProgramInput {
 
 # A line flux value with integrated units
 input LineFluxIntegratedInput {
+  value: PosBigDecimal!
   units: LineFluxIntegratedUnits!
 }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/AirMassRangeInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/AirMassRangeInput.scala
@@ -4,9 +4,6 @@
 package lucuma.odb.graphql
 package input
 
-import cats.data.NonEmptyChain
-import cats.data.Validated
-import cats.data.ValidatedNec
 import cats.syntax.apply.*
 import cats.syntax.either.*
 import cats.syntax.option.*
@@ -31,12 +28,12 @@ final case class AirMassRangeInput(
   def maxPosBigDecimal: Option[PosBigDecimal] =
     max.flatMap(dv => PosBigDecimal.from(dv.value).toOption)
 
-  def create: ValidatedNec[String, AirMass] =
-    Validated.fromOption(
+  def create: Result[AirMass] =
+    Result.fromOption(
       (min, max)
         .tupled
         .flatMap(AirMass.fromOrderedDecimalValues.getOption),
-      NonEmptyChain.one(AirMassRangeInput.messages.BothMinAndMax)
+      AirMassRangeInput.messages.BothMinAndMax
     )
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/AirMassRangeInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/AirMassRangeInput.scala
@@ -4,17 +4,19 @@
 package lucuma.odb.graphql
 package input
 
-import cats.syntax.apply._
-import cats.syntax.either._
-import cats.syntax.option._
-import cats.syntax.parallel._
+import cats.data.{NonEmptyChain, Validated, ValidatedNec}
+import cats.syntax.apply.*
+import cats.syntax.either.*
+import cats.syntax.option.*
+import cats.syntax.parallel.*
+import cats.syntax.validated.*
 import edu.gemini.grackle.Result
 import eu.timepit.refined.api.Refined.value
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import lucuma.core.model.ElevationRange.AirMass
 import lucuma.core.model.ElevationRange.AirMass.DecimalValue
-import lucuma.odb.graphql.binding._
-import lucuma.odb.graphql.util.Bindings._
+import lucuma.odb.graphql.binding.*
+import lucuma.odb.graphql.util.Bindings.*
 
 final case class AirMassRangeInput(
   min: Option[DecimalValue],
@@ -27,17 +29,22 @@ final case class AirMassRangeInput(
   def maxPosBigDecimal: Option[PosBigDecimal] =
     max.flatMap(dv => PosBigDecimal.from(dv.value).toOption)
 
-  def create: Result[AirMass] =
-    Result.fromOption[AirMass](
+  def create: ValidatedNec[String, AirMass] =
+    Validated.fromOption(
       (min, max)
         .tupled
         .flatMap(AirMass.fromOrderedDecimalValues.getOption),
-      "Creating an air mass range requires specifying both min and max where min < max"
+      NonEmptyChain.one(AirMassRangeInput.messages.BothMinAndMax)
     )
 
 }
 
 object AirMassRangeInput {
+
+  object messages {
+    val BothMinAndMax: String =
+      "Creating an air mass range requires specifying both min and max where min < max"
+  }
 
   val Default: AirMassRangeInput =
     AirMassRangeInput(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/AirMassRangeInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/AirMassRangeInput.scala
@@ -4,7 +4,9 @@
 package lucuma.odb.graphql
 package input
 
-import cats.data.{NonEmptyChain, Validated, ValidatedNec}
+import cats.data.NonEmptyChain
+import cats.data.Validated
+import cats.data.ValidatedNec
 import cats.syntax.apply.*
 import cats.syntax.either.*
 import cats.syntax.option.*

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ConstraintSetInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ConstraintSetInput.scala
@@ -4,8 +4,10 @@
 package lucuma.odb.graphql
 package input
 
-import cats.syntax.option._
-import cats.syntax.parallel._
+import cats.data.ValidatedNec
+import cats.syntax.option.*
+import cats.syntax.parallel.*
+import cats.syntax.validated.*
 import edu.gemini.grackle.Result
 import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
@@ -13,9 +15,9 @@ import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ElevationRange
-import lucuma.odb.graphql.binding._
+import lucuma.odb.graphql.binding.*
 import lucuma.odb.graphql.input.ConstraintSetInput.NominalConstraints
-import lucuma.odb.graphql.util.Bindings._
+import lucuma.odb.graphql.util.Bindings.*
 
 final case class ConstraintSetInput(
   cloudExtinction: Option[CloudExtinction],
@@ -25,14 +27,14 @@ final case class ConstraintSetInput(
   elevationRange:  Option[ElevationRangeInput]
 ) {
 
-  def create: Result[ConstraintSet] = {
+  def create: ValidatedNec[String, ConstraintSet] = {
     // TODO: default this (as below) or fail when missing?
     val ce = cloudExtinction.getOrElse(NominalConstraints.cloudExtinction)
     val iq = imageQuality.getOrElse(NominalConstraints.imageQuality)
     val sb = skyBackground.getOrElse(NominalConstraints.skyBackground)
     val wv = waterVapor.getOrElse(NominalConstraints.waterVapor)
 
-    elevationRange.fold(Result(NominalConstraints.elevationRange))(_.create).map { er =>
+    elevationRange.fold(NominalConstraints.elevationRange.validNec[String])(_.create).map { er =>
       ConstraintSet(iq, ce, sb, wv, er)
     }
   }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ConstraintSetInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ConstraintSetInput.scala
@@ -4,7 +4,6 @@
 package lucuma.odb.graphql
 package input
 
-import cats.data.ValidatedNec
 import cats.syntax.option.*
 import cats.syntax.parallel.*
 import cats.syntax.validated.*
@@ -27,14 +26,14 @@ final case class ConstraintSetInput(
   elevationRange:  Option[ElevationRangeInput]
 ) {
 
-  def create: ValidatedNec[String, ConstraintSet] = {
+  def create: Result[ConstraintSet] = {
     // TODO: default this (as below) or fail when missing?
     val ce = cloudExtinction.getOrElse(NominalConstraints.cloudExtinction)
     val iq = imageQuality.getOrElse(NominalConstraints.imageQuality)
     val sb = skyBackground.getOrElse(NominalConstraints.skyBackground)
     val wv = waterVapor.getOrElse(NominalConstraints.waterVapor)
 
-    elevationRange.fold(NominalConstraints.elevationRange.validNec[String])(_.create).map { er =>
+    elevationRange.fold(Result(NominalConstraints.elevationRange))(_.create).map { er =>
       ConstraintSet(iq, ce, sb, wv, er)
     }
   }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CoordinatesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CoordinatesInput.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.data.ValidatedNec
+import cats.syntax.option.*
+import cats.syntax.parallel.*
+import cats.syntax.validated.*
+import edu.gemini.grackle.Result
+import lucuma.core.math.{Coordinates, Declination, RightAscension}
+import lucuma.odb.graphql.util.Bindings.{Matcher, ObjectFieldsBinding}
+
+//# Absolute coordinates relative base epoch
+//input CoordinatesInput {
+//  ra: RightAscensionInput
+//  dec: DeclinationInput
+//}
+
+final case class CoordinatesInput(
+  ra:  Option[RightAscension],
+  dec: Option[Declination]
+) {
+
+  def create: ValidatedNec[String, Option[Coordinates]] =
+    (ra, dec) match {
+      case (Some(r), Some(d)) => Coordinates(r, d).some.validNec
+      case (None, None)       => none.validNec
+      case _                  => CoordinatesInput.messages.BothRaAndDecNeeded.invalidNec
+    }
+
+}
+
+object CoordinatesInput {
+
+  object messages {
+    val BothRaAndDecNeeded: String =
+      "Both ra and dec are required in order to specify a coordinate."
+  }
+
+  val Binding: Matcher[CoordinatesInput] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        RightAscensionInput.Binding.Option("ra", rRa),
+        DeclinationInput.Binding.Option("dec", rDec)
+      ) => (rRa, rDec).parMapN(CoordinatesInput(_, _))
+    }
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CoordinatesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CoordinatesInput.scala
@@ -9,8 +9,11 @@ import cats.syntax.option.*
 import cats.syntax.parallel.*
 import cats.syntax.validated.*
 import edu.gemini.grackle.Result
-import lucuma.core.math.{Coordinates, Declination, RightAscension}
-import lucuma.odb.graphql.util.Bindings.{Matcher, ObjectFieldsBinding}
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Declination
+import lucuma.core.math.RightAscension
+import lucuma.odb.graphql.util.Bindings.Matcher
+import lucuma.odb.graphql.util.Bindings.ObjectFieldsBinding
 
 //# Absolute coordinates relative base epoch
 //input CoordinatesInput {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CoordinatesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CoordinatesInput.scala
@@ -4,7 +4,6 @@
 package lucuma.odb.graphql
 package input
 
-import cats.data.ValidatedNec
 import cats.syntax.option.*
 import cats.syntax.parallel.*
 import cats.syntax.validated.*
@@ -26,11 +25,11 @@ final case class CoordinatesInput(
   dec: Option[Declination]
 ) {
 
-  def create: ValidatedNec[String, Option[Coordinates]] =
+  def create: Result[Option[Coordinates]] =
     (ra, dec) match {
-      case (Some(r), Some(d)) => Coordinates(r, d).some.validNec
-      case (None, None)       => none.validNec
-      case _                  => CoordinatesInput.messages.BothRaAndDecNeeded.invalidNec
+      case (Some(r), Some(d)) => Result(Coordinates(r, d).some)
+      case (None, None)       => Result(none)
+      case _                  => Result.failure(CoordinatesInput.messages.BothRaAndDecNeeded)
     }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ElevationRangeInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ElevationRangeInput.scala
@@ -4,7 +4,6 @@
 package lucuma.odb.graphql
 package input
 
-import cats.data.ValidatedNec
 import cats.syntax.flatMap.*
 import cats.syntax.option.*
 import cats.syntax.parallel.*
@@ -20,12 +19,12 @@ final case class ElevationRangeInput(
   hourAngle: Option[HourAngleRangeInput]
 ) {
 
-  def create: ValidatedNec[String, ElevationRange] =
+  def create: Result[ElevationRange] =
     (airMass, hourAngle) match {
       case (Some(am), None)   => am.create
       case (None, Some(hr))   => hr.create
-      case (None, None)       => AirMass.Default.validNec
-      case (Some(_), Some(_)) => ElevationRangeInput.messages.OnlyOneDefinition.invalidNec
+      case (None, None)       => Result(AirMass.Default)
+      case (Some(_), Some(_)) => Result.failure(ElevationRangeInput.messages.OnlyOneDefinition)
     }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ElevationRangeInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ElevationRangeInput.scala
@@ -4,28 +4,28 @@
 package lucuma.odb.graphql
 package input
 
-import cats.syntax.flatMap._
-import cats.syntax.option._
-import cats.syntax.parallel._
+import cats.data.ValidatedNec
+import cats.syntax.flatMap.*
+import cats.syntax.option.*
+import cats.syntax.parallel.*
+import cats.syntax.validated.*
 import edu.gemini.grackle.Result
 import lucuma.core.model.ElevationRange
 import lucuma.core.model.ElevationRange.AirMass
 import lucuma.core.model.ElevationRange.HourAngle
-import lucuma.odb.graphql.util.Bindings._
+import lucuma.odb.graphql.util.Bindings.*
 
 final case class ElevationRangeInput(
   airMass:   Option[AirMassRangeInput],
   hourAngle: Option[HourAngleRangeInput]
 ) {
 
-  import ElevationRangeInput.OnlyOneFailure
-
-  def create: Result[ElevationRange] =
+  def create: ValidatedNec[String, ElevationRange] =
     (airMass, hourAngle) match {
       case (Some(am), None)   => am.create
       case (None, Some(hr))   => hr.create
-      case (None, None)       => Result(AirMass.Default)
-      case (Some(_), Some(_)) => OnlyOneFailure
+      case (None, None)       => AirMass.Default.validNec
+      case (Some(_), Some(_)) => ElevationRangeInput.messages.OnlyOneDefinition.invalidNec
     }
 
 }
@@ -38,8 +38,9 @@ object ElevationRangeInput {
       none
     )
 
-  private def OnlyOneFailure[A]: Result[A] =
-    Result.failure[A]("Only one of airMass or hourAngle may be specified.")
+  object messages {
+    val OnlyOneDefinition: String = "Only one of airMass or hourAngle may be specified."
+  }
 
   val Binding: Matcher[ElevationRangeInput] =
     ObjectFieldsBinding.rmap {
@@ -47,7 +48,7 @@ object ElevationRangeInput {
         AirMassRangeInput.Binding.Option("airMass", rAir),
         HourAngleRangeInput.Binding.Option("hourAngle", rHour)
       ) => (rAir, rHour).parMapN(ElevationRangeInput(_, _)).flatMap {
-        case ElevationRangeInput(Some(_), Some(_)) => OnlyOneFailure[ElevationRangeInput]
+        case ElevationRangeInput(Some(_), Some(_)) => Result.failure[ElevationRangeInput](messages.OnlyOneDefinition)
         case other                                 => Result(other)
       }
     }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/HourAngleRangeInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/HourAngleRangeInput.scala
@@ -4,9 +4,6 @@
 package lucuma.odb.graphql
 package input
 
-import cats.data.NonEmptyChain
-import cats.data.Validated
-import cats.data.ValidatedNec
 import cats.syntax.apply._
 import cats.syntax.either._
 import cats.syntax.option._
@@ -29,12 +26,12 @@ final case class HourAngleRangeInput(
   def maxBigDecimal: Option[BigDecimal] =
     maxHours.map(_.value)
 
-  def create: ValidatedNec[String, HourAngle] =
-    Validated.fromOption(
+  def create: Result[HourAngle] =
+    Result.fromOption(
       (minHours, maxHours)
         .tupled
         .flatMap(HourAngle.fromOrderedDecimalHours.getOption),
-      NonEmptyChain.one(HourAngleRangeInput.messages.BothMinAndMax)
+      HourAngleRangeInput.messages.BothMinAndMax
     )
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/HourAngleRangeInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/HourAngleRangeInput.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.graphql
 package input
 
+import cats.data.{NonEmptyChain, Validated, ValidatedNec}
 import cats.syntax.apply._
 import cats.syntax.either._
 import cats.syntax.option._
@@ -26,17 +27,22 @@ final case class HourAngleRangeInput(
   def maxBigDecimal: Option[BigDecimal] =
     maxHours.map(_.value)
 
-  def create: Result[HourAngle] =
-    Result.fromOption[HourAngle](
+  def create: ValidatedNec[String, HourAngle] =
+    Validated.fromOption(
       (minHours, maxHours)
         .tupled
         .flatMap(HourAngle.fromOrderedDecimalHours.getOption),
-      "Creating an hour angle range requires specifying both minHours and maxHours where minHours < maxHours"
+      NonEmptyChain.one(HourAngleRangeInput.messages.BothMinAndMax)
     )
 
 }
 
 object HourAngleRangeInput {
+
+  object messages {
+    val BothMinAndMax: String =
+      "Creating an hour angle range requires specifying both minHours and maxHours where minHours < maxHours"
+  }
 
   val Default: HourAngleRangeInput =
     HourAngleRangeInput(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/HourAngleRangeInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/HourAngleRangeInput.scala
@@ -4,7 +4,9 @@
 package lucuma.odb.graphql
 package input
 
-import cats.data.{NonEmptyChain, Validated, ValidatedNec}
+import cats.data.NonEmptyChain
+import cats.data.Validated
+import cats.data.ValidatedNec
 import cats.syntax.apply._
 import cats.syntax.either._
 import cats.syntax.option._

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
@@ -21,7 +21,7 @@ final case class ObservationPropertiesInput(
   activeStatus:  Option[ObsActiveStatus],
   // visualizationTime: Option[Instant],
   // posAngleConstraint: Option[PosAngleConstraintInput],
-  // targetEnvironment: Option[TargetEnvironmentInput],
+  targetEnvironment: Option[TargetEnvironmentInput],
   constraintSet: Option[ConstraintSetInput],
   // scienceRequirements: Option[ScienceRequirementsInput],
   // scienceMode: Option[ScienceModeInput],
@@ -32,11 +32,12 @@ object ObservationPropertiesInput {
 
   val Default: ObservationPropertiesInput =
     ObservationPropertiesInput(
-      subtitle      = Nullable.Null,
-      status        = ObsStatus.New.some,
-      activeStatus  = ObsActiveStatus.Active.some,
-      existence     = Existence.Present.some,
-      constraintSet = ConstraintSetInput.Default.some
+      subtitle          = Nullable.Null,
+      status            = ObsStatus.New.some,
+      activeStatus      = ObsActiveStatus.Active.some,
+      targetEnvironment = None,
+      constraintSet     = ConstraintSetInput.Default.some,
+      existence         = Existence.Present.some
     )
 
   val CreateBinding: Matcher[ObservationPropertiesInput] =
@@ -47,13 +48,13 @@ object ObservationPropertiesInput {
         ObsActiveStatusBinding.Option("activeStatus", rObsActiveStatus),
         ("visualizationTime", _),     // ignore for now
         ("posAngleConstraint", _),    // ignore for now
-        ("targetEnvironment", _),     // ignore for now
+        TargetEnvironmentInput.Binding.Option("targetEnvironment", rTargetEnvironment),
         ConstraintSetInput.Binding.Option("constraintSet", rConstraintSet),
         ("scienceRequirements", _),   // ignore for now
         ("scienceMode", _),           // ignore for now
         ExistenceBinding.Option("existence", rExistence),
       ) =>
-        (rSubtitle.map(Nullable.orNull), rObsStatus, rObsActiveStatus, rConstraintSet, rExistence).parMapN(apply)
+        (rSubtitle.map(Nullable.orNull), rObsStatus, rObsActiveStatus, rTargetEnvironment, rConstraintSet, rExistence).parMapN(apply)
     }
 
   val EditBinding: Matcher[ObservationPropertiesInput] =
@@ -64,13 +65,13 @@ object ObservationPropertiesInput {
         ObsActiveStatusBinding.Option("activeStatus", rObsActiveStatus),
         ("visualizationTime", _),     // ignore for now
         ("posAngleConstraint", _),    // ignore for now
-        ("targetEnvironment", _),     // ignore for now
+        TargetEnvironmentInput.Binding.Option("targetEnvironment", rTargetEnvironment),     // ignore for now
         ConstraintSetInput.Binding.Option("constraintSet", rConstraintSet),
         ("scienceRequirements", _),   // ignore for now
         ("scienceMode", _),           // ignore for now
         ExistenceBinding.Option("existence", rExistence),
       ) =>
-        (rSubtitle, rObsStatus, rObsActiveStatus, rConstraintSet, rExistence).parMapN(apply)
+        (rSubtitle, rObsStatus, rObsActiveStatus, rTargetEnvironment, rConstraintSet, rExistence).parMapN(apply)
     }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/README.md
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/README.md
@@ -1,3 +1,3 @@
 
 This package contains bindings for structured input types. Bindings for leaf types (scalars and
-enums) are in the `bindings` package.
+enums) are in the `binding` package.

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/SiderealInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/SiderealInput.scala
@@ -21,7 +21,7 @@ final case class SiderealInput(
   properMotion: Option[ProperMotion],
   radialVelocity: Option[RadialVelocity],
   parallax: Option[Parallax],
-  catalogInfo: Option[CatalogInfoInput],
+  catalogInfo: Option[CatalogInfoInput]
 )
 
 object SiderealInput {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/TargetEnvironmentInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/TargetEnvironmentInput.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import lucuma.core.model.Target
+import lucuma.odb.data.Nullable
+import lucuma.odb.graphql.binding.TargetIdBinding
+import lucuma.odb.graphql.util.Bindings.*
+
+//# Target environment editing and creation parameters
+//input TargetEnvironmentInput {
+//  # The explicitBase field may be unset by assigning a null value, or ignored by skipping it altogether
+//  explicitBase: CoordinatesInput
+//  asterism: [TargetId!]
+//}
+
+final case class TargetEnvironmentInput(
+  explicitBase: Nullable[CoordinatesInput],
+  asterism:     Nullable[List[Target.Id]]
+)
+
+object TargetEnvironmentInput {
+
+  val Binding: Matcher[TargetEnvironmentInput] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        CoordinatesInput.Binding.Nullable("explicitBase", rBase),
+        TargetIdBinding.List.Nullable("asterism", rAsterism)
+      ) => (rBase, rAsterism).parMapN(TargetEnvironmentInput(_, _))
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -98,12 +98,9 @@ trait MutationMapping[F[_]: MonadCancelThrow]
   private val CreateObservation =
     MutationField("createObservation", CreateObservationInput.Binding) { (input, child)=>
       observationService.use { svc =>
-        import ObservationService.CreateResult._
-        svc.createObservation(input.programId, input.SET.getOrElse(ObservationPropertiesInput.Default)).map {
-          case bi@BadInput(_)      => bi.toResult
-          case na@NotAuthorized(_) => na.toResult
-          case Success(id)         => Result(Unique(Filter(ObservationPredicates.hasObservationId(id), child)))
-        }
+        svc.createObservation(input.programId, input.SET.getOrElse(ObservationPropertiesInput.Default)).map(
+          _.map(id => Unique(Filter(ObservationPredicates.hasObservationId(id), child)))
+        )
       }
     }
 
@@ -177,16 +174,11 @@ trait MutationMapping[F[_]: MonadCancelThrow]
           "Could not construct a subquery for the provided WHERE condition."
         )
 
-      import ObservationService.UpdateResult._
-
       idSelect.flatTraverse { which =>
         observationService.use { svc =>
           svc
             .updateObservations(input.SET, which)
-            .map {
-              case bi@BadInput(_) => bi.toResult
-              case Success(lst)   => Result(Filter(ObservationPredicates.inObservationIds(lst), child))
-            }
+            .map(_.map(ids => Filter(ObservationPredicates.inObservationIds(ids), child)))
         }
       }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -100,8 +100,8 @@ trait MutationMapping[F[_]: MonadCancelThrow]
       observationService.use { svc =>
         import ObservationService.CreateResult._
         svc.createObservation(input.programId, input.SET.getOrElse(ObservationPropertiesInput.Default)).map {
-          case BadInput(problems)  => Ior.left(NonEmptyChain.fromNonEmptyList(problems))
-          case NotAuthorized(user) => Result.failure(s"User ${user.id} is not authorized to perform this action")
+          case bi@BadInput(_)      => bi.toResult
+          case na@NotAuthorized(_) => na.toResult
           case Success(id)         => Result(Unique(Filter(ObservationPredicates.hasObservationId(id), child)))
         }
       }
@@ -184,8 +184,8 @@ trait MutationMapping[F[_]: MonadCancelThrow]
           svc
             .updateObservations(input.SET, which)
             .map {
-              case BadInput(ps) => Ior.left(NonEmptyChain.fromNonEmptyList(ps))
-              case Success(lst) => Result(Filter(ObservationPredicates.inObservationIds(lst), child))
+              case bi@BadInput(_) => bi.toResult
+              case Success(lst)   => Result(Filter(ObservationPredicates.inObservationIds(lst), child))
             }
         }
       }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/RightAscensionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/RightAscensionMapping.scala
@@ -43,7 +43,7 @@ trait RightAscensionMapping[F[_]]
         FieldRef[RightAscension]("value").as("hms", RightAscension.fromStringHMS.reverseGet),
         FieldRef[RightAscension]("value").as("hours", c => BigDecimal(c.toHourAngle.toDoubleHours)),
         FieldRef[RightAscension]("value").as("degrees", c => BigDecimal(c.toAngle.toDoubleDegrees)),
-        FieldRef[RightAscension]("value").as("microarcseconds", _.toAngle.toMicroarcseconds),
+        FieldRef[RightAscension]("value").as("microarcseconds", _.toAngle.toMicroarcseconds)
       )
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -3,9 +3,12 @@
 
 package lucuma.odb.service
 
-import cats.data.{Ior, NonEmptyChain, NonEmptyList, ValidatedNec}
+import cats.data.Ior
+import cats.data.NonEmptyChain
+import cats.data.NonEmptyList
 import cats.data.Validated.Invalid
 import cats.data.Validated.Valid
+import cats.data.ValidatedNec
 import cats.effect.Sync
 import cats.syntax.all.*
 import edu.gemini.grackle.Predicate
@@ -19,7 +22,9 @@ import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
 import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
-import lucuma.core.math.{Coordinates, Declination, RightAscension}
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Declination
+import lucuma.core.math.RightAscension
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ElevationRange
 import lucuma.core.model.ElevationRange.AirMass.DecimalValue
@@ -37,7 +42,12 @@ import lucuma.odb.data.Nullable.NonNull
 import lucuma.odb.data.ObsActiveStatus
 import lucuma.odb.data.ObsStatus
 import lucuma.odb.data.Tag
-import lucuma.odb.graphql.input.{AirMassRangeInput, ConstraintSetInput, ElevationRangeInput, HourAngleRangeInput, ObservationPropertiesInput, TargetEnvironmentInput}
+import lucuma.odb.graphql.input.AirMassRangeInput
+import lucuma.odb.graphql.input.ConstraintSetInput
+import lucuma.odb.graphql.input.ElevationRangeInput
+import lucuma.odb.graphql.input.HourAngleRangeInput
+import lucuma.odb.graphql.input.ObservationPropertiesInput
+import lucuma.odb.graphql.input.TargetEnvironmentInput
 import lucuma.odb.util.Codecs.*
 import natchez.Trace
 import skunk.*

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
@@ -7,7 +7,6 @@ package mutation
 import cats.effect.IO
 import cats.syntax.all.*
 import io.circe.Json
-import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.model.Observation


### PR DESCRIPTION
This is the second (see #57) of several updates to add target environment.  In this installment, I add the optional `explicitBase` position.