### PR TITLE
Asterism update in observation edit

### DIFF
--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -2469,6 +2469,10 @@ type UpdateDatasetsResult {
 
 # Observation selection and update description.  Use `SET` to specify the changes, `WHERE` to select the observations to update, and `LIMIT` to control the size of the return value.
 input UpdateObservationsInput {
+
+  # The program whose observations will be updated.
+  programId: ProgramId!
+
   # Describes the observation values to modify.
   SET: ObservationPropertiesInput!
 
@@ -5716,9 +5720,6 @@ input WhereObservation {
 
   # Matches the observation id.
   id: WhereOrderObservationId
-
-  # Matches the id of the program associated with this observation.
-  programId: WhereOrderProgramId
 
   # Matches the subtitle of the observation.
   subtitle: WhereOptionString

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CreateObservationInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CreateObservationInput.scala
@@ -15,15 +15,11 @@ import lucuma.odb.graphql.util.Bindings._
 
 final case class CreateObservationInput(
   programId: Program.Id,
-  SET: Option[ObservationPropertiesInput]
+  SET:       Option[ObservationPropertiesInput]
 ) {
 
   def asterism: Nullable[NonEmptyList[Target.Id]] =
-    for {
-      p <- Nullable.orAbsent(SET)
-      t <- Nullable.orAbsent(p.targetEnvironment)
-      a <- t.asterism.flatMap(tids => Nullable.orAbsent(NonEmptyList.fromList(tids)))
-    } yield a
+    Nullable.orAbsent(SET).flatMap(_.asterism)
 
 }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
@@ -16,16 +16,16 @@ import lucuma.odb.graphql.binding._
 import lucuma.odb.graphql.util.Bindings._
 
 final case class ObservationPropertiesInput(
-  subtitle:      Nullable[NonEmptyString],
-  status:        Option[ObsStatus],
-  activeStatus:  Option[ObsActiveStatus],
+  subtitle:          Nullable[NonEmptyString],
+  status:            Option[ObsStatus],
+  activeStatus:      Option[ObsActiveStatus],
   // visualizationTime: Option[Instant],
   // posAngleConstraint: Option[PosAngleConstraintInput],
   targetEnvironment: Option[TargetEnvironmentInput],
-  constraintSet: Option[ConstraintSetInput],
+  constraintSet:     Option[ConstraintSetInput],
   // scienceRequirements: Option[ScienceRequirementsInput],
   // scienceMode: Option[ScienceModeInput],
-  existence:     Option[Existence]
+  existence:         Option[Existence]
 )
 
 object ObservationPropertiesInput {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
@@ -5,9 +5,11 @@ package lucuma.odb.graphql
 
 package input
 
+import cats.data.NonEmptyList
 import cats.syntax.all._
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.model.ConstraintSet
+import lucuma.core.model.Target
 import lucuma.odb.data.Existence
 import lucuma.odb.data.Nullable
 import lucuma.odb.data.ObsActiveStatus
@@ -26,7 +28,15 @@ final case class ObservationPropertiesInput(
   // scienceRequirements: Option[ScienceRequirementsInput],
   // scienceMode: Option[ScienceModeInput],
   existence:         Option[Existence]
-)
+) {
+
+  def asterism: Nullable[NonEmptyList[Target.Id]] =
+    for {
+      t <- Nullable.orAbsent(targetEnvironment)
+      a <- t.asterism.flatMap(tids => Nullable.orAbsent(NonEmptyList.fromList(tids)))
+    } yield a
+
+}
 
 object ObservationPropertiesInput {
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateObservationsInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateObservationsInput.scala
@@ -5,10 +5,13 @@ package lucuma.odb.graphql
 
 package input
 
+import cats.data.NonEmptyList
 import cats.syntax.parallel.*
 import edu.gemini.grackle.Predicate
 import eu.timepit.refined.types.numeric.NonNegInt
 import lucuma.core.model.Observation
+import lucuma.core.model.Target
+import lucuma.odb.data.Nullable
 import lucuma.odb.graphql.binding._
 import lucuma.odb.graphql.util.Bindings.*
 
@@ -17,7 +20,12 @@ final case class UpdateObservationsInput(
   WHERE:          Option[Predicate],
   LIMIT:          Option[NonNegInt],
   includeDeleted: Option[Boolean]
-)
+) {
+
+  def asterism: Nullable[NonEmptyList[Target.Id]] =
+    SET.asterism
+
+}
 
 object UpdateObservationsInput {
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateObservationsInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateObservationsInput.scala
@@ -10,12 +10,14 @@ import cats.syntax.parallel.*
 import edu.gemini.grackle.Predicate
 import eu.timepit.refined.types.numeric.NonNegInt
 import lucuma.core.model.Observation
+import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.odb.data.Nullable
 import lucuma.odb.graphql.binding._
 import lucuma.odb.graphql.util.Bindings.*
 
 final case class UpdateObservationsInput(
+  programId:      Program.Id,
   SET:            ObservationPropertiesInput,
   WHERE:          Option[Predicate],
   LIMIT:          Option[NonNegInt],
@@ -32,12 +34,13 @@ object UpdateObservationsInput {
   val Binding: Matcher[UpdateObservationsInput] =
     ObjectFieldsBinding.rmap {
       case List(
+        ProgramIdBinding("programId", rPid),
         ObservationPropertiesInput.EditBinding("SET", rSET),
         WhereObservation.Binding.Option("WHERE", rWHERE),
         NonNegIntBinding.Option("LIMIT", rLIMIT),
         BooleanBinding.Option("includeDeleted", rIncludeDeleted)
       ) =>
-        (rSET, rWHERE, rLIMIT, rIncludeDeleted).parMapN(apply)
+        (rPid, rSET, rWHERE, rLIMIT, rIncludeDeleted).parMapN(apply)
     }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
@@ -16,9 +16,6 @@ import lucuma.odb.graphql.util.Bindings._
 
 object WhereObservation {
 
-  private val ProgramIdBinding: Matcher[Predicate] =
-    WhereOrder.ProgramIdWithPath("programId")
-
   private val SubtitleBinding: Matcher[Predicate] =
     WhereOptionString.binding(UniquePath(List("subtitle")))
 
@@ -35,18 +32,16 @@ object WhereObservation {
         WhereObservation.Binding.List.Option("OR", rOR),
         WhereObservation.Binding.Option("NOT", rNOT),
         WhereOrder.ObservationId.Option("id", rId),
-        ProgramIdBinding.Option("programId", rPid),
         SubtitleBinding.Option("subtitle", rSubtitle),
         StatusBinding.Option("status", rStatus),
         ActiveStatusBinding.Option("activeStatus", rActiveStatus)
       ) =>
-        (rAND, rOR, rNOT, rId, rPid, rSubtitle, rStatus, rActiveStatus).parMapN { (AND, OR, NOT, id, pid, subtitle, status, activeStatus) =>
+        (rAND, rOR, rNOT, rId, rSubtitle, rStatus, rActiveStatus).parMapN { (AND, OR, NOT, id, subtitle, status, activeStatus) =>
           and(List(
             AND.map(and),
             OR.map(or),
             NOT.map(Not(_)),
             id,
-            pid,
             subtitle,
             status,
             activeStatus

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -114,7 +114,7 @@ trait MutationMapping[F[_]: MonadCancelThrow]
       def insertAsterism(oid: Option[Observation.Id]): F[Result[Unit]] =
         oid.flatTraverse { o =>
           input.asterism.toOption.traverse { a =>
-            asterismService.use(_.insertAsterism(input.programId, o, a))
+            asterismService.use(_.insertAsterism(input.programId, NonEmptyList.one(o), a))
           }
         }.map(_.getOrElse(Result.unit))
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -105,7 +105,7 @@ trait MutationMapping[F[_]: MonadCancelThrow]
   private val CreateObservation: MutationField =
     MutationField("createObservation", CreateObservationInput.Binding) { (input, child) =>
 
-      val createObs: F[Result[(Observation.Id, Query)]] =
+      val createObservation: F[Result[(Observation.Id, Query)]] =
         observationService.use { svc =>
           svc.createObservation(input.programId, input.SET.getOrElse(ObservationPropertiesInput.Default)).map(
             _.fproduct(id => Unique(Filter(ObservationPredicates.hasObservationId(id), child)))
@@ -122,7 +122,7 @@ trait MutationMapping[F[_]: MonadCancelThrow]
       pool.use { s =>
         s.transaction.use { xa =>
           for {
-            rTup  <- createObs
+            rTup  <- createObservation
             oid    = rTup.toOption.map(_._1)
             rUnit <- insertAsterism(oid)
             query  = (rTup, rUnit).parMapN { case ((_, query), _) => query }
@@ -185,8 +185,9 @@ trait MutationMapping[F[_]: MonadCancelThrow]
   private val UpdateObservations: MutationField =
     MutationField("updateObservations", UpdateObservationsInput.Binding) { (input, child) =>
 
-      // Predicate for selecting programs to update
+      // Predicate for selecting observations to update
       val filterPredicate: Predicate = and(List(
+        Eql(UniquePath(List("program", "id")), Const(input.programId)),
         ObservationPredicates.isWritableBy(user),
         ObservationPredicates.includeDeleted(input.includeDeleted.getOrElse(false)),
         input.WHERE.getOrElse(True)
@@ -208,20 +209,43 @@ trait MutationMapping[F[_]: MonadCancelThrow]
           observationService.use { svc =>
             svc
               .updateObservations(input.SET, which)
-              .map(_.fproduct(ids => Filter(ObservationPredicates.inObservationIds(ids), child)))
+              .map(_.fproduct {
+
+                // When there are no selected ids, return a Query which matches
+                // nothing (i.e., no results for the update).
+
+                // "In" Predicate is used in the normal case where there is
+                // at least one matching observation id.  But "In" requires a
+                // non-empty list (eventually) so we need to catch the Nil
+                // case.
+
+                // Produces "Unable to map query":
+                // case Nil => Filter(False, child)
+
+                // Work around using a zero limit
+                case Nil => Limit(0, child)
+
+                case ids => Filter(ObservationPredicates.inObservationIds(ids), child)
+              })
           }
         }
 
-/*
-      val updateAsterisms(oids: List[Observation.Id]): F[Result[Unit]] = {
-        input.asterism
-        NonEmptyList.of(oids).map { os =>
-          asterismService.use(_.updateAsterism())
+      def updateAsterisms(oids: List[Observation.Id]): F[Result[Unit]] =
+        NonEmptyList.fromList(oids).traverse { os =>
+          asterismService.use(_.updateAsterism(input.programId, os, input.asterism))
+        }.map(_.getOrElse(Result.unit))
+
+      pool.use { s =>
+        s.transaction.use { xa =>
+          for {
+            rTup  <- updateObservations
+            oids   = rTup.toList.flatMap(_._1)
+            rUnit <- updateAsterisms(oids)
+            query  = (rTup, rUnit).parMapN { case ((_, query), _) => query }
+            _     <- query.left.traverse_(_ => xa.rollback)
+          } yield query
         }
       }
-*/
-
-      updateObservations.map(_.map(_._2))
     }
 
   private val UpdatePrograms =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/ObservationPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/ObservationPredicates.scala
@@ -8,16 +8,16 @@ package predicates
 import edu.gemini.grackle.Path.ListPath
 import edu.gemini.grackle.Path.UniquePath
 import edu.gemini.grackle.Predicate
-import edu.gemini.grackle.Predicate._
+import edu.gemini.grackle.Predicate.*
 import edu.gemini.grackle.skunk.SkunkMapping
-import lucuma.core.model.Access._
+import lucuma.core.model.Access.*
 import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.odb.data.Existence
-
 import mapping.ObservationMapping
 
-trait ObservationPredicates[F[_]] extends ObservationMapping[F] { this: SkunkMapping[F] =>
+trait ObservationPredicates[F[_]] extends ObservationMapping[F]
+                                     with ProgramPredicates[F] { this: SkunkMapping[F] =>
 
     object ObservationPredicates {
 
@@ -31,15 +31,7 @@ trait ObservationPredicates[F[_]] extends ObservationMapping[F] { this: SkunkMap
         In(UniquePath(List("id")), oids)
 
       def isVisibleTo(user: User): Predicate =
-        user.role.access match {
-          case Guest | Pi =>
-            Or(
-              Contains(ListPath(List("program", "users", "userId")), Const(user.id)), // user is linked, or
-              Eql(UniquePath(List("program", "piUserId")), Const(user.id))            // user is the PI
-            )
-          case Ngo => ???
-          case Staff | Admin | Service => True
-        }
+        ProgramPredicates.isVisibleTo(user, List("program"))
 
       def isWritableBy(user: User): Predicate =
         isVisibleTo(user)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/ObservationPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/ObservationPredicates.scala
@@ -14,6 +14,7 @@ import lucuma.core.model.Access.*
 import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.odb.data.Existence
+
 import mapping.ObservationMapping
 
 trait ObservationPredicates[F[_]] extends ObservationMapping[F]

--- a/modules/service/src/main/scala/lucuma/odb/service/AsterismService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AsterismService.scala
@@ -148,7 +148,7 @@ object AsterismService {
         links.intercalate(void", ")
 
       val as: AppliedFragment =
-        void""") AS t (c_program_id, c_observation_id, c_target_id)"""
+        void""") AS t (c_program_id, c_observation_id, c_target_id) """
 
       insert |+| values |+| as |+| whereUserAccess(user, programId)
     }
@@ -168,7 +168,7 @@ object AsterismService {
         }
 
       void"DELETE FROM ONLY t_asterism_target "                  |+|
-        void"WHERE c_observation_id IN (" |+| which |+| void")" |+|
+        void"WHERE c_observation_id IN (" |+| which |+| void") " |+|
         andExistsUserAccess
     }
 

--- a/modules/service/src/main/scala/lucuma/odb/service/AsterismService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AsterismService.scala
@@ -92,12 +92,11 @@ object AsterismService {
       override def deleteAsterism(
         programId:      Program.Id,
         observationIds: NonEmptyList[Observation.Id]
-      ): F[Result[Unit]] = {
+      ): F[Result[Unit]] =
         val af = Statements.deleteLinksAs(user, programId, observationIds)
         session.prepare(af.fragment.command).use { p =>
           p.execute(af.argument).as(Result.unit)
         }
-      }
 
       override def updateAsterism(
         programId:      Program.Id,

--- a/modules/service/src/main/scala/lucuma/odb/service/ProgramService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProgramService.scala
@@ -179,20 +179,26 @@ object ProgramService {
         EXISTS (select c_duration from t_allocation where c_program_id = $program_id and c_partner=$tag and c_duration > 'PT')
         """.apply(programId ~ partner)
 
+    def existsUserAccess(
+      user:      User,
+      programId: Program.Id
+    ): Option[AppliedFragment] =
+      user.role match {
+        case GuestRole             => existsUserAsPi(programId, user.id).some
+        case Pi(_)                 => (existsUserAsPi(programId, user.id) |+| void" OR " |+| existsUserAsCoi(programId, user.id)).some
+        case Ngo(_, partner)       => existsAllocationForPartner(programId, Tag(partner.tag)).some
+        case ServiceRole(_) |
+             StandardRole.Admin(_) |
+             StandardRole.Staff(_) => none
+      }
 
     def whereUserAccess(
       user:      User,
       programId: Program.Id
     ): AppliedFragment =
-      user.role match {
-        case GuestRole       => void"WHERE " |+| existsUserAsPi(programId, user.id)
-        case Pi(_)           => void"WHERE " |+| existsUserAsPi(programId, user.id) |+| void" OR " |+| existsUserAsCoi(programId, user.id)
-        case Ngo(_, partner) => void"WHERE " |+| existsAllocationForPartner(programId, Tag(partner.tag))
-        case ServiceRole(_)        |
-             StandardRole.Admin(_) |
-             StandardRole.Staff(_)   => AppliedFragment.empty
+      existsUserAccess(user, programId).fold(AppliedFragment.empty) { af =>
+        void"WHERE " |+| af
       }
-
 
     /** Insert a program, making the passed user PI if it's a non-service user. */
     val InsertProgram: Query[Option[NonEmptyString] ~ User, Program.Id] =


### PR DESCRIPTION
Adds support for updating the `asterism` array in an observation edit.

```
mutation {
  updateObservations(input: {
    programId: "p-100"
    SET: {
      targetEnvironment: {
        asterism: [ "t-100", "t-101" ]
      }
      WHERE: {
        id: { EQ: "o-100" }
      }
    }
  }) {
    targetEnvironment {
      asterism {
        id
      }
    }
  }
}
```

Because the asterism array mentions specific target ids, and these targets must be associated with a single program, matching observations from multiple programs would always fail.  Accordingly I removed `programId` from the observation matching `WHERE` and put it into the `UpdateObservationsInput`.  Is this what we want to do?