### PR TITLE
Pos angle constraint

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0030__observations.sql
+++ b/modules/service/src/main/resources/db/migration/V0030__observations.sql
@@ -1,3 +1,5 @@
+create type e_pos_angle_cons_mode as enum('unbounded', 'fixed', 'allow_flip', 'average_parallactic', 'parallactic_override');
+
 --- AIR MASS
 
 create domain d_air_mass as numeric(3,2)
@@ -93,18 +95,22 @@ comment on domain d_observation_id is 'GID type for observations.';
 
 create sequence s_observation_id START with 256; -- three hex digits
 create table t_observation (
-  c_program_id         d_program_id        not null    references t_program(c_program_id),
-  c_observation_id     d_observation_id    primary key default 'o-' || to_hex(nextval('s_observation_id')),
-  c_existence          e_existence         not null    default 'present',
-  c_subtitle           text                null        check (length(c_subtitle) > 0),
-  c_instrument         d_tag               null        references t_instrument(c_tag),
-  c_status             e_obs_status        not null    default 'new',
-  c_active_status      e_obs_active_status not null    default 'active',
-  c_visualization_time timestamp           null        default null,
+  c_program_id           d_program_id          not null    references t_program(c_program_id),
+  c_observation_id       d_observation_id      primary key default 'o-' || to_hex(nextval('s_observation_id')),
+  c_existence            e_existence           not null    default 'present',
+  c_subtitle             text                  null        check (length(c_subtitle) > 0),
+  c_instrument           d_tag                 null        references t_instrument(c_tag),
+  c_status               e_obs_status          not null    default 'new',
+  c_active_status        e_obs_active_status   not null    default 'active',
+  c_visualization_time   timestamp             null        default null,
+
+  -- position angle constraint
+  c_pos_angle_cons_mode  e_pos_angle_cons_mode not null    default 'unbounded',
+  c_pos_angle_cons_angle d_angle_µas           not null    default 0,
 
   -- target environment
-  c_explicit_ra        d_angle_µas         null        default null,
-  c_explicit_dec       d_angle_µas         null        default null,
+  c_explicit_ra          d_angle_µas           null        default null,
+  c_explicit_dec         d_angle_µas           null        default null,
 
   -- both explicit coordinates are defined or neither are defined
   constraint explicit_base_neither_or_both

--- a/modules/service/src/main/resources/db/migration/V0030__observations.sql
+++ b/modules/service/src/main/resources/db/migration/V0030__observations.sql
@@ -1,4 +1,4 @@
-create type e_pos_angle_cons_mode as enum('unbounded', 'fixed', 'allow_flip', 'average_parallactic', 'parallactic_override');
+create type e_pac_mode as enum('unbounded', 'fixed', 'allow_flip', 'average_parallactic', 'parallactic_override');
 
 --- AIR MASS
 
@@ -95,22 +95,22 @@ comment on domain d_observation_id is 'GID type for observations.';
 
 create sequence s_observation_id START with 256; -- three hex digits
 create table t_observation (
-  c_program_id           d_program_id          not null    references t_program(c_program_id),
-  c_observation_id       d_observation_id      primary key default 'o-' || to_hex(nextval('s_observation_id')),
-  c_existence            e_existence           not null    default 'present',
-  c_subtitle             text                  null        check (length(c_subtitle) > 0),
-  c_instrument           d_tag                 null        references t_instrument(c_tag),
-  c_status               e_obs_status          not null    default 'new',
-  c_active_status        e_obs_active_status   not null    default 'active',
-  c_visualization_time   timestamp             null        default null,
+  c_program_id         d_program_id        not null    references t_program(c_program_id),
+  c_observation_id     d_observation_id    primary key default 'o-' || to_hex(nextval('s_observation_id')),
+  c_existence          e_existence         not null    default 'present',
+  c_subtitle           text                null        check (length(c_subtitle) > 0),
+  c_instrument         d_tag               null        references t_instrument(c_tag),
+  c_status             e_obs_status        not null    default 'new',
+  c_active_status      e_obs_active_status not null    default 'active',
+  c_visualization_time timestamp           null        default null,
 
   -- position angle constraint
-  c_pos_angle_cons_mode  e_pos_angle_cons_mode not null    default 'unbounded',
-  c_pos_angle_cons_angle d_angle_µas           not null    default 0,
+  c_pac_mode           e_pac_mode          not null    default 'unbounded',
+  c_pac_angle          d_angle_µas         not null    default 0,
 
   -- target environment
-  c_explicit_ra          d_angle_µas           null        default null,
-  c_explicit_dec         d_angle_µas           null        default null,
+  c_explicit_ra        d_angle_µas         null        default null,
+  c_explicit_dec       d_angle_µas         null        default null,
 
   -- both explicit coordinates are defined or neither are defined
   constraint explicit_base_neither_or_both

--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -1925,8 +1925,8 @@ input PoorWeatherInput {
 #
 input PosAngleConstraintInput {
 
-  # The constraint mode field determines whether the angle field, 'degrees', is
-  # respected or ignored.
+  # The constraint mode field determines whether the angle field is respected
+  # or ignored.
   mode: PosAngleConstraintMode
 
   # The fixed position angle that is used when the mode is FIXED, ALLOW_FLIP or
@@ -4383,11 +4383,11 @@ type PoorWeather implements ProposalClass {
 type PosAngleConstraint {
 
   # The position angle constraint mode in use.  The value will determine whether
-  # the angle in degrees is respected or ignored.
+  # the angle is respected or ignored.
   mode: PosAngleConstraintMode!
 
-  # Describes the fixed position angle, in degrees.  This will be kept but
-  # ignored for UNBOUNDED and AVERAGE_PARALLACTIC modes.
+  # The fixed position angle.  This will be kept but ignored for UNBOUNDED and
+  # AVERAGE_PARALLACTIC modes.
   angle: Angle!
 }
 

--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -1924,10 +1924,13 @@ input PoorWeatherInput {
 # position angle required to reach the best guide star option will be used.
 #
 input PosAngleConstraintInput {
-  # The constraint field is required when creating a new instance of position angle constraint type, but optional when editing
-  constraint: PosAngleConstraintType
 
-  # The angle field is required when creating a new instance of fixed any, if any (not required for average parallactic, but optional when editing
+  # The constraint mode field determines whether the angle field, 'degrees', is
+  # respected or ignored.
+  mode: PosAngleConstraintMode
+
+  # The fixed position angle that is used when the mode is FIXED, ALLOW_FLIP or
+  # PARALLACTIC_OVERRIDE.  Set but ignored when UNBOUNDED or AVERAGE_PARALLACTIC.
   angle: AngleInput
 }
 
@@ -4372,23 +4375,34 @@ type PoorWeather implements ProposalClass {
 
 # Constraints (if any) on the observation's position angle.
 type PosAngleConstraint {
-  # The position angle constraint type in use
-  constraint: PosAngleConstraintType!
 
-  # Describes the fixed position angle constraint, if set
-  angle: Angle
+  # The position angle constraint mode in use.  The value will determine whether
+  # the angle in degrees is respected or ignored.
+  mode: PosAngleConstraintMode!
+
+  # Describes the fixed position angle, in degrees.  This will be kept but
+  # ignored for UNBOUNDED and AVERAGE_PARALLACTIC modes.
+  angle: Angle!
 }
 
 # Position angle constraint type
-enum PosAngleConstraintType {
-  # PosAngleConstraintType Fixed
+enum PosAngleConstraintMode {
+
+  # PosAngleConstraintMode Unbounded
+  UNBOUNDED
+
+  # PosAngleConstraintMode Fixed
   FIXED
 
-  # PosAngleConstraintType AllowFlip
+  # PosAngleConstraintMode AllowFlip
   ALLOW_FLIP
 
-  # PosAngleConstraintType AverageParallactic
+  # PosAngleConstraintMode AverageParallactic
   AVERAGE_PARALLACTIC
+
+  # PosAngleConstraintMode ParallacticOverride
+  PARALLACTIC_OVERRIDE
+
 }
 
 # A `BigDecimal` greater than 0

--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -2687,6 +2687,12 @@ type Angle {
 
   # Angle in hrs
   hours: BigDecimal!
+
+  # Angle in HH:MM:SS
+  hms: String!
+
+  # Angle in DD:MM:SS
+  dms: String!
 }
 
 type AsterismGroup {

--- a/modules/service/src/main/scala/lucuma/odb/data/PosAngleConstraintMode.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/PosAngleConstraintMode.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+
+import lucuma.core.util.Enumerated
+
+// There is something similar in lucuma-core.  It needs to be updated and then
+// we can switch to that.
+
+enum PosAngleConstraintMode(val dbTag: String):
+  case Unbounded           extends PosAngleConstraintMode("unbounded")
+  case Fixed               extends PosAngleConstraintMode("fixed")
+  case AllowFlip           extends PosAngleConstraintMode("allow_flip")
+  case AverageParallactic  extends PosAngleConstraintMode("average_parallactic")
+  case ParallacticOverride extends PosAngleConstraintMode("parallactic_override")
+
+object PosAngleConstraintMode:
+
+  val Default: PosAngleConstraintMode =
+    Unbounded
+
+  given Enumerated[PosAngleConstraintMode] =
+    Enumerated.from(
+      Unbounded,
+      Fixed,
+      AllowFlip,
+      AverageParallactic,
+      ParallacticOverride
+    ).withTag(_.dbTag)
+

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -74,6 +74,7 @@ object OdbMapping {
         new SkunkMapping[F](database, monitor) with SchemaSemigroup
           with AirMassRangeMapping[F]
           with AllocationMapping[F]
+          with AngleMapping[F]
           with CatalogInfoMapping[F]
           with ConstraintSetMapping[F]
           with CoordinatesMapping[F]
@@ -94,6 +95,7 @@ object OdbMapping {
           with PartnerMetaMapping[F]
           with PartnerSplitMapping[F]
           with PlannedTimeSummaryMapping[F]
+          with PosAngleConstraintMapping[F]
           with ProgramEditMapping[F]
           with ProgramMapping[F]
           with ProgramUserMapping[F]
@@ -130,6 +132,7 @@ object OdbMapping {
             List(
               AirMassRangeMapping,
               AllocationMapping,
+              AngleMapping,
               CatalogInfoMapping,
               ConstraintSetMapping,
               CoordinatesMapping,
@@ -149,6 +152,7 @@ object OdbMapping {
               PartnerMetaMapping,
               PartnerSplitMapping,
               PlannedTimeSummaryMapping,
+              PosAngleConstraintMapping,
               ProgramMapping,
               ProgramEditMapping,
               ProgramUserMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/PosAngleConstraintModeBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/PosAngleConstraintModeBinding.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.odb.data.PosAngleConstraintMode
+
+val PosAngleConstraintModeBinding: Matcher[PosAngleConstraintMode] =
+  enumeratedBinding

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
@@ -18,16 +18,16 @@ import lucuma.odb.data.Timestamp
 import lucuma.odb.graphql.binding._
 
 final case class ObservationPropertiesInput(
-  subtitle:          Nullable[NonEmptyString],
-  status:            Option[ObsStatus],
-  activeStatus:      Option[ObsActiveStatus],
-  visualizationTime: Nullable[Timestamp],
-  // posAngleConstraint: Option[PosAngleConstraintInput],
-  targetEnvironment: Option[TargetEnvironmentInput],
-  constraintSet:     Option[ConstraintSetInput],
+  subtitle:           Nullable[NonEmptyString],
+  status:             Option[ObsStatus],
+  activeStatus:       Option[ObsActiveStatus],
+  visualizationTime:  Nullable[Timestamp],
+  posAngleConstraint: Option[PosAngleConstraintInput],
+  targetEnvironment:  Option[TargetEnvironmentInput],
+  constraintSet:      Option[ConstraintSetInput],
   // scienceRequirements: Option[ScienceRequirementsInput],
   // scienceMode: Option[ScienceModeInput],
-  existence:         Option[Existence]
+  existence:          Option[Existence]
 ) {
 
   def asterism: Nullable[NonEmptyList[Target.Id]] =
@@ -42,13 +42,14 @@ object ObservationPropertiesInput {
 
   val Default: ObservationPropertiesInput =
     ObservationPropertiesInput(
-      subtitle          = Nullable.Null,
-      status            = ObsStatus.New.some,
-      activeStatus      = ObsActiveStatus.Active.some,
-      visualizationTime = Nullable.Null,
-      targetEnvironment = None,
-      constraintSet     = ConstraintSetInput.Default.some,
-      existence         = Existence.Present.some
+      subtitle           = Nullable.Null,
+      status             = ObsStatus.New.some,
+      activeStatus       = ObsActiveStatus.Active.some,
+      visualizationTime  = Nullable.Null,
+      posAngleConstraint = None,
+      targetEnvironment  = None,
+      constraintSet      = ConstraintSetInput.Default.some,
+      existence          = Existence.Present.some
     )
 
   val CreateBinding: Matcher[ObservationPropertiesInput] =
@@ -58,7 +59,7 @@ object ObservationPropertiesInput {
         ObsStatusBinding.Option("status", rObsStatus),
         ObsActiveStatusBinding.Option("activeStatus", rObsActiveStatus),
         TimestampBinding.Option("visualizationTime", rVisualizationTime),
-        ("posAngleConstraint", _),    // ignore for now
+        PosAngleConstraintInput.Binding.Option("posAngleConstraint", rPosAngleConstraint),
         TargetEnvironmentInput.Binding.Option("targetEnvironment", rTargetEnvironment),
         ConstraintSetInput.Binding.Option("constraintSet", rConstraintSet),
         ("scienceRequirements", _),   // ignore for now
@@ -69,6 +70,7 @@ object ObservationPropertiesInput {
          rObsStatus,
          rObsActiveStatus,
          rVisualizationTime.map(Nullable.orNull),
+         rPosAngleConstraint,
          rTargetEnvironment,
          rConstraintSet,
          rExistence
@@ -82,8 +84,8 @@ object ObservationPropertiesInput {
         ObsStatusBinding.Option("status", rObsStatus),
         ObsActiveStatusBinding.Option("activeStatus", rObsActiveStatus),
         TimestampBinding.Nullable("visualizationTime", rVisualizationTime),
-        ("posAngleConstraint", _),    // ignore for now
-        TargetEnvironmentInput.Binding.Option("targetEnvironment", rTargetEnvironment),     // ignore for now
+        PosAngleConstraintInput.Binding.Option("posAngleConstraint", rPosAngleConstraint),
+        TargetEnvironmentInput.Binding.Option("targetEnvironment", rTargetEnvironment),
         ConstraintSetInput.Binding.Option("constraintSet", rConstraintSet),
         ("scienceRequirements", _),   // ignore for now
         ("scienceMode", _),           // ignore for now
@@ -93,6 +95,7 @@ object ObservationPropertiesInput {
          rObsStatus,
          rObsActiveStatus,
          rVisualizationTime,
+         rPosAngleConstraint,
          rTargetEnvironment,
          rConstraintSet,
          rExistence

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/PosAngleConstraintInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/PosAngleConstraintInput.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.input
+
+import cats.syntax.parallel._
+import lucuma.core.math.Angle
+import lucuma.odb.data.PosAngleConstraintMode
+import lucuma.odb.graphql.binding.AngleBinding
+import lucuma.odb.graphql.binding.Matcher
+import lucuma.odb.graphql.binding.ObjectFieldsBinding
+import lucuma.odb.graphql.binding.PosAngleConstraintModeBinding
+
+final case class PosAngleConstraintInput(
+  mode:  Option[PosAngleConstraintMode],
+  angle: Option[Angle]
+)
+
+object PosAngleConstraintInput {
+
+  val Binding: Matcher[PosAngleConstraintInput] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        PosAngleConstraintModeBinding.Option("mode", rMode),
+        AngleInput.Binding.Option("angle", rAngle)
+      ) =>
+        (rMode, rAngle).parMapN(apply)
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AngleMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AngleMapping.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mapping
+
+import edu.gemini.grackle.skunk.SkunkMapping
+import lucuma.core.math.Angle
+import lucuma.odb.graphql.table.ObservationView
+import lucuma.odb.graphql.util.MappingExtras
+
+
+trait AngleMapping[F[_]]
+  extends ObservationView[F]
+     with MappingExtras[F]
+{ this: SkunkMapping[F] =>
+
+  lazy val AngleType = schema.ref("Angle")
+
+  private def angleMapping(
+    idColumn: ColumnRef,
+    valueColumn: ColumnRef
+  ): ObjectMapping =
+    ObjectMapping(
+      tpe = AngleType,
+      fieldMappings = List(
+        SqlField("synthentic_id", idColumn, key = true, hidden = true),
+        SqlField("value", valueColumn, hidden = true),
+        FieldRef[Angle]("value").as("microarcseconds", _.toMicroarcseconds),
+        FieldRef[Angle]("value").as("degrees", c => BigDecimal(c.toDoubleDegrees))
+      )
+    )
+
+  lazy val AngleMapping =
+    PrefixedMapping(
+      tpe = AngleType,
+      mappings = List(
+        // Observation PosAngleConstraint
+        List("posAngleConstraint", "angle") -> angleMapping(ObservationView.Id, ObservationView.PosAngleConstraint.Angle)
+      )
+    )
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AngleMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AngleMapping.scala
@@ -6,6 +6,7 @@ package mapping
 
 import edu.gemini.grackle.skunk.SkunkMapping
 import lucuma.core.math.Angle
+import lucuma.core.math.HourAngle
 import lucuma.odb.graphql.table.ObservationView
 import lucuma.odb.graphql.util.MappingExtras
 
@@ -17,6 +18,14 @@ trait AngleMapping[F[_]]
 
   lazy val AngleType = schema.ref("Angle")
 
+  private val µPerMilli: Long = 1000L
+  private val µPerSec: Long   = 1000L * µPerMilli
+  private val µPerMin: Long   =   60L * µPerSec
+  private val µPerUnit: Long  =   60L * µPerMin
+
+  private def angleToTime(µs: Long): Angle => BigDecimal = angleToArc(µs * 15)
+  private def angleToArc(µas: Long)(a: Angle): BigDecimal = BigDecimal(a.toMicroarcseconds) / µas
+
   private def angleMapping(
     idColumn: ColumnRef,
     valueColumn: ColumnRef
@@ -27,7 +36,17 @@ trait AngleMapping[F[_]]
         SqlField("synthentic_id", idColumn, key = true, hidden = true),
         SqlField("value", valueColumn, hidden = true),
         FieldRef[Angle]("value").as("microarcseconds", _.toMicroarcseconds),
-        FieldRef[Angle]("value").as("degrees", c => BigDecimal(c.toDoubleDegrees))
+        FieldRef[Angle]("value").as("microseconds",    angleToTime(1L)),
+        FieldRef[Angle]("value").as("milliarcseconds", angleToArc(µPerMilli)),
+        FieldRef[Angle]("value").as("milliseconds",    angleToTime(µPerMilli)),
+        FieldRef[Angle]("value").as("arcseconds",      angleToArc(µPerSec)),
+        FieldRef[Angle]("value").as("seconds",         angleToTime(µPerSec)),
+        FieldRef[Angle]("value").as("arcminutes",      angleToArc(µPerMin)),
+        FieldRef[Angle]("value").as("minutes",         angleToTime(µPerMin)),
+        FieldRef[Angle]("value").as("degrees",         angleToArc(µPerUnit)),
+        FieldRef[Angle]("value").as("hours",           angleToTime(µPerUnit)),
+        FieldRef[Angle]("value").as("dms", c => Angle.dms.get(c).format),
+        FieldRef[Angle]("value").as("hms", c => HourAngle.fromStringHMS.reverseGet(Angle.hourAngle.get(c)))
       )
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
@@ -30,6 +30,7 @@ import lucuma.odb.data.EditType
 import lucuma.odb.data.Existence
 import lucuma.odb.data.ObsActiveStatus
 import lucuma.odb.data.ObsStatus
+import lucuma.odb.data.PosAngleConstraintMode
 import lucuma.odb.data.ProgramUserRole
 import lucuma.odb.data.Tag
 import lucuma.odb.data.Timestamp
@@ -40,36 +41,37 @@ trait LeafMappings[F[_]] { this: Mapping[F] =>
   private given Encoder[Epoch] =
     e => Json.fromString(Epoch.fromString.reverseGet(e))
 
-  lazy val BigDecimalType        = schema.ref("BigDecimal")
-  lazy val CloudExtinctionType   = schema.ref("CloudExtinction")
-  lazy val DmsStringType         = schema.ref("DmsString")
-  lazy val EditTypeType          = schema.ref("EditType")
-  lazy val EphemerisKeyTypeType  = schema.ref("EphemerisKeyType")
-  lazy val EpochStringType       = schema.ref("EpochString")
-  lazy val ExistenceType         = schema.ref("Existence")
-  lazy val FilterTypeType        = schema.ref("FilterType")
-  lazy val HmsStringType         = schema.ref("HmsString")
-  lazy val ImageQualityType      = schema.ref("ImageQuality")
-  lazy val IntPercentType        = schema.ref("IntPercent")
-  lazy val LongType              = schema.ref("Long")
-  lazy val NonEmptyStringType    = schema.ref("NonEmptyString")
-  lazy val NonNegBigDecimalType  = schema.ref("NonNegBigDecimal")
-  lazy val NonNegLongType        = schema.ref("NonNegLong")
-  lazy val ObsActiveStatusType   = schema.ref("ObsActiveStatus")
-  lazy val ObservationIdType     = schema.ref("ObservationId")
-  lazy val ObsStatusType         = schema.ref("ObsStatus")
-  lazy val PartnerType           = schema.ref("Partner")
-  lazy val PosBigDecimalType     = schema.ref("PosBigDecimal")
-  lazy val ProgramIdType         = schema.ref("ProgramId")
-  lazy val ProgramUserRoleType   = schema.ref("ProgramUserRole")
-  lazy val SkyBackgroundType     = schema.ref("SkyBackground")
-  lazy val TacCategoryType       = schema.ref("TacCategory")
-  lazy val TargetIdType          = schema.ref("TargetId")
-  lazy val TimestampType         = schema.ref("Timestamp")
-  lazy val ToOActivationType     = schema.ref("ToOActivation")
-  lazy val UserIdType            = schema.ref("UserId")
-  lazy val UserTypeType          = schema.ref("UserType")
-  lazy val WaterVaporType        = schema.ref("WaterVapor")
+  lazy val BigDecimalType             = schema.ref("BigDecimal")
+  lazy val CloudExtinctionType        = schema.ref("CloudExtinction")
+  lazy val DmsStringType              = schema.ref("DmsString")
+  lazy val EditTypeType               = schema.ref("EditType")
+  lazy val EphemerisKeyTypeType       = schema.ref("EphemerisKeyType")
+  lazy val EpochStringType            = schema.ref("EpochString")
+  lazy val ExistenceType              = schema.ref("Existence")
+  lazy val FilterTypeType             = schema.ref("FilterType")
+  lazy val HmsStringType              = schema.ref("HmsString")
+  lazy val ImageQualityType           = schema.ref("ImageQuality")
+  lazy val IntPercentType             = schema.ref("IntPercent")
+  lazy val LongType                   = schema.ref("Long")
+  lazy val NonEmptyStringType         = schema.ref("NonEmptyString")
+  lazy val NonNegBigDecimalType       = schema.ref("NonNegBigDecimal")
+  lazy val NonNegLongType             = schema.ref("NonNegLong")
+  lazy val ObsActiveStatusType        = schema.ref("ObsActiveStatus")
+  lazy val ObservationIdType          = schema.ref("ObservationId")
+  lazy val ObsStatusType              = schema.ref("ObsStatus")
+  lazy val PartnerType                = schema.ref("Partner")
+  lazy val PosAngleConstraintModeType = schema.ref("PosAngleConstraintMode")
+  lazy val PosBigDecimalType          = schema.ref("PosBigDecimal")
+  lazy val ProgramIdType              = schema.ref("ProgramId")
+  lazy val ProgramUserRoleType        = schema.ref("ProgramUserRole")
+  lazy val SkyBackgroundType          = schema.ref("SkyBackground")
+  lazy val TacCategoryType            = schema.ref("TacCategory")
+  lazy val TargetIdType               = schema.ref("TargetId")
+  lazy val TimestampType              = schema.ref("Timestamp")
+  lazy val ToOActivationType          = schema.ref("ToOActivation")
+  lazy val UserIdType                 = schema.ref("UserId")
+  lazy val UserTypeType               = schema.ref("UserType")
+  lazy val WaterVaporType             = schema.ref("WaterVapor")
 
   lazy val LeafMappings: List[TypeMapping] =
     List(
@@ -92,6 +94,7 @@ trait LeafMappings[F[_]] { this: Mapping[F] =>
       LeafMapping[ObsStatus](ObsStatusType),
       LeafMapping[ObsStatus](ObsStatusType),
       LeafMapping[Tag](PartnerType),
+      LeafMapping[PosAngleConstraintMode](PosAngleConstraintModeType),
       LeafMapping[PosBigDecimal](PosBigDecimalType),
       LeafMapping[Program.Id](ProgramIdType),
       LeafMapping[ProgramUserRole](ProgramUserRoleType),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -29,6 +29,7 @@ trait ObservationMapping[F[_]]
         SqlField("status", ObservationView.Status),
         SqlField("activeStatus", ObservationView.ActiveStatus),
         SqlField("visualizationTime", ObservationView.VisualizationTime),
+        SqlObject("posAngleConstraint"),
         SqlObject("targetEnvironment"),
         SqlObject("constraintSet"),
         SqlObject("program", Join(ObservationView.ProgramId, ProgramTable.Id))

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/PosAngleConstraintMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/PosAngleConstraintMapping.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mapping
+
+import edu.gemini.grackle.TypeRef
+import edu.gemini.grackle.skunk.SkunkMapping
+import lucuma.core.math.Angle
+import lucuma.odb.graphql.util.MappingExtras
+
+import table.ObservationView
+
+trait PosAngleConstraintMapping[F[_]]
+  extends ObservationView[F]
+     with MappingExtras[F] { this: SkunkMapping[F] =>
+
+  lazy val PosAngleConstraintType: TypeRef =
+    schema.ref("PosAngleConstraint")
+
+  lazy val PosAngleConstraintMapping =
+    ObjectMapping(
+      tpe = PosAngleConstraintType,
+      fieldMappings = List(
+        SqlField("id", ObservationView.Id, key = true, hidden = true),
+        SqlField("mode",  ObservationView.PosAngleConstraint.Mode),
+        SqlObject("angle")
+      )
+    )
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
@@ -22,8 +22,8 @@ trait ObservationView[F[_]] { self: SkunkMapping[F] =>
       val VisualizationTime: ColumnRef = col("c_visualization_time", data_timestamp.opt)
 
       object PosAngleConstraint {
-        val Mode: ColumnRef            = col("c_pos_angle_cons_mode",  pos_angle_cons_mode.embedded)
-        val Angle: ColumnRef           = col("c_pos_angle_cons_angle", angle_µas.embedded)
+        val Mode: ColumnRef            = col("c_pac_mode",  pac_mode.embedded)
+        val Angle: ColumnRef           = col("c_pac_angle", angle_µas.embedded)
       }
 
       object TargetEnvironment {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
@@ -21,6 +21,11 @@ trait ObservationView[F[_]] { self: SkunkMapping[F] =>
       val ActiveStatus: ColumnRef      = col("c_active_status",      obs_active_status)
       val VisualizationTime: ColumnRef = col("c_visualization_time", data_timestamp.opt)
 
+      object PosAngleConstraint {
+        val Mode: ColumnRef            = col("c_pos_angle_cons_mode",  pos_angle_cons_mode.embedded)
+        val Angle: ColumnRef           = col("c_pos_angle_cons_angle", angle_µas.embedded)
+      }
+
       object TargetEnvironment {
         object Coordinates {
           val SyntheticId: ColumnRef = col("c_explicit_base_id",  observation_id.embedded)

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -19,6 +19,7 @@ import lucuma.core.enums.CloudExtinction
 import lucuma.core.enums.ImageQuality
 import lucuma.core.enums.SkyBackground
 import lucuma.core.enums.WaterVapor
+import lucuma.core.math.Angle
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
 import lucuma.core.math.RightAscension
@@ -38,6 +39,7 @@ import lucuma.odb.data.Nullable.Absent
 import lucuma.odb.data.Nullable.NonNull
 import lucuma.odb.data.ObsActiveStatus
 import lucuma.odb.data.ObsStatus
+import lucuma.odb.data.PosAngleConstraintMode
 import lucuma.odb.data.Tag
 import lucuma.odb.data.Timestamp
 import lucuma.odb.graphql.input.AirMassRangeInput
@@ -45,6 +47,7 @@ import lucuma.odb.graphql.input.ConstraintSetInput
 import lucuma.odb.graphql.input.ElevationRangeInput
 import lucuma.odb.graphql.input.HourAngleRangeInput
 import lucuma.odb.graphql.input.ObservationPropertiesInput
+import lucuma.odb.graphql.input.PosAngleConstraintInput
 import lucuma.odb.graphql.input.TargetEnvironmentInput
 import lucuma.odb.util.Codecs.*
 import natchez.Trace
@@ -179,6 +182,8 @@ object ObservationService {
           SET.status.getOrElse(ObsStatus.Default),
           SET.activeStatus.getOrElse(ObsActiveStatus.Default),
           SET.visualizationTime.toOption,
+          SET.posAngleConstraint.flatMap(_.mode).getOrElse(PosAngleConstraintMode.Unbounded),
+          SET.posAngleConstraint.flatMap(_.angle).getOrElse(Angle.Angle0),
           eb,
           cs.getOrElse(ConstraintSetInput.NominalConstraints)
         )
@@ -191,6 +196,8 @@ object ObservationService {
       status:            ObsStatus,
       activeState:       ObsActiveStatus,
       visualizationTime: Option[Timestamp],
+      posAngleConsMode:  PosAngleConstraintMode,
+      posAngle:          Angle,
       explicitBase:      Option[Coordinates],
       constraintSet:     ConstraintSet
     ): AppliedFragment = {
@@ -203,6 +210,8 @@ object ObservationService {
            status      ~
            activeState ~
            visualizationTime             ~
+           posAngleConsMode              ~
+           posAngle                      ~
            explicitBase.map(_.ra)        ~
            explicitBase.map(_.dec)       ~
            constraintSet.cloudExtinction ~
@@ -230,6 +239,8 @@ object ObservationService {
       ObsStatus              ~
       ObsActiveStatus        ~
       Option[Timestamp]      ~
+      PosAngleConstraintMode ~
+      Angle                  ~
       Option[RightAscension] ~
       Option[Declination]    ~
       CloudExtinction        ~
@@ -249,6 +260,8 @@ object ObservationService {
           c_status,
           c_active_status,
           c_visualization_time,
+          c_pos_angle_cons_mode,
+          c_pos_angle_cons_angle,
           c_explicit_ra,
           c_explicit_dec,
           c_cloud_extinction,
@@ -267,6 +280,8 @@ object ObservationService {
           $obs_status,
           $obs_active_status,
           ${data_timestamp.opt},
+          ${pos_angle_cons_mode},
+          ${angle_µas},
           ${right_ascension.opt},
           ${declination.opt},
           $cloud_extinction,
@@ -278,6 +293,14 @@ object ObservationService {
           ${hour_angle_range_value.opt},
           ${hour_angle_range_value.opt}
       """
+
+    def posAngleConstraintUpdates(in: PosAngleConstraintInput): List[AppliedFragment] = {
+
+      val upMode  = sql"c_pos_angle_cons_mode  = $pos_angle_cons_mode"
+      val upAngle = sql"c_pos_angle_cons_angle = $angle_µas"
+
+      in.mode.map(upMode).toList ++ in.angle.map(upAngle).toList
+    }
 
     def explicitBaseUpdates(in: TargetEnvironmentInput): Result[List[AppliedFragment]] = {
 
@@ -365,6 +388,11 @@ object ObservationService {
           }
         ).flatten
 
+      val posAngleConstraint: List[AppliedFragment] =
+        SET.posAngleConstraint
+           .toList
+           .flatMap(posAngleConstraintUpdates)
+
       val explicitBase: Result[List[AppliedFragment]] =
         SET.targetEnvironment
            .toList
@@ -376,7 +404,7 @@ object ObservationService {
            .flatTraverse(constraintSetUpdates)
 
       (explicitBase, constraintSet).mapN { (eb, cs) =>
-        NonEmptyList.fromList(eb ++ cs ++ ups)
+        NonEmptyList.fromList(eb ++ cs ++ ups ++ posAngleConstraint)
       }
     }
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -260,8 +260,8 @@ object ObservationService {
           c_status,
           c_active_status,
           c_visualization_time,
-          c_pos_angle_cons_mode,
-          c_pos_angle_cons_angle,
+          c_pac_mode,
+          c_pac_angle,
           c_explicit_ra,
           c_explicit_dec,
           c_cloud_extinction,
@@ -280,7 +280,7 @@ object ObservationService {
           $obs_status,
           $obs_active_status,
           ${data_timestamp.opt},
-          ${pos_angle_cons_mode},
+          ${pac_mode},
           ${angle_µas},
           ${right_ascension.opt},
           ${declination.opt},
@@ -296,8 +296,8 @@ object ObservationService {
 
     def posAngleConstraintUpdates(in: PosAngleConstraintInput): List[AppliedFragment] = {
 
-      val upMode  = sql"c_pos_angle_cons_mode  = $pos_angle_cons_mode"
-      val upAngle = sql"c_pos_angle_cons_angle = $angle_µas"
+      val upMode  = sql"c_pac_mode  = $pac_mode"
+      val upAngle = sql"c_pac_angle = $angle_µas"
 
       in.mode.map(upMode).toList ++ in.angle.map(upAngle).toList
     }

--- a/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
@@ -180,8 +180,8 @@ trait Codecs {
   val int_percent: Codec[IntPercent] =
     int2.eimap(n => IntPercent.from(n))(_.value.toShort)
 
-  val pos_angle_cons_mode: Codec[PosAngleConstraintMode] =
-    enumerated(Type("e_pos_angle_cons_mode"))
+  val pac_mode: Codec[PosAngleConstraintMode] =
+    enumerated(Type("e_pac_mode"))
 
 }
 

--- a/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
@@ -29,6 +29,7 @@ import lucuma.odb.data.EditType
 import lucuma.odb.data.Existence
 import lucuma.odb.data.ObsActiveStatus
 import lucuma.odb.data.ObsStatus
+import lucuma.odb.data.PosAngleConstraintMode
 import lucuma.odb.data.ProgramUserRole
 import lucuma.odb.data.ProgramUserSupportType
 import lucuma.odb.data.Tag
@@ -179,6 +180,8 @@ trait Codecs {
   val int_percent: Codec[IntPercent] =
     int2.eimap(n => IntPercent.from(n))(_.value.toShort)
 
+  val pos_angle_cons_mode: Codec[PosAngleConstraintMode] =
+    enumerated(Type("e_pos_angle_cons_mode"))
 
 }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
@@ -641,6 +641,39 @@ class updateObservations extends OdbSuite
 
   }
 
+  test("update pos angle constraint") {
+    oneUpdateTest(
+      user = pi,
+      update =
+        """
+        posAngleConstraint: {
+          mode: ALLOW_FLIP
+          angle: { degrees: 14 }
+        }
+      """,
+      query =
+        """
+        posAngleConstraint {
+          mode
+          angle { degrees }
+        }
+      """,
+      expected =
+        json"""
+        {
+          "updateObservations": [
+            {
+              "posAngleConstraint": {
+                "mode": "ALLOW_FLIP",
+                "angle": { "degrees": 14.0 }
+              }
+            }
+          ]
+        }
+      """.asRight
+    )
+  }
+
 }
 
 trait UpdateConstraintSetOps { this: OdbSuite =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
@@ -648,14 +648,27 @@ class updateObservations extends OdbSuite
         """
         posAngleConstraint: {
           mode: ALLOW_FLIP
-          angle: { degrees: 14 }
+          angle: { degrees: 15 }
         }
       """,
       query =
         """
         posAngleConstraint {
           mode
-          angle { degrees }
+          angle {
+            microarcseconds
+            microseconds
+            milliarcseconds
+            milliseconds
+            arcseconds
+            seconds
+            arcminutes
+            minutes
+            degrees
+            hours
+            dms
+            hms
+          }
         }
       """,
       expected =
@@ -665,7 +678,20 @@ class updateObservations extends OdbSuite
             {
               "posAngleConstraint": {
                 "mode": "ALLOW_FLIP",
-                "angle": { "degrees": 14.0 }
+                "angle": {
+                  "microarcseconds": 54000000000,
+                  "microseconds": 3600000000,
+                  "milliarcseconds": 54000000,
+                  "milliseconds": 3600000,
+                  "arcseconds": 54000,
+                  "seconds": 3600,
+                  "arcminutes": 900,
+                  "minutes": 60,
+                  "degrees": 15,
+                  "hours": 1,
+                  "dms": "15:00:00.000000",
+                  "hms": "01:00:00.000000"
+                }
               }
             }
           ]


### PR DESCRIPTION
Adds the position angle constraint observation property.  There is a change from the `tmp-api` version.  Namely, we were asked to keep up with the user-supplied angle regardless of whether the constraint itself requires it.  In that way, if the user switches from fixed to unbounded and then back again we won't have clobbered their original angle choice.  As a consequence, instead of relying on the absence of the angle to distinguish average parallactic from parallactic override, the mode type has to explicitly include both options.