### PR TITLE
ITC Client Service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ val natchezVersion             = "0.1.6"
 val postgresVersion            = "42.5.1"
 val skunkVersion               = "0.3.2"
 val lucumaSsoVersion           = "0.4.4"
+val lucumaItcVersion           = "0.3"
 val testcontainersScalaVersion = "0.40.12"
 
 enablePlugins(NoPublishPlugin)
@@ -42,6 +43,7 @@ lazy val service = project
       "com.monovore"   %% "decline"                         % declineVersion,
       "edu.gemini"     %% "gsp-graphql-skunk"               % grackleVersion,
       "edu.gemini"     %% "lucuma-graphql-routes-grackle"   % lucumaGraphQLRoutesVersion,
+      "edu.gemini"     %% "lucuma-itc-client"               % lucumaItcVersion,
       "edu.gemini"     %% "lucuma-sso-backend-client"       % lucumaSsoVersion,
       "edu.gemini"     %% "lucuma-core"                     % lucumaCoreVersion,
       "edu.gemini"     %% "lucuma-core-testkit"             % lucumaCoreVersion          % Test,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -29,8 +29,8 @@ import lucuma.odb.graphql.util._
 import lucuma.odb.service.AllocationService
 import lucuma.odb.service.AsterismService
 import lucuma.odb.service.ItcClientService
-import lucuma.odb.service.ObservingModeServices
 import lucuma.odb.service.ObservationService
+import lucuma.odb.service.ObservingModeServices
 import lucuma.odb.service.ProgramService
 import lucuma.odb.service.TargetService
 import natchez.Trace

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -161,14 +161,14 @@ object OdbMapping {
           override val targetService: Resource[F, TargetService[F]] =
             pool.map(TargetService.fromSession(_, user))
 
-          override val itcClientService: Resource[F, ItcClientService[F]] =
-            for {
-              o <- observationService
-              m <- observingModeServices
-              a <- asterismService
-              t <- targetService
-              i <- pool.map(s => ItcClientService.fromSession(s, user, o, m, a, t))
-            } yield i
+//          override val itcClientService: Resource[F, ItcClientService[F]] =
+//            for {
+//              o <- observationService
+//              m <- observingModeServices
+//              a <- asterismService
+//              t <- targetService
+//              i <- pool.map(s => ItcClientService.fromSession(s, user, o, m, a, t))
+//            } yield i
 
           // Our combined type mappings
           override val typeMappings: List[TypeMapping] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -150,10 +150,14 @@ object OdbMapping {
             pool.map(ObservingModeServices.fromSession)
 
           override val observationService: Resource[F, ObservationService[F]] =
-            for {
-              oms <- observingModeServices
-              os  <- pool.map(ObservationService.fromSessionAndUser(_, user, oms))
-            } yield os
+            pool.map { s =>
+              val oms = ObservingModeServices.fromSession(s)
+              ObservationService.fromSessionAndUser(s, user, oms)
+            }
+//            for {
+//              oms <- observingModeServices
+//              os  <- pool.map(ObservationService.fromSessionAndUser(_, user, oms))
+//            } yield os
 
           override val programService: Resource[F, ProgramService[F]] =
             pool.map(ProgramService.fromSessionAndUser(_, user))
@@ -161,14 +165,14 @@ object OdbMapping {
           override val targetService: Resource[F, TargetService[F]] =
             pool.map(TargetService.fromSession(_, user))
 
-//          override val itcClientService: Resource[F, ItcClientService[F]] =
-//            for {
-//              o <- observationService
-//              m <- observingModeServices
-//              a <- asterismService
-//              t <- targetService
-//              i <- pool.map(s => ItcClientService.fromSession(s, user, o, m, a, t))
-//            } yield i
+          override val itcClientService: Resource[F, ItcClientService[F]] =
+            for {
+              o <- observationService
+              m <- observingModeServices
+              a <- asterismService
+              t <- targetService
+              i <- pool.map(s => ItcClientService.fromSession(s, user, o, m, a, t))
+            } yield i
 
           // Our combined type mappings
           override val typeMappings: List[TypeMapping] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
@@ -5,6 +5,7 @@ package lucuma.odb.graphql
 
 package mapping
 
+import cats.effect.Resource
 import cats.effect.kernel.Par
 import cats.syntax.all._
 import edu.gemini.grackle.Cursor
@@ -26,6 +27,7 @@ import lucuma.odb.graphql.input.WhereObservation
 import lucuma.odb.graphql.input.WhereProgram
 import lucuma.odb.graphql.input.WhereTargetInput
 import lucuma.odb.graphql.predicate.Predicates
+import lucuma.odb.service.ItcClientService
 import lucuma.odb.instances.given
 
 import scala.reflect.ClassTag
@@ -38,6 +40,7 @@ trait QueryMapping[F[_]] extends Predicates[F] {
    with ProgramMapping[F]
    with ObservationMapping[F] =>
 
+  def itcClientService: Resource[F, ItcClientService[F]]
 
   lazy val QueryMapping =
     ObjectMapping(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
@@ -40,7 +40,7 @@ trait QueryMapping[F[_]] extends Predicates[F] {
    with ProgramMapping[F]
    with ObservationMapping[F] =>
 
-  def itcClientService: Resource[F, ItcClientService[F]]
+//  def itcClientService: Resource[F, ItcClientService[F]]
 
   lazy val QueryMapping =
     ObjectMapping(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
@@ -27,8 +27,8 @@ import lucuma.odb.graphql.input.WhereObservation
 import lucuma.odb.graphql.input.WhereProgram
 import lucuma.odb.graphql.input.WhereTargetInput
 import lucuma.odb.graphql.predicate.Predicates
-import lucuma.odb.service.ItcClientService
 import lucuma.odb.instances.given
+import lucuma.odb.service.ItcClientService
 
 import scala.reflect.ClassTag
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
@@ -40,7 +40,7 @@ trait QueryMapping[F[_]] extends Predicates[F] {
    with ProgramMapping[F]
    with ObservationMapping[F] =>
 
-//  def itcClientService: Resource[F, ItcClientService[F]]
+  def itcClientService: Resource[F, ItcClientService[F]]
 
   lazy val QueryMapping =
     ObjectMapping(

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcClientService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcClientService.scala
@@ -1,0 +1,134 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service
+
+import cats.data.NonEmptyList
+import cats.effect.Sync
+import cats.syntax.applicative.*
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import edu.gemini.grackle.Result
+import lucuma.core.enums.Band
+import lucuma.core.math.BrightnessUnits.{BrightnessMeasure, Integrated, Surface}
+import lucuma.core.math.Wavelength
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.SourceProfile
+import lucuma.core.model.Target
+import lucuma.core.model.User
+import lucuma.itc.client.InstrumentMode
+import lucuma.itc.client.SpectroscopyModeInput
+
+import scala.collection.immutable.SortedMap
+import skunk.Session
+
+
+/*
+final case class SpectroscopyModeInput(
+  wavelength:     Wavelength,
+  signalToNoise:  PosBigDecimal,
+  sourceProfile:  SourceProfile,
+  band:           Band,
+  radialVelocity: RadialVelocity,
+  constraints:    ConstraintSet,
+  mode:           InstrumentMode
+)
+*/
+
+trait ItcClientService[F[_]] {
+
+  def selectSpectroscopyInput(
+    programId: Program.Id,
+    which:     List[Observation.Id]
+  ): F[Map[Observation.Id, NonEmptyList[SpectroscopyModeInput]]]
+
+}
+
+object ItcClientService {
+
+  def fromSession[F[_]: Sync](
+    session:  Session[F],
+    user:     User,
+    oService: ObservationService[F],
+    mService: ObservingModeServices[F],
+    aService: AsterismService[F],
+    tService: TargetService[F]
+  ): ItcClientService[F] =
+
+    new ItcClientService[F] {
+
+      private def spectroscopy(
+        o: ObservationService.ItcParams,
+        m: ObservingModeServices.ItcParams,
+        t: TargetService.ItcParams
+      ): Option[SpectroscopyModeInput] = {
+
+        def extractBand[T](w: Wavelength, bMap: SortedMap[Band, BrightnessMeasure[T]]): Option[Band] =
+          bMap.minByOption { case (b, _) =>
+            (w.toPicometers.value.value - b.center.toPicometers.value.value).abs
+          }.map(_._1)
+
+        def band: Option[Band] =
+          SourceProfile
+            .integratedBrightnesses
+            .getOption(t.sourceProfile)
+            .flatMap(bMap => extractBand[Integrated](m.wavelength, bMap))
+            .orElse(
+              SourceProfile
+                .surfaceBrightnesses
+                .getOption(t.sourceProfile)
+                .flatMap(bMap => extractBand[Surface](m.wavelength, bMap))
+            )
+
+        band.map { b =>
+          SpectroscopyModeInput(
+            m.wavelength,
+            o.signalToNoise,
+            o.signalToNoiseAt,
+            t.sourceProfile,
+            b,
+            t.radialVelocity,
+            o.constraints,
+            m.mode
+          )
+        }
+      }
+
+      override def selectSpectroscopyInput(
+        programId: Program.Id,
+        which:     List[Observation.Id]
+      ): F[Map[Observation.Id, NonEmptyList[SpectroscopyModeInput]]] =
+
+        for {
+          // Select ITC data from the observation table
+          o <- oService.selectItcParams(programId, which)
+
+          // Using the observing modes in the return value above, select the ITC
+          // observing mode data
+          m <- mService.selectItcParams(o.toList.map { case (oid, itc) => (oid, itc.observingMode) })
+
+          // Obtain the asterisms for each of the observations.
+          a <- NonEmptyList.fromList(which).fold(Map.empty[Observation.Id, List[Target.Id]].pure[F]) { oids =>
+            aService.selectAsterism(programId, oids)
+          }
+
+          // ITC params for each of the targets in the collection of asterisms
+          t <- tService.selectItcParams(a.values.toList.flatten.distinct)
+        } yield
+
+          // Combine all the ITC parameter data into SpectroscopyModeInput when
+          // possible.
+          o.keySet
+           .intersect(m.keySet)
+           .intersect(a.keySet)
+           .foldLeft(Map.empty[Observation.Id, NonEmptyList[SpectroscopyModeInput]]) { (r, oid) =>
+             NonEmptyList.fromList(
+               a(oid)
+                 .flatMap(t.get(_).toList)
+                 .flatMap(spectroscopy(o(oid), m(oid), _).toList)
+             ).fold(r) { nel => r.updated(oid, nel) }
+           }
+
+    }
+}

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcClientService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcClientService.scala
@@ -10,7 +10,9 @@ import cats.syntax.flatMap.*
 import cats.syntax.functor.*
 import edu.gemini.grackle.Result
 import lucuma.core.enums.Band
-import lucuma.core.math.BrightnessUnits.{BrightnessMeasure, Integrated, Surface}
+import lucuma.core.math.BrightnessUnits.BrightnessMeasure
+import lucuma.core.math.BrightnessUnits.Integrated
+import lucuma.core.math.BrightnessUnits.Surface
 import lucuma.core.math.Wavelength
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
@@ -19,9 +21,9 @@ import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.itc.client.InstrumentMode
 import lucuma.itc.client.SpectroscopyModeInput
+import skunk.Session
 
 import scala.collection.immutable.SortedMap
-import skunk.Session
 
 
 /*

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -8,7 +8,16 @@ import cats.data.Ior
 import cats.data.NonEmptyChain
 import cats.data.NonEmptyList
 import cats.effect.Sync
-import cats.syntax.all.*
+import cats.syntax.apply.*
+import cats.syntax.applicative.*
+import cats.syntax.applicativeError.*
+import cats.syntax.flatMap.*
+import cats.syntax.foldable.*
+import cats.syntax.functor.*
+import cats.syntax.functorFilter.*
+import cats.syntax.option.*
+import cats.syntax.parallel.*
+import cats.syntax.traverse.*
 import edu.gemini.grackle.Predicate
 import edu.gemini.grackle.Problem
 import edu.gemini.grackle.Result
@@ -33,7 +42,10 @@ import lucuma.core.math.RightAscension
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ElevationRange
+import lucuma.core.model.ElevationRange.AirMass
+import lucuma.core.model.ElevationRange.HourAngle
 import lucuma.core.model.ElevationRange.AirMass.DecimalValue
+import lucuma.core.model.ElevationRange.AirMass.max
 import lucuma.core.model.ElevationRange.HourAngle.DecimalHour
 import lucuma.core.model.GuestRole
 import lucuma.core.model.Observation
@@ -86,10 +98,22 @@ sealed trait ObservationService[F[_]] {
     which: AppliedFragment
   ): F[Result[List[Observation.Id]]]
 
+  def selectItcParams(
+    programId: Program.Id,
+    which:     List[Observation.Id]
+  ): F[Map[Observation.Id, ObservationService.ItcParams]]
+
 }
 
 
 object ObservationService {
+
+  final case class ItcParams(
+    constraints:     ConstraintSet,
+    signalToNoise:   PosBigDecimal,
+    signalToNoiseAt: Option[Wavelength],
+    observingMode:   ObservingModeType
+  )
 
   final case class DatabaseConstraint(
     constraint: String,
@@ -132,12 +156,10 @@ object ObservationService {
 
   def fromSessionAndUser[F[_]: Sync: Trace](
     session: Session[F],
-    user:    User
+    user:    User,
+    observingModeServices: ObservingModeServices[F]
   ): ObservationService[F] =
     new ObservationService[F] {
-
-      lazy val observingModeServices: ObservingModeServices[F] =
-        ObservingModeServices.fromSession(session)
 
       override def createObservation(
         programId: Program.Id,
@@ -264,10 +286,23 @@ object ObservationService {
             } yield r
           }
         }
+
+      override def selectItcParams(
+        programId: Program.Id,
+        which:     List[Observation.Id]
+      ): F[Map[Observation.Id, ItcParams]] =
+        NonEmptyList.fromList(which).fold(Applicative[F].pure(Map.empty[Observation.Id, ItcParams])) { oids =>
+          val (af, decoder) = Statements.selectItcParams(user, programId, oids)
+          session
+            .prepare(af.fragment.query(decoder))
+            .use(_.stream(af.argument, chunkSize = 64).compile.to(List))
+            .map(_.collect { case (oid, Some(itc)) => (oid, itc) }.toMap)
+        }
     }
 
   object Statements {
 
+    import ProgramService.Statements.existsUserAccess
     import ProgramService.Statements.whereUserAccess
 
     def insertObservationAs(
@@ -454,6 +489,80 @@ object ObservationService {
         void"WHERE c_observation_id IN ("                                      |+|
           observationIds.map(sql"$observation_id").intercalate(void", ")       |+|
         void")"
+
+    val elevation_range: Decoder[ElevationRange] = {
+      (air_mass_range_value.opt   ~
+       air_mass_range_value.opt   ~
+       hour_angle_range_value.opt ~
+       hour_angle_range_value.opt
+      ).emap { case (((am_min, am_max), ha_min), ha_max) =>
+
+        val am = (am_min, am_max).traverseN { case (min, max) =>
+          for {
+            n <- DecimalValue.from(min.value)
+            x <- DecimalValue.from(max.value)
+            a <- AirMass.fromOrderedDecimalValues.getOption((n, x)).toRight(s"airmass min and max out of order: ($min, $max)")
+          } yield a
+        }
+
+        val ha = (ha_min, ha_max).traverseN { case (min, max) =>
+          for {
+            n <- DecimalHour.from(min)
+            x <- DecimalHour.from(max)
+            h <- HourAngle.fromOrderedDecimalHours.getOption((n, x)).toRight(s"hour angle min and max out of order: ($min, $max)")
+          } yield h
+        }
+
+        for {
+          a <- am
+          h <- ha
+          e <- a.orElse(h).toRight("Undefined elevation range")
+        } yield e
+      }
+    }
+
+    val conditions_set: Decoder[ConstraintSet] =
+      (image_quality    ~
+       cloud_extinction ~
+       sky_background   ~
+       water_vapor      ~
+       elevation_range
+      ).gmap[ConstraintSet]
+
+    val itc_params_opt: Decoder[Option[ItcParams]] =
+      (conditions_set ~ signal_to_noise.opt ~ wavelength_pm.opt ~ observing_mode_type.opt)
+        .map { case (((cs, s2n), w), om) =>
+          for {
+            s <- s2n
+            m <- om
+          } yield ItcParams(cs, s, w, m)
+        }
+
+    def selectItcParams(
+      user:      User,
+      programId: Program.Id,
+      which:     NonEmptyList[Observation.Id]
+    ): (AppliedFragment, Decoder[(Observation.Id, Option[ItcParams])]) =
+      (void"""
+        SELECT
+          c_observation_id,
+          c_image_quality,
+          c_cloud_extinction,
+          c_sky_background,
+          c_water_vapor,
+          c_air_mass_min,
+          c_air_mass_max,
+          c_hour_angle_min,
+          c_hour_angle_max,
+          c_spec_signal_to_noise,
+          c_spec_signal_to_noiseAt,
+          c_observing_mode_type
+        FROM t_observation
+        WHERE c_observation_id IN (""" |+|
+          which.map(sql"$observation_id").intercalate(void", ") |+|
+        void")" |+| existsUserAccess(user, programId).fold(AppliedFragment.empty) { af => void""" AND """ |+| af },
+        (observation_id ~ itc_params_opt)
+      )
 
     def posAngleConstraintUpdates(in: PosAngleConstraintInput): List[AppliedFragment] = {
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -8,9 +8,9 @@ import cats.data.Ior
 import cats.data.NonEmptyChain
 import cats.data.NonEmptyList
 import cats.effect.Sync
-import cats.syntax.apply.*
 import cats.syntax.applicative.*
 import cats.syntax.applicativeError.*
+import cats.syntax.apply.*
 import cats.syntax.flatMap.*
 import cats.syntax.foldable.*
 import cats.syntax.functor.*
@@ -43,9 +43,9 @@ import lucuma.core.math.Wavelength
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ElevationRange
 import lucuma.core.model.ElevationRange.AirMass
-import lucuma.core.model.ElevationRange.HourAngle
 import lucuma.core.model.ElevationRange.AirMass.DecimalValue
 import lucuma.core.model.ElevationRange.AirMass.max
+import lucuma.core.model.ElevationRange.HourAngle
 import lucuma.core.model.ElevationRange.HourAngle.DecimalHour
 import lucuma.core.model.GuestRole
 import lucuma.core.model.Observation


### PR DESCRIPTION
Work in progress gathering up all the information needed to make an ITC query for GMOS spectroscopy.  It just bangs out all the various queries to construct the arguments for the ITC query.  Is there a Grackle-way that this is supposed to be done to avoid all of this?  I wanted to check before going much further.

While this code isn't exactly used per se, it does generate a lot of smoke when the tests are run:

```
🔥  An unhandled backend message was encountered
🔥    at /home/runner/work/skunk/skunk/modules/core/shared/src/main/scala/net/protocol/Close.scala:40
🔥  
🔥    Message: ReadyForQuery(Idle)
🔥  
🔥  This is an implementation error in Skunk.
🔥  Please report a bug with the full contents of this error message.

skunk.exception.ProtocolError: ReadyForQuery(Idle)

🔥  An unhandled backend message was encountered
🔥    at /home/runner/work/skunk/skunk/modules/core/shared/src/main/scala/net/protocol/Execute.scala:37
🔥  
🔥    Message: ErrorResponse(s -> public, n ->
🔥             t_gmos_north_long_slit_c_observation_id_c_observing_mode_t_fkey, t ->
🔥             t_gmos_north_long_slit, F -> ri_triggers.c, M -> insert or update on
🔥             table "t_gmos_north_long_slit" violates foreign key constraint
🔥             "t_gmos_north_long_slit_c_observation_id_c_observing_mode_t_fkey", V
🔥             -> ERROR, L -> 2528, C -> 23503, R -> ri_ReportViolation, D -> Key
🔥             (c_observation_id, c_observing_mode_type)=(o-110,
🔥             gmos_north_long_slit) is not present in table "t_observation"., S ->
🔥             ERROR
🔥  
🔥  This is an implementation error in Skunk.
🔥  Please report a bug with the full contents of this error message.

skunk.exception.ProtocolError: ErrorResponse(s -> public, n -> t_gmos_north_long_slit_c_observation_id_c_observing_mode_t_fkey, t -> t_gmos_north_long_slit, F -> ri_triggers.c, M -> insert or update on table "t_gmos_north_long_slit" violates foreign key constraint "t_gmos_north_long_slit_c_observation_id_c_observing_mode_t_fkey", V -> ERROR, L -> 2528, C -> 23503, R -> ri_ReportViolation, D -> Key (c_observation_id, c_observing_mode_type)=(o-110, gmos_north_long_slit) is not present in table "t_observation"., S -> ERROR
```