### PR TITLE
ITC

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ val natchezVersion             = "0.1.6"
 val postgresVersion            = "42.5.1"
 val skunkVersion               = "0.3.2"
 val lucumaSsoVersion           = "0.4.4"
+val lucumaItcVersion           = "0.3"
 val testcontainersScalaVersion = "0.40.12"
 val paigesVersion              = "0.4.2"
 
@@ -43,6 +44,7 @@ lazy val service = project
       "com.monovore"   %% "decline"                         % declineVersion,
       "edu.gemini"     %% "gsp-graphql-skunk"               % grackleVersion,
       "edu.gemini"     %% "lucuma-graphql-routes-grackle"   % lucumaGraphQLRoutesVersion,
+      "edu.gemini"     %% "lucuma-itc-client"               % lucumaItcVersion,
       "edu.gemini"     %% "lucuma-sso-backend-client"       % lucumaSsoVersion,
       "edu.gemini"     %% "lucuma-core"                     % lucumaCoreVersion,
       "edu.gemini"     %% "lucuma-core-testkit"             % lucumaCoreVersion          % Test,

--- a/modules/service/src/main/resources/db/migration/V0110_itc_params.sql
+++ b/modules/service/src/main/resources/db/migration/V0110_itc_params.sql
@@ -1,0 +1,30 @@
+CREATE VIEW v_itc_params AS
+SELECT
+  o.c_observation_id,
+  o.c_image_quality,
+  o.c_cloud_extinction,
+  o.c_sky_background,
+  o.c_water_vapor,
+  o.c_air_mass_min,
+  o.c_air_mass_max,
+  o.c_hour_angle_min,
+  o.c_hour_angle_max,
+  o.c_spec_signal_to_noise,
+  o.c_spec_signal_to_noise_at,
+  o.c_observing_mode_type,
+  t.c_target_id,
+  t.c_sid_rv,
+  t.c_source_profile
+FROM
+  t_observation o
+INNER JOIN t_asterism_target a
+  ON o.c_observation_id = a.c_observation_id
+INNER JOIN t_target t
+  ON a.c_target_id      = t.c_target_id
+WHERE
+      o.c_spec_signal_to_noise IS NOT NULL
+  AND o.c_observing_mode_type  IS NOT NULL
+  AND t.c_sid_rv               IS NOT NULL
+ORDER BY
+  o.c_observation_id,
+  t.c_target_id

--- a/modules/service/src/main/resources/db/migration/V0110_itc_params.sql
+++ b/modules/service/src/main/resources/db/migration/V0110_itc_params.sql
@@ -17,14 +17,10 @@ SELECT
   t.c_source_profile
 FROM
   t_observation o
-INNER JOIN t_asterism_target a
+LEFT JOIN t_asterism_target a
   ON o.c_observation_id = a.c_observation_id
-INNER JOIN t_target t
+LEFT JOIN t_target t
   ON a.c_target_id      = t.c_target_id
-WHERE
-      o.c_spec_signal_to_noise IS NOT NULL
-  AND o.c_observing_mode_type  IS NOT NULL
-  AND t.c_sid_rv               IS NOT NULL
 ORDER BY
   o.c_observation_id,
   t.c_target_id

--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4325,12 +4325,6 @@ type Observation {
   # The science configuration
   observingMode: ObservingMode
 
-  # ITC execution results
-  itc(
-    # Whether to use cached results (true) or ignore the cache and make a remote ITC call (false).
-    useCache: Boolean! = true
-  ): ItcSuccess
-
   # Manual instrument configuration
   manualConfig: ManualConfig
 
@@ -4686,6 +4680,16 @@ type Query {
 
   # Metadata for `enum FilterType`
   filterTypeMeta: [FilterTypeMeta!]!
+
+  # ITC execution results
+  itc(
+    programId:     ProgramId!
+
+    observationId: ObservationId!
+
+    # Whether to use cached results (true) or ignore the cache and make a remote ITC call (false).
+    useCache: Boolean! = true
+  ): ItcSuccess
 
   # Returns the observation with the given id, if any.
   observation(

--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4147,7 +4147,18 @@ type Intensive implements ProposalClass {
   totalTime: NonNegDuration!
 }
 
-enum ItcResultStatus {
+type ItcResultSet {
+  programId:     ProgramId!
+  observationId: ObservationId!
+  result:        ItcResult!
+  all:           [ItcResult!]
+}
+
+interface ItcResult {
+  status: ItcStatus!
+}
+
+enum ItcStatus {
 
   # A successful result
   SUCCESS
@@ -4161,27 +4172,24 @@ enum ItcResultStatus {
 
 }
 
-type ItcSuccess {
+type ItcSuccess implements ItcResult {
+  status:        ItcStatus!
+  targetId:      TargetId!
   exposureTime:  NonNegDuration!
   exposures:     NonNegInt!
   signalToNoise: PosBigDecimal!
 }
 
-type ItcTargetResult {
-  targetId:      TargetId!
-  status:        ItcResultStatus!
-  missingParams: [String!]
-  serviceError:  String
-  success:       ItcSuccess
+type ItcMissingParams implements ItcResult {
+  status:   ItcStatus!
+  targetId: TargetId
+  params:   [String!]!
 }
 
-type ItcObservationResult {
-  programId:     ProgramId!
-  observationId: ObservationId!
-  status:        ItcResultStatus!
-  missingParams: [String!]
-  selected:      ItcTargetResult
-  all:           [ItcTargetResult!]
+type ItcServiceError implements ItcResult {
+  status:   ItcStatus!
+  targetId: TargetId!
+  message:  String!
 }
 
 
@@ -4721,7 +4729,7 @@ type Query {
 
     # Whether to use cached results (true) or ignore the cache and make a remote ITC call (false).
     useCache: Boolean! = true
-  ): ItcObservationResult
+  ): ItcResultSet
 
   # Returns the observation with the given id, if any.
   observation(

--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4147,11 +4147,43 @@ type Intensive implements ProposalClass {
   totalTime: NonNegDuration!
 }
 
+enum ItcResultStatus {
+
+  # A successful result
+  SUCCESS
+
+  # Could not calculate the result because not all the required parameters are
+  # present
+  MISSING_PARAMS
+
+  # A failure in the remote ITC service
+  SERVICE_ERROR
+
+}
+
 type ItcSuccess {
-  exposureTime: NonNegDuration!
-  exposures: NonNegInt!
+  exposureTime:  NonNegDuration!
+  exposures:     NonNegInt!
   signalToNoise: PosBigDecimal!
 }
+
+type ItcTargetResult {
+  targetId:      TargetId!
+  status:        ItcResultStatus!
+  missingParams: [String!]
+  serviceError:  String
+  success:       ItcSuccess
+}
+
+type ItcObservationResult {
+  programId:     ProgramId!
+  observationId: ObservationId!
+  status:        ItcResultStatus!
+  missingParams: [String!]
+  selected:      ItcTargetResult
+  all:           [ItcTargetResult!]
+}
+
 
 # Large program observing at Gemini
 type LargeProgram implements ProposalClass {
@@ -4689,7 +4721,7 @@ type Query {
 
     # Whether to use cached results (true) or ignore the cache and make a remote ITC call (false).
     useCache: Boolean! = true
-  ): ItcSuccess
+  ): ItcObservationResult
 
   # Returns the observation with the given id, if any.
   observation(

--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4147,6 +4147,13 @@ type Intensive implements ProposalClass {
   totalTime: NonNegDuration!
 }
 
+# Contains the result of calling the ITC for a particular observation.  Since
+# the observation may contain multiple targets, there may be multiple results.
+# The "result" field contains the selected, representative, result for all
+# targets.  If there are multiple successful results, this will be the one that
+# prescribes the longest observation. If there is a mix of failures and
+# successes, the overall "result" will be a failure. The "all" field contains
+# results for all targets regardless.
 type ItcResultSet {
   programId:     ProgramId!
   observationId: ObservationId!
@@ -4154,6 +4161,7 @@ type ItcResultSet {
   all:           [ItcResult!]
 }
 
+# A single ITC call result.
 interface ItcResult {
   status: ItcStatus!
 }

--- a/modules/service/src/main/scala/lucuma/odb/Config.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Config.scala
@@ -9,6 +9,7 @@ import cats.syntax.all._
 import ciris._
 import com.comcast.ip4s.Port
 import lucuma.core.model.User
+import lucuma.itc.client.ItcClient
 import lucuma.sso.client.SsoClient
 import lucuma.sso.client.SsoJwtReader
 import lucuma.sso.client.util.GpgPublicKeyReader
@@ -18,38 +19,44 @@ import natchez.http4s.NatchezMiddleware
 import org.http4s.Uri
 import org.http4s.client.Client
 import org.http4s.ember.client.EmberClientBuilder
+import org.typelevel.log4cats.Logger
 
 import java.net.URI
 import java.net.URISyntaxException
 import java.security.PublicKey
 
 case class Config(
-  port:         Port,            // Our port, nothing fancy.
-  ssoRoot:      Uri,             // Root URI for the SSO server we're using.
-  ssoPublicKey: PublicKey,       // We need to verify user JWTs, which requires the SSO server's public key.
-  serviceJwt:   String,          // Only service users can exchange API keys, so we need a service user JWT.
-  hcWriteKey:   String,          // Honeycomb API key
-  hcDataset:    String,          // Honeycomb dataset
-  database:     Config.Database, // Database config
-  domain:       String,          // Domain, for CORS headers
+  port:       Port,             // Our port, nothing fancy.
+  itcRoot:    Uri,              // ITC service URI
+  sso:        Config.Sso,       // SSO config
+  serviceJwt: String,           // Only service users can exchange API keys, so we need a service user JWT.
+  honeycomb:  Config.Honeycomb, // Honeycomb config
+  database:   Config.Database,  // Database config
+  domain:     String,           // Domain, for CORS headers
 ) {
 
   // People send us their JWTs. We need to be able to extract them from the request, decode them,
   // verify the signature using the SSO server's public key, and then extract the user.
   def jwtReader[F[_]: Concurrent]: SsoJwtReader[F] =
-    SsoJwtReader(JwtDecoder.withPublicKey(ssoPublicKey))
+    SsoJwtReader(JwtDecoder.withPublicKey(sso.publicKey))
 
   // People also send us their API keys. We need to be able to exchange them for [longer-lived] JWTs
   // via an API call to SSO, so we need an HTTP client for that.
   def httpClientResource[F[_]: Async]: Resource[F, Client[F]] =
     EmberClientBuilder.default[F].build
 
+  // ITC client resource
+  def itcClient[F[_]: Async: Logger]: Resource[F, ItcClient[F]] =
+    httpClientResource[F].evalMap { httpClient =>
+      ItcClient.create(itcRoot, httpClient)
+    }
+
   // SSO Client resource (has to be a resource because it owns an HTTP client).
   def ssoClient[F[_]: Async: Trace]: Resource[F, SsoClient[F, User]] =
     httpClientResource[F].evalMap { httpClient =>
       SsoClient.initial(
         serviceJwt = serviceJwt,
-        ssoRoot    = ssoRoot,
+        ssoRoot    = sso.root,
         jwtReader  = jwtReader[F],
         httpClient = NatchezMiddleware.client(httpClient), // Note!
       ) .map(_.map(_.user))
@@ -59,6 +66,34 @@ case class Config(
 
 
 object Config {
+
+  case class Sso(
+    root:      Uri,       // Root URI for the SSO server we're using.
+    publicKey: PublicKey  // We need to verify user JWTs, which requires the SSO server's public key.
+  )
+
+  object Sso {
+
+    val fromCiris: ConfigValue[Effect, Sso] = (
+      envOrProp("ODB_SSO_ROOT").as[Uri],
+      envOrProp("ODB_SSO_PUBLIC_KEY").as[PublicKey]
+    ).parMapN(Sso.apply)
+
+  }
+
+  case class Honeycomb(
+    writeKey: String,
+    dataset:  String
+  )
+
+  object Honeycomb {
+
+    val fromCiris: ConfigValue[Effect, Honeycomb] = (
+      envOrProp("ODB_HONEYCOMB_WRITE_KEY"),
+      envOrProp("ODB_HONEYCOMB_DATASET")
+    ).parMapN(Honeycomb.apply)
+
+  }
 
   case class Database(
     host: String,
@@ -120,13 +155,14 @@ object Config {
   private def envOrProp(name: String): ConfigValue[Effect, String] =
     env(name) or prop(name)
 
-  val fromCiris = (
+//    envOrProp("ODB_ITC_ROOT").as[Uri],
+
+  val fromCiris: ConfigValue[Effect, Config] = (
     envOrProp("PORT").as[Int].as[Port], // passed by Heroku
-    envOrProp("ODB_SSO_ROOT").as[Uri],
-    envOrProp("ODB_SSO_PUBLIC_KEY").as[PublicKey],
+    envOrProp("ODB_ITC_ROOT").as[Uri],
+    Sso.fromCiris,
     envOrProp("ODB_SERVICE_JWT"),
-    envOrProp("ODB_HONEYCOMB_WRITE_KEY"),
-    envOrProp("ODB_HONEYCOMB_DATASET"),
+    Honeycomb.fromCiris,
     Database.fromCiris,
     envOrProp("ODB_DOMAIN"),
   ).parMapN(Config.apply)

--- a/modules/service/src/main/scala/lucuma/odb/Config.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Config.scala
@@ -155,8 +155,6 @@ object Config {
   private def envOrProp(name: String): ConfigValue[Effect, String] =
     env(name) or prop(name)
 
-//    envOrProp("ODB_ITC_ROOT").as[Uri],
-
   val fromCiris: ConfigValue[Effect, Config] = (
     envOrProp("PORT").as[Int].as[Port], // passed by Heroku
     envOrProp("ODB_ITC_ROOT").as[Uri],

--- a/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
@@ -12,11 +12,13 @@ import lucuma.core.model.User
 import lucuma.graphql.routes.GrackleGraphQLService
 import lucuma.graphql.routes.GraphQLService
 import lucuma.graphql.routes.{Routes => LucumaGraphQLRoutes}
+import lucuma.itc.client.ItcClient
 import lucuma.odb.service.UserService
 import lucuma.odb.util.Cache
 import lucuma.sso.client.SsoClient
 import natchez.Trace
 import org.http4s._
+import org.http4s.client.Client
 import org.http4s.headers.Authorization
 import org.http4s.server.websocket.WebSocketBuilder2
 import org.typelevel.log4cats.Logger
@@ -34,11 +36,12 @@ object GraphQLRoutes {
    * based on the `Authorization` header and discarded when `ttl` expires.
    */
   def apply[F[_]: Async: Trace: Logger](
-    client:   SsoClient[F, User],
-    pool:     Resource[F, Session[F]],
-    monitor:  SkunkMonitor[F],
-    ttl:      FiniteDuration,
-    userSvc:  UserService[F],
+    itcClient: ItcClient[F],
+    ssoClient: SsoClient[F, User],
+    pool:      Resource[F, Session[F]],
+    monitor:   SkunkMonitor[F],
+    ttl:       FiniteDuration,
+    userSvc:   UserService[F],
   ): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
     OdbMapping.Topics(pool).flatMap { topics =>
       Cache.timed[F, Authorization, Option[GraphQLService[F]]](ttl).map { cache => wsb =>
@@ -53,11 +56,11 @@ object GraphQLRoutes {
                   Logger[F].info(s"Cache miss for $a") *>
                   {
                     for {
-                      user <- OptionT(client.get(a))
+                      user <- OptionT(ssoClient.get(a))
                       // If the user has never hit the ODB using http then there will be no user
                       // entry in the database. So go ahead and [re]canonicalize here to be sure.
                       _    <- OptionT.liftF(userSvc.canonicalizeUser(user))
-                      map  <- OptionT.liftF(OdbMapping(pool, monitor, user, topics))
+                      map  <- OptionT.liftF(OdbMapping(pool, monitor, user, topics, itcClient))
                       svc   = new GrackleGraphQLService(map)
                     } yield svc
                   } .widen[GraphQLService[F]]

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -45,7 +45,7 @@ import lucuma.odb.graphql.topic.ProgramTopic
 import lucuma.odb.graphql.util._
 import lucuma.odb.service.AllocationService
 import lucuma.odb.service.AsterismService
-import lucuma.odb.service.ItcClientService
+import lucuma.odb.service.ItcInputService
 import lucuma.odb.service.ObservationService
 import lucuma.odb.service.ObservingModeServices
 import lucuma.odb.service.ProgramService
@@ -180,10 +180,10 @@ object OdbMapping {
           override val targetService: Resource[F, TargetService[F]] =
             pool.map(TargetService.fromSession(_, user))
 
-          override val itcClientService: Resource[F, ItcClientService[F]] =
+          override val itcClientService: Resource[F, ItcInputService[F]] =
             pool.map { s =>
               val oms = ObservingModeServices.fromSession(s)
-              ItcClientService.fromSession(s, user, oms)
+              ItcInputService.fromSession(s, user, oms)
             }
 
           override def itcQuery(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -167,11 +167,8 @@ object OdbMapping {
 
           override val itcClientService: Resource[F, ItcClientService[F]] =
             pool.map { s =>
-              val m = ObservingModeServices.fromSession(s)
-              val o = ObservationService.fromSessionAndUser(s, user, m)
-              val a = AsterismService.fromSessionAndUser(s, user)
-              val t = TargetService.fromSession(s, user)
-              ItcClientService.fromSession(s, user, o, m, a, t)
+              val oms = ObservingModeServices.fromSession(s)
+              ItcClientService.fromSession(s, user, oms)
             }
 
           // Our combined type mappings

--- a/modules/service/src/main/scala/lucuma/odb/graphql/client/Itc.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/client/Itc.scala
@@ -1,0 +1,221 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.client
+
+import cats.Order
+import cats.Order.catsKernelOrderingForOrder
+import cats.data.NonEmptyList
+import cats.data.NonEmptySet
+import cats.data.ValidatedNel
+import cats.effect.MonadCancel
+import cats.effect.Resource
+import cats.syntax.applicative.*
+import cats.syntax.bifunctor.*
+import cats.syntax.either.*
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import cats.syntax.option.*
+import cats.syntax.order.*
+import cats.syntax.traverse.*
+import eu.timepit.refined.types.numeric.NonNegInt
+import eu.timepit.refined.types.numeric.PosBigDecimal
+import lucuma.core.data.Zipper
+import lucuma.core.model.NonNegDuration
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.Target
+import lucuma.itc.client.ItcClient
+import lucuma.itc.client.ItcResult
+import lucuma.itc.client.SpectroscopyModeInput
+import lucuma.odb.service.ItcClientService
+import lucuma.odb.util.NonEmptyListExtensions.*
+
+sealed trait Itc[F[_]] {
+  def queryOne(
+    programId:     Program.Id,
+    observationId: Observation.Id,
+    useCache:      Boolean
+  ): F[Option[Itc.ObservationResult]]
+
+  def queryAll(
+    programId:      Program.Id,
+    observationIds: List[Observation.Id],
+    useCache:       Boolean
+  ): F[List[Itc.ObservationResult]]
+}
+
+
+object Itc {
+
+  opaque type Param = String
+
+  extension (p: Param) {
+    def stringValue: String =
+      p
+  }
+
+  sealed trait Result extends Product with Serializable {
+
+    val missing: Option[Result.Missing] =
+      fold(_.some, _ => none, _ => none)
+
+    val serviceError: Option[Result.ServiceError] =
+      fold(_ => none, _.some, _ => none)
+
+    val success: Option[Result.Success] =
+      fold(_ => none, _ => none, _.some)
+
+    def fold[A](
+      mf: Result.Missing      => A,
+      ef: Result.ServiceError => A,
+      sf: Result.Success      => A
+    ): A =
+      this match {
+        case m @ Result.Missing(_)          => mf(m)
+        case e @ Result.ServiceError(_, _)  => ef(e)
+        case s @ Result.Success(_, _, _, _) => sf(s)
+      }
+
+  }
+
+  object Result {
+    final case class Missing(
+      params: NonEmptySet[Param]
+    ) extends Result
+
+    final case class ServiceError(
+      input:   SpectroscopyModeInput,
+      message: String
+    ) extends Result
+
+    def serviceError(
+      input:   SpectroscopyModeInput,
+      message: String
+    ): Result =
+      ServiceError(input, message)
+
+    final case class Success(
+      input:         SpectroscopyModeInput,
+      exposureTime:  NonNegDuration,
+      exposures:     NonNegInt,
+      signalToNoise: PosBigDecimal
+    ) extends Result
+
+    def success(
+      input:         SpectroscopyModeInput,
+      exposureTime:  NonNegDuration,
+      exposures:     NonNegInt,
+      signalToNoise: PosBigDecimal
+    ): Result =
+      Success(input, exposureTime, exposures, signalToNoise)
+
+    given Order[Result] with {
+      def compare(x: Result, y: Result): Int =
+        (x, y) match {
+          case (ServiceError(_, _), _)                        => -1
+          case (_, ServiceError(_, _))                        =>  1
+          case (Missing(_), _)                                => -1
+          case (_, Missing(_))                                =>  1
+          case (Success(_, at, ac, _), Success(_, bt, bc, _)) =>
+            at.value.multipliedBy(ac.value).compareTo(bt.value.multipliedBy(bc.value))
+        }
+
+    }
+  }
+
+  final case class TargetResult(
+    targetId: Target.Id,
+    result:   Result
+  )
+
+  object TargetResult {
+    given Order[TargetResult] =
+      Order.by { tr => (tr.result, tr.targetId) }
+
+  }
+
+  final case class ObservationResult(
+    programId:     Program.Id,
+    observationId: Observation.Id,
+    value:         Either[Result.Missing, Zipper[TargetResult]]
+  )
+
+  object ObservationResult {
+
+    def missing(
+      pid: Program.Id,
+      oid: Observation.Id,
+      ps:  NonEmptyList[Param]
+    ): ObservationResult =
+      ObservationResult(pid, oid, Result.Missing(ps.toNes).asLeft)
+
+    def fromTargets(
+      pid: Program.Id,
+      oid: Observation.Id,
+      ts:  NonEmptyList[TargetResult]
+    ): ObservationResult =
+      ObservationResult(pid, oid, ts.focusMax.asRight)
+  }
+
+  def fromClientAndService[F[_]](
+    client:  ItcClient[F],
+    service: Resource[F, ItcClientService[F]]
+  )(implicit ev: MonadCancel[F, Throwable]): Itc[F] =
+    new Itc[F] {
+
+      def queryOne(
+        programId:     Program.Id,
+        observationId: Observation.Id,
+        useCache:      Boolean
+      ): F[Option[ObservationResult]] =
+        queryAll(programId, List(observationId), useCache)
+          .map(_.find(_.observationId === observationId))
+
+      def queryAll(
+        programId:      Program.Id,
+        observationIds: List[Observation.Id],
+        useCache:       Boolean
+      ): F[List[ObservationResult]] =
+
+        service.use { s =>
+          s.selectSpectroscopyInput(programId, observationIds).flatMap { m =>
+             m.toList.traverse { case (oid, v) => // (Observation.Id, ValidatedNel[String, NonEmptyList[(Target.Id, SpectroscopyModeInput)]])
+               callForObservation(programId, oid, v, useCache)
+             }
+          }
+        }
+
+      def callForObservation(
+        pid:      Program.Id,
+        oid:      Observation.Id,
+        v:        ValidatedNel[String, NonEmptyList[(Target.Id, SpectroscopyModeInput)]],
+        useCache: Boolean
+      ): F[ObservationResult] =
+
+        v.fold(
+          ps => ObservationResult.missing(pid, oid, ps).pure[F],
+          _.traverse { case (tid, si) => // (Target.Id, SpectroscopyModeInput)
+            callForTarget(tid, si, useCache)
+          }.map(ObservationResult.fromTargets(pid, oid, _))
+        )
+
+
+      def callForTarget(
+        tid:      Target.Id,
+        input:    SpectroscopyModeInput,
+        useCache: Boolean
+      ): F[TargetResult] =
+        client.spectroscopy(input, useCache).map { sr =>
+          TargetResult(
+            tid,
+            sr.result.fold(Result.serviceError(input, "ITC Service returned nothing.")) {
+              case ItcResult.Error(msg)       => Result.serviceError(input, msg)
+              case ItcResult.Success(t, c, s) => Result.success(input, t, c, s)
+            }
+          )
+        }
+
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/client/Itc.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/client/Itc.scala
@@ -31,18 +31,25 @@ import lucuma.itc.client.SpectroscopyModeInput
 import lucuma.odb.service.ItcInputService
 import lucuma.odb.util.NonEmptyListExtensions.*
 
+/**
+ * The ITC client combines the input parameter lookup and the actual remote
+ * call to the ITC service in a single method.
+ */
 sealed trait Itc[F[_]] {
+  import Itc.ObservationResult
+
   def queryOne(
     programId:     Program.Id,
     observationId: Observation.Id,
     useCache:      Boolean
-  ): F[Option[Itc.ObservationResult]]
+  ): F[Option[ObservationResult]]
 
   def queryAll(
     programId:      Program.Id,
     observationIds: List[Observation.Id],
     useCache:       Boolean
-  ): F[List[Itc.ObservationResult]]
+  ): F[List[ObservationResult]]
+
 }
 
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/client/Itc.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/client/Itc.scala
@@ -219,7 +219,7 @@ object Itc {
 
         service.use { s =>
           s.selectSpectroscopyInput(programId, observationIds).flatMap { m =>
-             m.toList.traverse { case (oid, e) => // (Observation.Id, EitherNel[(Option[Target.Id], String), NonEmptyList[(Target.Id, SpectroscopyModeInput)]])
+             m.toList.traverse { case (oid, e) =>
                callForObservation(programId, oid, e, useCache)
              }
           }
@@ -234,7 +234,7 @@ object Itc {
 
         e.fold(
           ps => ResultSet.missing(pid, oid, ps).pure[F],
-          _.traverse { case (tid, si) => // (Target.Id, SpectroscopyModeInput)
+          _.traverse { case (tid, si) =>
             callForTarget(tid, si, useCache)
           }.map(ResultSet.fromResults(pid, oid, _))
         )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/instances/ItcResultEncoder.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/instances/ItcResultEncoder.scala
@@ -26,9 +26,6 @@ trait ItcResultEncoder {
   private def status(r: Itc.TargetResult): String =
     r.result.fold(_ => MissingParams, _ => ServiceError, _ => Success)
 
-  private def typename(r: Itc.TargetResult): String =
-    r.result.fold(_ => "ItcMissingParams", _ => "ItcServiceError", _ => "ItcSuccess")
-
   given Encoder[Itc.Param] =
     Encoder.instance(_.stringValue.asJson)
 
@@ -39,7 +36,6 @@ trait ItcResultEncoder {
     def apply(r: Itc.TargetResult): Json =
       Json.fromFields(
         List(
-//          "__typename" -> typename(r).asJson,
           "status"     -> status(r).asJson,
           "targetId"   -> r.targetId.asJson
         ) ++ r.result.fold(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/instances/ItcResultEncoder.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/instances/ItcResultEncoder.scala
@@ -59,15 +59,8 @@ trait ItcResultEncoder {
       Json.obj(
         "programId"     -> r.programId.asJson,
         "observationId" -> r.observationId.asJson,
-        "result"        ->
-          r.value.fold(
-            m => Json.obj(
-              "status"  -> MissingParams.asJson,
-              "params"  -> m.params.asJson
-            ),
-            z => z.focus.asJson
-          ),
-        "all"           -> r.value.toOption.toList.flatMap(_.toList).asJson
+        "result"        -> r.value.focus.asJson,
+        "all"           -> r.value.toList.asJson
       )
   }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/instances/ItcResultEncoder.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/instances/ItcResultEncoder.scala
@@ -3,11 +3,10 @@
 
 package lucuma.odb.graphql.instances
 
-import lucuma.itc.client.ItcResult
-
 import io.circe.Encoder
 import io.circe.Json
 import io.circe.syntax._
+import lucuma.itc.client.ItcResult
 
 import java.time.Duration
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/instances/ItcResultEncoder.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/instances/ItcResultEncoder.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.instances
+
+import lucuma.itc.client.ItcResult
+
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.syntax._
+
+import java.time.Duration
+
+
+object ItcResultEncoder extends ItcResultEncoder
+
+
+/**
+ * ItcResult Encoder matching the ODB Schema.
+ */
+trait ItcResultEncoder {
+
+  given Encoder[ItcResult.Success] with {
+
+    def duration(d: Duration): Json = {
+
+      import java.math.RoundingMode.DOWN
+      import java.time.temporal.ChronoUnit.MICROS
+
+      val d2 = d.truncatedTo(MICROS)
+
+      val micro = BigDecimal(
+        new java.math.BigDecimal(d2.getSeconds)
+          .movePointRight(9)
+          .add(new java.math.BigDecimal(d2.getNano))
+          .movePointLeft(3)
+          .setScale(0, DOWN)
+      )
+
+      Json.obj(
+        "microseconds" -> micro.longValue.asJson,
+        "milliseconds" -> (micro / 1_000L).asJson,
+        "seconds"      -> (micro / 1_000_000L).asJson,
+        "minutes"      -> (micro / 60_000_000L).asJson,
+        "hours"        -> (micro / 3_600_000_000L).asJson,
+        "iso"          -> d2.toString.asJson
+      )
+    }
+
+
+    def apply(r: ItcResult.Success): Json =
+      Json.obj(
+        "exposureTime"  -> duration(r.exposureTime.value),
+        "exposures"     -> r.exposures.value.asJson,
+        "signalToNoise" -> r.signalToNoise.value.asJson
+      )
+  }
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
@@ -5,6 +5,7 @@ package lucuma.odb.graphql
 
 package mapping
 
+import cats.effect.Resource
 import cats.effect.kernel.Par
 import cats.syntax.all._
 import edu.gemini.grackle.Cursor
@@ -27,6 +28,7 @@ import lucuma.odb.graphql.input.WhereProgram
 import lucuma.odb.graphql.input.WhereTargetInput
 import lucuma.odb.graphql.predicate.Predicates
 import lucuma.odb.instances.given
+import lucuma.odb.service.ItcClientService
 
 import scala.reflect.ClassTag
 
@@ -38,6 +40,7 @@ trait QueryMapping[F[_]] extends Predicates[F] {
    with ProgramMapping[F]
    with ObservationMapping[F] =>
 
+  def itcClientService: Resource[F, ItcClientService[F]]
 
   lazy val QueryMapping =
     ObjectMapping(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
@@ -30,7 +30,7 @@ import lucuma.odb.graphql.input.WhereProgram
 import lucuma.odb.graphql.input.WhereTargetInput
 import lucuma.odb.graphql.predicate.Predicates
 import lucuma.odb.instances.given
-import lucuma.odb.service.ItcClientService
+import lucuma.odb.service.ItcInputService
 
 import scala.reflect.ClassTag
 
@@ -42,7 +42,7 @@ trait QueryMapping[F[_]] extends Predicates[F] {
    with ProgramMapping[F]
    with ObservationMapping[F] =>
 
-  def itcClientService: Resource[F, ItcClientService[F]]
+  def itcClientService: Resource[F, ItcInputService[F]]
 
   def itcQuery(
     path:     Path,

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcClientService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcClientService.scala
@@ -148,7 +148,7 @@ object ItcClientService {
     import ProgramService.Statements.existsUserAccess
 
     private val source_profile: Decoder[SourceProfile] =
-      json.emap { sp =>
+      jsonb.emap { sp =>
         sp.as[SourceProfile].leftMap(f => s"Could not decode SourceProfile: ${f.message}")
       }
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcClientService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcClientService.scala
@@ -1,0 +1,136 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service
+
+import cats.data.NonEmptyList
+import cats.effect.Sync
+import cats.syntax.applicative.*
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import edu.gemini.grackle.Result
+import lucuma.core.enums.Band
+import lucuma.core.math.BrightnessUnits.BrightnessMeasure
+import lucuma.core.math.BrightnessUnits.Integrated
+import lucuma.core.math.BrightnessUnits.Surface
+import lucuma.core.math.Wavelength
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.SourceProfile
+import lucuma.core.model.Target
+import lucuma.core.model.User
+import lucuma.itc.client.InstrumentMode
+import lucuma.itc.client.SpectroscopyModeInput
+import skunk.Session
+
+import scala.collection.immutable.SortedMap
+
+
+/*
+final case class SpectroscopyModeInput(
+  wavelength:     Wavelength,
+  signalToNoise:  PosBigDecimal,
+  sourceProfile:  SourceProfile,
+  band:           Band,
+  radialVelocity: RadialVelocity,
+  constraints:    ConstraintSet,
+  mode:           InstrumentMode
+)
+*/
+
+trait ItcClientService[F[_]] {
+
+  def selectSpectroscopyInput(
+    programId: Program.Id,
+    which:     List[Observation.Id]
+  ): F[Map[Observation.Id, NonEmptyList[SpectroscopyModeInput]]]
+
+}
+
+object ItcClientService {
+
+  def fromSession[F[_]: Sync](
+    session:  Session[F],
+    user:     User,
+    oService: ObservationService[F],
+    mService: ObservingModeServices[F],
+    aService: AsterismService[F],
+    tService: TargetService[F]
+  ): ItcClientService[F] =
+
+    new ItcClientService[F] {
+
+      private def spectroscopy(
+        o: ObservationService.ItcParams,
+        m: ObservingModeServices.ItcParams,
+        t: TargetService.ItcParams
+      ): Option[SpectroscopyModeInput] = {
+
+        def extractBand[T](w: Wavelength, bMap: SortedMap[Band, BrightnessMeasure[T]]): Option[Band] =
+          bMap.minByOption { case (b, _) =>
+            (w.toPicometers.value.value - b.center.toPicometers.value.value).abs
+          }.map(_._1)
+
+        def band: Option[Band] =
+          SourceProfile
+            .integratedBrightnesses
+            .getOption(t.sourceProfile)
+            .flatMap(bMap => extractBand[Integrated](m.wavelength, bMap))
+            .orElse(
+              SourceProfile
+                .surfaceBrightnesses
+                .getOption(t.sourceProfile)
+                .flatMap(bMap => extractBand[Surface](m.wavelength, bMap))
+            )
+
+        band.map { b =>
+          SpectroscopyModeInput(
+            m.wavelength,
+            o.signalToNoise,
+            o.signalToNoiseAt,
+            t.sourceProfile,
+            b,
+            t.radialVelocity,
+            o.constraints,
+            m.mode
+          )
+        }
+      }
+
+      override def selectSpectroscopyInput(
+        programId: Program.Id,
+        which:     List[Observation.Id]
+      ): F[Map[Observation.Id, NonEmptyList[SpectroscopyModeInput]]] =
+
+        for {
+          // Select ITC data from the observation table
+          o <- oService.selectItcParams(programId, which)
+
+          // Using the observing modes in the return value above, select the ITC
+          // observing mode data
+          m <- mService.selectItcParams(o.toList.map { case (oid, itc) => (oid, itc.observingMode) })
+
+          // Obtain the asterisms for each of the observations.
+          a <- NonEmptyList.fromList(which).fold(Map.empty[Observation.Id, List[Target.Id]].pure[F]) { oids =>
+            aService.selectAsterism(programId, oids)
+          }
+
+          // ITC params for each of the targets in the collection of asterisms
+          t <- tService.selectItcParams(a.values.toList.flatten.distinct)
+        } yield
+
+          // Combine all the ITC parameter data into SpectroscopyModeInput when
+          // possible.
+          o.keySet
+           .intersect(m.keySet)
+           .intersect(a.keySet)
+           .foldLeft(Map.empty[Observation.Id, NonEmptyList[SpectroscopyModeInput]]) { (r, oid) =>
+             NonEmptyList.fromList(
+               a(oid)
+                 .flatMap(t.get(_).toList)
+                 .flatMap(spectroscopy(o(oid), m(oid), _).toList)
+             ).fold(r) { nel => r.updated(oid, nel) }
+           }
+
+    }
+}

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcInputService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcInputService.scala
@@ -43,19 +43,6 @@ import skunk.implicits.*
 
 import scala.collection.immutable.SortedMap
 
-
-/*
-final case class SpectroscopyModeInput(
-  wavelength:     Wavelength,
-  signalToNoise:  PosBigDecimal,
-  sourceProfile:  SourceProfile,
-  band:           Band,
-  radialVelocity: RadialVelocity,
-  constraints:    ConstraintSet,
-  mode:           InstrumentMode
-)
-*/
-
 /**
  * A database query service to gather input parameters to send to the ITC.
  */
@@ -105,7 +92,7 @@ object ItcInputService {
         (o.signalToNoise.toValidNel("signal to noise"),
          o.targetId.toValidNel("target")
         ).tupled.andThen { case (s2n, tid) =>
-          // these dependent on having a target in the first place
+          // these are dependent on having a target in the first place
           (band.toValidNel(s"${tid.toString}: brightness measure"),
            o.radialVelocity.toValidNel(s"${tid.toString}: radial velocity"),
            o.sourceProfile.toValidNel(s"${tid.toString}: source profile")

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -8,7 +8,16 @@ import cats.data.Ior
 import cats.data.NonEmptyChain
 import cats.data.NonEmptyList
 import cats.effect.Sync
-import cats.syntax.all.*
+import cats.syntax.applicative.*
+import cats.syntax.applicativeError.*
+import cats.syntax.apply.*
+import cats.syntax.flatMap.*
+import cats.syntax.foldable.*
+import cats.syntax.functor.*
+import cats.syntax.functorFilter.*
+import cats.syntax.option.*
+import cats.syntax.parallel.*
+import cats.syntax.traverse.*
 import edu.gemini.grackle.Predicate
 import edu.gemini.grackle.Problem
 import edu.gemini.grackle.Result
@@ -33,7 +42,10 @@ import lucuma.core.math.RightAscension
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ElevationRange
+import lucuma.core.model.ElevationRange.AirMass
 import lucuma.core.model.ElevationRange.AirMass.DecimalValue
+import lucuma.core.model.ElevationRange.AirMass.max
+import lucuma.core.model.ElevationRange.HourAngle
 import lucuma.core.model.ElevationRange.HourAngle.DecimalHour
 import lucuma.core.model.GuestRole
 import lucuma.core.model.Observation
@@ -86,10 +98,22 @@ sealed trait ObservationService[F[_]] {
     which: AppliedFragment
   ): F[Result[List[Observation.Id]]]
 
+  def selectItcParams(
+    programId: Program.Id,
+    which:     List[Observation.Id]
+  ): F[Map[Observation.Id, ObservationService.ItcParams]]
+
 }
 
 
 object ObservationService {
+
+  final case class ItcParams(
+    constraints:     ConstraintSet,
+    signalToNoise:   PosBigDecimal,
+    signalToNoiseAt: Option[Wavelength],
+    observingMode:   ObservingModeType
+  )
 
   final case class DatabaseConstraint(
     constraint: String,
@@ -132,12 +156,10 @@ object ObservationService {
 
   def fromSessionAndUser[F[_]: Sync: Trace](
     session: Session[F],
-    user:    User
+    user:    User,
+    observingModeServices: ObservingModeServices[F]
   ): ObservationService[F] =
     new ObservationService[F] {
-
-      lazy val observingModeServices: ObservingModeServices[F] =
-        ObservingModeServices.fromSession(session)
 
       override def createObservation(
         programId: Program.Id,
@@ -264,10 +286,23 @@ object ObservationService {
             } yield r
           }
         }
+
+      override def selectItcParams(
+        programId: Program.Id,
+        which:     List[Observation.Id]
+      ): F[Map[Observation.Id, ItcParams]] =
+        NonEmptyList.fromList(which).fold(Applicative[F].pure(Map.empty[Observation.Id, ItcParams])) { oids =>
+          val (af, decoder) = Statements.selectItcParams(user, programId, oids)
+          session
+            .prepare(af.fragment.query(decoder))
+            .use(_.stream(af.argument, chunkSize = 64).compile.to(List))
+            .map(_.collect { case (oid, Some(itc)) => (oid, itc) }.toMap)
+        }
     }
 
   object Statements {
 
+    import ProgramService.Statements.existsUserAccess
     import ProgramService.Statements.whereUserAccess
 
     def insertObservationAs(
@@ -454,6 +489,80 @@ object ObservationService {
         void"WHERE c_observation_id IN ("                                      |+|
           observationIds.map(sql"$observation_id").intercalate(void", ")       |+|
         void")"
+
+    val elevation_range: Decoder[ElevationRange] = {
+      (air_mass_range_value.opt   ~
+       air_mass_range_value.opt   ~
+       hour_angle_range_value.opt ~
+       hour_angle_range_value.opt
+      ).emap { case (((am_min, am_max), ha_min), ha_max) =>
+
+        val am = (am_min, am_max).traverseN { case (min, max) =>
+          for {
+            n <- DecimalValue.from(min.value)
+            x <- DecimalValue.from(max.value)
+            a <- AirMass.fromOrderedDecimalValues.getOption((n, x)).toRight(s"airmass min and max out of order: ($min, $max)")
+          } yield a
+        }
+
+        val ha = (ha_min, ha_max).traverseN { case (min, max) =>
+          for {
+            n <- DecimalHour.from(min)
+            x <- DecimalHour.from(max)
+            h <- HourAngle.fromOrderedDecimalHours.getOption((n, x)).toRight(s"hour angle min and max out of order: ($min, $max)")
+          } yield h
+        }
+
+        for {
+          a <- am
+          h <- ha
+          e <- a.orElse(h).toRight("Undefined elevation range")
+        } yield e
+      }
+    }
+
+    val conditions_set: Decoder[ConstraintSet] =
+      (image_quality    ~
+       cloud_extinction ~
+       sky_background   ~
+       water_vapor      ~
+       elevation_range
+      ).gmap[ConstraintSet]
+
+    val itc_params_opt: Decoder[Option[ItcParams]] =
+      (conditions_set ~ signal_to_noise.opt ~ wavelength_pm.opt ~ observing_mode_type.opt)
+        .map { case (((cs, s2n), w), om) =>
+          for {
+            s <- s2n
+            m <- om
+          } yield ItcParams(cs, s, w, m)
+        }
+
+    def selectItcParams(
+      user:      User,
+      programId: Program.Id,
+      which:     NonEmptyList[Observation.Id]
+    ): (AppliedFragment, Decoder[(Observation.Id, Option[ItcParams])]) =
+      (void"""
+        SELECT
+          c_observation_id,
+          c_image_quality,
+          c_cloud_extinction,
+          c_sky_background,
+          c_water_vapor,
+          c_air_mass_min,
+          c_air_mass_max,
+          c_hour_angle_min,
+          c_hour_angle_max,
+          c_spec_signal_to_noise,
+          c_spec_signal_to_noiseAt,
+          c_observing_mode_type
+        FROM t_observation
+        WHERE c_observation_id IN (""" |+|
+          which.map(sql"$observation_id").intercalate(void", ") |+|
+        void")" |+| existsUserAccess(user, programId).fold(AppliedFragment.empty) { af => void""" AND """ |+| af },
+        (observation_id ~ itc_params_opt)
+      )
 
     def posAngleConstraintUpdates(in: PosAngleConstraintInput): List[AppliedFragment] = {
 

--- a/modules/service/src/main/scala/lucuma/odb/service/TargetService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TargetService.scala
@@ -3,19 +3,15 @@
 
 package lucuma.odb.service
 
-import cats.Applicative
-import cats.data.NonEmptyList
-import cats.effect.Sync
+import cats.effect.MonadCancelThrow
 import cats.syntax.all._
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Json
 import io.circe.syntax.*
-import lucuma.core.math.RadialVelocity
 import lucuma.core.model.EphemerisKey
 import lucuma.core.model.GuestUser
 import lucuma.core.model.Program
 import lucuma.core.model.ServiceUser
-import lucuma.core.model.SourceProfile
 import lucuma.core.model.StandardRole.Admin
 import lucuma.core.model.StandardRole.Ngo
 import lucuma.core.model.StandardRole.Pi
@@ -29,7 +25,6 @@ import lucuma.odb.graphql.input.TargetPropertiesInput
 import lucuma.odb.graphql.instances.SourceProfileCodec.given
 import lucuma.odb.util.Codecs._
 import skunk.AppliedFragment
-import skunk.Decoder
 import skunk.Session
 import skunk.circe.codec.all._
 import skunk.codec.all._
@@ -38,16 +33,9 @@ import skunk.implicits._
 trait TargetService[F[_]] {
   import TargetService.CreateTargetResponse
   def createTarget(pid: Program.Id, input: TargetPropertiesInput): F[CreateTargetResponse]
-
-  def selectItcParams(targetIds: List[Target.Id]): F[Map[Target.Id, TargetService.ItcParams]]
 }
 
 object TargetService {
-
-  final case class ItcParams(
-    sourceProfile:  SourceProfile,
-    radialVelocity: RadialVelocity
-  )
 
   sealed trait CreateTargetResponse
   object CreateTargetResponse {
@@ -57,14 +45,14 @@ object TargetService {
   }
   import CreateTargetResponse._
 
-    def fromSession[F[_]: Sync](s: Session[F], u: User): TargetService[F] =
+    def fromSession[F[_]: MonadCancelThrow](s: Session[F], u: User): TargetService[F] =
       new TargetService[F] {
         import Statements._
 
         override def createTarget(pid: Program.Id, input: TargetPropertiesInput): F[CreateTargetResponse] = {
           val insert: AppliedFragment =
             input.tracking match {
-              case Left(s) => insertSiderealFragment(pid, input.name, s, input.sourceProfile.asJson)
+              case Left(s)  => insertSiderealFragment(pid, input.name, s, input.sourceProfile.asJson)
               case Right(n) => insertNonsiderealFragment(pid, input.name, n, input.sourceProfile.asJson)
             }
           val where = whereFragment(pid, u)
@@ -77,41 +65,10 @@ object TargetService {
           }
         }
 
-        override def selectItcParams(targetIds: List[Target.Id]): F[Map[Target.Id, ItcParams]] =
-          NonEmptyList.fromList(targetIds).fold(Applicative[F].pure(Map.empty[Target.Id, ItcParams])) { tids =>
-            val (af, decoder) = Statements.selectItcParams(tids)
-            s.prepare(af.fragment.query(decoder))
-             .use(_.stream(af.argument, 64).compile.to(List))
-             .map(_.collect { case (tid, Some(itc)) => (tid, itc) }.toMap)
-           }
-
       }
 
 
   object Statements {
-
-    val itc_params_opt: Decoder[Option[ItcParams]] =
-      (radial_velocity.opt ~ json).map { case (rv, sp) =>
-        (sp.as[SourceProfile].toOption, rv).mapN { (s, r) => ItcParams(s, r) }
-      }
-
-    def selectItcParams(
-      which: NonEmptyList[Target.Id]
-    ): (AppliedFragment, Decoder[(Target.Id, Option[ItcParams])]) =
-      (void"""
-        SELECT
-          c_target_id,
-          c_sid_rv,
-          c_source_profile
-        FROM
-          t_target
-        WHERE
-          c_target_id IN (""" |+|
-            which.map(sql"${target_id}").intercalate(void", ") |+|
-          void")",
-       (target_id ~ itc_params_opt)
-      )
-
 
     import ProgramService.Statements.{ existsUserAsPi, existsUserAsCoi, existsAllocationForPartner }
 

--- a/modules/service/src/main/scala/lucuma/odb/util/NonEmptyListExtensions.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/NonEmptyListExtensions.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.util
+
+import cats.Order
+import cats.data.NonEmptyList
+import cats.syntax.foldable.*
+import cats.syntax.order.*
+import lucuma.core.data.Zipper
+
+import scala.annotation.tailrec
+
+object NonEmptyListExtensions {
+
+  extension [A: Order](nel: NonEmptyList[A]) {
+
+    /**
+     * Creates a Zipper from the NonEmptyList where the focused element is the
+     * minimum according to the `Order` instance for `A`.
+     */
+    def focusMin: Zipper[A] =
+      focusCompare(_ < _)
+
+    /**
+     * Creates a Zipper from the NonEmptyList where the focused element is the
+     * maximum according to the `Order` instance for `A`.
+     */
+    def focusMax: Zipper[A] =
+      focusCompare(_ > _)
+
+    private def focusCompare(f: (A, A) => Boolean) = {
+
+      @tailrec
+      def go(cur: Zipper[A], res: Zipper[A]): Zipper[A] =
+        cur.next match {
+          case None    => res
+          case Some(n) => if (f(n.focus, res.focus)) go(n, n) else go(n, res)
+        }
+
+      val init = Zipper.fromNel(nel)
+      go(init, init)
+    }
+
+  }
+
+}
+
+

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -18,6 +18,8 @@ import com.dimafeng.testcontainers.PostgreSQLContainer
 import com.dimafeng.testcontainers.munit.TestContainerForAll
 import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.numeric.PosBigDecimal
+import io.circe.Decoder
+import io.circe.Encoder
 import io.circe.Json
 import io.circe.literal.*
 import lucuma.core.model.NonNegDuration
@@ -50,6 +52,7 @@ import org.typelevel.ci.CIString
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
+import java.time.Duration
 import scala.concurrent.duration.*
 
 /**
@@ -93,7 +96,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
 
   def validUsers: List[User]
 
-  val Bearer = CIString("Bearer")
+  val Bearer: AuthScheme = CIString("Bearer")
 
   def authorization(jwt: String): Authorization =
     Authorization(Credentials.Token(Bearer, jwt))
@@ -103,7 +106,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
 
   val FakeItcResult: ItcResult.Success =
     ItcResult.Success(
-      NonNegDuration.unsafeFrom(java.time.Duration.ofSeconds(10)),
+      NonNegDuration.unsafeFrom(Duration.ofSeconds(10)),
       NonNegInt.unsafeFrom(11),
       PosBigDecimal.unsafeFrom(50.0)
     )
@@ -177,8 +180,8 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
   ) extends GraphQLOperation[Nothing] {
     type Data       = Json
     type Variables  = Json
-    val varEncoder  = implicitly
-    val dataDecoder = implicitly
+    val varEncoder: Encoder[Variables] = implicitly
+    val dataDecoder: Decoder[Data]     = implicitly
   }
 
   private lazy val serverFixture: Fixture[Server] =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -41,7 +41,7 @@ import org.http4s.jdkhttpclient.JdkHttpClient
 import org.http4s.jdkhttpclient.JdkWSClient
 import org.http4s.server.Server
 import org.http4s.server.websocket.WebSocketBuilder2
-import org.http4s.{Uri as Http4sUri, *}
+import org.http4s.{Uri => Http4sUri, _}
 import org.slf4j
 import org.testcontainers.containers.BindMode
 import org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -1,0 +1,195 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package query
+
+import cats.effect.IO
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.Target
+import lucuma.core.model.User
+
+class itc extends OdbSuite {
+
+  val user: User = TestUsers.service(3)
+
+  override val validUsers: List[User] =
+    List(user)
+
+  val createProgram: IO[Program.Id] =
+    query(
+      user  = user,
+      query =
+      s"""
+         mutation {
+           createProgram(input: { SET: { name: "ITC Testing" } }) {
+             program {
+               id
+             }
+           }
+         }
+      """
+    ).map { json =>
+      json.hcursor.downFields("createProgram", "program", "id").require[Program.Id]
+    }
+
+  def createObservation(pid: Program.Id, tids: Target.Id*): IO[Observation.Id] =
+    query(
+      user  = user,
+      query =
+      s"""
+         mutation {
+           createObservation(input: {
+             programId: ${pid.asJson},
+             SET: {
+               constraintSet: {
+                 cloudExtinction: POINT_ONE,
+                 imageQuality: POINT_ONE,
+                 skyBackground: DARKEST
+               },
+               targetEnvironment: {
+                 asterism: ${tids.map(tid => s"\"${tid.toString}\"").mkString("[", ", ", "]")}
+               },
+               scienceRequirements: {
+                 mode: SPECTROSCOPY,
+                 spectroscopy: {
+                   wavelength: {
+                     nanometers: 500
+                   },
+                   resolution: 100,
+                   signalToNoise: 100.0,
+                   wavelengthCoverage: {
+                     nanometers: 20
+                   },
+                   focalPlane: SINGLE_SLIT,
+                   focalPlaneAngle: {
+                     microarcseconds: 0
+                   }
+                 }
+               },
+               observingMode: {
+                 gmosNorthLongSlit: {
+                   grating: R831_G5302,
+                   filter: R_PRIME,
+                   fpu: LONG_SLIT_0_50,
+                   centralWavelength: {
+                     nanometers: 500
+                   }
+                 }
+               }
+             }
+           }) {
+             observation {
+               id
+             }
+           }
+         }
+      """
+    ).map { json =>
+      json.hcursor.downFields("createObservation", "observation", "id").require[Observation.Id]
+    }
+
+  def createTarget(pid: Program.Id): IO[Target.Id] =
+    query(
+      user  = user,
+      query =
+      s"""
+         mutation {
+           createTarget(input: {
+             programId: ${pid.asJson},
+             SET: {
+               name: "V1647 Orionis"
+               sidereal: {
+                 ra: { hms: "05:46:13.137" },
+                 dec: { dms: "-00:06:04.89" },
+                 epoch: "J2000.0",
+                 properMotion: {
+                   ra: {
+                     milliarcsecondsPerYear: 0.918
+                   },
+                   dec: {
+                     milliarcsecondsPerYear: -1.057
+                   },
+                 },
+                 radialVelocity: {
+                   kilometersPerSecond: 27.58
+                 },
+                 parallax: {
+                   milliarcseconds: 2.422
+                 }
+               },
+               sourceProfile: {
+                 point: {
+                   bandNormalized: {
+                     sed: {
+                       stellarLibrary: O5_V
+                     },
+                     brightnesses: [
+                       {
+                         band: J,
+                         value: 14.74,
+                         units: VEGA_MAGNITUDE
+                       },
+                       {
+                         band: V,
+                         value: 18.1,
+                         units: VEGA_MAGNITUDE
+                       }
+                     ]
+                   }
+                 }
+               }
+             }
+           }) {
+             target {
+               id
+             }
+           }
+         }
+      """
+    ).map { json =>
+      json.hcursor.downFields("createTarget", "target", "id").require[Target.Id]
+    }
+
+  val setup: IO[(Program.Id, Observation.Id, Target.Id)] =
+    for {
+      p <- createProgram
+      t <- createTarget(p)
+      o <- createObservation(p, t)
+    } yield (p, o, t)
+
+  test("simple itc") {
+    setup.flatMap { case (pid, oid, _) =>
+      expect(
+        user = user,
+        query =
+          s"""
+            query {
+              itc(programId: "$pid", observationId: "$oid") {
+                exposureTime {
+                  seconds
+                }
+                exposures
+              }
+            }
+          """,
+        expected = Right(
+          json"""
+            {
+               "itc": {
+                 "exposureTime": {
+                   "seconds": ${FakeItcResult.exposureTime.value.getSeconds}
+                 },
+                 "exposures": ${FakeItcResult.exposures.value}
+               }
+            }
+          """
+        )
+      )
+    }
+  }
+
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -169,10 +169,15 @@ class itc extends OdbSuite {
           s"""
             query {
               itc(programId: "$pid", observationId: "$oid") {
-                exposureTime {
-                  seconds
+                status
+                selected {
+                  success {
+                    exposureTime {
+                      seconds
+                    }
+                    exposures
+                  }
                 }
-                exposures
               }
             }
           """,
@@ -180,10 +185,15 @@ class itc extends OdbSuite {
           json"""
             {
                "itc": {
-                 "exposureTime": {
-                   "seconds": ${FakeItcResult.exposureTime.value.getSeconds}
-                 },
-                 "exposures": ${FakeItcResult.exposures.value}
+                 "status": "SUCCESS",
+                 "selected": {
+                   "success": {
+                     "exposureTime": {
+                       "seconds": ${FakeItcResult.exposureTime.value.getSeconds}
+                     },
+                     "exposures": ${FakeItcResult.exposures.value}
+                   }
+                 }
                }
             }
           """

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -262,7 +262,7 @@ class itc extends OdbSuite {
             {
                "itc": {
                  "result": {
-                   "targetId": $tid1
+                   "targetId": $tid0
                  },
                  "all": [
                    {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/program.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/program.scala
@@ -12,7 +12,6 @@ import io.circe.syntax._
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.User
-import lucuma.odb.graphql.OdbSuite
 
 class program extends OdbSuite {
 
@@ -20,7 +19,7 @@ class program extends OdbSuite {
   val guest    = TestUsers.guest(2)
   val service  = TestUsers.service(3)
 
-  val validUsers = List(pi, guest, service).toList
+  val validUsers = List(pi, guest, service)
 
   def createProgram(user: User, name: String): IO[Program.Id] =
     query(


### PR DESCRIPTION
This PR is a bit of a monster, but about 1/3 is test code.  It implements the `itc` query for an observation.  I had to move it to the root in order to make it work with Grackle.   One guide to reviewing this work would be to look first at the schema updates.  Then there is code to produce corresponding data that can be thus encoded.  In particular:

* a new database view, `v_itc_params`, collecting ITC parameter data from disparate tables,
* an `ItcInputService` which just queries the database to collect the parameters needed to call the ITC,
* an `Itc` client which calls the aforementioned input service and then passes the parameters along to the actual `lucuma.itc.client.ItcClient`, collecting the data into a more easily digestible format, and
* an `ItcResultEncoder` to create schema-compatible JSON for the results.

Unfortunately the view cannot also include the observing mode parameters since there will eventually be scores of these each in their own instrument specific tables.

N.B. the `itc` query itself in the schema may go away, but all the code to implement it will be needed when the sequence is generated.