### PR TITLE
Query/asterismGroup

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0030__observations.sql
+++ b/modules/service/src/main/resources/db/migration/V0030__observations.sql
@@ -225,7 +225,8 @@ create table t_observation (
   -- observing mode
   c_observing_mode_type e_observing_mode_type null default null,
 
-  --
+  -- asterism group (computed by a trigger on t_asterism_target)
+  c_asterism_group jsonb not null default '[]'::jsonb,
 
   unique (c_observation_id, c_instrument),
   unique (c_observation_id, c_observing_mode_type),

--- a/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/service/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -2654,6 +2654,8 @@ type Angle {
 
 type AsterismGroup {
 
+  program: Program!
+
   # Observations associated with the common value
   observations(
     # Set to true to include deleted values

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -16,6 +16,8 @@ trait BaseMapping[F[_]]
   // TODO: auto-generate this
   lazy val AirMassRangeType                    = schema.ref("AirMassRange")
   lazy val AllocationType                      = schema.ref("Allocation")
+  lazy val AsterismGroupType                   = schema.ref("AsterismGroup")
+  lazy val AsterismGroupSelectResultType       = schema.ref("AsterismGroupSelectResult")
   lazy val AngleType                           = schema.ref("Angle")
   lazy val BigDecimalType                      = schema.ref("BigDecimal")
   lazy val CatalogInfoType                     = schema.ref("CatalogInfo")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -81,6 +81,8 @@ object OdbMapping {
           with AirMassRangeMapping[F]
           with AllocationMapping[F]
           with AngleMapping[F]
+          with AsterismGroupMapping[F]
+          with AsterismGroupSelectResultMapping[F]
           with CatalogInfoMapping[F]
           with ConstraintSetGroupMapping[F]
           with ConstraintSetGroupSelectResultMapping[F]
@@ -166,6 +168,8 @@ object OdbMapping {
               AirMassRangeMapping,
               AllocationMapping,
               AngleMapping,
+              AsterismGroupMapping,
+              AsterismGroupSelectResultMapping,
               CatalogInfoMapping,
               ConstraintSetGroupMapping,
               ConstraintSetGroupSelectResultMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AsterismGroupMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AsterismGroupMapping.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mapping
+
+import lucuma.odb.graphql.table._
+
+trait AsterismGroupMapping[F[_]] 
+  extends AsterismGroupView[F] 
+    with AsterismTargetTable[F]
+    with ObservationView[F] 
+    with ProgramTable[F]
+    with TargetView[F] {
+
+  lazy val AsterismGroupMapping: TypeMapping =
+    ObjectMapping(
+      tpe = AsterismGroupType,
+      fieldMappings = List(
+
+        // Our key, which is hidden
+        SqlField("asterismGroup", AsterismGroupView.AsterismGroup, key = true, hidden = true),
+
+        // User-visible fields
+        SqlObject("program", Join(AsterismGroupView.ProgramId, ProgramTable.Id)),
+        SqlObject("observations", Join(AsterismGroupView.AsterismGroup, ObservationView.AsterismGroup)),
+        SqlObject("asterism", Join(AsterismGroupView.ExampleObservationId, AsterismTargetTable.ObservationId), Join(AsterismTargetTable.TargetId, TargetView.TargetId)),
+
+      )
+    )
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AsterismGroupSelectResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AsterismGroupSelectResultMapping.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package mapping
+
+trait AsterismGroupSelectResultMapping[F[_]] extends ResultMapping[F] {
+  
+  lazy val AsterismGroupSelectResultMapping: ObjectMapping =
+    topLevelSelectResultMapping(AsterismGroupSelectResultType)
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationSelectResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationSelectResultMapping.scala
@@ -6,17 +6,13 @@ package lucuma.odb.graphql.mapping
 import edu.gemini.grackle.Cursor
 import edu.gemini.grackle.Result
 import lucuma.odb.graphql.BaseMapping
-import lucuma.odb.graphql.table.AsterismTargetTable
-import lucuma.odb.graphql.table.ConstraintSetGroupView
-import lucuma.odb.graphql.table.ObservationView
-import lucuma.odb.graphql.table.ProgramTable
-import lucuma.odb.graphql.table.TargetView
+import lucuma.odb.graphql.table.*
 import skunk.codec.numeric.int8
 
 import scala.tools.util.PathResolver.Environment
 
 trait ObservationSelectResultMapping[F[_]] 
-  extends ConstraintSetGroupView[F] with ObservationView[F] with ProgramTable[F] with TargetView[F] with AsterismTargetTable[F] with ResultMapping[F] {
+  extends ConstraintSetGroupView[F] with ObservationView[F] with ProgramTable[F] with TargetView[F] with AsterismTargetTable[F] with AsterismGroupView[F] with ResultMapping[F] {
 
   lazy val ObservationSelectResultMapping: TypeMapping =
     SwitchMapping(
@@ -26,6 +22,7 @@ trait ObservationSelectResultMapping[F[_]]
         (ProgramType, "observations", nestedSelectResultMapping(ObservationSelectResultType, ProgramTable.Id, Join(ProgramTable.Id, ObservationView.ProgramId))),
         (ConstraintSetGroupType, "observations", nestedSelectResultMapping(ObservationSelectResultType, ConstraintSetGroupView.ConstraintSetKey, Join(ConstraintSetGroupView.ConstraintSetKey, ObservationView.ConstraintSet.Key))),
         (TargetGroupType, "observations", nestedSelectResultMapping(ObservationSelectResultType, TargetView.TargetId, Join(TargetView.TargetId, AsterismTargetTable.TargetId), Join(AsterismTargetTable.ObservationId, ObservationView.Id))),
+        (AsterismGroupType, "observations", nestedSelectResultMapping(ObservationSelectResultType, AsterismGroupView.AsterismGroup, Join(AsterismGroupView.AsterismGroup, ObservationView.AsterismGroup))),
       )
     )
     

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
@@ -10,6 +10,7 @@ import cats.syntax.all._
 import edu.gemini.grackle.Cursor
 import edu.gemini.grackle.Cursor.Env
 import edu.gemini.grackle.Cursor.ListTransformCursor
+import edu.gemini.grackle.ListType
 import edu.gemini.grackle.Path
 import edu.gemini.grackle.Predicate._
 import edu.gemini.grackle.Query
@@ -18,6 +19,7 @@ import edu.gemini.grackle.Result
 import edu.gemini.grackle.TypeRef
 import edu.gemini.grackle.skunk.SkunkMapping
 import eu.timepit.refined.types.numeric.NonNegInt
+import io.circe.Json
 import lucuma.core.enums.ProgramType
 import lucuma.core.model.User
 import lucuma.odb.data.Tag
@@ -43,6 +45,7 @@ trait QueryMapping[F[_]] extends Predicates[F] {
     ObjectMapping(
       tpe = QueryType,
       fieldMappings = List(
+        SqlObject("asterismGroup"),
         SqlObject("constraintSetGroup"),
         SqlObject("filterTypeMeta"),
         SqlObject("observation"),
@@ -58,6 +61,7 @@ trait QueryMapping[F[_]] extends Predicates[F] {
 
   lazy val QueryElaborator: Map[TypeRef, PartialFunction[Select, Result[Query]]] =
     List(
+      AsterismGroup,
       ConstraintSetGroup,
       FilterTypeMeta,
       Observation,
@@ -74,8 +78,38 @@ trait QueryMapping[F[_]] extends Predicates[F] {
 
   // Elaborators below
 
+  private lazy val AsterismGroup: PartialFunction[Select, Result[Query]] = 
+    val WhereObservationBinding = WhereObservation.binding(AsterismGroupType / "observations" / "matches")
+    {
+      case Select("asterismGroup", List(
+        ProgramIdBinding("programId", rProgramId),
+        WhereObservationBinding.Option("WHERE", rWHERE),
+        NonNegIntBinding.Option("LIMIT", rLIMIT),
+        BooleanBinding("includeDeleted", rIncludeDeleted)
+      ), child) =>
+        (rProgramId, rWHERE, rLIMIT, rIncludeDeleted).parTupled.flatMap { (pid, WHERE, LIMIT, includeDeleted) =>
+          val limit = LIMIT.foldLeft(ResultMapping.MaxLimit)(_ min _.value)
+          ResultMapping.selectResult("asterismGroup", child, limit) { q =>         
+            FilterOrderByOffsetLimit(
+              pred = Some(
+                and(List(
+                  WHERE.getOrElse(True),
+                  Predicates.asterismGroup.program.id.eql(pid),
+                  Predicates.asterismGroup.program.existence.includeDeleted(includeDeleted),
+                  Predicates.asterismGroup.program.isVisibleTo(user),
+                ))
+              ),
+              oss = None,
+              offset = None,
+              limit = Some(limit + 1), // Select one extra row here.
+              child = q
+            )
+          }
+        }
+    }
+
   private lazy val ConstraintSetGroup: PartialFunction[Select, Result[Query]] = 
-    val WhereObservationBinding = WhereObservation.binding(ConstraintSetGroupType / "observations")
+    val WhereObservationBinding = WhereObservation.binding(ConstraintSetGroupType / "observations" / "matches")
     {
       case Select("constraintSetGroup", List(
         ProgramIdBinding("programId", rProgramId),
@@ -240,7 +274,7 @@ trait QueryMapping[F[_]] extends Predicates[F] {
       }
 
   private lazy val TargetGroup: PartialFunction[Select, Result[Query]] = 
-    val WhereObservationBinding = WhereObservation.binding(TargetGroupType / "observations")
+    val WhereObservationBinding = WhereObservation.binding(TargetGroupType / "observations" / "matches")
     {
       case Select("targetGroup", List(
         ProgramIdBinding("programId", rProgramId),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/AsterismGroupPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/AsterismGroupPredicates.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.predicate
+
+import edu.gemini.grackle.Path
+import edu.gemini.grackle.Predicate
+import edu.gemini.grackle.Predicate._
+import edu.gemini.grackle.skunk.SkunkMapping
+import lucuma.core.model.Target
+import lucuma.odb.data.Existence
+
+class AsterismGroupPredicates(path: Path) {
+  val program = ProgramPredicates(path / "program")
+  val observations = ObservationSelectResultPredicates(path / "observations")
+}
+

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
@@ -24,6 +24,7 @@ trait Predicates[F[_]] extends BaseMapping[F] {
     val target              = TargetPredicates(Path.from(TargetType))
     val constraintSetGroup  = ConstraintSetGroupPredicates(Path.from(ConstraintSetGroupType))
     val targetGroup         = TargetGroupPredicates(Path.from(TargetGroupType))
+    val asterismGroup       = AsterismGroupPredicates(Path.from(AsterismGroupType))
   }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/AsterismGroupView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/AsterismGroupView.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package table
+
+import edu.gemini.grackle.skunk.SkunkMapping
+import lucuma.odb.util.Codecs._
+import skunk.circe.codec.all._
+
+trait AsterismGroupView[F[_]] extends BaseMapping[F] {
+
+  object AsterismGroupView extends TableDef("v_asterism_group") {
+    val ProgramId            = col("c_program_id", program_id)
+    val AsterismGroup        = col("c_asterism_group",     jsonb)
+    val ExampleObservationId = col("c_example_observation_id", observation_id)
+  }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
@@ -6,6 +6,7 @@ package lucuma.odb.graphql
 package table
 
 import lucuma.odb.util.Codecs._
+import skunk.circe.codec.all._
 import skunk.codec.all._
 
 trait ObservationView[F[_]] extends BaseMapping[F] {
@@ -19,6 +20,7 @@ trait ObservationView[F[_]] extends BaseMapping[F] {
       val Status: ColumnRef            = col("c_status",             obs_status)
       val ActiveStatus: ColumnRef      = col("c_active_status",      obs_active_status)
       val VisualizationTime: ColumnRef = col("c_visualization_time", data_timestamp.opt)
+      val AsterismGroup: ColumnRef     = col("c_asterism_group",     jsonb)
 
       object PosAngleConstraint {
         val Mode: ColumnRef            = col("c_pac_mode",  pac_mode.embedded)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/asterismGroup.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/asterismGroup.scala
@@ -1,0 +1,265 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package query
+
+import cats.effect.IO
+import cats.syntax.all._
+import io.circe.Json
+import io.circe.literal._
+import io.circe.syntax._
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.Target
+import lucuma.core.model.User
+import lucuma.odb.graphql.OdbSuite
+
+class asterismGroup extends OdbSuite {
+
+  val pi       = TestUsers.Standard.pi(1, 30)
+  val validUsers = List(pi)
+
+  def createProgram(user: User): IO[Program.Id] =
+    query(
+      user = user,
+      query =
+        s"""
+          mutation {
+            createProgram(input: {}) {
+              program {
+                id
+              }
+            }
+          }
+        """
+    ) map { json =>
+      json.hcursor.downFields("createProgram", "program", "id").require[Program.Id]
+    }
+
+  def createTarget(user: User, pid: Program.Id): IO[Target.Id] =
+    query(
+      user = user,
+      query =
+        s"""
+          mutation {
+            createTarget(input: {
+              programId: ${pid.asJson}
+              SET: {
+                name: "my name"
+                sourceProfile: {
+                  point: {
+                    bandNormalized:{
+                      sed: {
+                        coolStar: T600_K
+                      }
+                      brightnesses: []
+                    }          
+                  }
+                }
+                sidereal: {                  
+                }
+              }
+            }) {
+              target {
+                id
+              }
+            }
+          }
+        """
+    ) map { json =>
+      json.hcursor.downFields("createTarget", "target", "id").require[Target.Id]
+    }
+
+  def createObservation(user: User, pid: Program.Id, tids: Target.Id*): IO[Observation.Id] =
+    query(
+      user = user,
+      query =
+        s"""
+          mutation {
+            createObservation(input: {
+            programId: ${pid.asJson},
+              SET: {
+                targetEnvironment: {
+                  asterism: ${tids.asJson}
+                }
+              }
+            }) {
+              observation {
+                id
+              }
+            }
+          }
+        """
+    ).map { json => 
+      json.hcursor.downFields("createObservation", "observation", "id").require[Observation.Id]
+    }
+
+  test("asterisms should be correctly grouped") {
+    List(pi).traverse { user =>
+      for {
+        pid  <- createProgram(user)
+        tids <- createTarget(user, pid).replicateA(5)
+        oid0 <- createObservation(user, pid, tids(3))
+        oid1 <- createObservation(user, pid, tids(0), tids(1))
+        oid2 <- createObservation(user, pid, tids(0), tids(1))
+        oid3 <- createObservation(user, pid, tids(0), tids(1), tids(2))
+        oid4 <- createObservation(user, pid)
+        _  <- expect(
+          user = user,
+          query =
+            s"""
+              query {
+                asterismGroup(programId: ${pid.asJson}) {
+                  matches {
+                    observations {
+                      matches {
+                        id
+                      }
+                    }
+                    asterism {
+                      id
+                    }
+                  }
+                }
+              }
+            """,
+          expected = Right(
+            json"""
+              {
+                "asterismGroup" : {
+                  "matches" : [
+                    {
+                      "observations" : {
+                        "matches" : [
+                          {
+                            "id" : $oid4
+                          }
+                        ]
+                      },
+                      "asterism" : [
+                      ]
+                    },
+                    {
+                      "observations" : {
+                        "matches" : [
+                          {
+                            "id" : $oid0
+                          }
+                        ]
+                      },
+                      "asterism" : [
+                        {
+                          "id" : ${tids(3)}
+                        }
+                      ]
+                    },
+                    {
+                      "observations" : {
+                        "matches" : [
+                          {
+                            "id" : $oid1
+                          },
+                          {
+                            "id" : $oid2
+                          }
+                        ]
+                      },
+                      "asterism" : [
+                        {
+                          "id" : ${tids(0)}
+                        },
+                        {
+                          "id" : ${tids(1)}
+                        }
+                      ]
+                    },
+                    {
+                      "observations" : {
+                        "matches" : [
+                          {
+                            "id" : $oid3
+                          }
+                        ]
+                      },
+                      "asterism" : [
+                        {
+                          "id" : ${tids(0)}
+                        },
+                        {
+                          "id" : ${tids(1)}
+                        },
+                        {
+                          "id" : ${tids(2)}
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            """
+          )
+        )
+      } yield true
+    }
+  }
+
+  test("asterisms should be correctly filtered") {
+    List(pi).traverse { user =>
+      for {
+        pid  <- createProgram(user)
+        tids <- createTarget(user, pid).replicateA(5)
+        oid0 <- createObservation(user, pid, tids(3))
+        oid1 <- createObservation(user, pid, tids(0), tids(1))
+        oid2 <- createObservation(user, pid, tids(0), tids(1))
+        oid3 <- createObservation(user, pid, tids(0), tids(1), tids(2))
+        oid4 <- createObservation(user, pid)
+        _  <- expect(
+          user = user,
+          query =
+            s"""
+              query {
+                asterismGroup(programId: ${pid.asJson}, WHERE: { id: { EQ: "$oid0"} }) {
+                  matches {
+                    observations {
+                      matches {
+                        id
+                      }
+                    }
+                    asterism {
+                      id
+                    }
+                  }
+                }
+              }
+            """,
+          expected = Right(
+            json"""
+              {
+                "asterismGroup" : {
+                  "matches" : [
+                    {
+                      "observations" : {
+                        "matches" : [
+                          {
+                            "id" : $oid0
+                          }
+                        ]
+                      },
+                      "asterism" : [
+                        {
+                          "id" : ${tids(3)}
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            """
+          )
+        )
+      } yield true
+    }
+  }
+
+}


### PR DESCRIPTION
This adds asterism groups via a mechanism that makes me feel shame but it's the best I could come up with.

- I added a `c_asterism_group` column on `t_observation` that contains a sorted list (as `jsonb`) of the targets associated with the observation, thus giving us a key we can use for efficient grouping. The field is automatically recomputed when a relevant row is added, updated, or deleted in `t_asterism_target`.

- There is also now a `v_asterism_group` view that contains unique program+asterism pairs, plus the key of one observation that uses the asterism, through which we can join to get the asterism's targets. 

The rest of the mapping follows trivially, as they say.