### PR TITLE
Observation/title

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0030__observations.sql
+++ b/modules/service/src/main/resources/db/migration/V0030__observations.sql
@@ -143,6 +143,7 @@ create table t_observation (
   c_program_id         d_program_id        not null    references t_program(c_program_id),
   c_observation_id     d_observation_id    primary key default 'o-' || to_hex(nextval('s_observation_id')),
   c_existence          e_existence         not null    default 'present',
+  c_title              text                not null    default 'Untargeted',
   c_subtitle           text                null        check (length(c_subtitle) > 0),
   c_instrument         d_tag               null        references t_instrument(c_tag),
   c_status             e_obs_status        not null    default 'new',

--- a/modules/service/src/main/resources/db/migration/V0080__asterism.sql
+++ b/modules/service/src/main/resources/db/migration/V0080__asterism.sql
@@ -33,6 +33,17 @@ BEGIN
     from t_asterism_target b
     where a.c_observation_id = b.c_observation_id),
     '[]'::jsonb
+  ), c_title = (
+    select array_to_string(
+      coalesce(
+          array_agg(coalesce(t.c_name, 'Unnamed') order by t.c_target_id), 
+          array['Untargeted']
+      ), 
+      ', '
+    )
+    from t_asterism_target b
+    join t_target t on b.c_target_id = t.c_target_id
+    where a.c_observation_id = b.c_observation_id
   )
   where a.c_observation_id = obsid;
   RETURN NEW;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -22,6 +22,7 @@ trait ObservationMapping[F[_]]
         SqlField("id", ObservationView.Id, key = true),
         SqlField("programId", ObservationView.ProgramId, hidden = true),
         SqlField("existence", ObservationView.Existence, hidden = true),
+        SqlField("title", ObservationView.Title),
         SqlField("subtitle", ObservationView.Subtitle),
         SqlField("status", ObservationView.Status),
         SqlField("activeStatus", ObservationView.ActiveStatus),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
@@ -15,10 +15,11 @@ trait ObservationView[F[_]] extends BaseMapping[F] {
       val ProgramId: ColumnRef         = col("c_program_id",         program_id)
       val Id: ColumnRef                = col("c_observation_id",     observation_id)
       val Existence: ColumnRef         = col("c_existence",          existence)
+      val Title: ColumnRef             = col("c_title",              text_nonempty)
       val Subtitle: ColumnRef          = col("c_subtitle",           text_nonempty.opt)
 //      val Instrument: m.ColumnRef   = col("c_instrument", tag.opt)
       val Status: ColumnRef            = col("c_status",             obs_status)
-      val ActiveStatus: ColumnRef      = col("c_active_status",      obs_active_status)
+      val ActiveStatus: ColumnRef      = col("c_active_status",      obs_active_status) 
       val VisualizationTime: ColumnRef = col("c_visualization_time", data_timestamp.opt)
       val AsterismGroup: ColumnRef     = col("c_asterism_group",     jsonb)
 


### PR DESCRIPTION
This adds the `title` field to `type Observation`, implemented as a trigger-maintained field. The field is updated when the asterism changes and when the target is renamed (which we can't do yet in the API but I monkey-tested it ... we'll add a real test when it's user-visible). Observations with no targets are titled "Untargeted".