### PR TITLE
generalize switchmapping

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AngleMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AngleMapping.scala
@@ -49,8 +49,8 @@ trait AngleMapping[F[_]] extends ObservationView[F] with MappingExtras[F]  {
     SwitchMapping(
       AngleType,
       List(
-        (PosAngleConstraintType,              "angle",           angleMapping(ObservationView.Id, ObservationView.PosAngleConstraint.Angle)),
-        (SpectroscopyScienceRequirementsType, "focalPlaneAngle", angleMapping(ObservationView.Id, ObservationView.ScienceRequirements.Spectroscopy.FocalPlaneAngle))
+        PosAngleConstraintType / "angle"                        -> angleMapping(ObservationView.Id, ObservationView.PosAngleConstraint.Angle),
+        SpectroscopyScienceRequirementsType / "focalPlaneAngle" -> angleMapping(ObservationView.Id, ObservationView.ScienceRequirements.Spectroscopy.FocalPlaneAngle),
       )
     )
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/DeclinationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/DeclinationMapping.scala
@@ -44,8 +44,8 @@ trait DeclinationMapping[F[_]] extends ObservationView[F] with TargetView[F] {
     SwitchMapping(
       DeclinationType,
       List(
-        (CoordinatesType, "dec", declinationMapping(ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Dec)),
-        (SiderealType,    "dec", declinationMapping(TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Dec))
+        CoordinatesType / "dec" -> declinationMapping(ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Dec),
+        SiderealType / "dec"    -> declinationMapping(TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Dec),
       )
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/NonNegDurationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/NonNegDurationMapping.scala
@@ -21,12 +21,12 @@ trait NonNegDurationMapping[F[_]] extends AllocationTable[F] with ProgramTable[F
     SwitchMapping(
       NonNegDurationType,
       List(
-        (PlannedTimeSummaryType, "pi",        nonNegDurationMapping(ProgramTable.PlannedTime.Pi)(ProgramTable.Id)),
-        (PlannedTimeSummaryType, "uncharged", nonNegDurationMapping(ProgramTable.PlannedTime.Uncharged)(ProgramTable.Id)),
-        (PlannedTimeSummaryType, "execution", nonNegDurationMapping(ProgramTable.PlannedTime.Execution)(ProgramTable.Id)),
-        (IntensiveType,          "totalTime", nonNegDurationMapping(ProposalTable.TotalTime)(ProposalTable.ProgramId)),
-        (LargeProgramType,       "totalTime", nonNegDurationMapping(ProposalTable.TotalTime)(ProposalTable.ProgramId)),
-        (AllocationType,         "duration",  nonNegDurationMapping(AllocationTable.Duration)(AllocationTable.ProgramId, AllocationTable.Partner)),
+        PlannedTimeSummaryType / "pi"        -> nonNegDurationMapping(ProgramTable.PlannedTime.Pi)(ProgramTable.Id),
+        PlannedTimeSummaryType / "uncharged" -> nonNegDurationMapping(ProgramTable.PlannedTime.Uncharged)(ProgramTable.Id),
+        PlannedTimeSummaryType / "execution" -> nonNegDurationMapping(ProgramTable.PlannedTime.Execution)(ProgramTable.Id),
+        IntensiveType / "totalTime"          -> nonNegDurationMapping(ProposalTable.TotalTime)(ProposalTable.ProgramId),
+        LargeProgramType / "totalTime"       -> nonNegDurationMapping(ProposalTable.TotalTime)(ProposalTable.ProgramId),
+        AllocationType / "duration"          -> nonNegDurationMapping(AllocationTable.Duration)(AllocationTable.ProgramId, AllocationTable.Partner),
       ),
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationSelectResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationSelectResultMapping.scala
@@ -18,11 +18,11 @@ trait ObservationSelectResultMapping[F[_]]
     SwitchMapping(
       ObservationSelectResultType, 
       List(
-        (QueryType, "observations", topLevelSelectResultMapping(ObservationSelectResultType)),
-        (ProgramType, "observations", nestedSelectResultMapping(ObservationSelectResultType, ProgramTable.Id, Join(ProgramTable.Id, ObservationView.ProgramId))),
-        (ConstraintSetGroupType, "observations", nestedSelectResultMapping(ObservationSelectResultType, ConstraintSetGroupView.ConstraintSetKey, Join(ConstraintSetGroupView.ConstraintSetKey, ObservationView.ConstraintSet.Key))),
-        (TargetGroupType, "observations", nestedSelectResultMapping(ObservationSelectResultType, TargetView.TargetId, Join(TargetView.TargetId, AsterismTargetTable.TargetId), Join(AsterismTargetTable.ObservationId, ObservationView.Id))),
-        (AsterismGroupType, "observations", nestedSelectResultMapping(ObservationSelectResultType, AsterismGroupView.AsterismGroup, Join(AsterismGroupView.AsterismGroup, ObservationView.AsterismGroup))),
+        QueryType / "observations"              -> topLevelSelectResultMapping(ObservationSelectResultType),
+        ProgramType / "observations"            -> nestedSelectResultMapping(ObservationSelectResultType, ProgramTable.Id, Join(ProgramTable.Id, ObservationView.ProgramId)),
+        ConstraintSetGroupType / "observations" -> nestedSelectResultMapping(ObservationSelectResultType, ConstraintSetGroupView.ConstraintSetKey, Join(ConstraintSetGroupView.ConstraintSetKey, ObservationView.ConstraintSet.Key)),
+        TargetGroupType / "observations"        -> nestedSelectResultMapping(ObservationSelectResultType, TargetView.TargetId, Join(TargetView.TargetId, AsterismTargetTable.TargetId), Join(AsterismTargetTable.ObservationId, ObservationView.Id)),
+        AsterismGroupType / "observations"      -> nestedSelectResultMapping(ObservationSelectResultType, AsterismGroupView.AsterismGroup, Join(AsterismGroupView.AsterismGroup, ObservationView.AsterismGroup)),
       )
     )
     

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/PlannedTimeSummaryMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/PlannedTimeSummaryMapping.scala
@@ -23,13 +23,19 @@ import input._
 import table._
 
 trait PlannedTimeSummaryMapping[F[_]]
-  extends ProgramTable[F] { this: SkunkMapping[F] =>
+  extends ProgramTable[F] with ObservationView[F] {
 
   lazy val PlannedTimeSummaryMapping: TypeMapping =
+    SwitchMapping(PlannedTimeSummaryType, List(
+      ProgramType / "plannedTimeSummary"     -> plannedTimeSummaryMapping(ProgramTable.Id),
+      ObservationType / "plannedTimeSummary" -> plannedTimeSummaryMapping(ObservationView.Id),
+    ))
+
+  private def plannedTimeSummaryMapping(keyColumnRef: ColumnRef): ObjectMapping =
     ObjectMapping(
       tpe = PlannedTimeSummaryType,
       fieldMappings = List(
-        SqlField("id", ProgramTable.Id, key = true, hidden = true),
+        SqlField("id", keyColumnRef, key = true, hidden = true),
         SqlObject("pi"),
         SqlObject("execution"),
         SqlObject("uncharged"),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/RightAscensionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/RightAscensionMapping.scala
@@ -45,8 +45,8 @@ trait RightAscensionMapping[F[_]] extends ObservationView[F] with TargetView[F] 
     SwitchMapping(
       RightAscensionType,
       List(
-        (CoordinatesType, "ra", rightAscensionMapping(ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Ra)),
-        (SiderealType,    "ra", rightAscensionMapping(TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Ra))
+        CoordinatesType / "ra" -> rightAscensionMapping(ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Ra),
+        SiderealType / "ra"    -> rightAscensionMapping(TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Ra),
       )
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/WavelengthMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/WavelengthMapping.scala
@@ -43,13 +43,13 @@ trait WavelengthMapping[F[_]]
     SwitchMapping(
       WavelengthType,
       List(
-        (GmosNorthLongSlitType,               "centralWavelength",        wavelengthMapping(GmosNorthLongSlitView.Common.ObservationId, GmosNorthLongSlitView.Common.CentralWavelength)),
-        (GmosNorthLongSlitType,               "initialCentralWavelength", wavelengthMapping(GmosNorthLongSlitView.Common.ObservationId, GmosNorthLongSlitView.Common.InitialCentralWavelength)),
-        (GmosSouthLongSlitType,               "centralWavelength",        wavelengthMapping(GmosSouthLongSlitView.Common.ObservationId, GmosSouthLongSlitView.Common.CentralWavelength)),
-        (GmosSouthLongSlitType,               "initialCentralWavelength", wavelengthMapping(GmosSouthLongSlitView.Common.ObservationId, GmosSouthLongSlitView.Common.InitialCentralWavelength)),
-        (SpectroscopyScienceRequirementsType, "wavelength",               wavelengthMapping(ObservationView.Id, Spectroscopy.Wavelength)),
-        (SpectroscopyScienceRequirementsType, "signalToNoiseAt",          wavelengthMapping(ObservationView.Id, Spectroscopy.SignalToNoiseAt)),
-        (SpectroscopyScienceRequirementsType, "wavelengthCoverage",       wavelengthMapping(ObservationView.Id, Spectroscopy.WavelengthCoverage))
+        GmosNorthLongSlitType / "centralWavelength"                -> wavelengthMapping(GmosNorthLongSlitView.Common.ObservationId, GmosNorthLongSlitView.Common.CentralWavelength),
+        GmosNorthLongSlitType / "initialCentralWavelength"         -> wavelengthMapping(GmosNorthLongSlitView.Common.ObservationId, GmosNorthLongSlitView.Common.InitialCentralWavelength),
+        GmosSouthLongSlitType / "centralWavelength"                -> wavelengthMapping(GmosSouthLongSlitView.Common.ObservationId, GmosSouthLongSlitView.Common.CentralWavelength),
+        GmosSouthLongSlitType / "initialCentralWavelength"         -> wavelengthMapping(GmosSouthLongSlitView.Common.ObservationId, GmosSouthLongSlitView.Common.InitialCentralWavelength),
+        SpectroscopyScienceRequirementsType / "wavelength"         -> wavelengthMapping(ObservationView.Id, Spectroscopy.Wavelength),
+        SpectroscopyScienceRequirementsType / "signalToNoiseAt"    -> wavelengthMapping(ObservationView.Id, Spectroscopy.SignalToNoiseAt),
+        SpectroscopyScienceRequirementsType / "wavelengthCoverage" -> wavelengthMapping(ObservationView.Id, Spectroscopy.WavelengthCoverage),
       )
     )
 }


### PR DESCRIPTION
This generalize `SwitchMapping` to take a list of `(Path, ObjectMapping)` pairs (I have run into a case where type + fieldname isn't good enough).