### PR TITLE
query vs transport

### DIFF
--- a/modules/schema/src/main/scala/lucuma/odb/json/all.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/all.scala
@@ -3,8 +3,26 @@
 
 package lucuma.odb.json
 
-object all
-  extends AngleCodec
-     with NumericCodecs
-     with SourceProfileCodec
-     with WavelengthCodec
+object all {
+
+  trait UniversalCodecs
+    extends GmosCodec
+       with NumericCodec
+       with SourceProfileCodec
+       with StepConfigCodec
+
+  object query
+    extends angle.QueryCodec
+       with offset.QueryCodec
+       with time.QueryCodec
+       with wavelength.QueryCodec
+       with UniversalCodecs
+
+  object transport
+    extends angle.TransportCodec
+       with offset.TransportCodec
+       with time.TransportCodec
+       with wavelength.TransportCodec
+       with UniversalCodecs
+
+}

--- a/modules/schema/src/main/scala/lucuma/odb/json/gmos.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/gmos.scala
@@ -1,0 +1,195 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import cats.syntax.either.*
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.Codec
+import io.circe.Decoder
+import io.circe.DecodingFailure
+import io.circe.Encoder
+import io.circe.HCursor
+import io.circe.Json
+import io.circe.refined._
+import io.circe.syntax._
+import lucuma.core.enums.GmosAmpCount
+import lucuma.core.enums.GmosAmpGain
+import lucuma.core.enums.GmosAmpReadMode
+import lucuma.core.enums.GmosCustomSlitWidth
+import lucuma.core.enums.GmosDtax
+import lucuma.core.enums.GmosGratingOrder
+import lucuma.core.enums.GmosNorthFilter
+import lucuma.core.enums.GmosNorthFpu
+import lucuma.core.enums.GmosNorthGrating
+import lucuma.core.enums.GmosRoi
+import lucuma.core.enums.GmosSouthFilter
+import lucuma.core.enums.GmosSouthFpu
+import lucuma.core.enums.GmosSouthGrating
+import lucuma.core.enums.GmosXBinning
+import lucuma.core.enums.GmosYBinning
+import lucuma.core.math.Wavelength
+import lucuma.core.model.sequence.DynamicConfig.GmosNorth
+import lucuma.core.model.sequence.DynamicConfig.GmosSouth
+import lucuma.core.model.sequence.GmosCcdMode
+import lucuma.core.model.sequence.GmosFpuMask
+import lucuma.core.model.sequence.GmosGratingConfig
+
+import java.time.Duration
+
+trait GmosCodec {
+
+  import time.decoder.given
+  import wavelength.decoder.given
+
+  given Decoder[GmosCcdMode] =
+    Decoder.instance { c =>
+      for {
+        x <- c.downField("xBin").as[GmosXBinning]
+        y <- c.downField("yBin").as[GmosYBinning]
+        n <- c.downField("ampCount").as[GmosAmpCount]
+        g <- c.downField("ampGain").as[GmosAmpGain]
+        m <- c.downField("ampReadMode").as[GmosAmpReadMode]
+      } yield GmosCcdMode(x, y, n, g, m)
+    }
+
+  given Decoder[GmosFpuMask.Custom] =
+    Decoder.instance { c =>
+      for {
+        f <- c.downField("filename").as[String].flatMap { s =>
+          NonEmptyString.from(s).leftMap { m => DecodingFailure(s"GMOS custom mask file name cannot be empty", c.history) }
+        }
+        s <- c.downField("slitWidth").as[GmosCustomSlitWidth]
+      } yield GmosFpuMask.Custom(f, s)
+    }
+
+  given [A](using Decoder[A]): Decoder[GmosFpuMask[A]] =
+    Decoder.instance[GmosFpuMask[A]] { c =>
+      c.downField("builtin").as[A].map { a =>
+        GmosFpuMask.Builtin[A](a)
+      } orElse
+        c.downField("customMask").as[GmosFpuMask.Custom]
+    }
+
+  given Decoder[GmosGratingConfig.North] =
+    Decoder.instance { c =>
+      for {
+        g <- c.downField("grating").as[GmosNorthGrating]
+        o <- c.downField("order").as[GmosGratingOrder]
+        w <- c.downField("wavelength").as[Wavelength]
+      } yield GmosGratingConfig.North(g, o, w)
+    }
+
+  given Decoder[GmosGratingConfig.South] =
+    Decoder.instance { c =>
+      for {
+        g <- c.downField("grating").as[GmosSouthGrating]
+        o <- c.downField("order").as[GmosGratingOrder]
+        w <- c.downField("wavelength").as[Wavelength]
+      } yield GmosGratingConfig.South(g, o, w)
+    }
+
+  given Decoder[GmosNorth] =
+    Decoder.instance { c =>
+      for {
+        e <- c.downField("exposure").as[Duration]
+        r <- c.downField("readout").as[GmosCcdMode]
+        x <- c.downField("dtax").as[GmosDtax]
+        i <- c.downField("roi").as[GmosRoi]
+        g <- c.downField("gratingConfig").as[Option[GmosGratingConfig.North]]
+        f <- c.downField("filter").as[Option[GmosNorthFilter]]
+        u <- c.downField("fpu").as[Option[GmosFpuMask[GmosNorthFpu]]]
+      } yield GmosNorth(e, r, x, i, g, f, u)
+    }
+
+  given Decoder[GmosSouth] =
+    Decoder.instance { c =>
+      for {
+        e <- c.downField("exposure").as[Duration]
+        r <- c.downField("readout").as[GmosCcdMode]
+        x <- c.downField("dtax").as[GmosDtax]
+        i <- c.downField("roi").as[GmosRoi]
+        g <- c.downField("gratingConfig").as[Option[GmosGratingConfig.South]]
+        f <- c.downField("filter").as[Option[GmosSouthFilter]]
+        u <- c.downField("fpu").as[Option[GmosFpuMask[GmosSouthFpu]]]
+      } yield GmosSouth(e, r, x, i, g, f, u)
+    }
+
+  given Encoder[GmosCcdMode] =
+    Encoder.instance { (a: GmosCcdMode) =>
+      Json.obj(
+        "xBin"        -> a.xBin.asJson,
+        "yBin"        -> a.yBin.asJson,
+        "ampCount"    -> a.ampCount.asJson,
+        "ampGain"     -> a.ampGain.asJson,
+        "ampReadMode" -> a.ampReadMode.asJson
+      )
+    }
+
+  given Encoder[GmosFpuMask.Custom] =
+    Encoder.instance { (a: GmosFpuMask.Custom) =>
+      Json.obj(
+        "filename"  -> a.filename.value.asJson,
+        "slitWidth" -> a.slitWidth.asJson
+      )
+    }
+
+  given [A](using Encoder[A]): Encoder[GmosFpuMask[A]] =
+    Encoder.instance[GmosFpuMask[A]] {
+      case GmosFpuMask.Builtin(v)       =>
+        Json.obj(
+          "builtin"    -> v.asJson
+        )
+      case c @ GmosFpuMask.Custom(_, _) =>
+        Json.obj(
+          "customMask" -> c.asJson
+        )
+    }
+
+  given (using Encoder[Wavelength]): Encoder[GmosGratingConfig.North] =
+    Encoder.instance { (a: GmosGratingConfig.North) =>
+      Json.obj(
+        "grating"    -> a.grating.asJson,
+        "order"      -> a.order.asJson,
+        "wavelength" -> a.wavelength.asJson
+      )
+    }
+
+  given (using Encoder[Wavelength]): Encoder[GmosGratingConfig.South] =
+    Encoder.instance { (a: GmosGratingConfig.South) =>
+      Json.obj(
+        "grating"    -> a.grating.asJson,
+        "order"      -> a.order.asJson,
+        "wavelength" -> a.wavelength.asJson
+      )
+    }
+
+  given (using Encoder[Duration], Encoder[Wavelength]): Encoder[GmosNorth] =
+    Encoder.instance { (a: GmosNorth) =>
+      Json.obj(
+        "exposure"      -> a.exposure.asJson,
+        "readout"       -> a.readout.asJson,
+        "dtax"          -> a.dtax.asJson,
+        "roi"           -> a.roi.asJson,
+        "gratingConfig" -> a.gratingConfig.asJson,
+        "filter"        -> a.filter.asJson,
+        "fpu"           -> a.fpu.asJson
+      )
+    }
+
+  given (using Encoder[Duration], Encoder[Wavelength]): Encoder[GmosSouth] =
+    Encoder.instance { (a: GmosSouth) =>
+      Json.obj(
+        "exposure"      -> a.exposure.asJson,
+        "readout"       -> a.readout.asJson,
+        "dtax"          -> a.dtax.asJson,
+        "roi"           -> a.roi.asJson,
+        "gratingConfig" -> a.gratingConfig.asJson,
+        "filter"        -> a.filter.asJson,
+        "fpu"           -> a.fpu.asJson
+      )
+    }
+
+}
+
+object gmos extends GmosCodec

--- a/modules/schema/src/main/scala/lucuma/odb/json/numeric.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/numeric.scala
@@ -14,7 +14,7 @@ import io.circe.refined._
 import io.circe.syntax._
 
 
-trait NumericCodecs {
+trait NumericCodec {
 
   given Codec[PosBigDecimal] =
     Codec[BigDecimal].iemap(PosBigDecimal.from)(_.value)
@@ -33,4 +33,4 @@ trait NumericCodecs {
 
 }
 
-object numeric extends NumericCodecs
+object numeric extends NumericCodec

--- a/modules/schema/src/main/scala/lucuma/odb/json/offset.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/offset.scala
@@ -1,0 +1,99 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import io.circe.Codec
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.HCursor
+import io.circe.Json
+import io.circe.refined._
+import io.circe.syntax._
+import lucuma.core.math.Angle
+import lucuma.core.math.Offset
+import lucuma.core.optics.SplitMono
+
+import java.math.RoundingMode.HALF_UP
+
+object offset {
+
+  private def µas[A]: SplitMono[Offset.Component[A], Long] =
+    Angle.signedMicroarcseconds.reverse.andThen(Offset.Component.angle[A].reverse).reverse
+
+  trait DecoderOffset {
+
+    private def µasDecoder[A]: Decoder[Offset.Component[A]] =
+      Decoder.instance(_.downField("microarcseconds").as[Long].map(µas.reverseGet))
+
+    private def roundingDecoder[A](field: String, right: Int): Decoder[Offset.Component[A]] =
+      Decoder.instance(
+        _.downField(field)
+         .as[BigDecimal]
+         .map { bd =>
+           µas.reverseGet(
+             bd.bigDecimal.movePointRight(right).setScale(0, HALF_UP).longValueExact
+           )
+         }
+      )
+
+    given [A]: Decoder[Offset.Component[A]] =
+      µasDecoder                             or
+        roundingDecoder("milliarcseconds",3) or
+        roundingDecoder("arcseconds",     6)
+
+    given Decoder[Offset] =
+      Decoder.instance { c =>
+        for {
+          p <- c.downField("p").as[Offset.P]
+          q <- c.downField("q").as[Offset.Q]
+        } yield Offset(p, q)
+      }
+
+  }
+
+  object decoder extends DecoderOffset
+
+  trait QueryCodec extends DecoderOffset {
+
+    given Encoder_Offset_Component[A]: Encoder[Offset.Component[A]] =
+      Encoder.instance { a =>
+        Json.obj(
+          "microarcseconds" -> µas.get(a).asJson,
+          "milliarcseconds" -> BigDecimal(µas.get(a), 3).asJson,
+          "arcseconds"      -> BigDecimal(µas.get(a), 6).asJson
+        )
+      }
+
+    given Encoder_Offset: Encoder[Offset] =
+      Encoder.instance { a =>
+        Json.obj(
+          "p" -> a.p.asJson,
+          "q" -> a.q.asJson
+        )
+      }
+  }
+
+  object query extends QueryCodec
+
+  trait TransportCodec extends DecoderOffset {
+
+    given Encoder_Offset_Component[A]: Encoder[Offset.Component[A]] =
+      Encoder.instance { a =>
+        Json.obj(
+          "microarcseconds" -> µas.get(a).asJson
+        )
+      }
+
+    given Encoder_Offset: Encoder[Offset] =
+      Encoder.instance { a =>
+        Json.obj(
+          "p" -> a.p.asJson,
+          "q" -> a.q.asJson
+        )
+      }
+
+  }
+
+  object transport extends TransportCodec
+}

--- a/modules/schema/src/main/scala/lucuma/odb/json/stepconfig.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/stepconfig.scala
@@ -1,0 +1,88 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import cats.syntax.either.*
+import io.circe.Codec
+import io.circe.Decoder
+import io.circe.DecodingFailure
+import io.circe.Encoder
+import io.circe.HCursor
+import io.circe.Json
+import io.circe.refined._
+import io.circe.syntax._
+import lucuma.core.enums.GcalArc
+import lucuma.core.enums.GcalContinuum
+import lucuma.core.enums.GcalDiffuser
+import lucuma.core.enums.GcalFilter
+import lucuma.core.enums.GcalShutter
+import lucuma.core.enums.StepType
+import lucuma.core.math.Offset
+import lucuma.core.model.sequence.StepConfig
+
+trait StepConfigCodec {
+
+  import offset.decoder.given
+
+  given Decoder[StepConfig.Gcal] =
+    Decoder.instance { c =>
+      for {
+        u <- c.downField("continuum").as[Option[GcalContinuum]]
+        a <- c.downField("arcs").as[List[GcalArc]]
+        f <- c.downField("filter").as[GcalFilter]
+        d <- c.downField("diffuser").as[GcalDiffuser]
+        s <- c.downField("shutter").as[GcalShutter]
+      } yield StepConfig.Gcal(u, a, f, d, s)
+    }
+
+  given Encoder[StepConfig.Gcal] =
+    Encoder.instance { (a: StepConfig.Gcal) =>
+      Json.obj(
+        "continuum" -> a.continuum.asJson,
+        "arcs"      -> a.arcs.asJson,
+        "filter"    -> a.filter.asJson,
+        "diffuser"  -> a.diffuser.asJson,
+        "shutter"   -> a.shutter.asJson
+      )
+    }
+
+  given Decoder[StepConfig.Science] =
+    Decoder.instance { c =>
+      c.downField("offset").as[Offset].map { o =>
+        StepConfig.Science(o)
+      }
+    }
+
+  given (using Encoder[Offset]): Encoder[StepConfig.Science] =
+    Encoder.instance { (a: StepConfig.Science) =>
+      Json.obj(
+        "offset" -> a.offset.asJson
+      )
+    }
+
+  given Decoder[StepConfig] =
+    Decoder.instance { c =>
+      c.downField("stepType").as[StepType].flatMap {
+        case StepType.Bias      => StepConfig.Bias.asRight[DecodingFailure]
+        case StepType.Dark      => StepConfig.Dark.asRight[DecodingFailure]
+        case StepType.Gcal      => c.as[StepConfig.Gcal]
+        case StepType.Science   => c.as[StepConfig.Science]
+        case StepType.SmartGcal => DecodingFailure("SmartGcal not implemented", c.history).asLeft[StepConfig]
+      }
+    }
+
+  given (using Encoder[Offset]): Encoder[StepConfig] =
+    Encoder.instance { (a: StepConfig) =>
+      (a match {
+        case _: StepConfig.Bias.type => Json.obj()
+        case _: StepConfig.Dark.type => Json.obj()
+        case s: StepConfig.Science   => s.asJson
+        case g: StepConfig.Gcal      => g.asJson
+      }).mapObject(("stepType" -> a.stepType.asJson) +: _)
+    }
+
+}
+
+object stepconfig extends StepConfigCodec
+

--- a/modules/schema/src/main/scala/lucuma/odb/json/time.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/time.scala
@@ -1,0 +1,105 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import cats.syntax.bifunctor.*
+import cats.syntax.either.*
+import io.circe.Codec
+import io.circe.Decoder
+import io.circe.DecodingFailure
+import io.circe.Encoder
+import io.circe.HCursor
+import io.circe.Json
+import io.circe.refined._
+import io.circe.syntax._
+
+import java.math.RoundingMode.DOWN
+import java.time.Duration
+import java.time.temporal.ChronoUnit.MICROS
+import scala.util.Try
+
+object time {
+
+  // N.B. We cannot represent any random `Duration` with the existing GraphQL
+  // schema.  Only a Duration expressed as a `Long` in milliseconds can be
+  // represented.  We need to either change the schema or make a specialized
+  // duration type.
+
+  trait DecoderTime {
+
+    given Decoder[Duration] =
+      Decoder.instance { c =>
+        def fromDecimal(field: String, µs: Long): Decoder.Result[Duration] =
+          c.downField(field).as[BigDecimal].map { bd =>
+            val decMicro = (bd * µs).bigDecimal
+            val decSecs  = decMicro.movePointLeft(6)
+            val longSecs = decSecs.setScale(0, DOWN)
+            val longNano = (decSecs.subtract(longSecs)).movePointRight(6).setScale(0, DOWN).movePointRight(3)
+            Duration.ofSeconds(longSecs.longValueExact, longNano.longValueExact)
+          }
+
+        c.downField("microseconds").as[Long].map { µs =>
+          val secs = µs / 1_000_000L
+          val nano = (µs % 1_000_000L) * 1_000L
+          Duration.ofSeconds(secs, nano)
+        } orElse
+          fromDecimal("milliseconds",  1_000L) orElse
+          fromDecimal("seconds",   1_000_000L) orElse
+          fromDecimal("minutes",  60_000_000L) orElse
+          fromDecimal("hours", 3_600_000_000L) orElse
+          c.downField("iso").as[String].flatMap { iso =>
+            Try(Duration.parse(iso)).toEither.leftMap(_ => DecodingFailure(s"Could not parse `$iso` as a duration", c.history))
+          } orElse
+          DecodingFailure(s"Could not parse duration value", c.history).asLeft
+      }
+
+  }
+
+  object decoder extends DecoderTime
+
+  private def microseconds(d: Duration): BigDecimal = {
+    val d2 = d.truncatedTo(MICROS)
+
+    BigDecimal(
+      new java.math.BigDecimal(d2.getSeconds)
+        .movePointRight(9)
+        .add(new java.math.BigDecimal(d2.getNano))
+        .movePointLeft(3)
+        .setScale(0, DOWN)
+    )
+  }
+
+
+  trait QueryCodec extends DecoderTime {
+    given Encoder_Duration: Encoder[Duration] =
+      Encoder { (d: Duration) =>
+        val µs = microseconds(d)
+
+        Json.obj(
+          "microseconds" -> µs.longValue.asJson,
+          "milliseconds" -> (µs /         1_000L).asJson,
+          "seconds"      -> (µs /     1_000_000L).asJson,
+          "minutes"      -> (µs /    60_000_000L).asJson,
+          "hours"        -> (µs / 3_600_000_000L).asJson,
+          "iso"          -> µs.toString.asJson
+        )
+      }
+  }
+
+  object query extends QueryCodec
+
+  trait TransportCodec extends DecoderTime {
+    given Encoder_Duration: Encoder[Duration] =
+      Encoder.instance { (d: Duration) =>
+        Json.obj(
+          "microseconds" -> microseconds(d).longValue.asJson
+        )
+      }
+  }
+
+  object transport extends TransportCodec
+
+}
+
+

--- a/modules/schema/src/main/scala/lucuma/odb/json/wavelength.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/wavelength.scala
@@ -3,36 +3,69 @@
 
 package lucuma.odb.json
 
-
 import io.circe.Codec
 import io.circe.Decoder
 import io.circe.DecodingFailure
+import io.circe.Encoder
 import io.circe.HCursor
 import io.circe.Json
 import io.circe.refined._
 import io.circe.syntax._
 import lucuma.core.math.Wavelength
+import lucuma.core.optics.Format
 
-trait WavelengthCodec {
-  given Codec[Wavelength] with {
-    def apply(w: Wavelength): Json =
-      Json.obj(
-        "picometers"  -> w.toPicometers.value.value.asJson,
-        "angstroms"   -> Wavelength.decimalAngstroms.reverseGet(w).asJson,
-        "nanometers"  -> Wavelength.decimalNanometers.reverseGet(w).asJson,
-        "micrometers" -> Wavelength.decimalMicrometers.reverseGet(w).asJson,
-      )
+import java.math.RoundingMode.HALF_UP
 
-    def apply(c: HCursor): Decoder.Result[Wavelength] =
-      c.downField("picometers").as[Int].flatMap { pm =>
-        Wavelength
-          .intPicometers
-          .getOption(pm)
-          .toRight(DecodingFailure(s"Invalid wavelength picometers value: $pm", c.history))
+object wavelength {
+
+  trait DecoderWavelength {
+
+    given Decoder[Wavelength] =
+      Decoder.instance { c =>
+        def fromDecimal(field: String, fmt: Format[BigDecimal, Wavelength]): Decoder.Result[Wavelength] =
+          c.downField(field).as[BigDecimal].flatMap { bd =>
+            fmt.getOption(bd).toRight(DecodingFailure(s"Invalid $field wavelength value: $bd", c.history))
+          }
+
+        c.downField("picometers").as[Int].flatMap { pm =>
+          Wavelength
+            .intPicometers
+            .getOption(pm)
+            .toRight(DecodingFailure(s"Invalid wavelength picometers value: $pm", c.history))
+        } orElse
+        fromDecimal("angstroms", Wavelength.decimalAngstroms) orElse
+        fromDecimal("nanometers", Wavelength.decimalNanometers) orElse
+        fromDecimal("micrometers", Wavelength.decimalMicrometers)
+      }
+
+  }
+
+  object decoder extends DecoderWavelength
+
+  trait QueryCodec extends DecoderWavelength {
+    given Encoder_Wavelength: Encoder[Wavelength] =
+      Encoder.instance { (w: Wavelength) =>
+        Json.obj(
+          "picometers"  -> w.toPicometers.value.value.asJson,
+          "angstroms"   -> Wavelength.decimalAngstroms.reverseGet(w).asJson,
+          "nanometers"  -> Wavelength.decimalNanometers.reverseGet(w).asJson,
+          "micrometers" -> Wavelength.decimalMicrometers.reverseGet(w).asJson,
+        )
       }
   }
 
-}
+  object query extends QueryCodec
 
-object wavelength extends WavelengthCodec
+  trait TransportCodec extends DecoderWavelength {
+    given Encoder_Wavelength: Encoder[Wavelength] =
+      Encoder.instance { (w: Wavelength) =>
+        Json.obj(
+          "picometers"  -> w.toPicometers.value.value.asJson
+        )
+      }
+  }
+
+  object transport extends TransportCodec
+
+}
 

--- a/modules/schema/src/test/scala/lucuma/odb/json/AngleSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/json/AngleSuite.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import cats.syntax.eq.*
+import cats.syntax.functor.*
+import cats.syntax.traverse.*
+import io.circe.Codec
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.testing.ArbitraryInstances
+import io.circe.testing.CodecTests
+import lucuma.core.math.Angle
+import lucuma.core.math.arb.ArbAngle.*
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop
+import org.scalacheck.Prop.*
+
+abstract class AngleSuite(using Encoder[Angle]) extends DisciplineSuite with ArbitraryInstances {
+
+  import angle.decoder.given
+
+  checkAll("AngleCodec", CodecTests[Angle].codec)
+
+  val angleKeys: Set[String] =
+    Set(
+      "microarcseconds",
+      "milliarcseconds",
+      "arcseconds",
+      "arcminutes",
+      "degrees",
+      "dms"
+    )
+
+  test("all `angle` angle encoders produce the same angle") {
+    conversionTest[Angle](angleKeys)
+  }
+
+}
+
+class AngleQuerySuite extends AngleSuite(using
+  angle.query.Encoder_Angle
+) {
+
+  val timeKeys: Set[String] =
+    Set(
+      "microseconds",
+      "milliseconds",
+      "seconds",
+      "minutes",
+      "hours",
+      "hms"
+    )
+
+  import angle.query.given
+
+  test("all `time` angle encoders produce the same angle") {
+    conversionTest[Angle](timeKeys)
+  }
+
+}
+
+class AngleTransportSuite extends AngleSuite(using
+  angle.transport.Encoder_Angle
+)

--- a/modules/schema/src/test/scala/lucuma/odb/json/GmosSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/json/GmosSuite.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import io.circe.testing.ArbitraryInstances
+import io.circe.testing.CodecTests
+import lucuma.core.model.sequence.DynamicConfig.GmosNorth
+import lucuma.core.model.sequence.DynamicConfig.GmosSouth
+import lucuma.core.model.sequence.arb.ArbDynamicConfig
+import munit.DisciplineSuite
+
+class GmosSuite extends DisciplineSuite with ArbitraryInstances {
+
+  import ArbDynamicConfig.*
+  import angle.query.given
+  import gmos.given
+  import time.query.given
+  import wavelength.query.given
+
+  checkAll("GmosCodec", CodecTests[GmosNorth].codec)
+}

--- a/modules/schema/src/test/scala/lucuma/odb/json/OffsetSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/json/OffsetSuite.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import io.circe.Encoder
+import io.circe.testing.ArbitraryInstances
+import io.circe.testing.CodecTests
+import lucuma.core.math.Offset
+import lucuma.core.math.arb.ArbOffset.*
+import munit.DisciplineSuite
+
+abstract class OffsetSuite[A](using Encoder[Offset.Component[A]], Encoder[Offset]) extends DisciplineSuite with ArbitraryInstances {
+
+  import offset.decoder.given
+
+  checkAll("OffsetCodec",        CodecTests[Offset].codec)
+
+  test("all offset encoders produce the same offset") {
+    conversionTest[Offset.Component[A]]()
+  }
+
+}
+
+class OffsetQuerySuite extends OffsetSuite[Offset.P](using
+  offset.query.Encoder_Offset_Component,
+  offset.query.Encoder_Offset
+)
+
+class OffsetTransportSuite extends OffsetSuite[Offset.P](using
+  offset.transport.Encoder_Offset_Component,
+  offset.transport.Encoder_Offset
+)

--- a/modules/schema/src/test/scala/lucuma/odb/json/SourceProfileSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/json/SourceProfileSuite.scala
@@ -9,10 +9,12 @@ import lucuma.core.model.SourceProfile
 import lucuma.core.model.arb.ArbSourceProfile
 import munit.DisciplineSuite
 
-class SourceProfileCodecSuite extends DisciplineSuite with ArbitraryInstances {
+class SourceProfileSuite extends DisciplineSuite with ArbitraryInstances {
 
   import ArbSourceProfile.given
+  import angle.query.given
   import sourceprofile.given
+  import wavelength.query.given
 
   checkAll("SourceProfileCodec", CodecTests[SourceProfile].codec)
 

--- a/modules/schema/src/test/scala/lucuma/odb/json/StepConfigSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/json/StepConfigSuite.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import io.circe.testing.ArbitraryInstances
+import io.circe.testing.CodecTests
+import lucuma.core.model.sequence.StepConfig
+import lucuma.core.model.sequence.arb.ArbStepConfig
+import munit.DisciplineSuite
+
+class StepConfigSuite extends DisciplineSuite with ArbitraryInstances {
+
+  import ArbStepConfig.*
+
+  import offset.query.given
+  import stepconfig.given
+
+  checkAll("StepConfigCodec", CodecTests[StepConfig].codec)
+}

--- a/modules/schema/src/test/scala/lucuma/odb/json/TimeSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/json/TimeSuite.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import cats.Eq
+import cats.syntax.eq.*
+import cats.syntax.functor.*
+import cats.syntax.traverse.*
+import io.circe.Codec
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.testing.ArbitraryInstances
+import io.circe.testing.CodecTests
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Gen
+import org.scalacheck.Prop
+import org.scalacheck.Prop.*
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit.MICROS
+
+abstract class TimeSuite(using Encoder[Duration]) extends DisciplineSuite with ArbitraryInstances {
+
+  import time.decoder.given
+
+  // A real arbitrary duration cannot always be encoded in a way that matches
+  // the schema.  Only durations that fit in a `Long` with unit microseconds.
+  given Arbitrary[Duration] =
+    Arbitrary {
+      for {
+        m <- arbitrary[Long]
+        s  = m % 1
+        n <- Gen.chooseNum(0L, 999_999_999L)
+      } yield {
+        val n = (m % 1_000_000).abs * 1_000
+        val s = m/1_000_000
+        Duration.ofSeconds(s, n)
+      }
+    }
+
+  given Eq[Duration] =
+    Eq.by { d =>
+      (d.getSeconds, d.getNano)
+    }
+
+  import time.given
+
+  // This won't round-trip with a real arbitrary Duration.
+  checkAll("DurationCodec", CodecTests[Duration].codec)
+}
+
+class TimeQuerySuite extends TimeSuite(using time.query.Encoder_Duration)
+
+class TimeTransportSuite extends TimeSuite(using time.transport.Encoder_Duration)

--- a/modules/schema/src/test/scala/lucuma/odb/json/WavelengthSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/json/WavelengthSuite.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import cats.syntax.eq.*
+import cats.syntax.functor.*
+import cats.syntax.traverse.*
+import io.circe.Codec
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.testing.ArbitraryInstances
+import io.circe.testing.CodecTests
+import lucuma.core.math.Wavelength
+import lucuma.core.math.arb.ArbWavelength.*
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop
+import org.scalacheck.Prop.*
+
+abstract class WavelengthSuite(using Encoder[Wavelength]) extends DisciplineSuite with ArbitraryInstances {
+
+  import wavelength.decoder.given
+
+  checkAll("WavelengthCodec", CodecTests[Wavelength].codec)
+
+  test("all wavelength encoders produce the same wavelength") {
+    conversionTest[Wavelength]()
+  }
+
+}
+
+class WavelengthQuerySuite extends WavelengthSuite(using
+  wavelength.query.Encoder_Wavelength
+)
+
+class WavelengthTransportSuite extends WavelengthSuite(using
+  wavelength.transport.Encoder_Wavelength
+)

--- a/modules/schema/src/test/scala/lucuma/odb/json/conversionTest.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/json/conversionTest.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import cats.syntax.eq.*
+import cats.syntax.functor.*
+import cats.syntax.traverse.*
+import io.circe.Codec
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.testing.ArbitraryInstances
+import io.circe.testing.CodecTests
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop
+import org.scalacheck.Prop.*
+
+def conversionTest[A: Arbitrary : Decoder : Encoder](keys: Set[String] = Set.empty): Prop =
+  forAll { (a: A, i: Int) =>
+    Encoder[A].apply(a).asObject.exists { o =>
+
+      // Leave only the keys referring to equivalent values in distinct units
+      val o2 = if (keys.isEmpty) o else o.filterKeys(keys.contains)
+
+      // Now all values should decode to the same thing.
+      o2.toList.traverse { case (key, json) =>
+        Decoder[A].apply(Json.obj(key -> json).hcursor)
+      }.exists(_.toSet.size === 1)
+    }
+  }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/instances/ItcResultEncoder.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/instances/ItcResultEncoder.scala
@@ -8,6 +8,7 @@ import io.circe.Encoder
 import io.circe.Json
 import io.circe.syntax._
 import lucuma.odb.graphql.client.Itc
+import lucuma.odb.json.time
 
 import java.time.Duration
 
@@ -19,6 +20,9 @@ object ItcResultEncoder extends ItcResultEncoder
  * ItcResult Encoder matching the ODB Schema.
  */
 trait ItcResultEncoder {
+
+  import time.query.given
+
   private val MissingParams: String = "MISSING_PARAMS"
   private val ServiceError:  String = "SERVICE_ERROR"
   private val Success:       String = "SUCCESS"
@@ -62,33 +66,6 @@ trait ItcResultEncoder {
         "result"        -> r.value.focus.asJson,
         "all"           -> r.value.toList.asJson
       )
-  }
-
-  given Encoder[Duration] with {
-    def apply(d: Duration): Json = {
-
-      import java.math.RoundingMode.DOWN
-      import java.time.temporal.ChronoUnit.MICROS
-
-      val d2 = d.truncatedTo(MICROS)
-
-      val micro = BigDecimal(
-        new java.math.BigDecimal(d2.getSeconds)
-          .movePointRight(9)
-          .add(new java.math.BigDecimal(d2.getNano))
-          .movePointLeft(3)
-          .setScale(0, DOWN)
-      )
-
-      Json.obj(
-        "microseconds" -> micro.longValue.asJson,
-        "milliseconds" -> (micro / 1_000L).asJson,
-        "seconds"      -> (micro / 1_000_000L).asJson,
-        "minutes"      -> (micro / 60_000_000L).asJson,
-        "hours"        -> (micro / 3_600_000_000L).asJson,
-        "iso"          -> d2.toString.asJson
-      )
-    }
   }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GmosLongSlitMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GmosLongSlitMapping.scala
@@ -41,7 +41,9 @@ import lucuma.odb.graphql.binding.*
 import lucuma.odb.graphql.input.*
 import lucuma.odb.graphql.predicate.Predicates
 import lucuma.odb.graphql.table.*
+import lucuma.odb.json.angle.query.given
 import lucuma.odb.json.sourceprofile.given
+import lucuma.odb.json.wavelength.query.given
 import lucuma.odb.sequence.gmos.longslit.GmosLongSlitConfig
 
 import java.math.RoundingMode

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcInputService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcInputService.scala
@@ -35,6 +35,7 @@ import lucuma.core.model.User
 import lucuma.itc.client.InstrumentMode
 import lucuma.itc.client.SpectroscopyModeInput
 import lucuma.odb.data.ObservingModeType
+import lucuma.odb.json.angle.decoder.given
 import lucuma.odb.json.sourceprofile.given
 import lucuma.odb.util.Codecs.*
 import skunk.*

--- a/modules/service/src/main/scala/lucuma/odb/service/TargetService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TargetService.scala
@@ -22,7 +22,9 @@ import lucuma.core.model.User
 import lucuma.odb.data.Tag
 import lucuma.odb.graphql.input.SiderealInput
 import lucuma.odb.graphql.input.TargetPropertiesInput
+import lucuma.odb.json.angle.query.given
 import lucuma.odb.json.sourceprofile.given
+import lucuma.odb.json.wavelength.query.given
 import lucuma.odb.util.Codecs._
 import skunk.AppliedFragment
 import skunk.Session


### PR DESCRIPTION
This PR is a bit of an experiment.  The idea is to reconcile a few incompatible goals:

1. It would be nice for the ODB `schema` module to be the one source of truth for the ODB GraphQL schema and corresponding json codecs.
2. For servicing queries with json results, we have to produce json containing fully expanded objects.  For example, wavelengths in pm, nm, etc and angles in microarcseconds, milliarcseconds, etc.  Grackle can then trim the actual result down to match just what the user asked for.
3. For normal encoding though, only the canonical unit should be used (pm for wavelength, microarcseconds for angle, etc.)

To make this possible, a single shared `Decoder` is fine for all types but two different `Encoder`s are required depending on context.  I called these "query" and "transport" for lack of a better idea.  You get the appropriate codec depending on which alternative that you import.  

My heart is in the right place, I think, but I'm open to other names, to pointing out flaws in the implementation, or to being steered off this course altogether if it doesn't make sense.