### PR TITLE
bugfix

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -408,7 +408,7 @@ input FixedExposureModeInput {
   count: NonNegInt!
 
   # exposure time
-  time: TimeSpan!
+  time: TimeSpanInput!
 }
 
 # Flux density entry


### PR DESCRIPTION
Inadvertently changed an input field from an `input` object to a `type`, breaking introspection among other things.