### PR TITLE
Additional config logging

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -60,6 +60,9 @@ object Main extends IOApp {
             |
             |This is the Lucuma observing database.
             |CORS domain is ${config.domain}.
+            |Running on port ${config.port.value}.
+            |ITC Service at ${config.itcRoot}.
+            |SSO Service at ${config.sso.root}.
             |
             |""".stripMargin
     banner.linesIterator.toList.traverse_(Logger[F].info(_))


### PR DESCRIPTION
How would we feel about adding a bit of information to the log after the banner?  It took me a while to figure out what port the database was running on for example.

```
service [INFO ] lucuma-odb - This is the Lucuma observing database. 
service [INFO ] lucuma-odb - CORS domain is lucuma.xyz. 
service [INFO ] lucuma-odb - Running on port 8082. 
service [INFO ] lucuma-odb - ITC Service at https://itc-staging.herokuapp.com/itc. 
service [INFO ] lucuma-odb - SSO Service at https://sso.gpp.lucuma.xyz.
```