### PR TITLE
Subscription/targetEdit

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -2258,12 +2258,17 @@ type Subscription {
   # that program.
   #
   targetEdit(
+    input: TargetEditInput
+  ): TargetEdit!
+}
+
+input TargetEditInput {
     # Target ID
     targetId: TargetId
 
     # Program ID
     programId: ProgramId
-  ): TargetEdit!
+
 }
 
 input ObservationEditInput {
@@ -2283,9 +2288,9 @@ input SystemVerificationInput {
 }
 
 # Event sent when a new object is created or updated
-type TargetEdit implements Event {
+type TargetEdit {
   # Type of edit
-  editType: EditType!
+  editType: EditType! 
 
   # Edited object
   value: Target!

--- a/modules/service/src/main/resources/db/migration/V0150__target_update.sql
+++ b/modules/service/src/main/resources/db/migration/V0150__target_update.sql
@@ -1,0 +1,18 @@
+
+CREATE OR REPLACE FUNCTION ch_target_edit()
+  RETURNS trigger AS $$
+DECLARE
+BEGIN
+  PERFORM pg_notify('ch_target_edit', NEW.c_target_id || ',' || NEW.c_program_id  || ',' || nextval('s_event_id')::text || ',' || TG_OP);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER ch_target_insert_update_trigger
+  AFTER INSERT OR UPDATE ON t_target
+  DEFERRABLE
+  FOR EACH ROW
+  EXECUTE PROCEDURE ch_target_edit();
+
+
+

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -115,6 +115,7 @@ trait BaseMapping[F[_]]
   lazy val SpectroscopyScienceRequirementsType = schema.ref("SpectroscopyScienceRequirements")
   lazy val SystemVerificationType              = schema.ref("SystemVerification")
   lazy val TacCategoryType                     = schema.ref("TacCategory")
+  lazy val TargetEditType                      = schema.ref("TargetEdit")
   lazy val TargetEnvironmentType               = schema.ref("TargetEnvironment")
   lazy val TargetGroupSelectResultType         = schema.ref("TargetGroupSelectResult")
   lazy val TargetGroupType                     = schema.ref("TargetGroup")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -43,6 +43,7 @@ import lucuma.odb.graphql.mapping.UpdateObservationsResultMapping
 import lucuma.odb.graphql.mapping._
 import lucuma.odb.graphql.topic.ObservationTopic
 import lucuma.odb.graphql.topic.ProgramTopic
+import lucuma.odb.graphql.topic.TargetTopic
 import lucuma.odb.graphql.util._
 import lucuma.odb.service.AllocationService
 import lucuma.odb.service.AsterismService
@@ -61,7 +62,8 @@ object OdbMapping {
 
   case class Topics[F[_]](
     program:     Topic[F, ProgramTopic.Element],
-    observation: Topic[F, ObservationTopic.Element]
+    observation: Topic[F, ObservationTopic.Element],
+    target:      Topic[F, TargetTopic.Element],
   )
 
   object Topics {
@@ -71,7 +73,8 @@ object OdbMapping {
         ses <- pool
         pro <- Resource.eval(ProgramTopic(ses, 1024, sup))
         obs <- Resource.eval(ObservationTopic(ses, 1024, sup))
-      } yield Topics(pro, obs)
+        tar <- Resource.eval(TargetTopic(ses, 1024, sup))
+      } yield Topics(pro, obs, tar)
   }
 
   // Loads a GraphQL file from the classpath, relative to this Class.
@@ -143,6 +146,7 @@ object OdbMapping {
           with SiderealMapping[F]
           with SpectroscopyScienceRequirementsMapping[F]
           with SubscriptionMapping[F]
+          with TargetEditMapping[F]
           with TargetEnvironmentMapping[F]
           with TargetMapping[F]
           with TargetGroupMapping[F]
@@ -255,6 +259,7 @@ object OdbMapping {
               SetAllocationResultMapping,
               SiderealMapping,
               SubscriptionMapping,
+              TargetEditMapping,
               TargetEnvironmentMapping,
               TargetGroupMapping,
               TargetGroupSelectResultMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/TargetEditInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/TargetEditInput.scala
@@ -5,8 +5,8 @@ package lucuma.odb.graphql
 package input
 
 import cats.syntax.apply.*
-import lucuma.core.model.Target
 import lucuma.core.model.Program
+import lucuma.core.model.Target
 import lucuma.odb.graphql.binding.*
 
 final case class TargetEditInput(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/TargetEditInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/TargetEditInput.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.apply.*
+import lucuma.core.model.Target
+import lucuma.core.model.Program
+import lucuma.odb.graphql.binding.*
+
+final case class TargetEditInput(
+  targetId: Option[Target.Id],
+  programId:     Option[Program.Id]
+)
+
+object TargetEditInput {
+
+  val Binding = ObjectFieldsBinding.rmap {
+    case List(
+      TargetIdBinding.Option("targetId", rTargetId),
+      ProgramIdBinding.Option("programId", rProgramId)
+    ) =>
+      (rTargetId, rProgramId).mapN(apply)
+  }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEditMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEditMapping.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mapping
+
+
+import lucuma.odb.data.EditType
+import lucuma.odb.graphql.table.TargetView
+
+
+trait TargetEditMapping[F[_]] extends TargetView[F] {
+
+  // N.B. env is populated by the subscription elaborator
+  lazy val TargetEditMapping: ObjectMapping =
+    ObjectMapping(
+      tpe = TargetEditType,
+      fieldMappings = List(
+        SqlField("synthetic-id", TargetView.TargetId, key = true, hidden = true),
+        CursorField("id", _.envR[Long]("id")),
+        CursorField("editType", _.envR[EditType]("editType")),
+        SqlObject("value")
+      )
+    )
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
@@ -14,6 +14,8 @@ trait Predicates[F[_]] extends BaseMapping[F] {
    * constructing filters, etc.
    */
   object Predicates {
+    val asterismGroup       = AsterismGroupPredicates(Path.from(AsterismGroupType))
+    val constraintSetGroup  = ConstraintSetGroupPredicates(Path.from(ConstraintSetGroupType))
     val linkUserResult      = LinkUserResultPredicates(Path.from(LinkUserResultType))
     val observation         = ObservationPredicates(Path.from(ObservationType))
     val observationEdit     = ObservationEditPredicates(Path.from(ObservationEditType))
@@ -22,9 +24,8 @@ trait Predicates[F[_]] extends BaseMapping[F] {
     val proposalClass       = ProposalClassPredicates(Path.from(ProposalClassType))
     val setAllocationResult = SetAllocationResultPredicates(Path.from(SetAllocationResultType))
     val target              = TargetPredicates(Path.from(TargetType))
-    val constraintSetGroup  = ConstraintSetGroupPredicates(Path.from(ConstraintSetGroupType))
+    val targetEdit          = TargetEditPredicates(Path.from(TargetEditType))
     val targetGroup         = TargetGroupPredicates(Path.from(TargetGroupType))
-    val asterismGroup       = AsterismGroupPredicates(Path.from(AsterismGroupType))
   }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/TargetEditPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/TargetEditPredicates.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.predicate
+
+import edu.gemini.grackle.Path
+
+class TargetEditPredicates(path: Path) {
+  val value = TargetPredicates(path / "value")
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/TargetTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/TargetTopic.scala
@@ -14,8 +14,8 @@ import lucuma.core.model.Access.Ngo
 import lucuma.core.model.Access.Pi
 import lucuma.core.model.Access.Service
 import lucuma.core.model.Access.Staff
-import lucuma.core.model.Target
 import lucuma.core.model.Program
+import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.core.util.Enumerated
 import lucuma.core.util.Gid

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/TargetTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/TargetTopic.scala
@@ -14,7 +14,7 @@ import lucuma.core.model.Access.Ngo
 import lucuma.core.model.Access.Pi
 import lucuma.core.model.Access.Service
 import lucuma.core.model.Access.Staff
-import lucuma.core.model.Observation
+import lucuma.core.model.Target
 import lucuma.core.model.Program
 import lucuma.core.model.User
 import lucuma.core.util.Enumerated
@@ -26,24 +26,22 @@ import skunk.Query
 import skunk.*
 import skunk.implicits.*
 
-object ObservationTopic {
+object TargetTopic {
 
   /**
-   * @param observationId the id of the observation that was inserted or edited
-   * @param programId the observation's program's id
+   * @param targetId the id of the target that was inserted or edited
+   * @param programId the target's program's id
    * @param eventId serial event id
    * @param editType determines creation vs update
    * @param users users associated with this program
    */
   case class Element(
-    observationId: Observation.Id,
-    programId:     Program.Id,
-    eventId:       Long,
-    editType:      EditType,
-    users:         List[User.Id]
+    targetId:  Target.Id,
+    programId: Program.Id,
+    eventId:   Long,
+    editType:  EditType,
+    users:     List[User.Id]
   ) {
-
-    // Same as ProgramTopic `canRead` ...
 
     def canRead(u: User): Boolean =
       u.role.access match {
@@ -54,16 +52,16 @@ object ObservationTopic {
 
   }
 
-  /** Infinite stream of observation id, program id, event id, and edit type. */
-  def updates[F[_]: Logger](s: Session[F], maxQueued: Int): Stream[F, (Observation.Id, Program.Id, Long, EditType)] =
-    s.channel(id"ch_observation_edit").listen(maxQueued).flatMap { n =>
+  /** Infinite stream of target id, program id, event id, and edit type. */
+  def updates[F[_]: Logger](s: Session[F], maxQueued: Int): Stream[F, (Target.Id, Program.Id, Long, EditType)] =
+    s.channel(id"ch_target_edit").listen(maxQueued).flatMap { n =>
       n.value.split(",") match {
         case Array(_oid, _pid, _eid, _tg_op) =>
-          (Gid[Observation.Id].fromString.getOption(_oid), Gid[Program.Id].fromString.getOption(_pid), _eid.toLongOption, EditType.fromTgOp(_tg_op)).tupled match {
+          (Gid[Target.Id].fromString.getOption(_oid), Gid[Program.Id].fromString.getOption(_pid), _eid.toLongOption, EditType.fromTgOp(_tg_op)).tupled match {
             case Some(tuple) => Stream(tuple)
-            case None        => Stream.exec(Logger[F].warn(s"Invalid observation and/or event: $n"))
+            case None        => Stream.exec(Logger[F].warn(s"Invalid target and/or event: $n"))
           }
-        case _ => Stream.exec(Logger[F].warn(s"Invalid observation and/or event: $n"))
+        case _ => Stream.exec(Logger[F].warn(s"Invalid target and/or event: $n"))
       }
     }
 
@@ -76,7 +74,7 @@ object ObservationTopic {
       oid   <- updates(s, maxQueued)
       users <- Stream.eval(pq.stream(oid._2, 1024).compile.toList)
       elem   = Element(oid._1, oid._2, oid._3, oid._4, users)
-      _     <- Stream.eval(Logger[F].info(s"ObservationChannel: $elem"))
+      _     <- Stream.eval(Logger[F].info(s"TargetChannel: $elem"))
     } yield elem
 
   def apply[F[_]: Concurrent: Logger](
@@ -87,8 +85,8 @@ object ObservationTopic {
     for {
       top <- Topic[F, Element]
       els  = elements(s, maxQueued).through(top.publish)
-      _   <- sup.supervise(els.compile.drain.onError { case e => Logger[F].error(e)("Observation Event Stream crashed!") } >> Logger[F].info("Observation Event Stream terminated.") )
-      _   <- Logger[F].info("Started topic for ch_observation_edit")
+      _   <- sup.supervise(els.compile.drain.onError { case e => Logger[F].error(e)("Target Event Stream crashed!") } >> Logger[F].info("Target Event Stream terminated.") )
+      _   <- Logger[F].info("Started topic for ch_target_edit")
     } yield top
 
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/targetEdit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/targetEdit.scala
@@ -1,0 +1,178 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package subscription
+
+import cats.syntax.show.*
+import cats.syntax.traverse.*
+import io.circe.Json
+import io.circe.literal.*
+import lucuma.core.model.Target
+import lucuma.core.model.Program
+import lucuma.core.model.User
+import lucuma.odb.data.EditType
+import lucuma.odb.graphql.mutation.CreateProgramOps
+import lucuma.odb.graphql.mutation.CreateObservationOps
+import lucuma.odb.graphql.mutation.createTarget
+
+class targetEdit extends OdbSuite with CreateProgramOps with CreateObservationOps {
+
+  val pi = TestUsers.Standard.pi(11, 110)
+
+  override def validUsers = List(pi)
+
+  def updateTarget(user: User, tid: Target.Id, name: String) =
+    expect(
+      user = user,
+      query = s"""
+        mutation {
+          updateTargets(input: {
+            SET: { name: "$name" }
+            WHERE: {
+              id: { EQ: "$tid"}
+            }
+          }) {
+            targets {
+              id
+              name
+            }
+          }
+        }
+      """,
+      expected = Right(
+        json"""
+          {
+            "updateTargets" : {
+              "targets" : [
+                {
+                  "id" : $tid,
+                  "name" : $name
+                }
+              ]
+            }
+          }
+        """
+      )
+    )      
+
+  def nameSubscription(
+    pid: Option[Program.Id],
+    oid: Option[Target.Id]
+  ): String = {
+    val args: String =
+      (pid, oid) match {
+        case (Some(p), Some(o)) => s"""(input: { programId: "${p.show}", targetId: "${o.show}" } )"""
+        case (Some(p), None   ) => s"""(input: { programId: "${p.show}" } )"""
+        case (None,    Some(o)) => s"""(input: { targetId: "${o.show}" } )"""
+        case (None,    None   ) => ""
+      }
+
+    s"""
+      subscription {
+        targetEdit$args {
+          editType
+          value {
+            name
+          }
+        }
+      }
+    """
+  }
+
+  def targetEdit(
+    editType: EditType,
+    name: String
+  ): Json =
+    Json.obj(
+      "targetEdit" -> Json.obj(
+        "editType" -> Json.fromString(editType.tag.toUpperCase),
+        "value"    -> Json.obj(
+          "name" -> Json.fromString(name)
+        )
+      )
+    )
+
+  def created(name: String): Json =
+    targetEdit(EditType.Created, name)
+
+  def updated(name: String): Json =
+    targetEdit(EditType.Updated, name)
+
+  test("trigger for a new target in any program") {
+    subscriptionExpect(
+      user      = pi,
+      query     = nameSubscription(None, None),
+      mutations =
+        Right(
+          createProgramAs(pi).flatMap(createEmptyTargetAs(pi, _, "target 1")) >>
+          createProgramAs(pi).flatMap(createEmptyTargetAs(pi, _, "target 2"))
+        ),
+      expected = List(created("target 1"), created("target 2"))
+    )
+  }
+
+  test("trigger for an updated target in any program") {
+    subscriptionExpect(
+      user      = pi,
+      query     = nameSubscription(None, None),
+      mutations =
+        Right(
+          for {
+            pid <- createProgramAs(pi)
+            tid <- createEmptyTargetAs(pi, pid, "old name")
+            _   <- updateTarget(pi, tid, "new name")
+          } yield ()
+        ),
+      expected = List(created("old name"), updated("new name"))
+    )
+  }
+
+  test("trigger for a new target in [only] a specific program") {
+    createProgramAs(pi).flatMap { pid =>
+      subscriptionExpect(
+        user      = pi,
+        query     = nameSubscription(Some(pid), None),
+        mutations =
+          Right(
+            createEmptyTargetAs(pi, pid, "should see this") >>
+            createProgramAs(pi).flatMap(createEmptyTargetAs(pi, _, "should not see this"))
+          ),
+        expected = List(created("should see this"))
+      )
+    }
+  }
+
+  test("trigger for an updated target in [only] a specific program") {
+    createProgramAs(pi).flatMap { pid =>
+      subscriptionExpect(
+        user      = pi,
+        query     = nameSubscription(Some(pid), None),
+        mutations =
+          Right(
+            createEmptyTargetAs(pi, pid, "should see this").flatMap(updateTarget(pi, _, "and this")) >>
+            createProgramAs(pi).flatMap(createEmptyTargetAs(pi, _, "should not see this").flatMap(updateTarget(pi, _, "or this")))
+          ),
+        expected = List(created("should see this"), updated("and this"))
+      )
+    }
+  }
+
+  test("trigger for [only] a specific updated target") {
+    createProgramAs(pi).flatMap { pid =>
+      createEmptyTargetAs(pi, pid, "old name").flatMap { tid =>
+        subscriptionExpect(
+          user      = pi,
+          query     = nameSubscription(None, Some(tid)),
+          mutations =
+            Right(
+              updateTarget(pi, tid, "new name") >>
+              createEmptyTargetAs(pi, pid, "should not see this").flatMap(updateTarget(pi, _, "or this"))
+            ),
+          expected = List(updated("new name"))
+        )
+      }
+    }
+  }
+
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/targetEdit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/targetEdit.scala
@@ -8,12 +8,12 @@ import cats.syntax.show.*
 import cats.syntax.traverse.*
 import io.circe.Json
 import io.circe.literal.*
-import lucuma.core.model.Target
 import lucuma.core.model.Program
+import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.odb.data.EditType
-import lucuma.odb.graphql.mutation.CreateProgramOps
 import lucuma.odb.graphql.mutation.CreateObservationOps
+import lucuma.odb.graphql.mutation.CreateProgramOps
 import lucuma.odb.graphql.mutation.createTarget
 
 class targetEdit extends OdbSuite with CreateProgramOps with CreateObservationOps {


### PR DESCRIPTION
This adds a mapping for the `targetEdit` subscription, which completes the mapping for `type Subscription`. The code for all of these is very similar so I'm going to look at abstracting it out in a followup PR.