### PR TITLE
checklist "test"

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/Checklist.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/Checklist.scala
@@ -3,16 +3,16 @@
 
 package lucuma.odb.graphql
 
-import edu.gemini.grackle.Mapping
 import cats.effect.IO
 import cats.syntax.all._
-import edu.gemini.grackle.TypeRef
-import edu.gemini.grackle.ScalarType
-import edu.gemini.grackle.InterfaceType
-import edu.gemini.grackle.ObjectType
-import edu.gemini.grackle.UnionType
 import edu.gemini.grackle.EnumType
 import edu.gemini.grackle.InputObjectType
+import edu.gemini.grackle.InterfaceType
+import edu.gemini.grackle.Mapping
+import edu.gemini.grackle.ObjectType
+import edu.gemini.grackle.ScalarType
+import edu.gemini.grackle.TypeRef
+import edu.gemini.grackle.UnionType
 
 class Checklist extends OdbSuite {
   val validUsers = Nil

--- a/modules/service/src/test/scala/lucuma/odb/graphql/Checklist.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/Checklist.scala
@@ -1,0 +1,85 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+import edu.gemini.grackle.Mapping
+import cats.effect.IO
+import cats.syntax.all._
+import edu.gemini.grackle.TypeRef
+import edu.gemini.grackle.ScalarType
+import edu.gemini.grackle.InterfaceType
+import edu.gemini.grackle.ObjectType
+import edu.gemini.grackle.UnionType
+import edu.gemini.grackle.EnumType
+import edu.gemini.grackle.InputObjectType
+
+class Checklist extends OdbSuite {
+  val validUsers = Nil
+
+  // These types are "mapped" by virtue of only appearing in Json blobs that
+  // we manufacture. This includes ITC and SourceProfile stuff.
+  val JsonMappedTypes: Set[String] =
+    Set(
+      "BandBrightnessIntegrated",
+      "BandBrightnessSurface",
+      "BandNormalizedIntegrated",
+      "BandNormalizedSurface",
+      "EmissionLineIntegrated",
+      "EmissionLineSurface",
+      "EmissionLinesIntegrated",
+      "EmissionLinesSurface",
+      "FluxDensityContinuumIntegrated",
+      "FluxDensityContinuumSurface",
+      "FluxDensityEntry",
+      "GaussianSource",
+      "ItcMissingParams",
+      "ItcResultSet",
+      "ItcServiceError",
+      "ItcSuccess",
+      "LineFluxIntegrated",
+      "LineFluxSurface",
+      "SourceProfile",
+      "SpectralDefinitionIntegrated",
+      "SpectralDefinitionSurface",
+    )
+
+  def printObjectType(m: BaseMapping[IO], t: ObjectType): IO[Unit] =
+    if JsonMappedTypes.contains(t.name) then
+      IO.println(s"- [x] ${t.name} (via Json blob)")
+    else
+      m.typeMapping(t) match
+        case None    => IO.println(s"- [ ] ${t.name}")
+        case Some(om: m.ObjectMapping) => 
+          IO.println(s"- [x] ${t.name}") >>
+          t.fields.traverse_ { f =>
+            om.fieldMapping(f.name) match
+              case None => IO.println(s"  - [ ] ${f.name}")
+              case Some(_) => IO.println(s"  - [x] ${f.name}")        
+          }
+        case Some(sm: m.SwitchMapping) =>
+          sm.lookup.traverse_ { (p, om) =>
+            IO.println(s"- [x] ${t.name} (at ${p.path.mkString(s"${p.rootTpe}/", "/", "")})") >>
+            t.fields.traverse_ { f =>
+              om.fieldMapping(f.name) match
+                case None => IO.println(s"  - [ ] ${f.name}")
+                case Some(_) => IO.println(s"  - [x] ${f.name}")        
+            }
+          }      
+        case m => fail(s"Can't handle object mapping $m")
+
+  def printChecklist(m: BaseMapping[IO]): IO[Unit] = {
+    IO.println("\n\n# Schema Coverage") >>
+    IO.println("") >>
+    m.schema.types.collect { case o: ObjectType => o } .sortBy(_.name).traverse_(printObjectType(m, _)) >>
+    IO.println("\n\n")
+  }
+
+  test("schema coverage checklist") {
+    mapping.use {
+      case m: BaseMapping[IO] => printChecklist(m)
+      case _ => fail("Not a base mapping??!??")
+    }
+  }
+
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -16,6 +16,8 @@ import clue.http4s.Http4sBackend
 import clue.http4s.Http4sWSBackend
 import com.dimafeng.testcontainers.PostgreSQLContainer
 import com.dimafeng.testcontainers.munit.TestContainerForAll
+import edu.gemini.grackle.Mapping
+import edu.gemini.grackle.skunk.SkunkMonitor
 import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import io.circe.Decoder
@@ -33,6 +35,7 @@ import lucuma.itc.client.SpectroscopyModeInput
 import lucuma.itc.client.SpectroscopyResult
 import lucuma.odb.Config
 import lucuma.odb.Main
+import lucuma.odb.graphql.OdbMapping
 import lucuma.sso.client.SsoClient
 import munit.CatsEffectSuite
 import munit.internal.console.AnsiColors
@@ -52,11 +55,9 @@ import org.testcontainers.utility.DockerImageName
 import org.typelevel.ci.CIString
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
-import lucuma.odb.graphql.OdbMapping
+
 import java.time.Duration
 import scala.concurrent.duration.*
-import edu.gemini.grackle.Mapping
-import edu.gemini.grackle.skunk.SkunkMonitor
 
 /**
  * Mixin that allows execution of GraphQL operations on a per-suite instance of the Odb, shared


### PR DESCRIPTION
This is very hacky but it will be useful while we're implementing the schema, then we can delete it.

When you run the tests it prints out a markdown-formatted checklist of what's mapped and what's not, which you can copy-paste into a gist or whatever. It could write to a file or something but I wanted to do the easiest possible thing.

Anyway output looks like this at the moment:

# Schema Coverage

- [ ] AddDatasetEventResult
- [ ] AddSequenceEventResult
- [ ] AddStepEventResult
- [x] AirMassRange
  - [x] minice / Test / testOnly 11s
  - [x] max
- [x] Allocation
  - [x] partner
  - [x] duration
- [x] Angle (at PosAngleConstraint/angle)
  - [x] microarcseconds
  - [x] microseconds
  - [x] milliarcseconds
  - [x] milliseconds
  - [x] arcseconds
  - [x] seconds
  - [x] arcminutes
  - [x] minutes
  - [x] degrees
  - [x] hours
  - [x] hms
  - [x] dms
- [x] Angle (at SpectroscopyScienceRequirements/focalPlaneAngle)
  - [x] microarcseconds
  - [x] microseconds
  - [x] milliarcseconds
  - [x] milliseconds
  - [x] arcseconds
  - [x] seconds
  - [x] arcminutes
  - [x] minutes
  - [x] degrees
  - [x] hours
  - [x] hms
  - [x] dms
- [x] AsterismGroup
  - [x] program
  - [x] observations
  - [x] asterism
- [x] AsterismGroupSelectResult
  - [x] matches
  - [x] hasMore
- [x] BandBrightnessIntegrated (via Json blob)
- [x] BandBrightnessSurface (via Json blob)
- [x] BandNormalizedIntegrated (via Json blob)
- [x] BandNormalizedSurface (via Json blob)
- [ ] Bias
- [x] CatalogInfo
  - [x] name
  - [x] id
  - [x] objectType
- [x] Classical
  - [ ] minPercentTime
- [ ] CloneObservationResult
- [ ] CloneTargetResult
- [x] ConstraintSet
  - [x] imageQuality
  - [x] cloudExtinction
  - [x] skyBackground
  - [x] waterVapor
  - [x] elevationRange
- [x] ConstraintSetGroup
  - [x] observations
  - [x] constraintSet
- [x] ConstraintSetGroupSelectResult
  - [x] matches
  - [x] hasMore
- [x] Coordinates
  - [x] ra
  - [x] dec
- [x] CreateObservationResult
  - [x] observation
- [x] CreateProgramResult
  - [x] program
- [x] CreateTargetResult
  - [x] target
- [ ] Dark
- [ ] Dataset
- [ ] DatasetEvent
- [ ] DatasetEventPayload
- [ ] DatasetId
- [ ] DatasetSelectResult
- [x] Declination (at Coordinates/dec)
  - [x] dms
  - [x] degrees
  - [x] microarcseconds
- [x] Declination (at Sidereal/dec)
  - [x] dms
  - [x] degrees
  - [x] microarcseconds
- [ ] DeleteObservationsResult
- [ ] DeleteTargetsResult
- [x] DemoScience
  - [ ] minPercentTime
- [x] DirectorsTime
  - [ ] minPercentTime
- [x] ElevationRange
  - [x] airMass
  - [x] hourAngle
- [x] EmissionLineIntegrated (via Json blob)
- [x] EmissionLineSurface (via Json blob)
- [x] EmissionLinesIntegrated (via Json blob)
- [x] EmissionLinesSurface (via Json blob)
- [x] Exchange
  - [ ] minPercentTime
- [ ] Execution
- [ ] ExecutionEventSelectResult
- [ ] ExposureTimeMode
- [x] FastTurnaround
  - [ ] minPercentTime
- [x] FilterTypeMeta
  - [x] tag
  - [x] shortName
  - [x] longName
- [ ] FixedExposureMode
- [x] FluxDensityContinuumIntegrated (via Json blob)
- [x] FluxDensityContinuumSurface (via Json blob)
- [x] FluxDensityEntry (via Json blob)
- [x] GaussianSource (via Json blob)
- [ ] Gcal
- [ ] GmosCcdMode
- [ ] GmosCustomMask
- [ ] GmosNodAndShuffle
- [ ] GmosNorthAtom
- [ ] GmosNorthDynamic
- [ ] GmosNorthExecutionConfig
- [ ] GmosNorthExecutionSequence
- [ ] GmosNorthFpu
- [ ] GmosNorthGratingConfig
- [x] GmosNorthLongSlit
  - [x] grating
  - [x] filter
  - [x] fpu
  - [x] centralWavelength
  - [x] xBin
  - [x] defaultXBin
  - [x] explicitXBin
  - [x] yBin
  - [x] defaultYBin
  - [x] explicitYBin
  - [x] ampReadMode
  - [x] defaultAmpReadMode
  - [x] explicitAmpReadMode
  - [x] ampGain
  - [x] defaultAmpGain
  - [x] explicitAmpGain
  - [x] roi
  - [x] defaultRoi
  - [x] explicitRoi
  - [x] wavelengthDithers
  - [x] defaultWavelengthDithers
  - [x] explicitWavelengthDithers
  - [x] spatialOffsets
  - [x] defaultSpatialOffsets
  - [x] explicitSpatialOffsets
  - [x] initialGrating
  - [x] initialFilter
  - [x] initialFpu
  - [x] initialCentralWavelength
- [ ] GmosNorthManualConfig
- [ ] GmosNorthSequence
- [ ] GmosNorthStatic
- [ ] GmosNorthStep
- [ ] GmosNorthStepRecord
- [ ] GmosNorthVisitRecord
- [ ] GmosSouthAtom
- [ ] GmosSouthDynamic
- [ ] GmosSouthExecutionConfig
- [ ] GmosSouthExecutionSequence
- [ ] GmosSouthFpu
- [ ] GmosSouthGratingConfig
- [x] GmosSouthLongSlit
  - [x] grating
  - [x] filter
  - [x] fpu
  - [x] centralWavelength
  - [x] xBin
  - [x] defaultXBin
  - [x] explicitXBin
  - [x] yBin
  - [x] defaultYBin
  - [x] explicitYBin
  - [x] ampReadMode
  - [x] defaultAmpReadMode
  - [x] explicitAmpReadMode
  - [x] ampGain
  - [x] defaultAmpGain
  - [x] explicitAmpGain
  - [x] roi
  - [x] defaultRoi
  - [x] explicitRoi
  - [x] wavelengthDithers
  - [x] defaultWavelengthDithers
  - [x] explicitWavelengthDithers
  - [x] spatialOffsets
  - [x] defaultSpatialOffsets
  - [x] explicitSpatialOffsets
  - [x] initialGrating
  - [x] initialFilter
  - [x] initialFpu
  - [x] initialCentralWavelength
- [ ] GmosSouthManualConfig
- [ ] GmosSouthSequence
- [ ] GmosSouthStatic
- [ ] GmosSouthStep
- [ ] GmosSouthStepRecord
- [ ] GmosSouthVisitRecord
- [x] HourAngleRange
  - [x] minHours
  - [x] maxHours
- [x] Intensive
  - [ ] minPercentTime
  - [x] minPercentTotalTime
  - [x] totalTime
- [x] ItcMissingParams (via Json blob)
- [x] ItcResultSet (via Json blob)
- [x] ItcServiceError (via Json blob)
- [x] ItcSuccess (via Json blob)
- [x] LargeProgram
  - [ ] minPercentTime
  - [x] minPercentTotalTime
  - [x] totalTime
- [x] LineFluxIntegrated (via Json blob)
- [x] LineFluxSurface (via Json blob)
- [x] LinkUserResult
  - [x] user
- [x] Mutation
  - [ ] addDatasetEvent
  - [ ] addSequenceEvent
  - [ ] addStepEvent
  - [ ] cloneObservation
  - [ ] cloneTarget
  - [x] createObservation
  - [x] createProgram
  - [x] createTarget
  - [ ] deleteObservations
  - [ ] deleteTargets
  - [x] linkUser
  - [ ] recordGmosNorthStep
  - [ ] recordGmosNorthVisit
  - [ ] recordGmosSouthStep
  - [ ] recordGmosSouthVisit
  - [x] setAllocation
  - [ ] undeleteObservations
  - [ ] undeleteTargets
  - [ ] unlinkUser
  - [x] updateAsterisms
  - [ ] updateDatasets
  - [x] updateObservations
  - [x] updatePrograms
  - [x] updateTargets
- [x] Nonsidereal
  - [x] des
  - [x] keyType
  - [x] key
- [x] Observation
  - [x] id
  - [x] existence
  - [x] title
  - [x] subtitle
  - [x] status
  - [x] activeStatus
  - [x] visualizationTime
  - [x] posAngleConstraint
  - [x] plannedTime
  - [x] program
  - [x] targetEnvironment
  - [x] constraintSet
  - [x] scienceRequirements
  - [x] observingMode
  - [ ] manualConfig
  - [ ] execution
- [x] ObservationEdit
  - [x] editType
  - [x] value
  - [x] id
- [x] ObservationSelectResult (at Query/observations)
  - [x] matches
  - [x] hasMore
- [x] ObservationSelectResult (at Program/observations)
  - [x] matches
  - [x] hasMore
- [x] ObservationSelectResult (at ConstraintSetGroup/observations)
  - [x] matches
  - [x] hasMore
- [x] ObservationSelectResult (at TargetGroup/observations)
  - [x] matches
  - [x] hasMore
- [x] ObservationSelectResult (at AsterismGroup/observations)
  - [x] matches
  - [x] hasMore
- [x] ObservingMode
  - [x] instrument
  - [x] mode
  - [x] gmosNorthLongSlit
  - [x] gmosSouthLongSlit
- [ ] ObservingModeGroup
- [ ] ObservingModeGroupSelectResult
- [ ] Offset
- [x] Parallax
  - [x] microarcseconds
  - [x] milliarcseconds
- [x] PartnerMeta
  - [x] tag
  - [x] shortName
  - [x] longName
  - [x] active
- [x] PartnerSplit
  - [x] partner
  - [x] percent
- [ ] PlannedTime
- [x] PlannedTimeSummary (at Program/plannedTime)
  - [x] pi
  - [x] uncharged
  - [x] execution
- [x] PlannedTimeSummary (at Observation/plannedTime)
  - [x] pi
  - [x] uncharged
  - [x] execution
- [x] PoorWeather
  - [ ] minPercentTime
- [x] PosAngleConstraint
  - [x] mode
  - [x] angle
- [x] Program
  - [x] id
  - [x] existence
  - [x] name
  - [x] proposal
  - [x] pi
  - [x] users
  - [x] observations
  - [x] plannedTime
- [x] ProgramEdit
  - [x] editType
  - [x] value
  - [x] id
- [x] ProgramSelectResult
  - [x] matches
  - [x] hasMore
- [x] ProgramUser
  - [x] role
  - [x] userId
  - [x] user
- [x] ProperMotion
  - [x] ra
  - [x] dec
- [x] ProperMotionDeclination
  - [x] microarcsecondsPerYear
  - [x] milliarcsecondsPerYear
- [x] ProperMotionRA
  - [x] microarcsecondsPerYear
  - [x] milliarcsecondsPerYear
- [x] Proposal
  - [x] title
  - [x] proposalClass
  - [x] category
  - [x] toOActivation
  - [x] abstract
  - [x] partnerSplits
- [x] Query
  - [ ] asterism
  - [x] asterismGroup
  - [x] constraintSetGroup
  - [ ] dataset
  - [ ] datasets
  - [ ] executionEvents
  - [x] filterTypeMeta
  - [x] itc
  - [x] observation
  - [x] observations
  - [x] partnerMeta
  - [x] program
  - [x] programs
  - [ ] observingModeGroup
  - [ ] scienceRequirementsGroup
  - [x] target
  - [ ] targetEnvironment
  - [ ] targetEnvironmentGroup
  - [x] targetGroup
  - [x] targets
- [x] Queue
  - [ ] minPercentTime
- [x] RadialVelocity
  - [x] centimetersPerSecond
  - [x] metersPerSecond
  - [x] kilometersPerSecond
- [ ] RecordGmosNorthStepResult
- [ ] RecordGmosNorthVisitResult
- [ ] RecordGmosSouthStepResult
- [ ] RecordGmosSouthVisitResult
- [x] RightAscension (at Coordinates/ra)
  - [x] hms
  - [x] hours
  - [x] degrees
  - [x] microarcseconds
- [x] RightAscension (at Sidereal/ra)
  - [x] hms
  - [x] hours
  - [x] degrees
  - [x] microarcseconds
- [ ] Science
- [x] ScienceRequirements
  - [x] mode
  - [x] spectroscopy
- [ ] ScienceRequirementsGroup
- [ ] ScienceRequirementsGroupSelectResult
- [ ] SequenceEvent
- [ ] SequenceEventLocation
- [ ] SequenceEventPayload
- [x] SetAllocationResult
  - [x] allocation
- [x] Sidereal
  - [x] ra
  - [x] dec
  - [x] epoch
  - [x] properMotion
  - [x] radialVelocity
  - [x] parallax
  - [x] catalogInfo
- [ ] SignalToNoiseMode
- [x] SourceProfile (via Json blob)
- [x] SpectralDefinitionIntegrated (via Json blob)
- [x] SpectralDefinitionSurface (via Json blob)
- [x] SpectroscopyScienceRequirements
  - [x] wavelength
  - [x] resolution
  - [x] signalToNoise
  - [x] signalToNoiseAt
  - [x] wavelengthCoverage
  - [x] focalPlane
  - [x] focalPlaneAngle
  - [x] capability
- [ ] StepEvent
- [ ] StepEventLocation
- [ ] StepEventPayload
- [ ] StepTime
- [x] Subscription
  - [x] observationEdit
  - [x] programEdit
  - [x] targetEdit
- [x] SystemVerification
  - [ ] minPercentTime
- [x] Target
  - [x] id
  - [x] existence
  - [x] program
  - [x] name
  - [x] sourceProfile
  - [x] sidereal
  - [x] nonsidereal
- [x] TargetEdit
  - [x] editType
  - [x] value
  - [x] id
- [x] TargetEnvironment
  - [x] asterism
  - [x] firstScienceTarget
  - [x] explicitBase
- [ ] TargetEnvironmentGroup
- [ ] TargetEnvironmentGroupSelectResult
- [x] TargetGroup
  - [x] observations
  - [x] target
  - [x] program
- [x] TargetGroupSelectResult
  - [x] matches
  - [x] hasMore
- [x] TargetSelectResult
  - [x] matches
  - [x] hasMore
- [x] TimeSpan (at Program/plannedTime/pi)
  - [x] microseconds
  - [x] milliseconds
  - [x] seconds
  - [x] minutes
  - [x] hours
  - [x] iso
- [x] TimeSpan (at Program/plannedTime/uncharged)
  - [x] microseconds
  - [x] milliseconds
  - [x] seconds
  - [x] minutes
  - [x] hours
  - [x] iso
- [x] TimeSpan (at Program/plannedTime/execution)
  - [x] microseconds
  - [x] milliseconds
  - [x] seconds
  - [x] minutes
  - [x] hours
  - [x] iso
- [x] TimeSpan (at Observation/plannedTime/pi)
  - [x] microseconds
  - [x] milliseconds
  - [x] seconds
  - [x] minutes
  - [x] hours
  - [x] iso
- [x] TimeSpan (at Observation/plannedTime/uncharged)
  - [x] microseconds
  - [x] milliseconds
  - [x] seconds
  - [x] minutes
  - [x] hours
  - [x] iso
- [x] TimeSpan (at Observation/plannedTime/execution)
  - [x] microseconds
  - [x] milliseconds
  - [x] seconds
  - [x] minutes
  - [x] hours
  - [x] iso
- [x] TimeSpan (at Intensive/totalTime)
  - [x] microseconds
  - [x] milliseconds
  - [x] seconds
  - [x] minutes
  - [x] hours
  - [x] iso
- [x] TimeSpan (at LargeProgram/totalTime)
  - [x] microseconds
  - [x] milliseconds
  - [x] seconds
  - [x] minutes
  - [x] hours
  - [x] iso
- [x] TimeSpan (at Allocation/duration)
  - [x] microseconds
  - [x] milliseconds
  - [x] seconds
  - [x] minutes
  - [x] hours
  - [x] iso
- [ ] UndeleteObservationsResult
- [ ] UndeleteTargetsResult
- [ ] UnlinkUserResult
- [ ] UnnormalizedSed
- [x] UpdateAsterismsResult
  - [x] observations
  - [x] hasMore
- [ ] UpdateDatasetsResult
- [x] UpdateObservationsResult
  - [x] observations
  - [x] hasMore
- [x] UpdateProgramsResult
  - [x] programs
  - [x] hasMore
- [x] UpdateTargetsResult
  - [x] targets
  - [x] hasMore
- [x] User
  - [x] id
  - [x] type
  - [x] serviceName
  - [x] orcidId
  - [x] orcidGivenName
  - [x] orcidCreditName
  - [x] orcidFamilyName
  - [x] orcidEmail
- [x] Wavelength (at GmosNorthLongSlit/centralWavelength)
  - [x] picometers
  - [x] angstroms
  - [x] nanometers
  - [x] micrometers
- [x] Wavelength (at GmosNorthLongSlit/initialCentralWavelength)
  - [x] picometers
  - [x] angstroms
  - [x] nanometers
  - [x] micrometers
- [x] Wavelength (at GmosSouthLongSlit/centralWavelength)
  - [x] picometers
  - [x] angstroms
  - [x] nanometers
  - [x] micrometers
- [x] Wavelength (at GmosSouthLongSlit/initialCentralWavelength)
  - [x] picometers
  - [x] angstroms
  - [x] nanometers
  - [x] micrometers
- [x] Wavelength (at SpectroscopyScienceRequirements/wavelength)
  - [x] picometers
  - [x] angstroms
  - [x] nanometers
  - [x] micrometers
- [x] Wavelength (at SpectroscopyScienceRequirements/signalToNoiseAt)
  - [x] picometers
  - [x] angstroms
  - [x] nanometers
  - [x] micrometers
- [x] Wavelength (at SpectroscopyScienceRequirements/wavelengthCoverage)
  - [x] picometers
  - [x] angstroms
  - [x] nanometers
  - [x] micrometers
- [ ] WavelengthDither
- [ ] p
- [ ] q




