### PR TITLE
WIP: Mutation/cloneTarget

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0160__target_pairs.sql
+++ b/modules/service/src/main/resources/db/migration/V0160__target_pairs.sql
@@ -1,7 +1,6 @@
--- This seems unethical but it's a straightforward to make a data type with a pair
--- of targets, like a CloneTargetResult. When provided with a pair of IDs in its
--- WHERE clause it will compile down to a pair of indexed lookups. Either column
--- can be used as the key in the mapping, assuming you're only selecting one pair.
+
+-- A view that contains every pair of target ids. When joined to the target table
+-- with conditions on the ids it all compiles down to hash lookups, which are fast.
 
 CREATE OR REPLACE VIEW v_target_pairs AS
   SELECT

--- a/modules/service/src/main/resources/db/migration/V0160__target_pairs.sql
+++ b/modules/service/src/main/resources/db/migration/V0160__target_pairs.sql
@@ -1,0 +1,13 @@
+-- This seems unethical but it's a straightforward to make a data type with a pair
+-- of targets, like a CloneTargetResult. When provided with a pair of IDs in its
+-- WHERE clause it will compile down to a pair of indexed lookups. Either column
+-- can be used as the key in the mapping, assuming you're only selecting one pair.
+
+CREATE OR REPLACE VIEW v_target_pairs AS
+  SELECT
+    a.c_target_id c_left,
+    b.c_target_id c_right
+  FROM
+    t_target a,
+    t_target b
+    

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -23,6 +23,7 @@ trait BaseMapping[F[_]]
   lazy val CatalogInfoType                     = schema.ref("CatalogInfo")
   lazy val CatalogNameType                     = schema.ref("CatalogName")
   lazy val ClassicalType                       = schema.ref("Classical")
+  lazy val CloneTargetResultType               = schema.ref("CloneTargetResult")
   lazy val CloudExtinctionType                 = schema.ref("CloudExtinction")
   lazy val ConstraintSetType                   = schema.ref("ConstraintSet")
   lazy val ConstraintSetGroupType              = schema.ref("ConstraintSetGroup")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -104,6 +104,7 @@ object OdbMapping {
           with AsterismGroupMapping[F]
           with AsterismGroupSelectResultMapping[F]
           with CatalogInfoMapping[F]
+          with CloneTargetResultMapping[F]
           with ConstraintSetGroupMapping[F]
           with ConstraintSetGroupSelectResultMapping[F]
           with ConstraintSetMapping[F]
@@ -218,6 +219,7 @@ object OdbMapping {
               AsterismGroupMapping,
               AsterismGroupSelectResultMapping,
               CatalogInfoMapping,
+              CloneTargetResultMapping,
               ConstraintSetGroupMapping,
               ConstraintSetGroupSelectResultMapping,
               ConstraintSetMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CloneTargetInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CloneTargetInput.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package input
+
+import cats.data.NonEmptyList
+import cats.syntax.all.*
+import edu.gemini.grackle.Path
+import edu.gemini.grackle.Predicate
+import eu.timepit.refined.types.numeric.NonNegInt
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.Target
+import lucuma.odb.data.Nullable
+import lucuma.odb.graphql.binding._
+
+final case class CloneTargetInput(
+  targetId:   Target.Id,
+  SET:        Option[TargetPropertiesInput.Edit],
+  REPLACE_IN: Option[NonEmptyList[Observation.Id]],
+)
+
+object CloneTargetInput {
+
+ val Binding: Matcher[CloneTargetInput] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        TargetIdBinding("targetId", rTargetId),
+        TargetPropertiesInput.EditBinding.Option("SET", rSET),
+        ObservationIdBinding.List.Option("REPLACE_IN", rREPLACE_IN)
+      ) =>
+        (rTargetId, rSET, rREPLACE_IN.map(_.flatMap(_.toNel))).mapN(CloneTargetInput.apply)
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CloneTargetResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CloneTargetResultMapping.scala
@@ -9,16 +9,17 @@ import lucuma.odb.graphql.BaseMapping
 
 import scala.tools.util.PathResolver.Environment
 import lucuma.odb.graphql.table.TargetView
+import lucuma.odb.graphql.table.TargetPairsView
 
-trait CloneTargetResultMapping[F[_]] extends ResultMapping[F] with TargetView[F] {
+trait CloneTargetResultMapping[F[_]] extends ResultMapping[F] with TargetView[F] with TargetPairsView[F] {
 
   lazy val CloneTargetResultMapping: ObjectMapping =
     ObjectMapping(
       tpe = CloneTargetResultType ,
       fieldMappings = List(
-        SqlField("synthetic-id", TargetView.TargetId, key = true, hidden = true),
-        SqlObject("originalTarget"),
-        SqlObject("newTarget"),
+        SqlField("synthetic-id", TargetPairsView.Left, key = true, hidden = true),
+        SqlObject("originalTarget", Join(TargetPairsView.Left, TargetView.TargetId)),
+        SqlObject("newTarget", Join(TargetPairsView.Right, TargetView.TargetId)),
       )
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CloneTargetResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CloneTargetResultMapping.scala
@@ -6,16 +6,17 @@ package lucuma.odb.graphql.mapping
 import edu.gemini.grackle.Cursor
 import edu.gemini.grackle.Result
 import lucuma.odb.graphql.BaseMapping
-import skunk.codec.numeric.int8
 
 import scala.tools.util.PathResolver.Environment
+import lucuma.odb.graphql.table.TargetView
 
-trait CloneTargetResultMapping[F[_]] extends ResultMapping[F] {
+trait CloneTargetResultMapping[F[_]] extends ResultMapping[F] with TargetView[F] {
 
   lazy val CloneTargetResultMapping: ObjectMapping =
     ObjectMapping(
       tpe = CloneTargetResultType ,
       fieldMappings = List(
+        SqlField("synthetic-id", TargetView.TargetId, key = true, hidden = true),
         SqlObject("originalTarget"),
         SqlObject("newTarget"),
       )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CloneTargetResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CloneTargetResultMapping.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.mapping
+
+import edu.gemini.grackle.Cursor
+import edu.gemini.grackle.Result
+import lucuma.odb.graphql.BaseMapping
+import skunk.codec.numeric.int8
+
+import scala.tools.util.PathResolver.Environment
+
+trait CloneTargetResultMapping[F[_]] extends ResultMapping[F] {
+
+  lazy val CloneTargetResultMapping: ObjectMapping =
+    ObjectMapping(
+      tpe = CloneTargetResultType ,
+      fieldMappings = List(
+        SqlObject("originalTarget"),
+        SqlObject("newTarget"),
+      )
+    )
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CloneTargetResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CloneTargetResultMapping.scala
@@ -6,10 +6,10 @@ package lucuma.odb.graphql.mapping
 import edu.gemini.grackle.Cursor
 import edu.gemini.grackle.Result
 import lucuma.odb.graphql.BaseMapping
+import lucuma.odb.graphql.table.TargetPairsView
+import lucuma.odb.graphql.table.TargetView
 
 import scala.tools.util.PathResolver.Environment
-import lucuma.odb.graphql.table.TargetView
-import lucuma.odb.graphql.table.TargetPairsView
 
 trait CloneTargetResultMapping[F[_]] extends ResultMapping[F] with TargetView[F] with TargetPairsView[F] {
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -152,7 +152,7 @@ trait MutationMapping[F[_]] extends Predicates[F] {
       targetService.use { svc =>
         svc.cloneTarget(input).map {          
 
-          
+          // Typical case          
           case Success(oldTargetId, newTargetId) =>
             Result(
               Filter(And(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -31,6 +31,7 @@ import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.odb.graphql.binding._
+import lucuma.odb.graphql.input.CloneTargetInput
 import lucuma.odb.graphql.input.CreateObservationInput
 import lucuma.odb.graphql.input.CreateProgramInput
 import lucuma.odb.graphql.input.CreateTargetInput
@@ -49,7 +50,9 @@ import lucuma.odb.service.ObservationService
 import lucuma.odb.service.ProgramService
 import lucuma.odb.service.ProposalService
 import lucuma.odb.service.TargetService
+import lucuma.odb.service.TargetService.CloneTargetResponse
 import lucuma.odb.service.TargetService.UpdateTargetsResponse
+import lucuma.odb.service.TargetService.UpdateTargetsResponse.TrackingSwitchFailed
 import org.tpolecat.typename.TypeName
 import skunk.AppliedFragment
 
@@ -59,6 +62,7 @@ trait MutationMapping[F[_]] extends Predicates[F] {
 
   private lazy val mutationFields: List[MutationField] =
     List(
+      CloneTarget,
       CreateObservation,
       CreateProgram,
       CreateTarget,
@@ -140,6 +144,33 @@ trait MutationMapping[F[_]] extends Predicates[F] {
     )
 
   // Field definitions
+
+  private lazy val CloneTarget: MutationField =
+    import CloneTargetResponse.*
+    import UpdateTargetsResponse.{ SourceProfileUpdatesFailed, TrackingSwitchFailed }
+    MutationField("cloneTarget", CloneTargetInput.Binding) { (input, child) =>
+      targetService.use { svc =>
+        svc.cloneTarget(input).map {          
+
+          
+          case Success(oldTargetId, newTargetId) =>
+            Result(
+              Filter(And(
+                Predicates.cloneTargetResult.originalTarget.id.eql(oldTargetId),
+                Predicates.cloneTargetResult.newTarget.id.eql(newTargetId)
+              ), child)
+            )
+          
+          // Failure Cases
+          case NoSuchTarget(targetId) => Result.failure(s"No such target: $targetId")
+          case UpdateFailed(problem)  =>
+            problem match
+              case SourceProfileUpdatesFailed(ps) => ps.leftIor
+              case TrackingSwitchFailed(p)        => Result.failure(p)
+
+        }  
+      }
+    }
 
   private lazy val CreateObservation: MutationField =
     MutationField("createObservation", CreateObservationInput.Binding) { (input, child) =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/CloneTargetResultPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/CloneTargetResultPredicates.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.predicate
+
+import edu.gemini.grackle.Path
+
+class CloneTargetResultPredicates(path: Path) {
+  val originalTarget = TargetPredicates(path / "originalTarget")
+  val newTarget = TargetPredicates(path / "newTarget")
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
@@ -15,6 +15,7 @@ trait Predicates[F[_]] extends BaseMapping[F] {
    */
   object Predicates {
     val asterismGroup       = AsterismGroupPredicates(Path.from(AsterismGroupType))
+    val cloneTargetResult   = CloneTargetResultPredicates(Path.from(CloneTargetResultType))
     val constraintSetGroup  = ConstraintSetGroupPredicates(Path.from(ConstraintSetGroupType))
     val linkUserResult      = LinkUserResultPredicates(Path.from(LinkUserResultType))
     val observation         = ObservationPredicates(Path.from(ObservationType))

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/TargetPairsView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/TargetPairsView.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package table
+
+import edu.gemini.grackle.skunk.SkunkMapping
+import lucuma.odb.util.Codecs._
+import skunk.codec.all._
+
+trait TargetPairsView[F[_]] extends BaseMapping[F] {
+
+  object TargetPairsView extends TableDef("v_target_pairs") {
+    val Left = col("c_left", target_id)
+    val Right = col("c_right", target_id)
+  }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/ObservationTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/ObservationTopic.scala
@@ -72,9 +72,8 @@ object ObservationTopic {
     maxQueued: Int,
   ): Stream[F, Element] =
     for {
-      pq    <- Stream.resource(s.prepareR(ProgramTopic.SelectProgramUsers))
       oid   <- updates(s, maxQueued)
-      users <- Stream.eval(pq.stream(oid._2, 1024).compile.toList)
+      users <- Stream.eval(ProgramTopic.selectProgramUsers(s, oid._2))
       elem   = Element(oid._1, oid._2, oid._3, oid._4, users)
       _     <- Stream.eval(Logger[F].info(s"ObservationChannel: $elem"))
     } yield elem

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/TargetTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/TargetTopic.scala
@@ -70,9 +70,8 @@ object TargetTopic {
     maxQueued: Int,
   ): Stream[F, Element] =
     for {
-      pq    <- Stream.resource(s.prepareR(ProgramTopic.SelectProgramUsers))
       oid   <- updates(s, maxQueued)
-      users <- Stream.eval(pq.stream(oid._2, 1024).compile.toList)
+      users <- Stream.eval(ProgramTopic.selectProgramUsers(s, oid._2))
       elem   = Element(oid._1, oid._2, oid._3, oid._4, users)
       _     <- Stream.eval(Logger[F].info(s"TargetChannel: $elem"))
     } yield elem

--- a/modules/service/src/main/scala/lucuma/odb/service/TargetService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TargetService.scala
@@ -19,6 +19,7 @@ import lucuma.core.math.ProperMotion
 import lucuma.core.model.CatalogInfo
 import lucuma.core.model.EphemerisKey
 import lucuma.core.model.GuestUser
+import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.ServiceUser
 import lucuma.core.model.SiderealTracking
@@ -34,6 +35,7 @@ import lucuma.odb.data.Nullable
 import lucuma.odb.data.Nullable.*
 import lucuma.odb.data.Tag
 import lucuma.odb.graphql.input.CatalogInfoInput
+import lucuma.odb.graphql.input.CloneTargetInput
 import lucuma.odb.graphql.input.SiderealInput
 import lucuma.odb.graphql.input.TargetPropertiesInput
 import lucuma.odb.graphql.input.UpdateTargetsInput
@@ -43,17 +45,20 @@ import lucuma.odb.json.wavelength.query.given
 import lucuma.odb.util.Codecs._
 import skunk.AppliedFragment
 import skunk.Encoder
+import skunk.Query
 import skunk.Session
 import skunk.SqlState
+import skunk.Transaction
 import skunk.Void
 import skunk.circe.codec.all._
 import skunk.codec.all._
 import skunk.implicits._
 
 trait TargetService[F[_]] {
-  import TargetService.{ CreateTargetResponse, UpdateTargetsResponse }
+  import TargetService.{ CloneTargetResponse, CreateTargetResponse, UpdateTargetsResponse }
   def createTarget(pid: Program.Id, input: TargetPropertiesInput.Create): F[CreateTargetResponse]
   def updateTargets(input: TargetPropertiesInput.Edit, which: AppliedFragment): F[UpdateTargetsResponse]
+  def cloneTarget(input: CloneTargetInput): F[CloneTargetResponse]
 }
 
 object TargetService {
@@ -66,10 +71,18 @@ object TargetService {
   }
   import CreateTargetResponse._
 
-  enum UpdateTargetsResponse:
-    case Success(selected: List[Target.Id])
-    case SourceProfileUpdatesFailed(problems: NonEmptyChain[Problem])
-    case TrackingSwitchFailed(problem: String)
+  sealed trait UpdateTargetsResponse
+  sealed trait UpdateTargetsError extends UpdateTargetsResponse
+  object UpdateTargetsResponse {
+    case class Success(selected: List[Target.Id]) extends UpdateTargetsResponse
+    case class SourceProfileUpdatesFailed(problems: NonEmptyChain[Problem]) extends UpdateTargetsError
+    case class TrackingSwitchFailed(problem: String) extends UpdateTargetsError
+  }
+
+  enum CloneTargetResponse:
+    case Success(oldTargetId: Target.Id, newTargetId: Target.Id)
+    case NoSuchTarget(targetId: Target.Id)
+    case UpdateFailed(problem: UpdateTargetsError)
 
   def fromSession[F[_]: Concurrent](s: Session[F], u: User): TargetService[F] =
     new TargetService[F] {
@@ -92,6 +105,10 @@ object TargetService {
 
       def updateTargets(input: TargetPropertiesInput.Edit, which: AppliedFragment): F[UpdateTargetsResponse] =
         s.transaction.use { xa =>
+          updateTargetsʹ(xa, input, which)
+        }
+
+      def updateTargetsʹ(xa: Transaction[F], input: TargetPropertiesInput.Edit, which: AppliedFragment): F[UpdateTargetsResponse] =
 
         // Updates that don't concern source profile
         val nonSourceProfileUpdates: Stream[F, Target.Id] = {
@@ -132,13 +149,36 @@ object TargetService {
               
             }
 
+          } recover {
+            case SqlState.CheckViolation(ex) if ex.constraintName == Some("ra_dec_epoch_all_defined") =>
+              UpdateTargetsResponse.TrackingSwitchFailed("Sidereal targets require RA, Dec, and Epoch to be defined.")
           }
 
-      } recover {
-          case SqlState.CheckViolation(ex) if ex.constraintName == Some("ra_dec_epoch_all_defined") =>
-            UpdateTargetsResponse.TrackingSwitchFailed("Sidereal targets require RA, Dec, and Epoch to be defined.")
-      }
+      def cloneTarget(input: CloneTargetInput): F[CloneTargetResponse] =
+        s.transaction.use { xa =>
+          
+          // TODO: need to ensure that the original target is visible to the user          
 
+          val clone: F[Target.Id] =
+            s.prepareR(Statements.cloneTarget).use(_.unique(input.targetId))
+
+          def update(tid: Target.Id): F[Option[UpdateTargetsResponse]] = 
+            input.SET.traverse(updateTargetsʹ(xa, _, sql"$target_id".apply(tid)))
+          
+          def replaceIn(tid: Target.Id): F[Unit] =
+            input.REPLACE_IN.traverse_ { which =>
+              val stmt = Statements.replaceTargetIn(which, input.targetId, tid)
+              s.prepareR(stmt.fragment.command).use(_.execute(stmt.argument))               
+            } 
+
+          clone.flatMap { tid =>
+            update(tid).flatMap {              
+                case Some(err: UpdateTargetsError) => CloneTargetResponse.UpdateFailed(err).pure[F]         
+                case _ => replaceIn(tid) as CloneTargetResponse.Success(input.targetId, tid)
+            }
+          }
+
+        }
 
     }
 
@@ -346,6 +386,58 @@ object TargetService {
       updates(SET).fold(which)(update)
     }
 
+    // an exact clone, except for c_target_id and c_existence (which are defaulted)
+    val cloneTarget: Query[Target.Id, Target.Id] =
+      sql"""
+        INSERT INTO t_target(
+          c_program_id,
+          c_name,
+          c_type,
+          c_sid_ra,
+          c_sid_dec,
+          c_sid_epoch,
+          c_sid_pm_ra,
+          c_sid_pm_dec,
+          c_sid_rv,
+          c_sid_parallax,
+          c_sid_catalog_name,
+          c_sid_catalog_id,
+          c_sid_catalog_object_type,
+          c_nsid_des,
+          c_nsid_key_type,
+          c_nsid_key,
+          c_source_profile,
+        )
+        SELECT 
+          c_program_id,
+          c_name,
+          c_type,
+          c_sid_ra,
+          c_sid_dec,
+          c_sid_epoch,
+          c_sid_pm_ra,
+          c_sid_pm_dec,
+          c_sid_rv,
+          c_sid_parallax,
+          c_sid_catalog_name,
+          c_sid_catalog_id,
+          c_sid_catalog_object_type,
+          c_nsid_des,
+          c_nsid_key_type,
+          c_nsid_key,
+          c_source_profile
+        FROM t_target
+        WHERE c_target_id = $target_id
+        RETURNING c_target_id
+      """.query(target_id)
+
+    def replaceTargetIn(which: NonEmptyList[Observation.Id], from: Target.Id, to: Target.Id): AppliedFragment =
+      sql"""
+      UPDATE t_target_asterism
+      SET    c_target_id = $target_id
+      WHERE  c_target_id = $target_id
+      AND    c_observation_id IN (${observation_id.list(which.length)})
+      """.apply(to ~ from ~ which.toList)
   }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/service/TargetService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TargetService.scala
@@ -406,7 +406,7 @@ object TargetService {
           c_nsid_des,
           c_nsid_key_type,
           c_nsid_key,
-          c_source_profile,
+          c_source_profile
         )
         SELECT 
           c_program_id,

--- a/modules/service/src/main/scala/lucuma/odb/service/TargetService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TargetService.scala
@@ -183,7 +183,7 @@ object TargetService {
                 case None => NoSuchTarget(input.targetId).pure[F] // not authorized
                 case Some(tid) =>
                   update(tid).flatMap {              
-                    case Some(err: UpdateTargetsError) => UpdateFailed(err).pure[F]         
+                    case Some(err: UpdateTargetsError) => xa.rollback.as(UpdateFailed(err))
                     case _ => replaceIn(tid) as Success(input.targetId, tid)
                   }
               }
@@ -447,7 +447,7 @@ object TargetService {
 
     def replaceTargetIn(which: NonEmptyList[Observation.Id], from: Target.Id, to: Target.Id): AppliedFragment =
       sql"""
-      UPDATE t_target_asterism
+      UPDATE t_asterism_target
       SET    c_target_id = $target_id
       WHERE  c_target_id = $target_id
       AND    c_observation_id IN (${observation_id.list(which.length)})

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
@@ -7,6 +7,9 @@ package mutation
 import io.circe.Json
 import io.circe.literal.*
 import lucuma.core.model.Target
+import cats.effect.IO
+import lucuma.core.model.Observation
+import io.circe.syntax.*
 
 class cloneTarget extends OdbSuite {
   import createTarget.FullTargetGraph
@@ -158,6 +161,60 @@ class cloneTarget extends OdbSuite {
           expected = Left(List(s"No such target: $tid"))
         )
       }
+    }
+  }
+
+  test("clone and replace in an observation") {
+
+    def cloneTarget(tid: Target.Id, oids: List[Observation.Id]): IO[Target.Id] =
+      query(pi, s"""
+        mutation { 
+          cloneTarget(input: { 
+            targetId: "$tid"
+            REPLACE_IN: ${oids.asJson}
+          }) { 
+            newTarget { id }
+          } 
+        }
+      """).map(_.hcursor.downFields("cloneTarget", "newTarget", "id").require[Target.Id])
+
+    def asterism(oid: Observation.Id): IO[List[Target.Id]] =
+      query(pi, s"""
+        query { 
+          observation(observationId: "$oid") {
+            targetEnvironment {
+              asterism {
+                id
+              }
+            }
+          }
+        }
+      """).map {
+        _.hcursor.downFields("observation", "targetEnvironment", "asterism").require[List[Json]]
+         .map(_.hcursor.downField("id").require[Target.Id])
+      }
+
+    for {
+      // one program
+      pid  <- createProgramAs(pi)
+      // several targets
+      tid1 <- createTargetAs(pi, pid, "Target 1")
+      tid2 <- createTargetAs(pi, pid, "Target 2")
+      tid3 <- createTargetAs(pi, pid, "Target 3")
+      // several obs with both targets
+      oid1 <- createObservationAs(pi, pid, tid1, tid3) // 1, 3
+      oid2 <- createObservationAs(pi, pid, tid1, tid3) // 1, 3
+      oid3 <- createObservationAs(pi, pid, tid2, tid3) // 2, 3
+      // clone a target and replace it in some obs
+      tid4 <- cloneTarget(tid3, List(oid2, oid3))
+      // fetch our asterisms
+      ast1 <- asterism(oid1)
+      ast2 <- asterism(oid2)
+      ast3 <- asterism(oid3)
+    } yield {
+      assertEquals(ast1, List(tid1, tid3)) // unchanged
+      assertEquals(ast2, List(tid1, tid4)) // 1, 3 -> 4
+      assertEquals(ast3, List(tid2, tid4)) // 2, 3 -> 4
     }
   }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
@@ -4,7 +4,9 @@
 package lucuma.odb.graphql
 package mutation
 
+import io.circe.Json
 import io.circe.literal.*
+import lucuma.core.model.Target
 
 class cloneTarget extends OdbSuite {
   import createTarget.FullTargetGraph
@@ -15,25 +17,74 @@ class cloneTarget extends OdbSuite {
   test("simple clone") {
     createProgramAs(pi).flatMap { pid =>
       createTargetAs(pi, pid, "My Target").flatMap { tid =>
-        expect(
+        query(
           user = pi,
           query = s"""
           mutation {
             cloneTarget(input: {
               targetId: "$tid"
             }) {
+              originalTarget $FullTargetGraph
+              newTarget $FullTargetGraph
+
+              originalTargetId: originalTarget { id }
+              newTargetId: newTarget { id }
+            }
+          }
+          """
+        ).map { json =>
+
+          // The data fields (i.e., everything but ID) should be the same
+          assertEquals(
+            json.hcursor.downFields("cloneTarget", "originalTarget").as[Json],
+            json.hcursor.downFields("cloneTarget", "newTarget").as[Json]
+          )
+
+          // The ids should be different
+          assertNotEquals(
+            json.hcursor.downFields("cloneTarget", "originalTargetId", "Id").as[Target.Id],
+            json.hcursor.downFields("cloneTarget", "newTargetId", "Id").as[Target.Id]
+          )
+        
+        }
+      }
+    }
+  }
+
+  test("clone with rename") {
+    createProgramAs(pi).flatMap { pid =>
+      createTargetAs(pi, pid, "My Target").flatMap { tid =>
+        expect(
+          user = pi,
+          query = s"""
+          mutation {
+            cloneTarget(input: {
+              targetId: "$tid"
+              SET: {
+                name: "New Name"
+              }
+            }) {
               originalTarget {
-                id
+                name
               }
               newTarget {
-                id
+                name
               }
             }
           }
           """,
           expected = Right(
             json"""
-            42
+              {
+                "cloneTarget" : {
+                  "originalTarget" : {
+                    "name" : "My Target"
+                  },
+                  "newTarget" : {
+                    "name" : "New Name"
+                  }
+                }
+              }
             """
           )
         )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
@@ -4,12 +4,41 @@
 package lucuma.odb.graphql
 package mutation
 
+import io.circe.literal.*
+
 class cloneTarget extends OdbSuite {
   import createTarget.FullTargetGraph
 
   val pi = TestUsers.Standard.pi(nextId, nextId)
   lazy val validUsers = List(pi)
 
-  
+  test("simple clone") {
+    createProgramAs(pi).flatMap { pid =>
+      createTargetAs(pi, pid, "My Target").flatMap { tid =>
+        expect(
+          user = pi,
+          query = s"""
+          mutation {
+            cloneTarget(input: {
+              targetId: "$tid"
+            }) {
+              originalTarget {
+                id
+              }
+              newTarget {
+                id
+              }
+            }
+          }
+          """,
+          expected = Right(
+            json"""
+            42
+            """
+          )
+        )
+      }
+    }
+  }
 
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
@@ -4,12 +4,12 @@
 package lucuma.odb.graphql
 package mutation
 
+import cats.effect.IO
 import io.circe.Json
 import io.circe.literal.*
-import lucuma.core.model.Target
-import cats.effect.IO
-import lucuma.core.model.Observation
 import io.circe.syntax.*
+import lucuma.core.model.Observation
+import lucuma.core.model.Target
 
 class cloneTarget extends OdbSuite {
   import createTarget.FullTargetGraph

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mutation
+
+class cloneTarget extends OdbSuite {
+  import createTarget.FullTargetGraph
+
+  val pi = TestUsers.Standard.pi(nextId, nextId)
+  lazy val validUsers = List(pi)
+
+  
+
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
@@ -20,17 +20,17 @@ class cloneTarget extends OdbSuite {
         query(
           user = pi,
           query = s"""
-          mutation {
-            cloneTarget(input: {
-              targetId: "$tid"
-            }) {
-              originalTarget $FullTargetGraph
-              newTarget $FullTargetGraph
+            mutation {
+              cloneTarget(input: {
+                targetId: "$tid"
+              }) {
+                originalTarget $FullTargetGraph
+                newTarget $FullTargetGraph
 
-              originalTargetId: originalTarget { id }
-              newTargetId: newTarget { id }
+                originalTargetId: originalTarget { id }
+                newTargetId: newTarget { id }
+              }
             }
-          }
           """
         ).map { json =>
 
@@ -57,21 +57,21 @@ class cloneTarget extends OdbSuite {
         expect(
           user = pi,
           query = s"""
-          mutation {
-            cloneTarget(input: {
-              targetId: "$tid"
-              SET: {
-                name: "New Name"
-              }
-            }) {
-              originalTarget {
-                name
-              }
-              newTarget {
-                name
+            mutation {
+              cloneTarget(input: {
+                targetId: "$tid"
+                SET: {
+                  name: "New Name"
+                }
+              }) {
+                originalTarget {
+                  name
+                }
+                newTarget {
+                  name
+                }
               }
             }
-          }
           """,
           expected = Right(
             json"""
@@ -87,6 +87,28 @@ class cloneTarget extends OdbSuite {
               }
             """
           )
+        )
+      }
+    }
+  }
+
+  test("clone with bogus target id") {
+    createProgramAs(pi).flatMap { pid =>
+      createTargetAs(pi, pid, "My Target").flatMap { tid =>
+        expect(
+          user = pi,
+          query = s"""
+            mutation {
+              cloneTarget(input: {
+                targetId: "t-ffff"
+              }) {
+                newTarget {
+                  id
+                }
+              }
+            }
+          """,
+          expected = Left(List("No such target: t-ffff"))
         )
       }
     }


### PR DESCRIPTION
Ok this adds Mutation/cloneTarget with two shameful hacks:

1. There is no obvious way in Grackle to return two values (the old and new targets in this case) so I added a view with every pair of target ids and am using that as the root of the result, which makes everything straightforward. `EXPLAIN ANALYZE` says this is fine and not slow, so I don't feel _that_ bad about it.

2. I found that during testing the change event streams for targets and observations were dying with non-existent portal errors, which I can't explain. I think maybe some changes in Skunk or fs2 are trying to be clever about when to close portals and are doing it too eagerly. In any case I replaced it with a straight interpolated string query and it works now. I will keep investigating.

