### PR TITLE
Roll back circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val catsTimeVersion            = "0.5.1"
-val circeVersion               = "0.14.4"
+val circeVersion               = "0.14.3"
 val cirisVersion               = "3.1.0"
 val clueVersion                = "0.23.2"
 val declineVersion             = "2.4.1"


### PR DESCRIPTION
ODB kinda crashes on startup today.  There was an automatic update of circe that may be related.  We may need to update SSO first.  This is an experiment.

```
2023-02-09T13:11:11.460991+00:00 app[web.1]: Exception in thread "io-compute-11" java.lang.NoSuchMethodError: 'scala.collection.Iterator io.circe.DerivedDecoder.resultIterator$(io.circe.DerivedDecoder, io.circe.HCursor)'
2023-02-09T13:11:11.461133+00:00 app[web.1]: 	at lucuma.sso.client.codec.OrcidProfileCodec$$anon$2.resultIterator(OrcidProfileCodec.scala:15)
2023-02-09T13:11:11.461165+00:00 app[web.1]: 	at lucuma.sso.client.codec.OrcidProfileCodec$$anon$2.apply(OrcidProfileCodec.scala:12)
2023-02-09T13:11:11.461194+00:00 app[web.1]: 	at io.circe.Decoder.tryDecode(Decoder.scala:89)
2023-02-09T13:11:11.461221+00:00 app[web.1]: 	at io.circe.Decoder.tryDecode$(Decoder.scala:54)
2023-02-09T13:11:11.461250+00:00 app[web.1]: 	at lucuma.sso.client.codec.OrcidProfileCodec$$anon$2.tryDecode(OrcidProfileCodec.scala:15)
2023-02-09T13:11:11.461279+00:00 app[web.1]: 	at io.circe.ACursor.as(ACursor.scala:304)
2023-02-09T13:11:11.461309+00:00 app[web.1]: 	at lucuma.sso.client.codec.UserCodec.$init$$$anonfun$2$$anonfun$1$$anonfun$3$$anonfun$1$$anonfun$1(UserCodec.scala:62)
2023-02-09T13:11:11.461335+00:00 app[web.1]: 	at scala.util.Either.flatMap(Either.scala:352)
2023-02-09T13:11:11.461367+00:00 app[web.1]: 	at lucuma.sso.client.codec.UserCodec.$init$$$anonfun$2$$anonfun$1$$anonfun$3$$anonfun$1(UserCodec.scala:63)
2023-02-09T13:11:11.461394+00:00 app[web.1]: 	at scala.util.Either.flatMap(Either.scala:352)
2023-02-09T13:11:11.461422+00:00 app[web.1]: 	at lucuma.sso.client.codec.UserCodec.$init$$$anonfun$2$$anonfun$1$$anonfun$3(UserCodec.scala:63)
2023-02-09T13:11:11.461450+00:00 app[web.1]: 	at scala.util.Either.flatMap(Either.scala:352)
2023-02-09T13:11:11.461478+00:00 app[web.1]: 	at lucuma.sso.client.codec.UserCodec.$init$$$anonfun$2$$anonfun$1(UserCodec.scala:63)
2023-02-09T13:11:11.461506+00:00 app[web.1]: 	at scala.util.Either.flatMap(Either.scala:352)
2023-02-09T13:11:11.461544+00:00 app[web.1]: 	at lucuma.sso.client.codec.UserCodec.$init$$$anonfun$2(UserCodec.scala:68)
2023-02-09T13:11:11.461570+00:00 app[web.1]: 	at io.circe.Decoder.tryDecode(Decoder.scala:89)
2023-02-09T13:11:11.461598+00:00 app[web.1]: 	at io.circe.ACursor.as(ACursor.scala:304)
2023-02-09T13:11:11.461626+00:00 app[web.1]: 	at lucuma.sso.client.SsoJwtClaim.getUser$$anonfun$1(SsoJwtClaim.scala:19)
2023-02-09T13:11:11.461653+00:00 app[web.1]: 	at scala.util.Either.flatMap(Either.scala:352)
2023-02-09T13:11:11.461681+00:00 app[web.1]: 	at lucuma.sso.client.SsoJwtClaim.getUser(SsoJwtClaim.scala:20)
2023-02-09T13:11:11.461709+00:00 app[web.1]: 	at lucuma.sso.client.SsoClient$.fetchApiInfo$1$$anonfun$1$$anonfun$1(SsoClient.scala:121)
2023-02-09T13:11:11.461737+00:00 app[web.1]: 	at cats.data.Kleisli.flatMap$$anonfun$2$$anonfun$1(Kleisli.scala:75)
2023-02-09T13:11:11.461764+00:00 app[web.1]: 	at cats.effect.IOFiber.succeeded(IOFiber.scala:1172)
2023-02-09T13:11:11.461793+00:00 app[web.1]: 	at cats.effect.IOFiber.runLoop(IOFiber.scala:247)
2023-02-09T13:11:11.461827+00:00 app[web.1]: 	at cats.effect.IOFiber.asyncContinueSuccessfulR(IOFiber.scala:1325)
2023-02-09T13:11:11.461855+00:00 app[web.1]: 	at cats.effect.IOFiber.run(IOFiber.scala:119)
2023-02-09T13:11:11.461882+00:00 app[web.1]: 	at cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:585)
```