### PR TITLE
Brightness Edit Bug

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/GaussianInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/GaussianInput.scala
@@ -40,6 +40,6 @@ object GaussianInput {
     }
 
   val CreateOrEditBinding =
-    CreateBinding orElse EditBinding
+    CreateBinding or EditBinding
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/SourceProfileInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/SourceProfileInput.scala
@@ -31,7 +31,7 @@ object SourceProfileInput {
           case (Some(point), None, None)     => Result(Point(point))
           case (None, Some(uniform), None)   => Result(Uniform(uniform))
           case (None, None, Some(gaussian))  => Result(gaussian)
-          case _                             => Result.failure("Expected exactly one of point, uniform, or guassian.")
+          case _                             => Result.failure("Expected exactly one of point, uniform, or gaussian.")
         }
     }
 
@@ -44,7 +44,7 @@ object SourceProfileInput {
       ) =>
         (rPoint, rUniform, rGaussian).parTupled.flatMap {
 
-          // If the user provides a full definitiom we can change the source profile
+          // If the user provides a full definition we can change the source profile
           case (Some(Left(p)), None, None) => Result(_ => Result(Point(p)))
           case (None, Some(Left(u)), None) => Result(_ => Result(Uniform(u)))
           case (None, None, Some(Left(g))) => Result(_ => Result(g))
@@ -55,7 +55,7 @@ object SourceProfileInput {
           case (None, None, Some(Right(f))) => Result(sp => sp.gaussian.flatMap(gs => f(gs)))
 
           // Otherwise we definitely fail.
-          case _ => Result.failure("Expected exactly one of point, uniform, or guassian.")
+          case _ => Result.failure("Expected exactly one of point, uniform, or gaussian.")
 
         }
     }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/SourceProfileInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/SourceProfileInput.scala
@@ -5,6 +5,7 @@ package lucuma.odb.graphql
 package input
 package sourceprofile
 
+import cats.data.Ior
 import cats.syntax.all._
 import edu.gemini.grackle.Result
 import lucuma.core.model.SourceProfile
@@ -44,15 +45,21 @@ object SourceProfileInput {
       ) =>
         (rPoint, rUniform, rGaussian).parTupled.flatMap {
 
-          // If the user provides a full definition we can change the source profile
-          case (Some(Left(p)), None, None) => Result(_ => Result(Point(p)))
-          case (None, Some(Left(u)), None) => Result(_ => Result(Uniform(u)))
-          case (None, None, Some(Left(g))) => Result(_ => Result(g))
+          // If the user provides an input that can be used for editing or replacement, apply the edit if the source profile types match,
+          // otherwise interpret it as a replacement.
+          case (Some(Ior.Both(c, e)), None, None) => Result(sp => sp.point.toOption.map(_.spectralDefinition).fold(Result(c))(e).map(Point(_)))
+          case (None, Some(Ior.Both(c, e)), None) => Result(sp => sp.uniform.toOption.map(_.spectralDefinition).fold(Result(c))(e).map(Uniform(_)))
+          case (None, None, Some(Ior.Both(c, e))) => Result(sp => sp.gaussian.toOption.fold(Result(c))(e))
+
+          // If the user provides a full definition then we will replace the source profile
+          case (Some(Ior.Left(p)), None, None) => Result(_ => Result(Point(p)))
+          case (None, Some(Ior.Left(u)), None) => Result(_ => Result(Uniform(u)))
+          case (None, None, Some(Ior.Left(g))) => Result(_ => Result(g))
 
           // Otherwise we will try to apply an edit, which may fail.
-          case (Some(Right(f)), None, None) => Result(sp => sp.point.flatMap(ps => f(ps.spectralDefinition)).map(Point(_)))
-          case (None, Some(Right(f)), None) => Result(sp => sp.uniform.flatMap(us => f(us.spectralDefinition)).map(Uniform(_)))
-          case (None, None, Some(Right(f))) => Result(sp => sp.gaussian.flatMap(gs => f(gs)))
+          case (Some(Ior.Right(f)), None, None) => Result(sp => sp.point.flatMap(ps => f(ps.spectralDefinition)).map(Point(_)))
+          case (None, Some(Ior.Right(f)), None) => Result(sp => sp.uniform.flatMap(us => f(us.spectralDefinition)).map(Uniform(_)))
+          case (None, None, Some(Ior.Right(f))) => Result(sp => sp.gaussian.flatMap(gs => f(gs)))
 
           // Otherwise we definitely fail.
           case _ => Result.failure("Expected exactly one of point, uniform, or gaussian.")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/SpectralDefinitionInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/SpectralDefinitionInput.scala
@@ -35,7 +35,7 @@ object SpectralDefinitionInput {
       )
 
     val CreateOrEditBinding =
-      CreateBinding orElse EditBinding
+      CreateBinding or EditBinding
 
   }
 
@@ -54,7 +54,7 @@ object SpectralDefinitionInput {
       )
 
     val CreateOrEditBinding =
-      CreateBinding orElse EditBinding
+      CreateBinding or EditBinding
 
   }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateTargets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateTargets.scala
@@ -463,6 +463,85 @@ class updateTargets extends OdbSuite {
     }
   }
 
+  test("update source profile (point/bandNormalized/brightnesses)") {
+    createProgramAs(pi).flatMap { pid =>
+      createTargetAs(pi, pid, "target-1").flatMap { tid =>
+        expect(
+          user = pi,
+          query = s"""
+            mutation {
+              updateTargets(input: {
+                SET: {
+                  sourceProfile: {
+                    point: {
+                      bandNormalized: {
+                        brightnesses: [
+                          {
+                             band: R
+                             value: 15.0
+                             units: VEGA_MAGNITUDE
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+                WHERE: {
+                  id: { EQ: "$tid"}
+                }
+              }) {
+                targets {
+                  sourceProfile {
+                    point {
+                      bandNormalized {
+                        sed {
+                          stellarLibrary
+                        }
+                        brightnesses {
+                          band
+                          value
+                          units
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          """,
+          expected = Right(
+            json"""
+              {
+                "updateTargets" : {
+                  "targets" : [
+                    {
+                      "sourceProfile" : {
+                        "point" : {
+                          "bandNormalized" : {
+                            "sed" : {
+                              "stellarLibrary" : "B5_III"
+                            },
+                            "brightnesses" : [
+                              {
+                                "band" : "R",
+                                 "value" : "15.0",
+                                 "units" : "VEGA_MAGNITUDE"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            """
+          )
+        )
+      }
+    }
+  }
+
   test("update source profile (point -> gaussian, incomplete)") {
     createProgramAs(pi).flatMap { pid =>
       createTargetAs(pi, pid, "target-1").flatMap { tid =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateTargets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateTargets.scala
@@ -542,6 +542,193 @@ class updateTargets extends OdbSuite {
     }
   }
 
+  test("update source profile (uniform/bandNormalized/brightnesses)") {
+    createProgramAs(pi).flatMap { pid =>
+      createTargetAs(pi, pid, "target-1", """
+        sourceProfile: {
+          uniform: {
+            bandNormalized: {
+              sed: {
+                stellarLibrary: B5_III
+              }
+              brightnesses: []
+            }
+          }
+        }
+      """).flatMap { tid =>
+        expect(
+          user = pi,
+          query = s"""
+            mutation {
+              updateTargets(input: {
+                SET: {
+                  sourceProfile: {
+                    uniform: {
+                      bandNormalized: {
+                        brightnesses: [
+                          {
+                             band: R
+                             value: 15.0
+                             units: VEGA_MAG_PER_ARCSEC_SQUARED
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+                WHERE: {
+                  id: { EQ: "$tid"}
+                }
+              }) {
+                targets {
+                  sourceProfile {
+                    uniform {
+                      bandNormalized {
+                        sed {
+                          stellarLibrary
+                        }
+                        brightnesses {
+                          band
+                          value
+                          units
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          """,
+          expected = Right(
+            json"""
+              {
+                "updateTargets" : {
+                  "targets" : [
+                    {
+                      "sourceProfile" : {
+                        "uniform" : {
+                          "bandNormalized" : {
+                            "sed" : {
+                              "stellarLibrary" : "B5_III"
+                            },
+                            "brightnesses" : [
+                              {
+                                "band" : "R",
+                                 "value" : "15.0",
+                                 "units" : "VEGA_MAG_PER_ARCSEC_SQUARED"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            """
+          )
+        )
+      }
+    }
+  }
+
+  test("update source profile (gaussian/bandNormalized/brightnesses)") {
+    createProgramAs(pi).flatMap { pid =>
+      createTargetAs(pi, pid, "target-1", """
+        sourceProfile: {
+          gaussian: {
+            spectralDefinition: {
+              bandNormalized: {
+                sed: {
+                  stellarLibrary: B5_III
+                }
+                brightnesses: []
+              }
+            }
+            fwhm: {
+              microarcseconds: 42
+            }
+          }
+        }
+      """).flatMap { tid =>
+        expect(
+          user = pi,
+          query = s"""
+            mutation {
+              updateTargets(input: {
+                SET: {
+                  sourceProfile: {
+                    gaussian: {
+                      spectralDefinition: {
+                        bandNormalized: {
+                          brightnesses: [
+                            {
+                              band: R
+                              value: 15.0
+                              units: VEGA_MAGNITUDE
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+                WHERE: {
+                  id: { EQ: "$tid"}
+                }
+              }) {
+                targets {
+                  sourceProfile {
+                    gaussian {
+                      bandNormalized {
+                        brightnesses {
+                          band
+                          value
+                          units
+                        }
+                      }
+                      fwhm {
+                        microarcseconds
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          """,
+          expected = Right(
+            json"""
+              {
+                "updateTargets" : {
+                  "targets" : [
+                    {
+                      "sourceProfile" : {
+                        "gaussian" : {
+                          "bandNormalized" : {
+                            "brightnesses" : [
+                              {
+                                "band" : "R",
+                                 "value" : "15.0",
+                                 "units" : "VEGA_MAGNITUDE"
+                              }
+                            ]
+                          },
+                          "fwhm" : {
+                            "microarcseconds" : 42
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            """
+          )
+        )
+      }
+    }
+  }
+
   test("update source profile (point -> gaussian, incomplete)") {
     createProgramAs(pi).flatMap { pid =>
       createTargetAs(pi, pid, "target-1").flatMap { tid =>


### PR DESCRIPTION
Adds a test case illustrating a problem reported by @rpiaggio.  In particular, when editing only the brightness information (ignoring SED), we are being fooled into thinking an entire point source definition is being provided because SED is optional. The result is that we swap out the existing point source for the new one without the SED instead of just updating the brightness information.

**RNC: EDIT:** ok I think this is fixed. I added code that favors editing where possible. Added analogous testcases for uniform and gaussian sources.