### PR TITLE
Mutation/cloneObservation

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0170__observation_pairs.sql
+++ b/modules/service/src/main/resources/db/migration/V0170__observation_pairs.sql
@@ -1,0 +1,12 @@
+
+-- A view that contains every pair of target ids. When joined to the target table
+-- with conditions on the ids it all compiles down to hash lookups, which are fast.
+
+CREATE OR REPLACE VIEW v_observation_pairs AS
+  SELECT
+    a.c_observation_id c_left,
+    b.c_observation_id c_right
+  FROM
+    t_observation a,
+    t_observation b
+    

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -23,6 +23,7 @@ trait BaseMapping[F[_]]
   lazy val CatalogInfoType                     = schema.ref("CatalogInfo")
   lazy val CatalogNameType                     = schema.ref("CatalogName")
   lazy val ClassicalType                       = schema.ref("Classical")
+  lazy val CloneObservationResultType          = schema.ref("CloneObservationResult")
   lazy val CloneTargetResultType               = schema.ref("CloneTargetResult")
   lazy val CloudExtinctionType                 = schema.ref("CloudExtinction")
   lazy val ConstraintSetType                   = schema.ref("ConstraintSet")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -110,6 +110,7 @@ object OdbMapping {
           with AsterismGroupMapping[F]
           with AsterismGroupSelectResultMapping[F]
           with CatalogInfoMapping[F]
+          with CloneObservationResultMapping[F]
           with CloneTargetResultMapping[F]
           with ConstraintSetGroupMapping[F]
           with ConstraintSetGroupSelectResultMapping[F]
@@ -275,6 +276,7 @@ object OdbMapping {
               AsterismGroupMapping,
               AsterismGroupSelectResultMapping,
               CatalogInfoMapping,
+              CloneObservationResultMapping,
               CloneTargetResultMapping,
               ConstraintSetGroupMapping,
               ConstraintSetGroupSelectResultMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -186,7 +186,8 @@ object OdbMapping {
           override val observationService: Resource[F, ObservationService[F]] =
             pool.map { s =>
               val oms = ObservingModeServices.fromSession(s)
-              ObservationService.fromSessionAndUser(s, user, oms)
+              val as  = AsterismService.fromSessionAndUser(s, user)
+              ObservationService.fromSessionAndUser(s, user, oms, as)
             }
 
           override val programService: Resource[F, ProgramService[F]] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CloneObservationInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CloneObservationInput.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package input
+
+import cats.syntax.all.*
+import lucuma.core.model.Observation
+import lucuma.odb.graphql.binding._
+
+final case class CloneObservationInput(
+  observationId: Observation.Id,
+  SET:           Option[ObservationPropertiesInput.Edit],
+)
+
+object CloneObservationInput {
+
+ val Binding: Matcher[CloneObservationInput] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        ObservationIdBinding("observationId", rObservationId),
+        ObservationPropertiesInput.Edit.Binding.Option("SET", rSET),
+      ) =>
+        (rObservationId, rSET).mapN(CloneObservationInput.apply)
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CloneObservationResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CloneObservationResultMapping.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.mapping
+
+import edu.gemini.grackle.Cursor
+import edu.gemini.grackle.Result
+import lucuma.odb.graphql.BaseMapping
+import lucuma.odb.graphql.table.ObservationPairsView
+import lucuma.odb.graphql.table.ObservationView
+
+import scala.tools.util.PathResolver.Environment
+
+trait CloneObservationResultMapping[F[_]] extends ResultMapping[F] with ObservationView[F] with ObservationPairsView[F] {
+
+  lazy val CloneObservationResultMapping: ObjectMapping =
+    ObjectMapping(
+      tpe = CloneObservationResultType,
+      fieldMappings = List(
+        SqlField("synthetic-id", ObservationPairsView.Left, key = true, hidden = true),
+        SqlObject("originalObservation", Join(ObservationPairsView.Left, ObservationView.Id)),
+        SqlObject("newObservation", Join(ObservationPairsView.Right, ObservationView.Id)),
+      )
+    )
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/CloneObservationResultPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/CloneObservationResultPredicates.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.predicate
+
+import edu.gemini.grackle.Path
+
+class CloneObservationResultPredicates(path: Path) {
+  val originalObservation = ObservationPredicates(path / "originalObservation")
+  val newObservation = ObservationPredicates(path / "newObservation")
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
@@ -14,19 +14,20 @@ trait Predicates[F[_]] extends BaseMapping[F] {
    * constructing filters, etc.
    */
   object Predicates {
-    val asterismGroup       = AsterismGroupPredicates(Path.from(AsterismGroupType))
-    val cloneTargetResult   = CloneTargetResultPredicates(Path.from(CloneTargetResultType))
-    val constraintSetGroup  = ConstraintSetGroupPredicates(Path.from(ConstraintSetGroupType))
-    val linkUserResult      = LinkUserResultPredicates(Path.from(LinkUserResultType))
-    val observation         = ObservationPredicates(Path.from(ObservationType))
-    val observationEdit     = ObservationEditPredicates(Path.from(ObservationEditType))
-    val program             = ProgramPredicates(Path.from(ProgramType))
-    val programEdit         = ProgramEditPredicates(Path.from(ProgramEditType))
-    val proposalClass       = ProposalClassPredicates(Path.from(ProposalClassType))
-    val setAllocationResult = SetAllocationResultPredicates(Path.from(SetAllocationResultType))
-    val target              = TargetPredicates(Path.from(TargetType))
-    val targetEdit          = TargetEditPredicates(Path.from(TargetEditType))
-    val targetGroup         = TargetGroupPredicates(Path.from(TargetGroupType))
+    val asterismGroup          = AsterismGroupPredicates(Path.from(AsterismGroupType))
+    val cloneObservationResult = CloneObservationResultPredicates(Path.from(CloneObservationResultType))
+    val cloneTargetResult      = CloneTargetResultPredicates(Path.from(CloneTargetResultType))
+    val constraintSetGroup     = ConstraintSetGroupPredicates(Path.from(ConstraintSetGroupType))
+    val linkUserResult         = LinkUserResultPredicates(Path.from(LinkUserResultType))
+    val observation            = ObservationPredicates(Path.from(ObservationType))
+    val observationEdit        = ObservationEditPredicates(Path.from(ObservationEditType))
+    val program                = ProgramPredicates(Path.from(ProgramType))
+    val programEdit            = ProgramEditPredicates(Path.from(ProgramEditType))
+    val proposalClass          = ProposalClassPredicates(Path.from(ProposalClassType))
+    val setAllocationResult    = SetAllocationResultPredicates(Path.from(SetAllocationResultType))
+    val target                 = TargetPredicates(Path.from(TargetType))
+    val targetEdit             = TargetEditPredicates(Path.from(TargetEditType))
+    val targetGroup            = TargetGroupPredicates(Path.from(TargetGroupType))
   }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationPairsView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationPairsView.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package table
+
+import edu.gemini.grackle.skunk.SkunkMapping
+import lucuma.odb.util.Codecs._
+import skunk.codec.all._
+
+trait ObservationPairsView[F[_]] extends BaseMapping[F] {
+
+  object ObservationPairsView extends TableDef("v_observation_pairs") {
+    val Left = col("c_left", observation_id)
+    val Right = col("c_right", observation_id)
+  }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/service/GmosLongSlitService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GmosLongSlitService.scala
@@ -525,9 +525,13 @@ object GmosLongSlitService {
           void"SET " |+| us.intercalate(void", ") |+| void" " |+|
           void"WHERE " |+| observationIdIn(oids)
 
-    def cloneGmosNorthLongSlit(originalId: Observation.Id, newId: Observation.Id): AppliedFragment =
+    private def cloneGmosLongSlit(
+      table: String,
+      originalId: Observation.Id, 
+      newId: Observation.Id
+    ): AppliedFragment =
       sql"""
-      INSERT INTO t_gmos_north_long_slit (
+      INSERT INTO #$table (
         c_observation_id,
         c_observing_mode_type,
         c_grating,
@@ -564,52 +568,15 @@ object GmosLongSlitService {
         c_initial_filter,
         c_initial_fpu,
         c_initial_central_wavelength
-      FROM t_gmos_north_long_slit
+      FROM #$table
       WHERE c_observation_id = $observation_id
       """.apply(newId ~ originalId)
 
+    def cloneGmosNorthLongSlit(originalId: Observation.Id, newId: Observation.Id): AppliedFragment =
+      cloneGmosLongSlit("t_gmos_north_long_slit", originalId, newId)
+
     def cloneGmosSouthLongSlit(originalId: Observation.Id, newId: Observation.Id): AppliedFragment =
-      sql"""
-      INSERT INTO t_gmos_south_long_slit (
-        c_observation_id,
-        c_observing_mode_type,
-        c_grating,
-        c_filter,
-        c_fpu,
-        c_central_wavelength,
-        c_xbin,
-        c_ybin,
-        c_amp_read_mode,
-        c_amp_gain,
-        c_roi,
-        c_wavelength_dithers,
-        c_spatial_offsets,
-        c_initial_grating,
-        c_initial_filter,
-        c_initial_fpu,
-        c_initial_central_wavelength
-      )
-      SELECT
-        $observation_id,
-        c_observing_mode_type,
-        c_grating,
-        c_filter,
-        c_fpu,
-        c_central_wavelength,
-        c_xbin,
-        c_ybin,
-        c_amp_read_mode,
-        c_amp_gain,
-        c_roi,
-        c_wavelength_dithers,
-        c_spatial_offsets,
-        c_initial_grating,
-        c_initial_filter,
-        c_initial_fpu,
-        c_initial_central_wavelength
-      FROM t_gmos_south_long_slit
-      WHERE c_observation_id = $observation_id
-      """.apply(newId ~ originalId)
+      cloneGmosLongSlit("t_gmos_south_long_slit", originalId, newId)
 
   }
 }

--- a/modules/service/src/main/scala/lucuma/odb/service/GmosLongSlitService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GmosLongSlitService.scala
@@ -208,15 +208,14 @@ object GmosLongSlitService {
         originalId: Observation.Id,
         newId: Observation.Id,
       ): F[Unit] =
-        Sync[F].delay(println(s"cloneNorth($originalId -> $newId)")) >>
         exec(Statements.cloneGmosNorthLongSlit(originalId, newId))
 
       def cloneSouth(
         originalId: Observation.Id,
         newId: Observation.Id,
       ): F[Unit] =
-        Sync[F].delay(println(s"cloneSouth($originalId -> $newId)")) >>
         exec(Statements.cloneGmosSouthLongSlit(originalId, newId))      
+
     }
 
   object Statements {

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -154,7 +154,8 @@ object ObservationService {
   def fromSessionAndUser[F[_]: Sync: Trace](
     session: Session[F],
     user:    User,
-    observingModeServices: ObservingModeServices[F]
+    observingModeServices: ObservingModeServices[F],
+    asterismService: AsterismService[F]
   ): ObservationService[F] =
     new ObservationService[F] {
 
@@ -289,13 +290,13 @@ object ObservationService {
       ): F[Result[Observation.Id]] = 
         session.transaction.use { xa =>
 
-          // We need the pid to do access checking, so let's just select it
-          val selPid = sql"select c_program_id from t_observation where c_observation_id = $observation_id"
-          session.prepareR(selPid.query(program_id)).use(_.option(input.observationId)).flatMap {
+          // First we need the pid and observing mode.
+          val selPid = sql"select c_program_id, c_observing_mode_type from t_observation where c_observation_id = $observation_id"
+          session.prepareR(selPid.query(program_id ~ observing_mode_type.opt)).use(_.option(input.observationId)).flatMap {
 
             case None => Result.failure(s"No such observation: ${input.observationId}").pure[F]
 
-            case Some(pid) =>
+            case Some(pid ~ observingMode) =>
 
               // Ok the obs exists, so let's clone its main row in t_observation. If this returns
               // None then it means the user doesn't have permission to see the obs.
@@ -311,17 +312,11 @@ object ObservationService {
 
                 case Some(oid2) =>
 
-                  // The remaining clone operations yield no results and can't fail (logically, anyway)
-                  val cloneTheRest = 
-                    List(
-                    Statements.cloneAsterism(input.observationId, oid2),
-                    Statements.cloneGmosNorthStatic(input.observationId, oid2),
-                    Statements.cloneGmosNorthDynamic(input.observationId, oid2),
-                    Statements.cloneGmosNorthLongSlit(input.observationId, oid2),
-                  ).traverse_(af => session.prepareR(af.fragment.command).use(_.execute(af.argument)))
+                  val cloneRelatedItems =
+                    asterismService.cloneAsterism(input.observationId, oid2) >>
+                    observingMode.traverse(observingModeServices.cloneFunction(_)(input.observationId, oid2))
 
-                  // Now we need to run the update, if any
-                  val update: F[Result[Observation.Id]] = 
+                  val doUpdate =
                     input.SET match
                       case None    => Result(oid2).pure[F] // nothing to do
                       case Some(s) => 
@@ -333,10 +328,11 @@ object ObservationService {
                               case other        => Result.failure(s"Observation update: expected [$oid2], found ${other.mkString("[", ",", "]")}")
                             }  
                           }
+                          .flatTap { 
+                            r => xa.rollback.whenA(r.isLeft)
+                          }
 
-                  // And put it all together
-                  (cloneTheRest >> update)
-                    .flatTap(r => xa.rollback.whenA(r.isLeft)) // roll back if we have a failing result
+                  cloneRelatedItems >> doUpdate
 
               }
           }
@@ -789,134 +785,6 @@ object ObservationService {
       void"""
         RETURNING c_observation_id
       """
-
-    def cloneAsterism(oldOid: Observation.Id, newOid: Observation.Id): AppliedFragment =
-      sql"""
-        INSERT INTO t_asterism_target (
-          c_program_id,
-          c_observation_id,
-          c_target_id
-        )
-        SELECT 
-          t_asterism_target.c_program_id,
-          $observation_id,
-          t_asterism_target.c_target_id
-        FROM t_asterism_target
-        JOIN t_target ON t_target.c_target_id = t_asterism_target.c_target_id
-        WHERE c_observation_id = $observation_id
-        AND t_target.c_existence = 'present' -- don't clone references to deleted targets
-      """.apply(newOid ~ oldOid)
-    
-    def cloneGmosNorthStatic(oldOid: Observation.Id, newOid: Observation.Id): AppliedFragment =
-      sql"""
-        INSERT INTO t_gmos_north_static (
-          c_observation_id,
-          c_instrument,
-          c_detector,
-          c_mos_pre_imaging,
-          c_nod_and_shuffle,
-          c_stage_mode
-        )
-        SELECT 
-          $observation_id,
-          c_instrument,
-          c_detector,
-          c_mos_pre_imaging,
-          c_nod_and_shuffle,
-          c_stage_mode
-        FROM t_gmos_north_static
-        WHERE c_observation_id = $observation_id
-      """.apply(newOid ~ oldOid)
-
-    def cloneGmosNorthDynamic(oldOid: Observation.Id, newOid: Observation.Id): AppliedFragment =
-      sql"""
-        INSERT INTO t_gmos_north_dynamic (
-          c_observation_id,
-          c_instrument,
-          c_index,
-          c_exposure,
-          c_readout_x_binning,
-          c_readout_y_binning,
-          c_readout_amp_count,
-          c_readout_amp_gain,
-          c_readout_amp_read_mode,
-          c_dtax,
-          c_roi,
-          c_grating_disperser,
-          c_grating_order,
-          c_grating_wavelength,
-          c_filter,
-          c_fpu_option,
-          c_fpu_custom_mask_filename,
-          c_fpu_custom_mask_custom_slit_width,
-          c_fpu_fpu
-        )
-        SELECT
-          $observation_id,
-          c_instrument,
-          c_index,
-          c_exposure,
-          c_readout_x_binning,
-          c_readout_y_binning,
-          c_readout_amp_count,
-          c_readout_amp_gain,
-          c_readout_amp_read_mode,
-          c_dtax,
-          c_roi,
-          c_grating_disperser,
-          c_grating_order,
-          c_grating_wavelength,
-          c_filter,
-          c_fpu_option,
-          c_fpu_custom_mask_filename,
-          c_fpu_custom_mask_custom_slit_width,
-          c_fpu_fpu
-        FROM t_gmos_north_dynamic
-        WHERE c_observation_id = $observation_id
-       """.apply(newOid ~ oldOid)
-
-    def cloneGmosNorthLongSlit(oldOid: Observation.Id, newOid: Observation.Id): AppliedFragment =
-      sql"""
-      INSERT INTO t_gmos_north_long_slit (
-        c_observation_id,
-        c_observing_mode_type,
-        c_grating,
-        c_filter,
-        c_fpu,
-        c_central_wavelength,
-        c_xbin,
-        c_ybin,
-        c_amp_read_mode,
-        c_amp_gain,
-        c_roi,
-        c_wavelength_dithers,
-        c_spatial_offsets,
-        c_initial_grating,
-        c_initial_filter,
-        c_initial_fpu,
-        c_initial_central_wavelength
-      )
-      SELECT
-        $observation_id,
-        c_observing_mode_type,
-        c_grating,
-        c_filter,
-        c_fpu,
-        c_central_wavelength,
-        c_xbin,
-        c_ybin,
-        c_amp_read_mode,
-        c_amp_gain,
-        c_roi,
-        c_wavelength_dithers,
-        c_spatial_offsets,
-        c_initial_grating,
-        c_initial_filter,
-        c_initial_fpu,
-        c_initial_central_wavelength
-      FROM t_gmos_north_long_slit
-      WHERE c_observation_id = $observation_id
-      """.apply(newOid ~ oldOid)
 
   }
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -754,8 +754,8 @@ object ObservationService {
           c_title,
           c_subtitle,
           c_instrument,
-          c_status,
-          c_active_status,
+          'new',
+          'active',
           c_visualization_time,
           c_pts_pi,
           c_pts_uncharged,
@@ -798,11 +798,13 @@ object ObservationService {
           c_target_id
         )
         SELECT 
-          c_program_id,
+          t_asterism_target.c_program_id,
           $observation_id,
-          c_target_id
+          t_asterism_target.c_target_id
         FROM t_asterism_target
+        JOIN t_target ON t_target.c_target_id = t_asterism_target.c_target_id
         WHERE c_observation_id = $observation_id
+        AND t_target.c_existence = 'present' -- don't clone references to deleted targets
       """.apply(newOid ~ oldOid)
     
     def cloneGmosNorthStatic(oldOid: Observation.Id, newOid: Observation.Id): AppliedFragment =

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -59,8 +59,8 @@ import lucuma.odb.data.PosAngleConstraintMode
 import lucuma.odb.data.Tag
 import lucuma.odb.data.Timestamp
 import lucuma.odb.graphql.input.AirMassRangeInput
-import lucuma.odb.graphql.input.ConstraintSetInput
 import lucuma.odb.graphql.input.CloneObservationInput
+import lucuma.odb.graphql.input.ConstraintSetInput
 import lucuma.odb.graphql.input.ElevationRangeInput
 import lucuma.odb.graphql.input.HourAngleRangeInput
 import lucuma.odb.graphql.input.ObservationPropertiesInput

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservingModeServices.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservingModeServices.scala
@@ -39,6 +39,10 @@ sealed trait ObservingModeServices[F[_]] {
     input: ObservingModeInput.Edit
   ): Result[(List[Observation.Id], Transaction[F]) => F[Unit]]
 
+  def cloneFunction(
+    mode: ObservingModeType
+  ): (Observation.Id, Observation.Id) => F[Unit]
+
 }
 
 object ObservingModeServices {
@@ -116,6 +120,15 @@ object ObservingModeServices {
           case Nil     => Result.failure("No observing mode edit parameters were provided.")
           case _       => Result.failure("Only one observing mode's edit parameters may be provided.")
         }
+
+      override def cloneFunction(
+        mode: ObservingModeType
+      ): (Observation.Id, Observation.Id) => F[Unit] =
+        mode match {
+          case ObservingModeType.GmosNorthLongSlit => gmosLongSlitService.cloneNorth
+          case ObservingModeType.GmosSouthLongSlit => gmosLongSlitService.cloneSouth
+        }
+
     }
 
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -14,11 +14,11 @@ import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.core.util.TimeSpan
 import lucuma.odb.data.Existence
+import lucuma.odb.data.ObservingModeType
 import lucuma.odb.data.ProgramUserRole
 import lucuma.odb.data.ProgramUserSupportType
 import lucuma.odb.data.Tag
 import org.checkerframework.checker.units.qual.s
-import lucuma.odb.data.ObservingModeType
 
 trait DatabaseOperations { this: OdbSuite =>
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -13,11 +13,11 @@ import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.core.util.TimeSpan
+import lucuma.odb.data.Existence
 import lucuma.odb.data.ProgramUserRole
 import lucuma.odb.data.ProgramUserSupportType
 import lucuma.odb.data.Tag
 import org.checkerframework.checker.units.qual.s
-import lucuma.odb.data.Existence
 
 trait DatabaseOperations { this: OdbSuite =>
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -34,7 +34,7 @@ trait DatabaseOperations { this: OdbSuite =>
     }
 
   def createObservationAs(user: User, pid: Program.Id, tids: Target.Id*): IO[Observation.Id] =
-    createObservationAs(user, pid, ObservingModeType.GmosNorthLongSlit, tids: _*)
+    createObservationAs(user, pid, None, tids: _*)
 
   private def scienceRequirementsObject(observingMode: ObservingModeType): String =
     observingMode match
@@ -73,7 +73,7 @@ trait DatabaseOperations { this: OdbSuite =>
           }
         }"""
 
-  def createObservationAs(user: User, pid: Program.Id, observingMode: ObservingModeType, tids: Target.Id*): IO[Observation.Id] =
+  def createObservationAs(user: User, pid: Program.Id, observingMode: Option[ObservingModeType] = None, tids: Target.Id*): IO[Observation.Id] =
     query(
       user = user,
       query =
@@ -85,8 +85,12 @@ trait DatabaseOperations { this: OdbSuite =>
                 targetEnvironment: {
                   asterism: ${tids.asJson}
                 }
-                scienceRequirements: ${scienceRequirementsObject(observingMode)}
-                observingMode: ${observingModeObject(observingMode)}
+                ${observingMode.foldMap { m =>
+                  s"""
+                    scienceRequirements: ${scienceRequirementsObject(m)}
+                    observingMode: ${observingModeObject(m)}
+                  """
+                }}
               }
             }) {
               observation {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
@@ -92,7 +92,7 @@ class cloneObservation extends OdbSuite {
     }      
   }
 
-  test("clones should have different ids".ignore) {
+  test("clones should have different ids") {
     createProgramAs(pi).flatMap { pid =>
       val t = createTargetAs(pi, pid)
       (t, t).tupled.flatMap { (tid1, tid2) =>
@@ -171,7 +171,7 @@ class cloneObservation extends OdbSuite {
 
   }
 
-  test("cloned asterism should not include deleted targets".ignore) {
+  test("cloned asterism should not include deleted targets") {
 
     val setup =
       for
@@ -221,7 +221,7 @@ class cloneObservation extends OdbSuite {
 
   }
 
-  test("cloned observation should always be present/new/active".ignore) {
+  test("cloned observation should always be present/new/active") {
 
     def updateFields(pid: Program.Id, oid: Observation.Id): IO[Unit] =
       expect(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
@@ -4,11 +4,17 @@
 package lucuma.odb.graphql
 package mutation
 
+import cats.syntax.all._
 import cats.effect.IO
 import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.Target
+import lucuma.odb.data.Existence
+import lucuma.core.enums.ObsStatus
+import lucuma.core.enums.ObsActiveStatus
 
 class cloneObservation extends OdbSuite {
   import createTarget.FullTargetGraph
@@ -16,32 +22,94 @@ class cloneObservation extends OdbSuite {
   val pi, pi2 = TestUsers.Standard.pi(nextId, nextId)
   lazy val validUsers = List(pi, pi2)
 
-  val FullObservationGraph = s"""
+  // N.B. this is copied from the test for Query/observation; if it doesn't end up changing we
+  // should factor it out.
+  def createObservation(pid: Program.Id, tid1: Target.Id, tid2: Target.Id) =
+    query(
+      user = pi,
+      query = s"""
+        mutation {
+          createObservation(
+            input: {
+              programId: "$pid"
+              SET: {
+                constraintSet: {
+                  cloudExtinction: POINT_ONE
+                  imageQuality: POINT_ONE
+                  skyBackground: DARKEST
+                }
+                targetEnvironment: { asterism: ["$tid1", "$tid2"] }
+                scienceRequirements: {
+                  mode: SPECTROSCOPY
+                  spectroscopy: {
+                    wavelength: { nanometers: 500 }
+                    resolution: 100
+                    signalToNoise: 100.0
+                    wavelengthCoverage: { nanometers: 20 }
+                    focalPlane: SINGLE_SLIT
+                    focalPlaneAngle: { microarcseconds: 0 }
+                  }
+                }
+                observingMode: {
+                  gmosNorthLongSlit: {
+                    grating: R831_G5302
+                    filter: R_PRIME
+                    fpu: LONG_SLIT_0_50
+                    centralWavelength: { nanometers: 500 }
+                  }
+                }
+              }
+            }
+          ) {
+            observation {
+              id
+            }
+          }
+        }
+      """
+    ).map{ j => j.hcursor.downFields("createObservation", "observation", "id").require[Observation.Id] }
+
+  // properties we expect to be the same
+  val ObservationGraph = s"""
     { 
-      existence
       title
       subtitle
-      status
-      activeStatus
-    # visualizationTime
-    # posAngleConstraint
-    # plannedTime
       program { id }
+      constraintSet {
+        cloudExtinction
+        imageQuality
+        skyBackground
+      }
       targetEnvironment { 
         asterism $FullTargetGraph
       }
-    # constraintSet
-    # scienceRequirements
-    # observingMode
-    # manualConfig
-    # execution
+      scienceRequirements {
+        mode
+        spectroscopy {
+          wavelength { nanometers }
+          resolution
+          signalToNoise
+          wavelengthCoverage { nanometers }
+          focalPlane
+          focalPlaneAngle { microarcseconds }
+        }
+      }
+      observingMode {
+        gmosNorthLongSlit {
+          grating 
+          filter 
+          fpu 
+          centralWavelength { nanometers }
+        }
+      }
     }
   """
 
   test("clones should have the same properties, including asterism") {
     createProgramAs(pi).flatMap { pid =>
-      createTargetAs(pi, pid, "Vega").flatMap { tid =>
-        createObservationAs(pi, pid, tid).flatMap { oid =>
+      val t = createTargetAs(pi, pid)
+      (t, t).tupled.flatMap { (tid1, tid2) =>
+        createObservation(pid, tid1, tid2).flatMap { oid =>
           query(
             user = pi,
             query = s"""
@@ -49,15 +117,15 @@ class cloneObservation extends OdbSuite {
                 cloneObservation(input: {
                   observationId: "$oid"
                 }) {
-                  originalObservation $FullObservationGraph
-                  newObservation $FullObservationGraph
+                  originalObservation $ObservationGraph
+                  newObservation $ObservationGraph
                 }
               }
             """
           ).map { json =>
             assertEquals(
-              json.hcursor.downFields("cloneObservation", "originalObservation").as[Json],
-              json.hcursor.downFields("cloneObservation", "newObservation").as[Json]
+              json.hcursor.downFields("cloneObservation", "originalObservation").require[Json],
+              json.hcursor.downFields("cloneObservation", "newObservation").require[Json]
             )
           }
         }
@@ -67,27 +135,166 @@ class cloneObservation extends OdbSuite {
 
   test("clones should have different ids") {
     createProgramAs(pi).flatMap { pid =>
-      createObservationAs(pi, pid).flatMap { oid =>
-        query(
-          user = pi,
-          query = s"""
-            mutation {
-              cloneObservation(input: {
-                observationId: "$oid"
-              }) {
-                originalObservation { id }
-                newObservation { id }
+      val t = createTargetAs(pi, pid)
+      (t, t).tupled.flatMap { (tid1, tid2) =>
+        createObservation(pid, tid1, tid2).flatMap { oid =>
+          query(
+            user = pi,
+            query = s"""
+              mutation {
+                cloneObservation(input: {
+                  observationId: "$oid"
+                }) {
+                  originalObservation { id }
+                  newObservation { id }
+                }
               }
-            }
-          """
-        ).map { json =>
-          assertNotEquals(
-            json.hcursor.downFields("cloneObservation", "originalObservationId", "Id").as[Observation.Id],
-            json.hcursor.downFields("cloneObservation", "newObservationId", "Id").as[Observation.Id]
-          )          
+            """
+          ).map { json =>
+            assertNotEquals(
+              json.hcursor.downFields("cloneObservation", "originalObservation", "id").require[Observation.Id],
+              json.hcursor.downFields("cloneObservation", "newObservation", "id").require[Observation.Id]
+            )          
+          }
         }
       }
     }
+  }
+
+  test("cloned asterism should not include deleted targets") {
+
+    val setup =
+      for
+        pid  <- createProgramAs(pi)
+        tid1 <- createTargetAs(pi, pid)
+        tid2 <- createTargetAs(pi, pid)
+        oid1 <- createObservation(pid, tid1, tid2)
+        _    <- updateTargetExistencetAs(pi, tid1, Existence.Deleted)
+        oid2 <- cloneObservationAs(pi, oid1)
+        _    <- updateTargetExistencetAs(pi, tid1, Existence.Present)
+      yield (tid2, oid2)
+
+    setup.flatMap { (tid, oid) =>
+      expect(
+        user = pi,
+        query = 
+          s"""
+          query {
+            observation(observationId: ${oid.asJson}) {
+              id
+              targetEnvironment {
+                asterism {
+                  id
+                }
+              }
+            }
+          }
+        """,
+        expected = Right(
+          json"""
+            {
+              "observation" : {
+                "id" : $oid,
+                "targetEnvironment" : {
+                  "asterism" : [
+                    {
+                      "id" : $tid
+                    }
+                  ]
+                }
+              }
+            }
+          """
+        )
+      )
+    }
+
+  }
+
+  test("cloned observation should always be present/new/active") {
+
+    def updateFields(pid: Program.Id, oid: Observation.Id): IO[Unit] =
+      expect(
+        user = pi,
+        query = s"""
+          mutation {
+            updateObservations(input: {
+              programId: ${pid.asJson}
+              SET: {
+                existence: ${Existence.Deleted.tag.toUpperCase}
+                status: ${ObsStatus.Observed.tag.toUpperCase}
+                activeStatus: ${ObsActiveStatus.Inactive.tag.toUpperCase}
+              },
+              WHERE: {
+                id: { EQ: ${oid.asJson} }
+              }
+            }) {
+              observations {
+                id
+                existence
+                status
+                activeStatus
+              }
+            }
+          }
+        """,
+        expected = Right(
+          json"""
+            {
+              "updateObservations" : {
+                "observations" : [
+                  {
+                    "id" : $oid,
+                    "existence" : "DELETED",
+                    "status" : "OBSERVED",
+                    "activeStatus" : "INACTIVE"
+                  }
+                ]
+              }
+            }
+          """        
+        )
+      )
+
+    val setup =
+      for
+        pid <- createProgramAs(pi)
+        oid <- createObservationAs(pi, pid)
+        _   <- updateFields(pid, oid)
+      yield oid
+
+    setup.flatMap { oid =>
+      expect(
+        user = pi,
+        query = s"""
+          mutation {
+            cloneObservation(input: {
+              observationId: "$oid"
+            }) {
+              newObservation {
+                existence
+                status
+                activeStatus
+              }
+            }
+          }
+        """,
+        expected = Right(
+          json"""
+            {
+              "cloneObservation" : {
+                "newObservation" : {
+                  "existence" : "PRESENT",
+                  "status" : "NEW",
+                  "activeStatus" : "ACTIVE"
+                }
+              }
+            }
+          """
+        )
+      )
+    }
+
   }
 
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
@@ -68,7 +68,7 @@ class cloneObservation extends OdbSuite {
       createProgramAs(pi).flatMap { pid =>
         val t = createTargetAs(pi, pid)
         (t, t).tupled.flatMap { (tid1, tid2) =>
-          createObservationAs(pi, pid, obsMode, tid1, tid2).flatMap { oid =>
+          createObservationAs(pi, pid, Some(obsMode), tid1, tid2).flatMap { oid =>
             query(
               user = pi,
               query = s"""

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
@@ -24,7 +24,7 @@ class cloneObservation extends OdbSuite {
   lazy val validUsers = List(pi, pi2)
 
   // N.B. if we include the asterism here we hit a Grakle bug that's not yet minimized
-  // see 
+  // see https://github.com/gemini-hlsw/lucuma-odb/issues/296
   val ObservationGraph = s"""
     { 
       title

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
@@ -4,17 +4,17 @@
 package lucuma.odb.graphql
 package mutation
 
-import cats.syntax.all._
 import cats.effect.IO
+import cats.syntax.all._
 import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
+import lucuma.core.enums.ObsActiveStatus
+import lucuma.core.enums.ObsStatus
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.odb.data.Existence
-import lucuma.core.enums.ObsStatus
-import lucuma.core.enums.ObsActiveStatus
 
 class cloneObservation extends OdbSuite {
   import createTarget.FullTargetGraph

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
@@ -1,0 +1,78 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mutation
+
+import cats.effect.IO
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.model.Observation
+
+class cloneObservation extends OdbSuite {
+  import createTarget.FullTargetGraph
+
+  val pi, pi2 = TestUsers.Standard.pi(nextId, nextId)
+  lazy val validUsers = List(pi, pi2)
+
+  val FullObservationGraph = s"""
+    { 
+      existence
+      title
+      subtitle
+      status
+      activeStatus
+    # visualizationTime
+    # posAngleConstraint
+    # plannedTime
+      program { id }
+    # targetEnvironment { asterism { id } }
+    # constraintSet
+    # scienceRequirements
+    # observingMode
+    # manualConfig
+    # execution
+    }
+  """
+
+  test("simple clone") {
+    createProgramAs(pi).flatMap { pid =>
+      createTargetAs(pi, pid, "Vega").flatMap { tid =>
+        createObservationAs(pi, pid, tid).flatMap { oid =>
+          query(
+            user = pi,
+            query = s"""
+              mutation {
+                cloneObservation(input: {
+                  observationId: "$oid"
+                }) {
+                  originalObservation $FullObservationGraph
+                  newObservation $FullObservationGraph
+
+                  originalObservationId: originalObservation { id }
+                  newObservationId: newObservation { id }
+                }
+              }
+            """
+          ).map { json =>
+
+            // The data fields (i.e., everything but ID) should be the same
+            assertEquals(
+              json.hcursor.downFields("cloneObservation", "originalObservation").as[Json],
+              json.hcursor.downFields("cloneObservation", "newObservation").as[Json]
+            )
+
+            // The ids should be different
+            assertNotEquals(
+              json.hcursor.downFields("cloneObservation", "originalObservationId", "Id").as[Observation.Id],
+              json.hcursor.downFields("cloneObservation", "newObservationId", "Id").as[Observation.Id]
+            )
+          
+          }
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This adds `Mutation/cloneObservation` via
- `ObservationService::cloneObservation`, which delegates to
  - `AsterismService::cloneAsterism` and
  - `ObservingModeServices::cloneFunction`, which delegates to
    - `GmosLongSlitService::cloneNorth` and `cloneSouth`
