### PR TITLE
fix RA isssue

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -2039,7 +2039,8 @@ type RecordGmosSouthVisitResult {
 
 # Right Ascension, choose one of the available units
 input RightAscensionInput {
-  microarcseconds: Long
+  microarcseconds: Long @deprecated
+  microseconds: Long
   degrees: BigDecimal
   hours: BigDecimal
   hms: HmsString
@@ -4877,7 +4878,11 @@ type RightAscension {
   degrees: BigDecimal!
 
   # Right Ascension (RA) in µas
-  microarcseconds: Long!
+  microarcseconds: Long! @deprecated
+
+  # Right Ascension (RA) in µs
+  microseconds: Long!
+
 }
 
 # Base science mode

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/HourAngleBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/HourAngleBinding.scala
@@ -4,11 +4,15 @@
 package lucuma.odb.graphql
 package binding
 
+import lucuma.core.math.Angle
 import lucuma.core.math.HourAngle
 
 object HourAngleBinding {
 
   val Microarcseconds: Matcher[HourAngle] =
+    LongBinding.map(Angle.fromMicroarcseconds).map(Angle.hourAngle.get)
+
+  val Microseconds: Matcher[HourAngle] =
     LongBinding.map(HourAngle.fromMicroseconds)
 
   val Degrees: Matcher[HourAngle] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/RightAscensionInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/RightAscensionInput.scala
@@ -15,12 +15,13 @@ object RightAscensionInput {
     ObjectFieldsBinding.rmap {
       case List(
         HourAngleBinding.Microarcseconds.Option("microarcseconds", rMicroarcseconds),
+        HourAngleBinding.Microseconds.Option("microseconds", rMicroseconds),
         HourAngleBinding.Degrees.Option("degrees", rDegrees),
         HourAngleBinding.Hours.Option("hours", rHours),
         HourAngleBinding.Hms.Option("hms", rHms),
-      ) => (rMicroarcseconds, rDegrees, rHours, rHms).parTupled.flatMap {
-        case (microarcseconds, degrees, hours, hms) =>
-          List(microarcseconds, degrees, hours, hms).flatten match {
+      ) => (rMicroarcseconds, rMicroseconds, rDegrees, rHours, rHms).parTupled.flatMap {
+        case (microarcseconds, microseconds, degrees, hours, hms) =>
+          List(microarcseconds, microseconds, degrees, hours, hms).flatten match {
             case List(ha) => Result(RightAscension(ha))
             case has => Result.failure(s"Expected exactly one right ascension format; found ${has.length}.")
           }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/RightAscensionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/RightAscensionMapping.scala
@@ -37,7 +37,8 @@ trait RightAscensionMapping[F[_]] extends ObservationView[F] with TargetView[F] 
         FieldRef[RightAscension]("value").as("hms", RightAscension.fromStringHMS.reverseGet),
         FieldRef[RightAscension]("value").as("hours", c => BigDecimal(c.toHourAngle.toDoubleHours)),
         FieldRef[RightAscension]("value").as("degrees", c => BigDecimal(c.toAngle.toDoubleDegrees)),
-        FieldRef[RightAscension]("value").as("microarcseconds", _.toAngle.toMicroarcseconds)
+        FieldRef[RightAscension]("value").as("microarcseconds", _.toAngle.toMicroarcseconds),
+        FieldRef[RightAscension]("value").as("microseconds", _.toHourAngle.toMicroseconds)
       )
     )
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/1939.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/1939.scala
@@ -1,0 +1,195 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package issue.shortcut
+
+import cats.effect.IO
+import cats.syntax.all._
+import io.circe.literal._
+import io.circe.syntax._
+import lucuma.core.model.Partner
+import lucuma.core.model.User
+import lucuma.odb.graphql.OdbSuite
+
+// https://app.shortcut.com/lucuma/story/1939
+class Shortcut_1939 extends OdbSuite {
+  val pi = TestUsers.Standard.pi(nextId, nextId)
+  lazy val validUsers = List(pi)
+
+  test("RA microseconds should round-trip") {
+    createProgramAs(pi).flatMap { pid =>
+      expect(
+        user = pi,
+        query = s"""
+          mutation {
+            createTarget(
+              input: {
+                programId: ${pid.asJson}
+                SET: {
+                  name: "Crunchy Target"
+                  sidereal: {
+                    ra: { microseconds: 12345 }
+                    dec: { degrees: 0 }
+                    epoch: "J2000.000"
+                  }
+                  sourceProfile: {
+                    point: {
+                      bandNormalized: {
+                        sed: { stellarLibrary: B5_III }
+                        brightnesses: []
+                      }
+                    }
+                  }
+                }
+              }
+            ) {
+              target {
+                sidereal {
+                  ra {
+                    microseconds
+                    microarcseconds
+                  }
+                }
+              }
+            }
+          }
+        """,
+        expected = Right(
+          json"""
+            {
+              "createTarget" : {
+                "target" : {
+                  "sidereal" : {
+                    "ra" : {
+                      "microseconds" : 12345,
+                      "microarcseconds" : 185175
+                    }
+                  }
+                }
+              }
+            }
+          """
+        )
+      )
+    }
+  }
+
+  test("RA microarcseconds should round-trip (when divisible by 15)") {
+    createProgramAs(pi).flatMap { pid =>
+      expect(
+        user = pi,
+        query = s"""
+          mutation {
+            createTarget(
+              input: {
+                programId: ${pid.asJson}
+                SET: {
+                  name: "Crunchy Target"
+                  sidereal: {
+                    ra: { microarcseconds: 185175 }
+                    dec: { degrees: 0 }
+                    epoch: "J2000.000"
+                  }
+                  sourceProfile: {
+                    point: {
+                      bandNormalized: {
+                        sed: { stellarLibrary: B5_III }
+                        brightnesses: []
+                      }
+                    }
+                  }
+                }
+              }
+            ) {
+              target {
+                sidereal {
+                  ra {
+                    microseconds
+                    microarcseconds
+                  }
+                }
+              }
+            }
+          }
+        """,
+        expected = Right(
+          json"""
+            {
+              "createTarget" : {
+                "target" : {
+                  "sidereal" : {
+                    "ra" : {
+                      "microseconds" : 12345,
+                      "microarcseconds" : 185175
+                    }
+                  }
+                }
+              }
+            }
+          """
+        )
+      )
+    }
+  }
+  
+  test("RA microarcseconds should round down (when not divisible by 15)") {
+    createProgramAs(pi).flatMap { pid =>
+      expect(
+        user = pi,
+        query = s"""
+          mutation {
+            createTarget(
+              input: {
+                programId: ${pid.asJson}
+                SET: {
+                  name: "Crunchy Target"
+                  sidereal: {
+                    ra: { microarcseconds: 185183 }
+                    dec: { degrees: 0 }
+                    epoch: "J2000.000"
+                  }
+                  sourceProfile: {
+                    point: {
+                      bandNormalized: {
+                        sed: { stellarLibrary: B5_III }
+                        brightnesses: []
+                      }
+                    }
+                  }
+                }
+              }
+            ) {
+              target {
+                sidereal {
+                  ra {
+                    microseconds
+                    microarcseconds
+                  }
+                }
+              }
+            }
+          }
+        """,
+        expected = Right(
+          json"""
+            {
+              "createTarget" : {
+                "target" : {
+                  "sidereal" : {
+                    "ra" : {
+                      "microseconds" : 12345,
+                      "microarcseconds" : 185175
+                    }
+                  }
+                }
+              }
+            }
+          """
+        )
+      )
+    }
+  }
+
+}
+


### PR DESCRIPTION
This fixes https://app.shortcut.com/lucuma/story/1939/error-storing-ra-coordinates as follows:

- The RA `microarcseconds` input now works correctly. Values divisible by 15 are round-trippable but other values are rounded down. Due to this asymmetry the fields are marked as deprecated in the schema.
- RA input and output types now have a `microseconds` field, which is always round-trippable and should be perferred,