### PR TITLE
Replace missing  field in atom

### DIFF
--- a/modules/schema/src/main/scala/lucuma/odb/json/sequence.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/sequence.scala
@@ -105,10 +105,14 @@ trait SequenceCodec {
       } yield Atom.GmosNorth(i, s)
     }
 
+  private val StepTimeZero: StepTime =
+    StepTime(TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero)
+
   given given_Encoder_Atom_GmosNorth(using Encoder[Offset], Encoder[TimeSpan], Encoder[Wavelength]): Encoder[Atom.GmosNorth] =
     Encoder.instance { (a: Atom.GmosNorth) =>
       Json.obj(
         "id"    -> a.id.asJson,
+        "time"  -> StepTimeZero.asJson,
         "steps" -> a.steps.asJson
       )
     }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/sequence.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/sequence.scala
@@ -51,6 +51,11 @@ class sequence extends OdbSuite with ObservingModeSetupOperations {
                      }
                      acquisition {
                        nextAtom {
+                         time {
+                           total {
+                             microseconds
+                           }
+                         }
                          steps {
                            instrumentConfig {
                              exposure {
@@ -104,6 +109,11 @@ class sequence extends OdbSuite with ObservingModeSetupOperations {
                   },
                   "acquisition": {
                     "nextAtom": {
+                      "time": {
+                        "total": {
+                          "microseconds": 0
+                        }
+                      },
                       "steps": [
                         {
                           "instrumentConfig": {


### PR DESCRIPTION
I left the atom `time` field out of the encoder by mistake.  This breaks something in explore so as a quick fix I'm adding it as zero time.

In the end I'm not sure this belongs here in the atom. At any rate if we _do_ keep it this way in the schema I'm not sure how to implement it.  It seems suboptimal to compute the planned time with every sequence generation (?) whether the user is asking for it or not, but that's the natural way it would fall out as implemented.  Perhaps it would be okay if we cache the sequence generation.