### PR TITLE
time field for GS atom

### DIFF
--- a/modules/schema/src/main/scala/lucuma/odb/json/sequence.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/sequence.scala
@@ -129,6 +129,7 @@ trait SequenceCodec {
     Encoder.instance { (a: Atom.GmosSouth) =>
       Json.obj(
         "id"    -> a.id.asJson,
+        "time"  -> StepTimeZero.asJson,
         "steps" -> a.steps.asJson
       )
     }


### PR DESCRIPTION
Addendum  for #295 -- I forgot to add the `time` field to the GMOS _south_ atom.