### PR TITLE
Execution config hack

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -821,6 +821,10 @@ input GmosNorthDynamicInput {
 
 # GMOS North Execution Config
 type GmosNorthExecutionConfig implements ExecutionConfig {
+
+  # Bogus field that makes the structure of this instrument distinct from the others.
+  gmosNorth: Boolean! @deprecated
+
   # GMOS North static configuration
   static: GmosNorthStatic!
 
@@ -1196,6 +1200,10 @@ input GmosSouthDynamicInput {
 
 # GMOS South Execution Config
 type GmosSouthExecutionConfig implements ExecutionConfig {
+
+  # Bogus field that makes the structure of this instrument distinct from the others.
+  gmosSouth: Boolean! @deprecated
+
   # GMOS South static configuration
   static: GmosSouthStatic!
 

--- a/modules/schema/src/main/scala/lucuma/odb/json/sequence.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/sequence.scala
@@ -169,6 +169,7 @@ trait SequenceCodec {
   given given_Decoder_FutureExecutionConfig_GmosNorth: Decoder[FutureExecutionConfig.GmosNorth] =
     Decoder.instance { c =>
       for {
+        _ <- c.downField("gmosNorth").as[Boolean]
         t <- c.downField("static").as[StaticConfig.GmosNorth]
         a <- c.downField("acquisition").as[ExecutionSequence.GmosNorth]
         s <- c.downField("science").as[ExecutionSequence.GmosNorth]
@@ -178,6 +179,7 @@ trait SequenceCodec {
   given given_Encoder_FutureExecutionConfig_GmosNorth(using Encoder[Offset], Encoder[TimeSpan], Encoder[Wavelength]): Encoder[FutureExecutionConfig.GmosNorth] =
     Encoder.instance { (a: FutureExecutionConfig.GmosNorth) =>
       Json.obj(
+        "gmosNorth"   -> true.asJson,
         "instrument"  -> (Instrument.GmosNorth: Instrument).asJson,
         "static"      -> a.static.asJson,
         "acquisition" -> a.acquisition.asJson,
@@ -188,6 +190,7 @@ trait SequenceCodec {
   given given_Decoder_FutureExecutionConfig_GmosSouth: Decoder[FutureExecutionConfig.GmosSouth] =
     Decoder.instance { c =>
       for {
+        _ <- c.downField("gmosSouth").as[Boolean]
         t <- c.downField("static").as[StaticConfig.GmosSouth]
         a <- c.downField("acquisition").as[ExecutionSequence.GmosSouth]
         s <- c.downField("science").as[ExecutionSequence.GmosSouth]
@@ -197,6 +200,7 @@ trait SequenceCodec {
   given given_Encoder_FutureExecutionConfig_GmosSouth(using Encoder[Offset], Encoder[TimeSpan], Encoder[Wavelength]): Encoder[FutureExecutionConfig.GmosSouth] =
     Encoder.instance { (a: FutureExecutionConfig.GmosSouth) =>
       Json.obj(
+        "gmosSouth"   -> true.asJson,
         "instrument"  -> (Instrument.GmosSouth: Instrument).asJson,
         "static"      -> a.static.asJson,
         "acquisition" -> a.acquisition.asJson,


### PR DESCRIPTION
`ExecutionConfig` is an interface, with two existing implementations `GmosNorthExecutionConfig` and `GmosSouthExecutionConfig`.  In theory there will be one per instrument.  The structure of these types is the same; only leaf values like filters, FPU options, etc. differ.

As I understand it, when a pure JSON result is calculated the structure of the object is used to determine the type.  Since it cannot distinguish the two types based on structure it ends up picking the first matching one.

It's suboptimal because it clutters the API, but this can be "solved" by adding a bogus field that differs for each type.