### PR TITLE
Use Decline for args

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./modules/service/target/universal/stage/bin/lucuma-odb-service -Dfile.encoding=UTF-8 -Dcats.effect.stackTracingMode=DISABLED -Dcats.effect.tracing.mode=none
+web: ./modules/service/target/universal/stage/bin/lucuma-odb-service -Dfile.encoding=UTF-8 -Dcats.effect.stackTracingMode=DISABLED -Dcats.effect.tracing.mode=none serve

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Alternatively, you can run the app from within SBT with `service/reStart`
 running `docker-compose` `down` and then `up` as described above.  You can
 supply optional arguments to simplify development though:
 
-* `-reset` - Drops then creates the database for you. Do this after cycling
+* `--reset` - Drops then creates the database for you. Do this after cycling
 `docker-compose` `down`, `up` to give flyway a chance to run the migration and
 update its schema table. 
-* `-skip-migration` - Skips the database migration.  This assumes that the 
+* `--skip-migration` - Skips the database migration.  This assumes that the 
 database has been initialized already.  Usually this won't be necessary since
 flyway already skips migrations that have previously run. 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can now run the app, and you can do `docker-compose stop`.  If you do
 
 ### Using reStart
 
-Alternatively, you can run the app from within SBT with `service/reStart serve`
+Alternatively, you can run the app from within SBT with `service/reStart`
 (stopping with `service/reStop`).  By default, this command will fail after
 running `docker-compose` `down` and then `up` as described above.  You can
 supply optional arguments to simplify development though:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can now run the app, and you can do `docker-compose stop`.  If you do
 
 ### Using reStart
 
-Alternatively, you can run the app from within SBT with `service/reStart`
+Alternatively, you can run the app from within SBT with `service/reStart serve`
 (stopping with `service/reStop`).  By default, this command will fail after
 running `docker-compose` `down` and then `up` as described above.  You can
 supply optional arguments to simplify development though:

--- a/build.sbt
+++ b/build.sbt
@@ -119,6 +119,7 @@ lazy val service = project
       "org.typelevel"  %% "paiges-core"                        % paigesVersion,
       "com.github.vertical-blank" % "sql-formatter" % "2.0.3",
     ),
-    reStart / envVars += "PORT" -> "8082"
+    reStart / envVars += "PORT" -> "8082",
+    reStartArgs       += "serve"
   )
 

--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -10,6 +10,7 @@ import cats.effect.std.Console
 import cats.implicits._
 import com.comcast.ip4s.Port
 import com.monovore.decline._
+import com.monovore.decline.effect.CommandIOApp
 import edu.gemini.grackle.skunk.SkunkMonitor
 import eu.timepit.refined.auto._
 import fs2.io.net.Network
@@ -47,13 +48,97 @@ import software.amazon.awssdk.services.s3.S3Configuration
 
 import scala.concurrent.duration._
 
-object Main extends IOApp {
+object MainArgs {
+  opaque type ResetDatabase = Boolean
+
+  object ResetDatabase {
+
+    val opt: Opts[ResetDatabase] =
+      Opts.flag("reset", help = "Drop and recreate the database before starting.").orFalse
+
+    extension (rd: ResetDatabase) {
+      def toBoolean: Boolean =
+        rd
+
+      def isRequested: Boolean =
+        toBoolean
+    }
+  }
+
+
+  opaque type SkipMigration = Boolean
+
+  object SkipMigration {
+
+    val opt: Opts[SkipMigration] =
+      Opts.flag("skip-migration", help = "Skip database migration on startup.").orFalse
+
+    extension (sm: SkipMigration) {
+      def toBoolean: Boolean =
+        sm
+
+      def isRequested: Boolean =
+        toBoolean
+    }
+  }
+}
+
+sealed trait MainParams {
+  val ServiceName: String =
+    "lucuma-odb"
+
+  val Header: String =
+    s"""|██╗     ██╗   ██╗ ██████╗██╗   ██╗███╗   ███╗ █████╗      ██████╗ ██████╗ ██████╗
+        |██║     ██║   ██║██╔════╝██║   ██║████╗ ████║██╔══██╗    ██╔═══██╗██╔══██╗██╔══██╗
+        |██║     ██║   ██║██║     ██║   ██║██╔████╔██║███████║    ██║   ██║██║  ██║██████╔╝
+        |██║     ██║   ██║██║     ██║   ██║██║╚██╔╝██║██╔══██║    ██║   ██║██║  ██║██╔══██╗
+        |███████╗╚██████╔╝╚██████╗╚██████╔╝██║ ╚═╝ ██║██║  ██║    ╚██████╔╝██████╔╝██████╔╝
+        |╚══════╝ ╚═════╝  ╚═════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝  ╚═╝     ╚═════╝ ╚═════╝ ╚═════╝
+        |
+        |This is the Lucuma observing database.
+        |""".stripMargin
+}
+
+object MainParams extends MainParams
+
+
+object Main extends CommandIOApp(
+  name   = MainParams.ServiceName,
+  header = MainParams.Header
+) {
+
+  import MainArgs.*
+
+  override def main: Opts[IO[ExitCode]] =
+    command
+
+  lazy val serve: Command[IO[ExitCode]] =
+    Command(
+      name    = "serve",
+      header  = "Run the ODB service.",
+    )((ResetDatabase.opt, SkipMigration.opt).tupled.map { case (reset, skipMigration) =>
+      implicit val log: SelfAwareStructuredLogger[IO] =
+        Slf4jLogger.getLoggerFromName[IO]("lucuma-odb")
+
+      for {
+        _ <- IO.whenA(reset.isRequested)(IO.println("Resetting database."))
+        _ <- IO.whenA(skipMigration.isRequested)(IO.println("Skipping migration.  Ensure that your database is up-to-date."))
+        e <- FMain.runF[IO](reset, skipMigration)
+      } yield e
+    })
+
+  lazy val command: Opts[IO[ExitCode]] =
+    Opts.subcommands(
+      serve
+    )
+}
+
+object FMain extends MainParams {
+
+  import MainArgs.*
 
   // TODO: put this in the config
   val MaxConnections = 10
-
-  // The name we're know by in the tracing back end.
-  val ServiceName = "lucuma-odb"
 
   // Time GraphQL service instances are cached
   val GraphQLServiceTTL = 30.minutes
@@ -62,14 +147,7 @@ object Main extends IOApp {
   def banner[F[_]: Applicative: Logger](config: Config): F[Unit] = {
     val banner =
         s"""|
-            |██╗     ██╗   ██╗ ██████╗██╗   ██╗███╗   ███╗ █████╗      ██████╗ ██████╗ ██████╗
-            |██║     ██║   ██║██╔════╝██║   ██║████╗ ████║██╔══██╗    ██╔═══██╗██╔══██╗██╔══██╗
-            |██║     ██║   ██║██║     ██║   ██║██╔████╔██║███████║    ██║   ██║██║  ██║██████╔╝
-            |██║     ██║   ██║██║     ██║   ██║██║╚██╔╝██║██╔══██║    ██║   ██║██║  ██║██╔══██╗
-            |███████╗╚██████╔╝╚██████╗╚██████╔╝██║ ╚═╝ ██║██║  ██║    ╚██████╔╝██████╔╝██████╔╝
-            |╚══════╝ ╚═════╝  ╚═════╝ ╚═════╝ ╚═╝     ╚═╝╚═╝  ╚═╝     ╚═════╝ ╚═════╝ ╚═════╝
-            |
-            |This is the Lucuma observing database.
+            |$Header
             |
             |CommitHash.: ${config.commitHash.format}
             |CORS domain: ${config.domain}
@@ -214,64 +292,13 @@ object Main extends IOApp {
   implicit def kleisliLogger[F[_]: Logger, A]: Logger[Kleisli[F, A, *]] =
     Logger[F].mapK(Kleisli.liftK)
 
-  object Args {
-    opaque type ResetDatabase = Boolean
-
-    object ResetDatabase {
-
-      val opt: Opts[ResetDatabase] =
-        Opts.flag("reset", help = "Drop and recreate the database before starting.").orFalse
-
-      extension (rd: ResetDatabase) {
-        def toBoolean: Boolean =
-          rd
-
-        def isRequested: Boolean =
-          toBoolean
-      }
-    }
-
-
-    opaque type SkipMigration = Boolean
-
-    object SkipMigration {
-
-      val opt: Opts[SkipMigration] =
-        Opts.flag("skip-migration", help = "Skip database migration on startup.").orFalse
-
-      extension (sm: SkipMigration) {
-        def toBoolean: Boolean =
-          sm
-
-        def isRequested: Boolean =
-          toBoolean
-      }
-    }
-
-    /** Prints a help message and produces a corresponding ExitCode. */
-    def printHelp(h: Help): IO[ExitCode] = {
-      val code = if (h.errors.isEmpty) ExitCode.Success else ExitCode.Error
-      IO.println(h.toString).as(code)
-    }
-
-    def parse(args: List[String]): Either[Help, (ResetDatabase, SkipMigration)] =
-      // Decline really seems to want you to have a `Command` but I have no
-      // natural values for the "name" or "header". I just want to parse the args
-      // but the parser is private.
-      Command("", "")((ResetDatabase.opt, SkipMigration.opt).tupled).parse(args)
-
-    def exec(args: List[String])(f: (ResetDatabase, SkipMigration) => IO[ExitCode]): IO[ExitCode] =
-      parse(args).fold(printHelp, f.tupled)
-
-  }
-
   /**
    * Our main server, as a resource that starts up our server on acquire and shuts it all down
    * in cleanup, yielding an `ExitCode`. Users will `use` this resource and hold it forever.
    */
   def server[F[_]: Async: Logger: Console](
-    reset:         Args.ResetDatabase,
-    skipMigration: Args.SkipMigration
+    reset:         ResetDatabase,
+    skipMigration: SkipMigration
   ): Resource[F, ExitCode] =
     for {
       c  <- Resource.eval(Config.fromCiris.load[F])
@@ -285,26 +312,10 @@ object Main extends IOApp {
 
   /** Our logical entry point. */
   def runF[F[_]: Async: Logger: Console](
-    reset:         Args.ResetDatabase,
-    skipMigration: Args.SkipMigration
+    reset:         ResetDatabase,
+    skipMigration: SkipMigration
   ): F[ExitCode] =
     server(reset, skipMigration).use(_ => Concurrent[F].never[ExitCode])
-
-
-  /** Our actual entry point. */
-  def run(args: List[String]): IO[ExitCode] = {
-    implicit val log: SelfAwareStructuredLogger[IO] =
-      Slf4jLogger.getLoggerFromName[IO]("lucuma-odb")
-
-    Args.exec(args) { (reset, skipMigration) =>
-      for {
-        _ <- IO.whenA(reset.isRequested)(IO.println("Resetting database."))
-        _ <- IO.whenA(skipMigration.isRequested)(IO.println("Skipping migration.  Ensure that your database is up-to-date."))
-        e <- runF[IO](reset, skipMigration)
-      } yield e
-    }
-
-  }
 
 }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -35,7 +35,7 @@ import lucuma.itc.client.ItcVersions
 import lucuma.itc.client.SpectroscopyModeInput
 import lucuma.itc.client.SpectroscopyResult
 import lucuma.odb.Config
-import lucuma.odb.Main
+import lucuma.odb.FMain
 import lucuma.odb.graphql.OdbMapping
 import lucuma.odb.sequence.util.CommitHash
 import lucuma.refined.*
@@ -144,10 +144,10 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
 
   // overriden in OdbSuiteWithS3 for tests that need it.
   protected def s3ClientOpsResource: Resource[IO, S3AsyncClientOp[IO]] =
-    Main.s3ClientOpsResource(awsConfig)
+    FMain.s3ClientOpsResource[IO](awsConfig)
 
   private def httpApp: Resource[IO, WebSocketBuilder2[IO] => HttpApp[IO]] =
-    Main.routesResource(
+    FMain.routesResource[IO](
       databaseConfig,
       awsConfig,
       itcClient.pure[Resource[IO, *]],
@@ -160,7 +160,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
   /** Resource yielding an instantiated OdbMapping, which we can use for some whitebox testing. */
   def mapping: Resource[IO, Mapping[IO]] =
     for {
-      db  <- Main.databasePoolResource[IO](databaseConfig)
+      db  <- FMain.databasePoolResource[IO](databaseConfig)
       mon  = SkunkMonitor.noopMonitor[IO]
       usr  = TestUsers.Standard.pi(11, 110)
       top <- OdbMapping.Topics(db)
@@ -235,7 +235,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
     super.beforeAll()
 
     dbInitialization.foreach { init =>
-      Main
+      FMain
         .databasePoolResource[IO](databaseConfig)
         .flatten
         .use(init)


### PR DESCRIPTION
Switches the argument parsing to use `Decline`.  I'm aware I may be "doing it wrong" so don't hesitate to say so.  Without a command name / header to use for the parser, it yields help messages like:

```
service Usage:  [--reset] [--skip-migration]
service 
service 
service 
service Options and flags:
service     --help
service         Display this help text.
service     --reset
service         Drop and recreate the database before starting.
service     --skip-migration
service         Skip database migration on startup.
service ... finished with exit code 0
```

which seems okay to me, I think.