### PR TITLE
Planned time enums

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0270__planned_time.sql
+++ b/modules/service/src/main/resources/db/migration/V0270__planned_time.sql
@@ -1,0 +1,214 @@
+
+-- Categories of planned time.
+CREATE TABLE t_planned_time_category (
+  c_tag         d_tag   PRIMARY KEY,
+  c_name        varchar NOT NULL,
+  c_description varchar NOT NULL
+);
+
+INSERT INTO t_planned_time_category VALUES(
+  'config_change',
+  'Config Change',
+  'An estimate of the cost of configuration changes between steps'
+);
+
+INSERT INTO t_planned_time_category VALUES(
+  'exposure',
+  'Exposure',
+  'Exposure time'
+);
+
+INSERT INTO t_planned_time_category VALUES(
+  'readout',
+  'Readout',
+  'Detector readout cost'
+);
+
+INSERT INTO t_planned_time_category VALUES(
+  'setup',
+  'Setup',
+  'An estimate of the cost of initial setup for an observation'
+);
+
+INSERT INTO t_planned_time_category VALUES(
+  'write',
+  'Write',
+  'Time required to write datasets to permanent storage'
+);
+
+-- A list of things associated with a planned time estimate.  For example, if
+-- the GMOS FPU changes from one step to another there is a 60 second cost
+-- (though it can run in parallel and therefore be subsumed under other config
+-- change costs).
+CREATE TABLE t_time_estimate (
+  c_tag         d_tag       PRIMARY KEY,
+  c_name        varchar     NOT NULL,
+  c_description varchar     NOT NULL,
+  c_instrument  d_tag       NULL DEFAULT NULL REFERENCES t_instrument(c_tag),
+  c_category    d_tag       NOT NULL REFERENCES t_planned_time_category(c_tag),
+  c_time        interval(6) NOT NULL
+);
+
+COMMENT ON COLUMN t_time_estimate.c_instrument IS 'Associated instrument, if any.';
+
+INSERT INTO t_time_estimate VALUES(
+  'gcal_diffuser',
+  'GCal Diffuser',
+  'GCal diffuser change cost',
+  NULL,
+  'config_change',
+  '5 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gcal_filter',
+  'GCal Filter',
+  'GCal filter change cost',
+  NULL,
+  'config_change',
+  '5 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gcal_shutter',
+  'GCal Shutter',
+  'GCal shutter open/close transition cost',
+  NULL,
+  'config_change',
+  '5 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gmos_north_disperser',
+  'GMOS North Disperser',
+  'GMOS North disperser change cost',
+  'GmosNorth',
+  'config_change',
+  '90 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gmos_north_filter',
+  'GMOS North Filter',
+  'GMOS North filter change cost',
+  'GmosNorth',
+  'config_change',
+  '20 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gmos_north_fpu',
+  'GMOS North FPU',
+  'GMOS North FPU change cost',
+  'GmosNorth',
+  'config_change',
+  '60 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gmos_north_nod',
+  'GMOS North N&S',
+  'GMOS North nod and shuffle (normal offset) fixed per-cycle overhead',
+  'GmosNorth',
+  'config_change',
+  '36 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gmos_north_nod_e_offset',
+  'GMOS North N&S E-Offset',
+  'GMOS North nod and shuffle e-offset fixed per-cycle overhead',
+  'GmosNorth',
+  'config_change',
+  '23.2 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gmos_north_write',
+  'GMOS North Write',
+  'GMOS North write out time',
+  'GmosNorth',
+  'write',
+  '10 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gmos_south_disperser',
+  'GMOS South Disperser',
+  'GMOS South disperser change cost',
+  'GmosSouth',
+  'config_change',
+  '90 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gmos_south_filter',
+  'GMOS South Filter',
+  'GMOS South filter change cost',
+  'GmosSouth',
+  'config_change',
+  '20 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gmos_south_fpu',
+  'GMOS South FPU',
+  'GMOS South FPU change cost',
+  'GmosSouth',
+  'config_change',
+  '60 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gmos_south_nod',
+  'GMOS South N&S',
+  'GMOS South nod and shuffle (normal offset) fixed per-cycle overhead',
+  'GmosSouth',
+  'config_change',
+  '36 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gmos_south_nod_e_offset',
+  'GMOS South N&S E-Offset',
+  'GMOS South nod and shuffle e-offset fixed per-cycle overhead',
+  'GmosSouth',
+  'config_change',
+  '23.2 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'gmos_south_write',
+  'GMOS South Write',
+  'GMOS South write out time',
+  'GmosSouth',
+  'write',
+  '10 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'offset_constant',
+  'Offset Constant',
+  'Constant cost (apart from distance) for an offset',
+  NULL,
+  'config_change',
+  '7 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'offset_distance',
+  'Offset Per-Arcsec',
+  'Offset cost per-arcsec of offset distance',
+  NULL,
+  'config_change',
+  '0.006250 seconds'
+);
+
+INSERT INTO t_time_estimate VALUES(
+  'science_fold',
+  'Science Fold',
+  'Cost for moving the science fold in or out',
+  NULL,
+  'config_change',
+  '15 seconds'
+);

--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -20,6 +20,7 @@ import lucuma.core.model.User
 import lucuma.itc.client.ItcClient
 import lucuma.odb.graphql.AttachmentRoutes
 import lucuma.odb.graphql.GraphQLRoutes
+import lucuma.odb.graphql.enums.Enums
 import lucuma.odb.sequence.util.CommitHash
 import lucuma.odb.service.AttachmentService
 import lucuma.odb.service.UserService
@@ -216,7 +217,8 @@ object FMain extends MainParams {
 
   /** A resource that yields our HttpRoutes, wrapped in accessory middleware. */
   def routesResource[F[_]: Async: Trace: Logger: Network: Console](
-    config: Config
+    config: Config,
+    enums:  Enums
   ): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
     routesResource(
       config.database,
@@ -225,7 +227,9 @@ object FMain extends MainParams {
       config.commitHash,
       config.ssoClient,
       config.domain,
-      s3ClientOpsResource(config.aws))
+      s3ClientOpsResource(config.aws),
+      enums
+    )
 
   /** A resource that yields our HttpRoutes, wrapped in accessory middleware. */
   def routesResource[F[_]: Async: Trace: Logger: Network: Console](
@@ -235,7 +239,8 @@ object FMain extends MainParams {
     commitHash:        CommitHash,
     ssoClientResource: Resource[F, SsoClient[F, User]],
     domain:            String,
-    s3OpsResource:     Resource[F, S3AsyncClientOp[F]]
+    s3OpsResource:     Resource[F, S3AsyncClientOp[F]],
+    enums:             Enums
   ): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
     for {
       pool             <- databasePoolResource[F](databaseConfig)
@@ -243,7 +248,7 @@ object FMain extends MainParams {
       ssoClient        <- ssoClientResource
       userSvc          <- pool.map(UserService.fromSession(_))
       middleware       <- Resource.eval(ServerMiddleware(domain, ssoClient, userSvc))
-      graphQLRoutes    <- GraphQLRoutes(itcClient, commitHash, ssoClient, pool, SkunkMonitor.noopMonitor[F], GraphQLServiceTTL, userSvc)
+      graphQLRoutes    <- GraphQLRoutes(itcClient, commitHash, ssoClient, pool, SkunkMonitor.noopMonitor[F], GraphQLServiceTTL, userSvc, enums)
       s3ClientOps      <- s3OpsResource
       attachmentSvc    <- pool.map(ses => AttachmentService.fromS3AndSession(awsConfig, s3ClientOps, ses))
     } yield { wsb =>
@@ -263,31 +268,36 @@ object FMain extends MainParams {
         .migrate()
     }
 
+  def singleSession[F[_]: Async: Console](
+    config:   Config.Database,
+    database: Option[String] = None
+  ): Resource[F, Session[F]] = {
+
+    import natchez.Trace.Implicits.noop
+
+    Session.single[F](
+      host     = config.host,
+      port     = config.port,
+      user     = config.user,
+      database = database.getOrElse(config.database),
+      password = config.password.some
+    )
+}
+
   def resetDatabase[F[_]: Async : Console](config: Config.Database): F[Unit] = {
 
     import skunk.*
     import skunk.implicits.*
-    import natchez.Trace.Implicits.noop
-
-    val session: Resource[F, Session[F]] =
-      Session.single[F](
-        host     = config.host,
-        port     = config.port,
-        user     = config.user,
-        database = "postgres",
-        password = config.password.some
-      )
 
     val drop   = sql"""DROP DATABASE "#${config.database}"""".command
     val create = sql"""CREATE DATABASE "#${config.database}"""".command
 
-    session.use { s =>
+    singleSession(config, "postgres".some).use { s =>
       for {
         _ <- s.execute(drop).void
         _ <- s.execute(create).void
       } yield()
     }
-
   }
 
   implicit def kleisliLogger[F[_]: Logger, A]: Logger[Kleisli[F, A, *]] =
@@ -299,15 +309,16 @@ object FMain extends MainParams {
    */
   def server[F[_]: Async: Logger: Console](
     reset:         ResetDatabase,
-    skipMigration: SkipMigration
+    skipMigration: SkipMigration,
   ): Resource[F, ExitCode] =
     for {
       c  <- Resource.eval(Config.fromCiris.load[F])
       _  <- Resource.eval(banner[F](c))
+      e  <- Resource.eval(singleSession(c.database).use(Enums.load))
       _  <- Applicative[Resource[F, *]].whenA(reset.isRequested)(Resource.eval(resetDatabase[F](c.database)))
       _  <- Applicative[Resource[F, *]].unlessA(skipMigration.isRequested)(Resource.eval(migrateDatabase[F](c.database)))
       ep <- entryPointResource(c)
-      ap <- ep.wsLiftR(routesResource(c)).map(_.map(_.orNotFound))
+      ap <- ep.wsLiftR(routesResource(c, e)).map(_.map(_.orNotFound))
       _  <- serverResource(c.port, ap)
     } yield ExitCode.Success
 

--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -300,6 +300,9 @@ object FMain extends MainParams {
     }
   }
 
+//  def loadEnums[F[_]: Async : Console](config: Config.Database): F[Enums] =
+//    singleSession(c.database).use(Enums.load)
+
   implicit def kleisliLogger[F[_]: Logger, A]: Logger[Kleisli[F, A, *]] =
     Logger[F].mapK(Kleisli.liftK)
 
@@ -317,6 +320,7 @@ object FMain extends MainParams {
       e  <- Resource.eval(singleSession(c.database).use(Enums.load))
       _  <- Applicative[Resource[F, *]].whenA(reset.isRequested)(Resource.eval(resetDatabase[F](c.database)))
       _  <- Applicative[Resource[F, *]].unlessA(skipMigration.isRequested)(Resource.eval(migrateDatabase[F](c.database)))
+//      e  <- singleSession(c.database).evalMap(Enums.load)
       ep <- entryPointResource(c)
       ap <- ep.wsLiftR(routesResource(c, e)).map(_.map(_.orNotFound))
       _  <- serverResource(c.port, ap)

--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -300,9 +300,6 @@ object FMain extends MainParams {
     }
   }
 
-//  def loadEnums[F[_]: Async : Console](config: Config.Database): F[Enums] =
-//    singleSession(c.database).use(Enums.load)
-
   implicit def kleisliLogger[F[_]: Logger, A]: Logger[Kleisli[F, A, *]] =
     Logger[F].mapK(Kleisli.liftK)
 
@@ -312,7 +309,7 @@ object FMain extends MainParams {
    */
   def server[F[_]: Async: Logger: Console](
     reset:         ResetDatabase,
-    skipMigration: SkipMigration,
+    skipMigration: SkipMigration
   ): Resource[F, ExitCode] =
     for {
       c  <- Resource.eval(Config.fromCiris.load[F])
@@ -320,7 +317,6 @@ object FMain extends MainParams {
       e  <- Resource.eval(singleSession(c.database).use(Enums.load))
       _  <- Applicative[Resource[F, *]].whenA(reset.isRequested)(Resource.eval(resetDatabase[F](c.database)))
       _  <- Applicative[Resource[F, *]].unlessA(skipMigration.isRequested)(Resource.eval(migrateDatabase[F](c.database)))
-//      e  <- singleSession(c.database).evalMap(Enums.load)
       ep <- entryPointResource(c)
       ap <- ep.wsLiftR(routesResource(c, e)).map(_.map(_.orNotFound))
       _  <- serverResource(c.port, ap)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -38,9 +38,7 @@ import lucuma.itc.client.ItcResult
 import lucuma.itc.client.SpectroscopyModeInput
 import lucuma.itc.client.SpectroscopyResult
 import lucuma.odb.graphql._
-import lucuma.odb.graphql.enums.AttachmentTypeEnumType
-import lucuma.odb.graphql.enums.FilterTypeEnumType
-import lucuma.odb.graphql.enums.PartnerEnumType
+import lucuma.odb.graphql.enums.Enums
 import lucuma.odb.graphql.mapping.UpdateObservationsResultMapping
 import lucuma.odb.graphql.mapping._
 import lucuma.odb.graphql.topic.ObservationTopic
@@ -102,11 +100,13 @@ object OdbMapping {
     user0:      User,
     topics0:    Topics[F],
     itcClient:  ItcClient[F],
-    commitHash: CommitHash
-  ):  F[Mapping[F]] =
-    Trace[F].span(s"Creating mapping for ${user0.displayName} (${user0.id}, ${user0.role})") {
-      database.use(enumSchema(_)).map { enums =>
-        new SkunkMapping[F](database, monitor) with BaseMapping[F]
+    commitHash: CommitHash,
+    enums:      Enums
+  ):  Mapping[F] =
+//    Trace[F].span(s"Creating mapping for ${user0.displayName} (${user0.id}, ${user0.role})") {
+//      database.use(Enums.load(_)).map { enums =>
+        new SkunkMapping[F](database, monitor)
+          with BaseMapping[F]
           with AirMassRangeMapping[F]
           with AllocationMapping[F]
           with AngleMapping[F]
@@ -176,7 +176,7 @@ object OdbMapping {
 
           // Our schema
           val schema: Schema =
-            unsafeLoadSchema("OdbSchema.graphql") |+| enums
+            unsafeLoadSchema("OdbSchema.graphql") |+| enums.schema
 
           // Our services and resources needed by various mappings.
           override val user: User         = user0
@@ -357,16 +357,7 @@ object OdbMapping {
           }
 
         }
-      }
-    }
-
-  def enumSchema[F[_]: Applicative](s: Session[F]): F[Schema] =
-    List(FilterTypeEnumType.fetch(s), PartnerEnumType.fetch(s), AttachmentTypeEnumType.fetch(s)).sequence.map { tpes =>
-      new Schema {
-        def pos: SourcePos = SourcePos.instance
-        def types: List[NamedType] = tpes
-        def directives: List[Directive] = Nil
-      }
-    }
+//      }
+//    }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -103,8 +103,6 @@ object OdbMapping {
     commitHash: CommitHash,
     enums:      Enums
   ):  Mapping[F] =
-//    Trace[F].span(s"Creating mapping for ${user0.displayName} (${user0.id}, ${user0.role})") {
-//      database.use(Enums.load(_)).map { enums =>
         new SkunkMapping[F](database, monitor)
           with BaseMapping[F]
           with AirMassRangeMapping[F]
@@ -357,7 +355,5 @@ object OdbMapping {
           }
 
         }
-//      }
-//    }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
@@ -98,7 +98,7 @@ final class Enums(
     case ScienceFold         extends TimeEstimate("science_fold")
 
     // Used to test that undefined values in the database produce immediate failure on startup.
-    // case FooBar              extends TimeEstimate("foo_bar")
+//     case FooBar              extends TimeEstimate("foo_bar")
   }
 
   object TimeEstimate {
@@ -122,8 +122,8 @@ final class Enums(
         GmosSouthWrite,
         OffsetConstant,
         OffsetDistance,
-        ScienceFold
-        // FooBar
+        ScienceFold,
+//        FooBar
       ).withTag(_.tag)
 
   }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
@@ -23,6 +23,14 @@ import org.tpolecat.sourcepos.SourcePos
 import org.typelevel.log4cats.Logger
 import skunk.Session
 
+/**
+ * Enums loaded from the database on startup.  These fall into two categories:
+ * "referenced" enums, those for which we need to reference individual values
+ * in code and "unreferenced" enums, those which are simply a listing of
+ * elements to add to the schema.
+ *
+ * @param enumMeta metadata for referenced enums
+ */
 final class Enums(
   enumMeta: Enums.Meta
 ) {
@@ -51,13 +59,7 @@ final class Enums(
   object PlannedTimeCategory {
 
     given Enumerated[PlannedTimeCategory] =
-      Enumerated.from(
-        ConfigChange,
-        Exposure,
-        Readout,
-        Setup,
-        Write
-      ).withTag(_.tag)
+      Enumerated.from(values.head, values.tail*).withTag(_.tag)
 
     def enumType: EnumType =
       Enumerated[PlannedTimeCategory]
@@ -98,33 +100,13 @@ final class Enums(
     case ScienceFold         extends TimeEstimate("science_fold")
 
     // Used to test that undefined values in the database produce immediate failure on startup.
-//     case FooBar              extends TimeEstimate("foo_bar")
+    // case FooBar              extends TimeEstimate("foo_bar")
   }
 
   object TimeEstimate {
 
     given Enumerated[TimeEstimate] =
-      Enumerated.from(
-        GcalDiffuser,
-        GcalFilter,
-        GcalShutter,
-        GmosNorthDisperser,
-        GmosNorthFilter,
-        GmosNorthFpu,
-        GmosNorthNod,
-        GmosNorthNodEOffset,
-        GmosNorthWrite,
-        GmosSouthDisperser,
-        GmosSouthFilter,
-        GmosSouthFpu,
-        GmosSouthNod,
-        GmosSouthNodEOffset,
-        GmosSouthWrite,
-        OffsetConstant,
-        OffsetDistance,
-        ScienceFold,
-//        FooBar
-      ).withTag(_.tag)
+      Enumerated.from(values.head, values.tail*).withTag(_.tag)
 
   }
 
@@ -150,6 +132,8 @@ object Enums {
       ptc <- PlannedTimeCategoryMeta.select(s)
       te  <- TimeEstimateMeta.select(s)
       un  <- List(
+              // "Unreferenced" types -- those for which we do not need to refer
+              // to individual instance in ODB code.
               AttachmentTypeEnumType.fetch(s),
               FilterTypeEnumType.fetch(s),
               PartnerEnumType.fetch(s),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
@@ -1,0 +1,160 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.enums
+
+import cats.Applicative
+import cats.Monad
+import cats.data.NonEmptyMap
+import cats.syntax.applicative.*
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import cats.syntax.traverse.*
+import edu.gemini.grackle.Directive
+import edu.gemini.grackle.EnumType
+import edu.gemini.grackle.EnumValue
+import edu.gemini.grackle.NamedType
+import edu.gemini.grackle.Schema
+import lucuma.core.enums.Instrument
+import lucuma.core.util.Enumerated
+import lucuma.core.util.TimeSpan
+import lucuma.odb.data.Tag
+import org.tpolecat.sourcepos.SourcePos
+import org.typelevel.log4cats.Logger
+import skunk.Session
+
+final class Enums(
+  enumMeta: Enums.Meta
+) {
+
+  // The referenced enums defined in this class appear to be lazily constructed.
+  // Since they reference metadata which comes from the database, we want them
+  // to fail immediately if the associated meta data was not found.  For this
+  // reason they must be explicitly "used" in the construction of `Enums`. Add
+  // any new enums to the list below.
+  Enumerated[PlannedTimeCategory]
+  Enumerated[TimeEstimate]
+
+  enum PlannedTimeCategory(val tag: String) {
+    private val meta = enumMeta.plannedTimeCategory.getOrElse(tag, sys.error(s"t_planned_time_category missing tag '$tag'"))
+
+    def name: String        = meta.name
+    def description: String = meta.description
+
+    case ConfigChange extends PlannedTimeCategory("config_change")
+    case Exposure     extends PlannedTimeCategory("exposure")
+    case Readout      extends PlannedTimeCategory("readout")
+    case Setup        extends PlannedTimeCategory("setup")
+    case Write        extends PlannedTimeCategory("write")
+  }
+
+  object PlannedTimeCategory {
+
+    given Enumerated[PlannedTimeCategory] =
+      Enumerated.from(
+        ConfigChange,
+        Exposure,
+        Readout,
+        Setup,
+        Write
+      ).withTag(_.tag)
+
+    def enumType: EnumType =
+      Enumerated[PlannedTimeCategory]
+        .toEnumType("PlannedTimeCategory", "Enumeration of planned time categories")(_.name)
+
+  }
+
+  /**
+   * Time estimates for config changes, etc.  Because this is internal to the
+   * ODB, it is not added to the schema.
+   */
+  enum TimeEstimate(val tag: String) {
+    private val meta = enumMeta.timeEstimate.getOrElse(tag, sys.error(s"t_time_estimate missing tag `$tag`"))
+
+    def name: String                   = meta.name
+    def description: String            = meta.description
+    def instrument: Option[Instrument] = meta.instrument
+    def category: PlannedTimeCategory  = Enumerated[PlannedTimeCategory].fromTag(meta.category).getOrElse(sys.error(s"t_time_estimate entry for '$tag' refers to missing planned time category '${meta.category}'"))
+    def time: TimeSpan                 = meta.time
+
+    case GcalDiffuser        extends TimeEstimate("gcal_diffuser")
+    case GcalFilter          extends TimeEstimate("gcal_filter")
+    case GcalShutter         extends TimeEstimate("gcal_shutter")
+    case GmosNorthDisperser  extends TimeEstimate("gmos_north_disperser")
+    case GmosNorthFilter     extends TimeEstimate("gmos_north_filter")
+    case GmosNorthFpu        extends TimeEstimate("gmos_north_fpu")
+    case GmosNorthNod        extends TimeEstimate("gmos_north_nod")
+    case GmosNorthNodEOffset extends TimeEstimate("gmos_north_nod_e_offset")
+    case GmosNorthWrite      extends TimeEstimate("gmos_north_write")
+    case GmosSouthDisperser  extends TimeEstimate("gmos_south_disperser")
+    case GmosSouthFilter     extends TimeEstimate("gmos_south_filter")
+    case GmosSouthFpu        extends TimeEstimate("gmos_south_fpu")
+    case GmosSouthNod        extends TimeEstimate("gmos_south_nod")
+    case GmosSouthNodEOffset extends TimeEstimate("gmos_south_nod_e_offset")
+    case GmosSouthWrite      extends TimeEstimate("gmos_south_write")
+    case OffsetConstant      extends TimeEstimate("offset_constant")
+    case OffsetDistance      extends TimeEstimate("offset_distance")
+    case ScienceFold         extends TimeEstimate("science_fold")
+
+    // Used to test that undefined values in the database produce immediate failure on startup.
+    // case FooBar              extends TimeEstimate("foo_bar")
+  }
+
+  object TimeEstimate {
+
+    given Enumerated[TimeEstimate] =
+      Enumerated.from(
+        GcalDiffuser,
+        GcalFilter,
+        GcalShutter,
+        GmosNorthDisperser,
+        GmosNorthFilter,
+        GmosNorthFpu,
+        GmosNorthNod,
+        GmosNorthNodEOffset,
+        GmosNorthWrite,
+        GmosSouthDisperser,
+        GmosSouthFilter,
+        GmosSouthFpu,
+        GmosSouthNod,
+        GmosSouthNodEOffset,
+        GmosSouthWrite,
+        OffsetConstant,
+        OffsetDistance,
+        ScienceFold
+        // FooBar
+      ).withTag(_.tag)
+
+  }
+
+  val schema: Schema =
+    new Schema {
+      def pos:        SourcePos       = SourcePos.instance
+      def types:      List[NamedType] = PlannedTimeCategory.enumType :: enumMeta.unreferencedTypes
+      def directives: List[Directive] = Nil
+    }
+
+}
+
+object Enums {
+
+  case class Meta(
+    plannedTimeCategory: Map[String, PlannedTimeCategoryMeta],
+    timeEstimate:        Map[String, TimeEstimateMeta],
+    unreferencedTypes:   List[EnumType]
+  )
+
+  def load[F[_]: Monad: Logger](s: Session[F]): F[Enums] =
+    for {
+      ptc <- PlannedTimeCategoryMeta.select(s)
+      te  <- TimeEstimateMeta.select(s)
+      un  <- List(
+              AttachmentTypeEnumType.fetch(s),
+              FilterTypeEnumType.fetch(s),
+              PartnerEnumType.fetch(s),
+            ).sequence
+      enums = Enums(Meta(ptc, te, un))
+    } yield enums
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
@@ -132,13 +132,12 @@ object Enums {
       ptc <- PlannedTimeCategoryMeta.select(s)
       te  <- TimeEstimateMeta.select(s)
       un  <- List(
-              // "Unreferenced" types -- those for which we do not need to refer
-              // to individual instance in ODB code.
-              AttachmentTypeEnumType.fetch(s),
-              FilterTypeEnumType.fetch(s),
-              PartnerEnumType.fetch(s),
-            ).sequence
-      enums = Enums(Meta(ptc, te, un))
-    } yield enums
+               // "Unreferenced" types -- those for which we do not need to refer
+               // to individual instance in ODB code.
+               AttachmentTypeEnumType.fetch(s),
+               FilterTypeEnumType.fetch(s),
+               PartnerEnumType.fetch(s),
+             ).sequence
+    } yield Enums(Meta(ptc, te, un))
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/enums/PlannedTimeCategoryMeta.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/enums/PlannedTimeCategoryMeta.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.enums
+
+import cats.Functor
+import cats.syntax.functor.*
+import skunk.*
+import skunk.implicits.*
+
+case class PlannedTimeCategoryMeta(
+  name:        String,
+  description: String
+)
+
+object PlannedTimeCategoryMeta {
+
+  private object statements {
+    import skunk.codec.text.varchar
+
+    val decoder: Decoder[PlannedTimeCategoryMeta] =
+      (varchar ~ varchar).gmap[PlannedTimeCategoryMeta]
+
+    val select: Query[Void, (String, PlannedTimeCategoryMeta)] =
+      sql"""
+        SELECT
+          c_tag,
+          c_name,
+          c_description
+        FROM
+          t_planned_time_category
+      """.query(varchar ~ decoder)
+  }
+
+  def select[F[_]: Functor](s: Session[F]): F[Map[String, PlannedTimeCategoryMeta]] =
+    s.execute(statements.select).map(_.toMap)
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/enums/TimeEstimateMeta.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/enums/TimeEstimateMeta.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.enums
+
+import cats.Functor
+import cats.syntax.functor.*
+import lucuma.core.enums.Instrument
+import lucuma.core.util.TimeSpan
+import skunk.*
+import skunk.implicits.*
+
+case class TimeEstimateMeta(
+  name:        String,
+  description: String,
+  instrument:  Option[Instrument],
+  category:    String,
+  time:        TimeSpan
+)
+
+object TimeEstimateMeta {
+
+  private object statements {
+
+    import lucuma.odb.util.Codecs.instrument
+    import lucuma.odb.util.Codecs.time_span
+    import skunk.codec.text.varchar
+
+    val decoder: Decoder[TimeEstimateMeta] =
+      (varchar        ~
+       varchar        ~
+       instrument.opt ~
+       varchar        ~
+       time_span
+      ).gmap[TimeEstimateMeta]
+
+    val select: Query[Void, (String, TimeEstimateMeta)] =
+      sql"""
+        SELECT
+          c_tag,
+          c_name,
+          c_description,
+          c_instrument,
+          c_category,
+          c_time
+        FROM
+          t_time_estimate
+      """.query(varchar ~ decoder)
+  }
+
+  def select[F[_]: Functor](s: Session[F]): F[Map[String, TimeEstimateMeta]] =
+    s.execute(statements.select).map(_.toMap)
+
+}
+

--- a/modules/service/src/main/scala/lucuma/odb/graphql/enums/extensions.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/enums/extensions.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.enums
+
+import cats.syntax.option.*
+import edu.gemini.grackle.EnumType
+import edu.gemini.grackle.EnumValue
+import lucuma.core.util.Enumerated
+
+extension [A](e: Enumerated[A]) {
+
+  /**
+   * Creates a Grackle `EnumType` from an `Enumerated` instance.
+   *
+   * @param typeName    type name for the `EnumType` instance
+   * @param description description of the enumeration
+   * @param valueName   function to obtain the name of a value
+   */
+  def toEnumType(typeName: String, description: String)(valueName: A => String): EnumType =
+    EnumType(
+      typeName,
+      description.some,
+      e.all.map { v => EnumValue(e.tag(v).toUpperCase(), valueName(v).some) }
+    )
+
+}


### PR DESCRIPTION
This is part of the work required to add planned time estimates.  It introduces an `Enums` type used for working with enums defined in the database.  In particular `TimeEstimate`s are named values corresponding to something for which there is an associated time cost.  For example, moving the science fold requires 15 seconds.  We want

* time estimate values defined in the database, and
* values that we can reference by name (e.g., `TimeEstimate.ScienceFold`)

For this reason there is a `TimeEstimateMeta` class with the data itself _and_ a Scala `TimeEstimate` `enum` that references the individual values.  This association between `enum` value and metadata needs to be done upon once upon startup and needs to fail if the linking entries cannot be found.