### PR TITLE
trusted

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -280,7 +280,8 @@ object FMain extends MainParams {
       port     = config.port,
       user     = config.user,
       database = database.getOrElse(config.database),
-      password = config.password.some
+      password = config.password.some,
+      ssl      = SSL.Trusted.withFallback(true)
     )
 }
 


### PR DESCRIPTION
Adds a bit of configuration from the normal database session pool to the single-use session that I employ for reading enumerations.

There is a startup issue in development, which is presumably related to #362.  Checking the difference in configuration, this seems like the only applicable discrepancy so I'm trying it here.

```
2023-04-18T12:33:14.928251+00:00 app[web.2]: [[34mINFO [0;39m] [36mlucuma-odb[0;39m -  
2023-04-18T12:33:14.928291+00:00 app[web.2]: [[34mINFO [0;39m] [36mlucuma-odb[0;39m - CommitHash.: f96f9fc96b736f141b112db128792cce7a90c8a0 
2023-04-18T12:33:14.928338+00:00 app[web.2]: [[34mINFO [0;39m] [36mlucuma-odb[0;39m - CORS domain: lucuma.xyz 
2023-04-18T12:33:14.928370+00:00 app[web.2]: [[34mINFO [0;39m] [36mlucuma-odb[0;39m - ITC Root...: https://itc-development.herokuapp.com/itc 
2023-04-18T12:33:14.928405+00:00 app[web.2]: [[34mINFO [0;39m] [36mlucuma-odb[0;39m - Port.......: 35049 
2023-04-18T12:33:14.928434+00:00 app[web.2]: [[34mINFO [0;39m] [36mlucuma-odb[0;39m -  
2023-04-18T12:33:15.154808+00:00 app[web.2]: skunk.exception.StartupException: 
2023-04-18T12:33:15.154810+00:00 app[web.2]: 🔥  Startup negotiation failed.
2023-04-18T12:33:15.154810+00:00 app[web.2]: 🔥  
2023-04-18T12:33:15.154811+00:00 app[web.2]: 🔥  
2023-04-18T12:33:15.154813+00:00 app[web.2]: 🔥  Postgres FATAL 28000 raised in ClientAuthentication (auth.c:536)
2023-04-18T12:33:15.154814+00:00 app[web.2]: 🔥  
2023-04-18T12:33:15.154814+00:00 app[web.2]: 🔥    Problem: [36mNo pg_hba.conf entry for host "54.175.235.216", user[0m
2023-04-18T12:33:15.154815+00:00 app[web.2]: 🔥  [36m           "lrwzaxxcyugqer", database "d7koa1u6u30mh2", no encryption.[0m
2023-04-18T12:33:15.154816+00:00 app[web.2]: 🔥  
2023-04-18T12:33:15.154816+00:00 app[web.2]: 🔥  Startup properties were:
2023-04-18T12:33:15.154817+00:00 app[web.2]: 🔥  
2023-04-18T12:33:15.154817+00:00 app[web.2]: 🔥    [32muser[0m    [0m  [0m=[0m  [0m[32mlrwzaxxcyugqer[0m
2023-04-18T12:33:15.154817+00:00 app[web.2]: 🔥    [0m[32mdatabase[0m  [0m=[0m  [0m[32md7koa1u6u30mh2[0m
2023-04-18T12:33:15.154817+00:00 app[web.2]: 🔥  
2023-04-18T12:33:15.154818+00:00 app[web.2]: 🔥  If this is an error you wish to trap and handle in your application, you can do
2023-04-18T12:33:15.154819+00:00 app[web.2]: 🔥  so with a SqlState extractor. For example:
2023-04-18T12:33:15.154819+00:00 app[web.2]: 🔥  
2023-04-18T12:33:15.154820+00:00 app[web.2]: 🔥    [32mdoSomething.recoverWith { case SqlState.InvalidAuthorizationSpecification(ex) =>  ...}[0m
2023-04-18T12:33:15.154821+00:00 app[web.2]: 🔥  
2023-04-18T12:33:15.154821+00:00 app[web.2]: 
2023-04-18T12:33:15.154822+00:00 app[web.2]: skunk.exception.StartupException: No pg_hba.conf entry for host "54.175.235.216", user "lrwzaxxcyugqer", database "d7koa1u6u30mh2", no encryption.
2023-04-18T12:33:15.154904+00:00 app[web.2]: 	at skunk.net.protocol.Startup$$anon$6.applyOrElse(Startup.scala:112)
2023-04-18T12:33:15.154933+00:00 app[web.2]: 	at skunk.net.protocol.Startup$$anon$6.applyOrElse(Startup.scala:110)
2023-04-18T12:33:15.154954+00:00 app[web.2]: 	at scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:35)
2023-04-18T12:33:15.154976+00:00 app[web.2]: 	at skunk.net.protocol.Startup$$anon$1$$anon$2.applyOrElse(Startup.scala:51)
2023-04-18T12:33:15.154996+00:00 app[web.2]: 	at skunk.net.protocol.Startup$$anon$1$$anon$2.applyOrElse(Startup.scala:41)
2023-04-18T12:33:15.155017+00:00 app[web.2]: 	at scala.PartialFunction$OrElse.apply(PartialFunction.scala:266)
2023-04-18T12:33:15.155037+00:00 app[web.2]: 	at skunk.net.AbstractMessageSocket.expect$$anonfun$1(AbstractMessageSocket.scala:18)
2023-04-18T12:33:15.155057+00:00 app[web.2]: 	at cats.effect.IOFiber.succeeded(IOFiber.scala:1177)
2023-04-18T12:33:15.155077+00:00 app[web.2]: 	at cats.effect.IOFiber.runLoop(IOFiber.scala:247)
2023-04-18T12:33:15.155096+00:00 app[web.2]: 	at cats.effect.IOFiber.asyncContinueSuccessfulR(IOFiber.scala:1330)
2023-04-18T12:33:15.155114+00:00 app[web.2]: 	at cats.effect.IOFiber.run(IOFiber.scala:119)
2023-04-18T12:33:15.155131+00:00 app[web.2]: 	at cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:485)
2023-04-18T12:33:15.184043+00:00 heroku[web.1]: State changed from starting to crashed
2023-04-18T12:33:15.142837+00:00 heroku[web.1]: Process exited with status 1
2023-04-18T12:33:15.602243+00:00 heroku[web.2]: Process exited with status 1
2023-04-18T12:33:15.638001+00:00 heroku[web.2]: State changed from starting to crashed
```