### PR TITLE
Add pre-signed URLs for S3 and other attachment changes

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0351__attachments_filekey.sql
+++ b/modules/service/src/main/resources/db/migration/V0351__attachments_filekey.sql
@@ -1,0 +1,24 @@
+-- Store the S3 file path in the attachments tables instead of 
+-- just the UUID used to build the path. This allows us to change the
+-- file key used in the future without "losing" attachments.
+alter table t_obs_attachment
+add column c_remote_path text;
+
+update t_obs_attachment
+set c_remote_path = c_program_id || '/obs/' || c_remote_id;
+
+alter table t_obs_attachment
+  alter column c_remote_path set not null,
+  add check (length(c_remote_path) > 0),
+  drop column c_remote_id;
+
+alter table t_proposal_attachment
+add column c_remote_path text;
+
+update t_proposal_attachment
+set c_remote_path = c_program_id || '/proposal/' || c_remote_id;
+
+alter table t_proposal_attachment
+  alter column c_remote_path set not null,
+  add check (length(c_remote_path) > 0),
+  drop column c_remote_id;

--- a/modules/service/src/main/scala/lucuma/odb/Config.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Config.scala
@@ -157,11 +157,14 @@ object Config {
     bucketName:      BucketName,
     fileUploadMaxMb: Int 
   ) {
-    def obsFileKey(programId: Program.Id, remoteId: UUID): FileKey = 
-      FileKey(NonEmptyString.unsafeFrom(s"$basePath/$programId/obs/$remoteId"))
-
-    def proposalFileKey(programId: Program.Id, remoteId: UUID): FileKey = 
-      FileKey(NonEmptyString.unsafeFrom(s"$basePath/$programId/proposal/$remoteId"))
+    // Within the ODB we work with the filepath, which is the S3 FileKey
+    // minus the basePath. The s3FileService adds the basePath using
+    // `fileKey` as needed.
+    def filePath(programId: Program.Id, remoteId: UUID, fileName: NonEmptyString): NonEmptyString = 
+      NonEmptyString.unsafeFrom(s"$programId/$remoteId/$fileName")
+    
+    def fileKey(path: NonEmptyString): FileKey =
+      FileKey(NonEmptyString.unsafeFrom(s"$basePath/$path"))
   }
 
   object Aws {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/ObsAttachmentRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/ObsAttachmentRoutes.scala
@@ -95,6 +95,14 @@ object ObsAttachmentRoutes {
             .flatMap(_ => Ok())
             .recoverWith { case e: AttachmentException => e.toResponse }
         }
+      
+      case req @ GET -> Root / "attachment" / "obs" / "url" / ProgramId(programId) / ObsAttachmentId(attachmentId) =>
+        ssoClient.require(req) { user =>
+          attachmentFileService
+            .getPresignedUrl(user, programId, attachmentId)
+            .flatMap(Ok(_))
+            .recoverWith { case e: AttachmentException => e.toResponse }
+        }
     }
 
     EntityLimiter(routes, maxUploadMb * 1000 * 1000)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/ProposalAttachmentRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/ProposalAttachmentRoutes.scala
@@ -95,6 +95,14 @@ object ProposalAttachmentRoutes {
             .flatMap(_ => Ok())
             .recoverWith { case e: AttachmentException => e.toResponse }
         }
+      
+      case req @ GET -> Root / "attachment" / "proposal" / "url" / ProgramId(programId) / TagPath(attachmentType) =>
+        ssoClient.require(req) { user =>
+          attachmentFileService
+            .getPresignedUrl(user, programId, attachmentType)
+            .flatMap(Ok(_))
+            .recoverWith { case e: AttachmentException => e.toResponse }
+        }
     }
 
     EntityLimiter(routes, maxUploadMb * 1000 * 1000)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
@@ -18,10 +18,12 @@ import edu.gemini.grackle.TypeRef
 import edu.gemini.grackle.skunk.SkunkMapping
 import eu.timepit.refined.types.numeric.NonNegShort
 import lucuma.core.model.Group
+import lucuma.core.model.ObsAttachment
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.User
 import lucuma.odb.data.Existence
+import lucuma.odb.data.Tag
 import lucuma.odb.graphql.predicate.Predicates
 import lucuma.odb.graphql.table.GroupElementView
 
@@ -111,6 +113,18 @@ trait ProgramMapping[F[_]]
                 limit = None,
                 child              
               )
+            )
+          )
+        case Select("obsAttachments", Nil, child) =>
+          Result(
+            Select("obsAttachments", Nil,
+              OrderBy(OrderSelections(List(OrderSelection[ObsAttachment.Id](ObsAttachmentType / "id"))), child)
+            )
+          )
+        case Select("proposalAttachments", Nil, child) =>
+          Result(
+            Select("proposalAttachments", Nil,
+              OrderBy(OrderSelections(List(OrderSelection[Tag](ProposalAttachmentType / "attachmentType"))), child)
             )
           )
       }

--- a/modules/service/src/main/scala/lucuma/odb/service/S3FileService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/S3FileService.scala
@@ -5,6 +5,7 @@ package lucuma.odb.service
 
 import cats.effect.Async
 import cats.effect.Ref
+import cats.effect.Resource
 import cats.syntax.all._
 import eu.timepit.refined._
 import eu.timepit.refined.boolean.Or
@@ -16,13 +17,23 @@ import fs2.aws.s3.S3
 import fs2.aws.s3.models.Models.FileKey
 import fs2.aws.s3.models.Models.PartSizeMB
 import fs2.io.file.Path
+import io.laserdisc.pure.s3.tagless.Interpreter
 import io.laserdisc.pure.s3.tagless.S3AsyncClientOp
 import lucuma.core.model.Program
 import lucuma.odb.Config
 import natchez.Trace
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import software.amazon.awssdk.services.s3.S3Configuration
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
 
+import java.time.Duration
 import java.util.UUID
 
 /**
@@ -33,11 +44,12 @@ import java.util.UUID
      or our DB is out of sync.
   */
 trait S3FileService[F[_]] {
+
   /** Get the file as a stream */
-  def get(fileKey: FileKey): Stream[F, Byte]
+  def get(filePath: NonEmptyString): Stream[F, Byte]
 
   /** Get metatada about the S3 file */
-  def getMetadata(fileKey: FileKey): F[HeadObjectResponse]
+  def getMetadata(filePath: NonEmptyString): F[HeadObjectResponse]
 
   /**
     * A convenience method for verifying eistence of and access to the file.
@@ -45,20 +57,20 @@ trait S3FileService[F[_]] {
     * terminates without a response code. This allows the request to at least finish
     * with Internal Server Error most of the time.
     */
-  def verifyFileAcess(fileKey: FileKey): F[Unit]
+  def verifyFileAcess(filePath: NonEmptyString): F[Unit]
 
   /** A meta-convenience method combining verify and get */
-  def verifyAndGet(fileKey: FileKey): F[Stream[F, Byte]]
+  def verifyAndGet(filePath: NonEmptyString): F[Stream[F, Byte]]
 
   /** Uploads a stream to S3 */
-  def upload(fileKey: FileKey, data: Stream[F, Byte]): F[Long]
+  def upload(filePath: NonEmptyString, data: Stream[F, Byte]): F[Long]
 
   /** Deletes a file from S3 */
-  def delete(fileKey: FileKey): F[Unit]
+  def delete(filePath: NonEmptyString): F[Unit]
 
-  def obsFileKey(programId: Program.Id, remoteId: UUID): FileKey
+  def presignedUrl(filePath: NonEmptyString): F[String]
 
-  def proposalFileKey(programId: Program.Id, remoteId: UUID): FileKey
+  def filePath(programId: Program.Id, uuid: UUID, fileName: NonEmptyString): NonEmptyString
 }
 
 object S3FileService {
@@ -71,57 +83,113 @@ object S3FileService {
 
   def fromS3ConfigAndClient[F[_]: Async: Trace](
     awsConfig: Config.Aws,
-    s3Ops:     S3AsyncClientOp[F]
+    s3Ops:     S3AsyncClientOp[F],
+    presigner: S3Presigner
   ): S3FileService[F] = {
 
     val s3 = S3.create[F](s3Ops)
 
+    extension (filePath: NonEmptyString)
+      def toKey: FileKey = awsConfig.fileKey(filePath)
+      def toKeyString: String = toKey.value.value
+
     new S3FileService[F] {
 
-      def get(fileKey: FileKey): Stream[F, Byte] = 
-        s3.readFileMultipart(awsConfig.bucketName, fileKey, partSize)
+      def get(filePath: NonEmptyString): Stream[F, Byte] =
+        s3.readFileMultipart(awsConfig.bucketName, filePath.toKey, partSize)
 
-      def getMetadata(fileKey: FileKey): F[HeadObjectResponse] = 
-        Trace[F].span(s"get remote file metadata for file key: $fileKey") {
+      def getMetadata(filePath: NonEmptyString): F[HeadObjectResponse] =
+        Trace[F].span(s"get remote file metadata for file key: ${filePath.toKey}") {
           s3Ops
             .headObject(
               HeadObjectRequest
                 .builder()
                 .bucket(awsConfig.bucketName.value.value)
-                .key(fileKey.value.value)
+                .key(filePath.toKeyString)
                 .build
             )
             .onError { case e => Trace[F].attachError(e, ("error", true)) }
         }
 
-      def verifyFileAcess(fileKey: FileKey): F[Unit] =
-        getMetadata(fileKey).void
+      def verifyFileAcess(filePath: NonEmptyString): F[Unit] =
+        getMetadata(filePath).void
 
-      def verifyAndGet(fileKey: FileKey): F[Stream[F, Byte]] = 
-        verifyFileAcess(fileKey).map(_ => get(fileKey))
+      def verifyAndGet(filePath: NonEmptyString): F[Stream[F, Byte]] =
+        verifyFileAcess(filePath).map(_ => get(filePath))
 
-      def upload(fileKey: FileKey, data:      Stream[F, Byte]): F[Long] = 
-        Trace[F].span(s"uploading remote file with file key: $fileKey") {
+      def upload(filePath: NonEmptyString, data: Stream[F, Byte]): F[Long] =
+        Trace[F].span(s"uploading remote file with file key: ${filePath.toKey}") {
           val f = for {
             ref  <- Ref.of(0L)
-            pipe  = s3.uploadFileMultipart(awsConfig.bucketName, fileKey, partSize)
+            pipe  = s3.uploadFileMultipart(awsConfig.bucketName, filePath.toKey, partSize)
             _    <- data.evalTapChunk(c => ref.update(_ + 1)).through(pipe).compile.drain
             size <- ref.get
           } yield size
           f.onError { case e => Trace[F].attachError(e, ("error", true)) }
         }
-      
-      def delete(fileKey: FileKey): F[Unit] = 
-        Trace[F].span(s"deleting remote file with file key: $fileKey") {
-          s3.delete(awsConfig.bucketName, fileKey)
+
+      def delete(filePath: NonEmptyString): F[Unit] =
+        Trace[F].span(s"deleting remote file with file key: ${filePath.toKey}") {
+          s3.delete(awsConfig.bucketName, filePath.toKey)
             .onError { case e => Trace[F].attachError(e, ("error", true)) }
         }
 
-      def obsFileKey(programId: Program.Id, remoteId: UUID): FileKey = 
-        awsConfig.obsFileKey(programId, remoteId)
+      def presignedUrl(filePath: NonEmptyString): F[String] =
+        Trace[F].span(s"getting presigned URL for file key: ${filePath.toKey}") {
+          val objectRequest = GetObjectRequest
+            .builder()
+            .bucket(awsConfig.bucketName.value.value)
+            .key(filePath.toKeyString)
+            .build
 
-      def proposalFileKey(programId: Program.Id, remoteId: UUID): FileKey = 
-        awsConfig.proposalFileKey(programId, remoteId)
+          val presignRequest = GetObjectPresignRequest
+            .builder()
+            .signatureDuration(Duration.ofMinutes(120))
+            .getObjectRequest(objectRequest)
+            .build
+
+          Async[F].blocking(presigner.presignGetObject(presignRequest)).map(_.url().toString)
+            .onError { case e => Trace[F].attachError(e, ("error", true)) }
+        }
+
+      def filePath(programId: Program.Id, uuid: UUID, fileName: NonEmptyString): NonEmptyString =
+        awsConfig.filePath(programId, uuid, fileName)
     }
+  }
+
+  def s3PresignerResource[F[_]: Async](awsConfig: Config.Aws): Resource[F, S3Presigner] = {
+    val credentials =
+      AwsBasicCredentials.create(awsConfig.accessKey.value, awsConfig.secretKey.value)
+    val builder     =
+      S3Presigner
+        .builder()
+        .credentialsProvider(StaticCredentialsProvider.create(credentials))
+        .serviceConfiguration(
+          S3Configuration
+            .builder()
+            .pathStyleAccessEnabled(true)
+            .build()
+        )
+        .region(Region.US_EAST_1)
+
+    Resource.fromAutoCloseable(Async[F].delay(builder.build()))
+  }
+
+  /** A resource that encapsulates an s3 async client */
+  def s3AsyncClientOpsResource[F[_]: Async](awsConfig: Config.Aws): Resource[F, S3AsyncClientOp[F]] = {
+    val credentials = AwsBasicCredentials.create(awsConfig.accessKey.value, awsConfig.secretKey.value)
+
+    Interpreter[F].S3AsyncClientOpResource(
+      S3AsyncClient
+            .builder()
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .serviceConfiguration(
+              S3Configuration
+                .builder()
+                .pathStyleAccessEnabled(true)
+                .build()
+            )
+            .region(Region.US_EAST_1)
+    )
   }
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentRoutesSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentRoutesSuite.scala
@@ -30,6 +30,7 @@ abstract class AttachmentRoutesSuite extends CatsEffectSuite with TestSsoClient 
   protected  val fileContents    = "Phred"
   protected  val notFound        = "Not found".some
   protected  val invalidFileName = "File name must be right"
+  protected val presignedUrl     = "http://wherever.com"
 
   // This isn't really what the errors depend on, but we're not testing the service.
   // Only the result matters.


### PR DESCRIPTION
- Adds endpoints for getting presigned S3 URLs for attachment files so that the files can be downloaded directly from Amazon
- Adds the filename to the end of the file path on S3 so that the links will download the file with that name (instead of just a UUID for the name).
- Change the information we store in the DB related to the s3 file keys. Instead of just storing the UUID we were using to generate the file key, we now store the full path (minus the "base path" needed by our Cloud Cube). This will allow us to change our file naming in the future if we need to, without having to worry about losing access to existing attachments.
- Provides an ordering for the attachments in graphQL.