### PR TITLE
Observation c_instrument column update

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4645,6 +4645,11 @@ type Observation {
   # The science configuration
   observingMode: ObservingMode
 
+  """
+  The instrument in use for this observation, if the observing mode is set.
+  """
+  instrument: Instrument
+
   # Manual instrument configuration
   manualConfig: ManualConfig
 

--- a/modules/service/src/main/resources/db/migration/V0353__observation_instrument.sql
+++ b/modules/service/src/main/resources/db/migration/V0353__observation_instrument.sql
@@ -1,0 +1,37 @@
+UPDATE t_observation
+   SET c_instrument = 'GmosNorth'
+ WHERE c_observing_mode_type = 'gmos_north_long_slit';
+
+UPDATE t_observation
+   SET c_instrument = 'GmosSouth'
+ WHERE c_observing_mode_type = 'gmos_south_long_slit';
+
+ALTER TABLE t_gmos_north_long_slit
+        ADD       c_instrument d_tag NOT NULL DEFAULT 'GmosNorth' REFERENCES t_instrument(c_tag),
+        ADD CHECK (c_instrument = 'GmosNorth'),
+  DROP CONSTRAINT t_gmos_north_long_slit_pkey,
+  DROP CONSTRAINT t_gmos_north_long_slit_c_observation_id_c_observing_mode_t_fkey;
+
+ALTER TABLE t_gmos_south_long_slit
+        ADD       c_instrument d_tag NOT NULL DEFAULT 'GmosSouth' REFERENCES t_instrument(c_tag),
+        ADD CHECK (c_instrument = 'GmosSouth'),
+  DROP CONSTRAINT t_gmos_south_long_slit_pkey,
+  DROP CONSTRAINT t_gmos_south_long_slit_c_observation_id_c_observing_mode_t_fkey;
+
+ALTER TABLE t_observation
+  DROP CONSTRAINT t_observation_c_observation_id_c_observing_mode_type_key,
+  ADD UNIQUE (c_observation_id, c_instrument, c_observing_mode_type);
+
+ALTER TABLE t_gmos_north_long_slit
+  ADD PRIMARY KEY (c_observation_id, c_instrument, c_observing_mode_type),
+   ADD CONSTRAINT t_gmos_north_long_slit_obs_fkey
+      FOREIGN KEY (c_observation_id, c_instrument, c_observing_mode_type)
+       REFERENCES t_observation(c_observation_id, c_instrument, c_observing_mode_type)
+                  ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE t_gmos_south_long_slit
+  ADD PRIMARY KEY (c_observation_id, c_instrument, c_observing_mode_type),
+   ADD CONSTRAINT t_gmos_south_long_slit_obs_fkey
+      FOREIGN KEY (c_observation_id, c_instrument, c_observing_mode_type)
+       REFERENCES t_observation(c_observation_id, c_instrument, c_observing_mode_type)
+                  ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -40,6 +40,7 @@ trait ObservationMapping[F[_]]
         SqlObject("timingWindows", Join(ObservationView.Id, TimingWindowView.ObservationId)),
         SqlObject("scienceRequirements"),
         SqlObject("observingMode"),
+        SqlField("instrument", ObservationView.Instrument),
         SqlObject("plannedTime"),
         SqlObject("program", Join(ObservationView.ProgramId, ProgramTable.Id))
       )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
@@ -17,7 +17,7 @@ trait ObservationView[F[_]] extends BaseMapping[F] {
       val Existence: ColumnRef         = col("c_existence",          existence)
       val Title: ColumnRef             = col("c_title",              text_nonempty)
       val Subtitle: ColumnRef          = col("c_subtitle",           text_nonempty.opt)
-//      val Instrument: m.ColumnRef   = col("c_instrument", tag.opt)
+      val Instrument: ColumnRef        = col("c_instrument",         instrument.opt)
       val Status: ColumnRef            = col("c_status",             obs_status)
       val ActiveStatus: ColumnRef      = col("c_active_status",      obs_active_status) 
       val VisualizationTime: ColumnRef = col("c_visualization_time", core_timestamp.opt)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
@@ -949,6 +949,7 @@ class updateObservations extends OdbSuite
 
     val query = """
       observations {
+        instrument
         observingMode {
           gmosNorthLongSlit {
             grating
@@ -968,6 +969,7 @@ class updateObservations extends OdbSuite
         "updateObservations": {
           "observations": [
             {
+              "instrument": "GMOS_NORTH",
               "observingMode": {
                 "gmosNorthLongSlit": {
                   "grating": "B1200_G5301",
@@ -1035,6 +1037,7 @@ class updateObservations extends OdbSuite
 
     val query = """
       observations {
+        instrument
         observingMode {
           gmosNorthLongSlit {
             grating
@@ -1049,6 +1052,7 @@ class updateObservations extends OdbSuite
         "updateObservations": {
           "observations": [
             {
+              "instrument": "GMOS_NORTH",
               "observingMode": {
                 "gmosNorthLongSlit": {
                   "grating": "B1200_G5301"
@@ -1074,6 +1078,7 @@ class updateObservations extends OdbSuite
         "updateObservations": {
           "observations": [
             {
+              "instrument": "GMOS_NORTH",
               "observingMode": {
                 "gmosNorthLongSlit": {
                   "grating": "R831_G5302"
@@ -1122,6 +1127,7 @@ class updateObservations extends OdbSuite
 
     val query = """
       observations {
+        instrument
         observingMode {
           gmosNorthLongSlit {
             grating
@@ -1152,6 +1158,7 @@ class updateObservations extends OdbSuite
         "updateObservations": {
           "observations": [
             {
+              "instrument": "GMOS_NORTH",
               "observingMode": {
                 "gmosNorthLongSlit": {
                   "grating": "B1200_G5301",
@@ -1219,6 +1226,7 @@ class updateObservations extends OdbSuite
         "updateObservations": {
           "observations": [
             {
+              "instrument": "GMOS_NORTH",
               "observingMode": {
                 "gmosNorthLongSlit": {
                   "grating": "R831_G5302",
@@ -1272,6 +1280,7 @@ class updateObservations extends OdbSuite
     val query0 =
       """
       observations {
+        instrument
         observingMode {
           gmosNorthLongSlit {
             grating
@@ -1286,6 +1295,7 @@ class updateObservations extends OdbSuite
         "updateObservations": {
           "observations": [
             {
+              "instrument": "GMOS_NORTH",
               "observingMode": {
                 "gmosNorthLongSlit": {
                   "grating": "B1200_G5301"
@@ -1314,6 +1324,7 @@ class updateObservations extends OdbSuite
     val query1 =
       """
       observations {
+        instrument
         observingMode {
           gmosSouthLongSlit {
             grating
@@ -1328,6 +1339,7 @@ class updateObservations extends OdbSuite
         "updateObservations": {
           "observations": [
             {
+              "instrument": "GMOS_SOUTH",
               "observingMode": {
                 "gmosSouthLongSlit": {
                   "grating": "R831_G5322"
@@ -1430,6 +1442,7 @@ class updateObservations extends OdbSuite
 
     val query = """
       observations {
+        instrument
         observingMode {
           mode
           gmosNorthLongSlit {
@@ -1445,6 +1458,7 @@ class updateObservations extends OdbSuite
         "updateObservations": {
           "observations": [
             {
+              "instrument": "GMOS_NORTH",
               "observingMode": {
                 "mode": "GMOS_NORTH_LONG_SLIT",
                 "gmosNorthLongSlit": {
@@ -1467,6 +1481,7 @@ class updateObservations extends OdbSuite
         "updateObservations": {
           "observations": [
             {
+              "instrument": null,
               "observingMode": null
             }
           ]


### PR DESCRIPTION
`t_observation` has a `c_instrument` column, but it wasn't being updated when the observing mode changes.  This PR fixes that oversight. The `(c_observation_id, c_instrument)` combination is going to be used as a foreign key into the `t_observation` table in various places to ensure that we never mix instrument types.  For example, the `recordGmosNorthVisit` mutation should only work if the observation is in fact a GMOS North observation.

The two existing mode tables, `t_gmos_north_long_slit` and `t_gmos_south_long_slit`, had an fkey constraint on observation's `(c_observation_id, c_observing_mode_type)`.  That unfortunately isn't enough to prevent an inconsistency between the observing mode and the observation instrument.  Accordingly, I changed the constraint to include all three columns: `(c_observation_id, c_instrument, c_observing_mode_type)`.

I added an `instrument` field to the `Observation` GraphQL type as well.  This may be overkill because you can get it from the mode, but it made it easier to test and is a slight convenience.
