### PR TITLE
Fix Publishing? Take 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ lazy val schema =
 
 lazy val sequence = project
   .in(file("modules/sequence"))
+  .disablePlugins(MimaPlugin, HeaderPlugin)
   .dependsOn(schema.jvm % "compile->test")
   .settings(
     name := "lucuma-odb-sequence",
@@ -76,6 +77,7 @@ lazy val sequence = project
 
 lazy val smartgcal = project
   .in(file("modules/smartgcal"))
+  .disablePlugins(MimaPlugin, HeaderPlugin)
   .settings(
     name := "lucuma-odb-smartgcal",
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,6 @@ lazy val schema =
 lazy val sequence = project
   .in(file("modules/sequence"))
   .dependsOn(schema.jvm % "compile->test")
-  .enablePlugins(NoPublishPlugin)
   .settings(
     name := "lucuma-odb-sequence",
     libraryDependencies ++= Seq(
@@ -77,7 +76,6 @@ lazy val sequence = project
 
 lazy val smartgcal = project
   .in(file("modules/smartgcal"))
-  .enablePlugins(NoPublishPlugin)
   .settings(
     name := "lucuma-odb-smartgcal",
     libraryDependencies ++= Seq(


### PR DESCRIPTION
@armanbilge This allows the internal project dependencies to be published so that the app packaging will include them.  This is a temporary work around, I hope.  Ideally `smartgcal` and `sequence` would not be published.

