### PR TITLE
Future length parameter

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -870,24 +870,37 @@ type GmosNorthExecutionConfig implements ExecutionConfig {
   setup: SetupTime!
 }
 
-# Next atom to execute and potential future atoms
+"""
+Next atom to execute and potential future atoms.
+"""
 type GmosNorthExecutionSequence implements ExecutionSequence {
-  # Next atom to execute
+
+  """
+  Next atom to execute.
+  """
   nextAtom: GmosNorthAtom!
 
-  # (Prefix of the) remaining atoms to execute, if any.
+  """
+  (Prefix of the) remaining atoms to execute, if any.
+  """
   possibleFuture: [GmosNorthAtom!]!
 
-  # Whether there are more anticipated atoms than those that appear in
-  # possibleFuture
-  hashMore: Boolean!
+  """
+  Whether there are more anticipated atoms than those that appear in
+  'possibleFuture'.
+  """
+  hasMore: Boolean!
 
-  # Total count of anticipated atoms, including nextAtom, possibleFuture and
-  # any remaining atoms not included in possibleFuture
+  """
+  Total count of anticipated atoms, including 'nextAtom', 'possibleFuture' and
+  any remaining atoms not included in 'possibleFuture'.
+  """
   atomCount: PosInt!
 
-  # Sequence digest (including all anticipated future values regardless of
-  # whether they appear in possibleFuture)
+  """
+  Sequence digest (including all anticipated future values regardless of
+  whether they appear in 'possibleFuture').
+  """
   digest: SequenceDigest!
 
 }
@@ -1256,24 +1269,37 @@ type GmosSouthExecutionConfig implements ExecutionConfig {
   setup: SetupTime!
 }
 
-# Next atom to execute and potential future atoms
+"""
+Next atom to execute and potential future atoms.
+"""
 type GmosSouthExecutionSequence implements ExecutionSequence {
-  # Next atom to execute
+
+  """
+  Next atom to execute.
+  """
   nextAtom: GmosSouthAtom!
 
-  # Remaining atoms to execute, if any
+  """
+  (Prefix of the) remaining atoms to execute, if any.
+  """
   possibleFuture: [GmosSouthAtom!]!
 
-  # Whether there are more anticipated atoms than those that appear in
-  # possibleFuture
-  hashMore: Boolean!
+  """
+  Whether there are more anticipated atoms than those that appear in
+  'possibleFuture'.
+  """
+  hasMore: Boolean!
 
-  # Total count of anticipated atoms, including nextAtom, possibleFuture and
-  # any remaining atoms not included in possibleFuture
+  """
+  Total count of anticipated atoms, including 'nextAtom', 'possibleFuture' and
+  any remaining atoms not included in 'possibleFuture'.
+  """
   atomCount: PosInt!
 
-  # Sequence digest (including all anticipated future values regardless of
-  # whether they appear in possibleFuture)
+  """
+  Sequence digest (including all anticipated future values regardless of
+  whether they appear in 'possibleFuture').
+  """
   digest: SequenceDigest!
 
 }
@@ -5284,6 +5310,10 @@ type Query {
   #   includeDeleted: Boolean! = false
   # ): ScienceRequirementsGroupSelectResult!
 
+  """
+  Produces the execution configuration with its acquisition and science
+  sequences for this observation.
+  """
   sequence(
     programId:     ProgramId!
 
@@ -5295,10 +5325,11 @@ type Query {
     useCache: Boolean! = true
 
     """
-    The maximum size, i.e. number of atoms, of the possibleFuture in the sequence.
-    If projected future is longer, the value returned will be capped at this value.
-    Use 0 if only interested in the nextAtom.  The maximum is 100 and the default
-    is 25.
+    The maximum size (number of atoms) of the 'possibleFuture' in the sequences.
+    If the projected future is longer, the size will be capped at this value.
+    Use 0 if only interested in the 'nextAtom'.  The maximum is 100.  Each
+    sequence has 'hasMore' and 'atomCount' fields that can be used to determine
+    whether and how many remaining atoms are yet to be executed.
     """
     futureLimit: PosInt! = 25
 

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -5289,8 +5289,19 @@ type Query {
 
     observationId: ObservationId!
 
-    # Whether to use cached results (true) or ignore the cache and make a remote ITC call (false).
+    """
+    Whether to use cached results (true) or ignore the cache and make a remote ITC call (false).
+    """
     useCache: Boolean! = true
+
+    """
+    The maximum size, i.e. number of atoms, of the possibleFuture in the sequence.
+    If projected future is longer, the value returned will be capped at this value.
+    Use 0 if only interested in the nextAtom.  The maximum is 100 and the default
+    is 25.
+    """
+    futureLimit: PosInt! = 25
+
   ): SequenceGenerationResult
 
   # Retrieves the target with the given id, if it exists

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -73,7 +73,7 @@ sealed trait Generator[F[_]] {
   def generate(
     programId:     Program.Id,
     observationId: Observation.Id,
-    useCache:      Boolean = true,
+    useCache:      Boolean     = true,
     futureLimit:   FutureLimit = FutureLimit.Default
   )(using Transaction[F]): F[Generator.Result]
 
@@ -84,14 +84,14 @@ object Generator {
   type FutureLimit = Int Refined Interval.Closed[0, 100]
 
   object FutureLimit extends RefinedTypeOps[FutureLimit, Int] {
-    val Default: FutureLimit = unsafeFrom(25)
-    val Min: FutureLimit = unsafeFrom(0)
-    val Max: FutureLimit = unsafeFrom(100)
+    val Default: FutureLimit = unsafeFrom( 25)
+    val Min: FutureLimit     = unsafeFrom(  0)
+    val Max: FutureLimit     = unsafeFrom(100)
 
     val Binding: lucuma.odb.graphql.binding.Matcher[FutureLimit] =
       lucuma.odb.graphql.binding.IntBinding.emap { v =>
         from(v).leftMap { _ =>
-          s"futureLimit must range from ${Min.value} to ${Max.value}, but was $v."
+          s"Future limit must range from ${Min.value} to ${Max.value}, but was $v."
         }
       }
   }

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -17,11 +17,11 @@ import cats.syntax.foldable.*
 import cats.syntax.functor.*
 import cats.syntax.monoid.*
 import cats.syntax.option.*
-import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.api.RefinedTypeOps
-import eu.timepit.refined.refineV
 import eu.timepit.refined.numeric.Interval
+import eu.timepit.refined.refineV
+import eu.timepit.refined.types.numeric.PosInt
 import fs2.Pure
 import fs2.Stream
 import io.circe.Encoder

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/sequence.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/sequence.scala
@@ -296,6 +296,7 @@ class sequence extends OdbSuite with ObservingModeSetupOperations {
                        possibleFuture {
                          observeClass
                        }
+                       hasMore
                      }
                    }
                  }
@@ -316,7 +317,8 @@ class sequence extends OdbSuite with ObservingModeSetupOperations {
                       {
                         "observeClass": "SCIENCE"
                       }
-                    ]
+                    ],
+                    "hasMore": true
                   }
                 }
               }


### PR DESCRIPTION
* Makes it possible to control (within limits) the size of the `possibleFuture` atoms of a sequence.
* Fixes a typo in a field name (was `hashMore`, is now `hasMore`)