### PR TITLE
Record Step Bindings

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -819,27 +819,43 @@ type GmosNorthDynamic {
   fpu: GmosNorthFpu
 }
 
-# GMOS North instrument configuration input
+"""
+GMOS North instrument configuration input
+"""
 input GmosNorthDynamicInput {
-  # Exposure time
+  """
+  Exposure time
+  """
   exposure: TimeSpanInput!
 
-  # GMOS CCD readout
+  """
+  GMOS CCD readout
+  """
   readout: GmosCcdModeInput!
 
-  # GMOS detector x offset
+  """
+  GMOS detector x offset
+  """
   dtax: GmosDtax!
 
-  # GMOS region of interest
+  """
+  GMOS region of interest
+  """
   roi: GmosRoi!
 
-  # GMOS North grating
+  """
+  GMOS North grating
+  """
   gratingConfig: GmosNorthGratingConfigInput
 
-  # GMOS North filter
+  """
+  GMOS North filter
+  """
   filter: GmosNorthFilter
 
-  # GMOS North FPU
+  """
+  GMOS North FPU
+  """
   fpu: GmosNorthFpuInput
 }
 
@@ -1180,27 +1196,43 @@ type GmosSouthDynamic {
   fpu: GmosSouthFpu
 }
 
-# GMOS South instrument configuration input
+"""
+GMOS South instrument configuration input
+"""
 input GmosSouthDynamicInput {
-  # Exposure time
+  """
+  Exposure time
+  """
   exposure: TimeSpanInput!
 
-  # GMOS CCD readout
+  """
+  GMOS CCD readout
+  """
   readout: GmosCcdModeInput!
 
-  # GMOS detector x offset
+  """
+  GMOS detector x offset
+  """
   dtax: GmosDtax!
 
-  # GMOS region of interest
+  """
+  GMOS region of interest
+  """
   roi: GmosRoi!
 
-  # GMOS South grating
+  """
+  GMOS South grating
+  """
   gratingConfig: GmosSouthGratingConfigInput
 
-  # GMOS South filter
+  """
+  GMOS South filter
+  """
   filter: GmosSouthFilter
 
-  # GMOS South FPU
+  """
+  GMOS South FPU
+  """
   fpu: GmosSouthFpuInput
 }
 
@@ -1671,9 +1703,13 @@ type Mutation {
   """
   linkUser(input: LinkUserInput!): LinkUserResult!
 
-  # Record a new step
+  """
+  Record a new GMOS North step
+  """
   recordGmosNorthStep(
-    # GmosNorth step configuration parameters
+    """
+    GmosNorth step configuration parameters
+    """
     input: RecordGmosNorthStepInput!
   ): RecordGmosNorthStepResult!
 
@@ -1687,9 +1723,13 @@ type Mutation {
     input: RecordGmosNorthVisitInput!
   ): RecordGmosNorthVisitResult!
 
-  # Record a new step
+  """
+  Record a new GMOS South step
+  """
   recordGmosSouthStep(
-    # GmosSouth step configuration parameters
+    """
+    GmosSouth step configuration parameters
+    """
     input: RecordGmosSouthStepInput!
   ): RecordGmosSouthStepResult!
 
@@ -2267,19 +2307,29 @@ interface StepConfig {
   stepType: StepType!
 }
 
-# Step configuration.  Choose exactly one step type.
+"""
+Step configuration.  Choose exactly one step type.
+"""
 input StepConfigInput {
 
-  # Bias step creation option
+  """
+  Bias step creation option
+  """
   bias: Boolean
 
-  # Dark step creation option
+  """
+  Dark step creation option
+  """
   dark: Boolean
 
-  # GCAL step creation option
+  """
+  GCAL step creation option
+  """
   gcal: StepConfigGcalInput
 
-  # Science step creation option
+  """
+  Science step creation option
+  """
   science: StepConfigScienceInput
 
 }
@@ -2296,7 +2346,9 @@ input StepConfigGcalInput {
   shutter: GcalShutter!
 }
 
-# Science step creation input
+"""
+Science step creation input
+"""
 input StepConfigScienceInput {
   # offset position
   offset: OffsetInput!

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -485,14 +485,6 @@ enum GcalArc {
   XE_ARC
 }
 
-# GCAL configuration creation input
-input GcalConfigurationInput {
-  continuum: GcalContinuum
-  arcs: [GcalArc!]!
-  diffuser: GcalDiffuser!
-  shutter: GcalShutter!
-}
-
 # GCAL continuum
 enum GcalContinuum {
   # GcalContinuum IrGreyBodyLow
@@ -592,22 +584,36 @@ type GmosCcdMode {
   ampReadMode: GmosAmpReadMode!
 }
 
-# GMOS CCD readout input parameters
-input GmosCcdReadoutInput {
-  # X Binning
-  xBin: GmosXBinning! = ONE
+"""
+GMOS CCD readout input parameters
+"""
+input GmosCcdModeInput {
 
-  # Y Binning
-  yBin: GmosYBinning! = ONE
+  """
+  X Binning, defaults to 'ONE'.
+  """
+  xBin: GmosXBinning
 
-  # Amp Count
-  ampCount: GmosAmpCount! = TWELVE
+  """
+  Y Binning, defaults to 'ONE'.
+  """
+  yBin: GmosYBinning
 
-  # Amp Gain
-  ampGain: GmosAmpGain! = LOW
+  """
+  Amp Count, defaults to 'TWELVE'.
+  """
+  ampCount: GmosAmpCount
 
-  # Amp Read Mode
-  ampRead: GmosAmpReadMode! = SLOW
+  """
+  Amp Gain, defaults to 'LOW'
+  """
+  ampGain: GmosAmpGain
+
+  """
+  Amp Read Mode, defaults to 'SLOW'
+  """
+  ampRead: GmosAmpReadMode
+
 }
 
 # GMOS Custom Mask
@@ -780,18 +786,6 @@ type GmosNorthAtom implements Atom {
 
 }
 
-# GmosNorth bias step creation input
-input GmosNorthBiasInput {
-  # instrument configuration
-  config: GmosNorthDynamicInput!
-}
-
-# GmosNorth dark step creation input
-input GmosNorthDarkInput {
-  # instrument configuration
-  config: GmosNorthDynamicInput!
-}
-
 """
 GmosNorth Detector type
 """
@@ -831,7 +825,7 @@ input GmosNorthDynamicInput {
   exposure: TimeSpanInput!
 
   # GMOS CCD readout
-  readout: GmosCcdReadoutInput!
+  readout: GmosCcdModeInput!
 
   # GMOS detector x offset
   dtax: GmosDtax!
@@ -917,22 +911,19 @@ type GmosNorthFpu {
   builtin: GmosNorthBuiltinFpu
 }
 
-# GMOS North FPU input parameters (choose custom or builtin).
+"""
+GMOS North FPU input parameters (choose custom or builtin).
+"""
 input GmosNorthFpuInput {
-  # Custom mask FPU option
+  """
+  Custom mask FPU option
+  """
   customMask: GmosCustomMaskInput
 
-  # Builtin FPU option
+  """
+  Builtin FPU option
+  """
   builtin: GmosNorthBuiltinFpu
-}
-
-# GmosNorth GCAL step creation input
-input GmosNorthGcalInput {
-  # instrument configuration
-  config: GmosNorthDynamicInput!
-
-  # GCAL configuration
-  gcalConfig: GcalConfigurationInput!
 }
 
 # GMOS North Grating Configuration
@@ -994,15 +985,6 @@ input GmosNorthLongSlitInput {
 
   # The explicitSpatialOffsets field may be unset by assigning a null value, or ignored by skipping it altogether
   explicitSpatialOffsets: [OffsetComponentInput!]
-}
-
-# GmosNorth science step creation input
-input GmosNorthScienceInput {
-  # instrument configuration
-  config: GmosNorthDynamicInput!
-
-  # offset position
-  offset: OffsetInput!
 }
 
 # GMOS North stage mode
@@ -1081,21 +1063,6 @@ type GmosNorthStep implements Step {
   # Observe class for this step
   observeClass: ObserveClass!
 
-}
-
-# GmosNorth step creation input.  Choose exactly one step type.
-input GmosNorthStepInput {
-  # Bias step creation option
-  bias: GmosNorthBiasInput
-
-  # Dark step creation option
-  dark: GmosNorthDarkInput
-
-  # GCAL step creation option
-  gcal: GmosNorthGcalInput
-
-  # Science step creation option
-  science: GmosNorthScienceInput
 }
 
 # A GmosNorth step configuration as recorded by Observe
@@ -1180,18 +1147,6 @@ type GmosSouthAtom implements Atom {
   steps: [GmosSouthStep!]!
 }
 
-# GmosSouth bias step creation input
-input GmosSouthBiasInput {
-  # instrument configuration
-  config: GmosSouthDynamicInput!
-}
-
-# GmosSouth dark step creation input
-input GmosSouthDarkInput {
-  # instrument configuration
-  config: GmosSouthDynamicInput!
-}
-
 """
 GmosSouth Detector type
 """
@@ -1231,7 +1186,7 @@ input GmosSouthDynamicInput {
   exposure: TimeSpanInput!
 
   # GMOS CCD readout
-  readout: GmosCcdReadoutInput!
+  readout: GmosCcdModeInput!
 
   # GMOS detector x offset
   dtax: GmosDtax!
@@ -1325,15 +1280,6 @@ input GmosSouthFpuInput {
   builtin: GmosSouthBuiltinFpu
 }
 
-# GmosSouth GCAL step creation input
-input GmosSouthGcalInput {
-  # instrument configuration
-  config: GmosSouthDynamicInput!
-
-  # GCAL configuration
-  gcalConfig: GcalConfigurationInput!
-}
-
 # GMOS South Grating Configuration
 type GmosSouthGratingConfig {
   # GMOS South Grating
@@ -1394,15 +1340,6 @@ input GmosSouthLongSlitInput {
   # The explicitSpatialOffsets field may be unset by assigning a null value, or ignored by skipping it altogether
   explicitSpatialOffsets: [OffsetComponentInput!]
 
-}
-
-# GmosSouth science step creation input
-input GmosSouthScienceInput {
-  # instrument configuration
-  config: GmosSouthDynamicInput!
-
-  # offset position
-  offset: OffsetInput!
 }
 
 # GMOS South stage mode
@@ -1493,21 +1430,6 @@ type GmosSouthStep implements Step {
   # Observe class for this step
   observeClass: ObserveClass!
 
-}
-
-# GmosSouth step creation input.  Choose exactly one step type.
-input GmosSouthStepInput {
-  # Bias step creation option
-  bias: GmosSouthBiasInput
-
-  # Dark step creation option
-  dark: GmosSouthDarkInput
-
-  # GCAL step creation option
-  gcal: GmosSouthGcalInput
-
-  # Science step creation option
-  science: GmosSouthScienceInput
 }
 
 # A GmosSouth step configuration as recorded by Observe
@@ -2132,11 +2054,13 @@ input RadialVelocityInput {
   kilometersPerSecond: BigDecimal
 }
 
-# Input parameters for creating a new GmosNorth StepRecord
+"""
+Input parameters for creating a new GmosNorth StepRecord
+"""
 input RecordGmosNorthStepInput {
-  observationId: ObservationId!
   visitId: VisitId!
-  stepConfig: GmosNorthStepInput!
+  instrument: GmosNorthDynamicInput!
+  step: StepConfigInput!
 }
 
 # The result of recording a GmosNorth step.
@@ -2161,9 +2085,9 @@ type RecordGmosNorthVisitResult {
 
 # Input parameters for creating a new GmosSouth StepRecord
 input RecordGmosSouthStepInput {
-  observationId: ObservationId!
   visitId: VisitId!
-  stepConfig: GmosSouthStepInput!
+  instrument: GmosSouthDynamicInput!
+  step: GmosSouthStepInput!
 }
 
 # The result of recording a GmosSouth step.
@@ -2341,6 +2265,41 @@ interface Step {
 interface StepConfig {
   # Step type
   stepType: StepType!
+}
+
+# Step configuration.  Choose exactly one step type.
+input StepConfigInput {
+
+  # Bias step creation option
+  bias: Boolean
+
+  # Dark step creation option
+  dark: Boolean
+
+  # GCAL step creation option
+  gcal: StepConfigGcalInput
+
+  # Science step creation option
+  science: StepConfigScienceInput
+
+}
+
+"""
+GCAL configuration creation input.  Specify either one or more arcs or else
+one continuum.
+"""
+input StepConfigGcalInput {
+  arcs: [GcalArc!]
+  continuum: GcalContinuum
+  diffuser: GcalDiffuser!
+  filter: GcalFilter!
+  shutter: GcalShutter!
+}
+
+# Science step creation input
+input StepConfigScienceInput {
+  # offset position
+  offset: OffsetInput!
 }
 
 # StepEvent location parameters

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/GcalArcBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/GcalArcBinding.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.core.enums.GcalArc
+
+val GcalArcBinding: Matcher[GcalArc] =
+  enumeratedBinding

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/GcalContinuumBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/GcalContinuumBinding.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.core.enums.GcalContinuum
+
+val GcalContinuumBinding: Matcher[GcalContinuum] =
+  enumeratedBinding

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/GcalDiffuserBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/GcalDiffuserBinding.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+ import lucuma.core.enums.GcalDiffuser
+
+ val GcalDiffuserBinding: Matcher[GcalDiffuser] =
+   enumeratedBinding

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/GcalFilterBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/GcalFilterBinding.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.core.enums.GcalFilter
+
+val GcalFilterBinding: Matcher[GcalFilter] =
+  enumeratedBinding

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/GcalShutterBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/GcalShutterBinding.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.core.enums.GcalShutter
+
+val GcalShutterBinding: Matcher[GcalShutter] =
+  enumeratedBinding

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/GmosAmpCountBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/GmosAmpCountBinding.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.core.enums.GmosAmpCount
+
+val GmosAmpCountBinding: Matcher[GmosAmpCount] =
+  enumeratedBinding
+

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/GmosCustomSlitWidthBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/GmosCustomSlitWidthBinding.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.core.enums.GmosCustomSlitWidth
+
+val GmosCustomSlitWidthBinding: Matcher[GmosCustomSlitWidth] =
+  enumeratedBinding

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/GmosDtaxBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/GmosDtaxBinding.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.core.enums.GmosDtax
+
+val GmosDtaxBinding: Matcher[GmosDtax] =
+  enumeratedBinding
+
+

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/GmosGratingOrderBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/GmosGratingOrderBinding.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.core.enums.GmosGratingOrder
+
+val GmosGratingOrderBinding: Matcher[GmosGratingOrder] =
+  enumeratedBinding

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosCcdModeInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosCcdModeInput.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import lucuma.core.enums.GmosAmpCount
+import lucuma.core.enums.GmosAmpGain
+import lucuma.core.enums.GmosAmpReadMode
+import lucuma.core.enums.GmosXBinning
+import lucuma.core.enums.GmosYBinning
+import lucuma.core.model.sequence.gmos.GmosCcdMode
+import lucuma.odb.graphql.binding.*
+
+
+object GmosCcdModeInput {
+
+  val Binding: Matcher[GmosCcdMode] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        GmosXBinningBinding.Option("xBin", rXBin),
+        GmosYBinningBinding.Option("yBin", rYBin),
+        GmosAmpCountBinding.Option("ampCount", rAmpCount),
+        GmosAmpGainBinding.Option("ampGain", rAmpGain),
+        GmosAmpReadModeBinding.Option("ampRead", rAmpRead)
+      ) => (rXBin, rYBin, rAmpCount, rAmpGain, rAmpRead).parMapN { (xBin, yBin, ampCount, ampGain, ampRead) =>
+        GmosCcdMode(
+          xBin.getOrElse(GmosXBinning.One),
+          yBin.getOrElse(GmosYBinning.One),
+          ampCount.getOrElse(GmosAmpCount.Twelve),
+          ampGain.getOrElse(GmosAmpGain.Low),
+          ampRead.getOrElse(GmosAmpReadMode.Slow)
+        )
+      }
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosCustomMaskInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosCustomMaskInput.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import edu.gemini.grackle.Result
+import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.core.enums.GmosCustomSlitWidth
+import lucuma.core.model.sequence.gmos.GmosFpuMask.Custom
+import lucuma.odb.graphql.binding.*
+
+object GmosCustomMaskInput {
+
+  val Binding: Matcher[Custom] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        StringBinding("filename", rFilename),
+        GmosCustomSlitWidthBinding("slitWidth", rSlitWidth)
+      ) => (rFilename, rSlitWidth).parTupled.flatMap { (filename, slitWidth) =>
+        NonEmptyString.from(filename) match {
+          case Left(_)  => Result.failure("The GMOS custom FPU mask 'filename' cannot be empty.")
+          case Right(n) => Result(Custom(n, slitWidth))
+        }
+      }
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosNorthDynamicInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosNorthDynamicInput.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import lucuma.core.model.sequence.gmos.DynamicConfig.GmosNorth
+import lucuma.odb.graphql.binding.*
+
+object GmosNorthDynamicInput {
+
+  val Binding: Matcher[GmosNorth] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        TimeSpanInput.Binding("exposure", rExposure),
+        GmosCcdModeInput.Binding("readout", rReadout),
+        GmosDtaxBinding("dtax", rDtax),
+        GmosRoiBinding("roi", rRoi),
+        GmosNorthGratingConfigInput.Binding.Option("gratingConfig", rGrating),
+        GmosNorthFilterBinding.Option("filter", rFilter),
+        GmosNorthFpuInput.Binding.Option("fpu", rFpu)
+      ) => (rExposure, rReadout, rDtax, rRoi, rGrating, rFilter, rFpu).parMapN { (exposure, readout, dtax, roi, grating, filter, fpu) =>
+        GmosNorth(
+          exposure,
+          readout,
+          dtax,
+          roi,
+          grating,
+          filter,
+          fpu
+        )
+      }
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosNorthFpuInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosNorthFpuInput.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.functor.*
+import cats.syntax.parallel.*
+import lucuma.core.enums.GmosNorthFpu
+import lucuma.core.model.sequence.gmos.GmosFpuMask
+import lucuma.odb.graphql.binding.*
+
+object GmosNorthFpuInput {
+
+  val Binding: Matcher[GmosFpuMask[GmosNorthFpu]] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        GmosCustomMaskInput.Binding.Option("customMask", rCustomMask),
+        GmosNorthFpuBinding.Option("builtin", rBuiltin)
+      ) => (rCustomMask, rBuiltin).parTupled.flatMap { (custom, builtin) =>
+        oneOrFail(
+          custom.widen[GmosFpuMask[GmosNorthFpu]] -> "customMask",
+          builtin.map(GmosFpuMask.Builtin(_))     -> "builtin"
+        )
+      }
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosNorthGratingConfigInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosNorthGratingConfigInput.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import lucuma.core.model.sequence.gmos.GmosGratingConfig.North
+import lucuma.odb.graphql.binding.*
+
+object GmosNorthGratingConfigInput {
+
+  val Binding: Matcher[North] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        GmosNorthGratingBinding("grating", rGrating),
+        GmosGratingOrderBinding("order", rOrder),
+        WavelengthInput.Binding("wavelength", rWavelength)
+      ) => (rGrating, rOrder, rWavelength).parMapN { (grating, order, wavelength) =>
+        North(grating, order, wavelength)
+      }
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosSouthDynamicInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosSouthDynamicInput.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import lucuma.core.model.sequence.gmos.DynamicConfig.GmosSouth
+import lucuma.odb.graphql.binding.*
+
+object GmosSouthDynamicInput {
+
+  val Binding: Matcher[GmosSouth] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        TimeSpanInput.Binding("exposure", rExposure),
+        GmosCcdModeInput.Binding("readout", rReadout),
+        GmosDtaxBinding("dtax", rDtax),
+        GmosRoiBinding("roi", rRoi),
+        GmosSouthGratingConfigInput.Binding.Option("gratingConfig", rGrating),
+        GmosSouthFilterBinding.Option("filter", rFilter),
+        GmosSouthFpuInput.Binding.Option("fpu", rFpu)
+      ) => (rExposure, rReadout, rDtax, rRoi, rGrating, rFilter, rFpu).parMapN { (exposure, readout, dtax, roi, grating, filter, fpu) =>
+        GmosSouth(
+          exposure,
+          readout,
+          dtax,
+          roi,
+          grating,
+          filter,
+          fpu
+        )
+      }
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosSouthFpuInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosSouthFpuInput.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.functor.*
+import cats.syntax.parallel.*
+import lucuma.core.enums.GmosSouthFpu
+import lucuma.core.model.sequence.gmos.GmosFpuMask
+import lucuma.odb.graphql.binding.*
+
+object GmosSouthFpuInput {
+
+  val Binding: Matcher[GmosFpuMask[GmosSouthFpu]] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        GmosCustomMaskInput.Binding.Option("customMask", rCustomMask),
+        GmosSouthFpuBinding.Option("builtin", rBuiltin)
+      ) => (rCustomMask, rBuiltin).parTupled.flatMap { (custom, builtin) =>
+        oneOrFail(
+          custom.widen[GmosFpuMask[GmosSouthFpu]] -> "customMask",
+          builtin.map(GmosFpuMask.Builtin(_))     -> "builtin"
+        )
+      }
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosSouthGratingConfigInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosSouthGratingConfigInput.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import lucuma.core.model.sequence.gmos.GmosGratingConfig.South
+import lucuma.odb.graphql.binding.*
+
+object GmosSouthGratingConfigInput {
+
+  val Binding: Matcher[South] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        GmosSouthGratingBinding("grating", rGrating),
+        GmosGratingOrderBinding("order", rOrder),
+        WavelengthInput.Binding("wavelength", rWavelength)
+      ) => (rGrating, rOrder, rWavelength).parMapN { (grating, order, wavelength) =>
+        South(grating, order, wavelength)
+      }
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/RecordGmosNorthStepInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/RecordGmosNorthStepInput.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import lucuma.core.model.Visit
+import lucuma.core.model.sequence.StepConfig
+import lucuma.core.model.sequence.gmos.DynamicConfig.GmosNorth
+import lucuma.odb.graphql.binding.*
+
+case class RecordGmosNorthStepInput(
+  visitId: Visit.Id,
+  instrument: GmosNorth,
+  step: StepConfig
+)
+
+object RecordGmosNorthStepInput {
+
+  val Binding: Matcher[RecordGmosNorthStepInput] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        VisitIdBinding("visitId", rVisitId),
+        GmosNorthDynamicInput.Binding("instrument", rInstrument),
+        StepConfigInput.Binding("stepConfig", rStepConfig)
+      ) => (rVisitId, rInstrument, rStepConfig).parMapN { (visitId, instrument, step) =>
+        RecordGmosNorthStepInput(visitId, instrument, step)
+      }
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/RecordGmosSouthStepInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/RecordGmosSouthStepInput.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import lucuma.core.model.Visit
+import lucuma.core.model.sequence.StepConfig
+import lucuma.core.model.sequence.gmos.DynamicConfig.GmosSouth
+import lucuma.odb.graphql.binding.*
+
+case class RecordGmosSouthStepInput(
+  visitId: Visit.Id,
+  instrument: GmosSouth,
+  step: StepConfig
+)
+
+object RecordGmosSouthStepInput {
+
+  val Binding: Matcher[RecordGmosSouthStepInput] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        VisitIdBinding("visitId", rVisitId),
+        GmosSouthDynamicInput.Binding("instrument", rInstrument),
+        StepConfigInput.Binding("stepConfig", rStepConfig)
+      ) => (rVisitId, rInstrument, rStepConfig).parMapN { (visitId, instrument, step) =>
+        RecordGmosSouthStepInput(visitId, instrument, step)
+      }
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/StepConfigGcalInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/StepConfigGcalInput.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import edu.gemini.grackle.Result
+import lucuma.core.model.sequence.StepConfig.Gcal
+import lucuma.core.model.sequence.StepConfig.Gcal.Lamp
+import lucuma.odb.graphql.binding.*
+
+object StepConfigGcalInput {
+
+  val Binding: Matcher[Gcal] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        GcalArcBinding.List.Option("arcs", rArcs),
+        GcalContinuumBinding.Option("continuum", rContinuum),
+        GcalDiffuserBinding("diffuser", rDiffuser),
+        GcalFilterBinding("filter", rFilter),
+        GcalShutterBinding("shutter", rShutter)
+      ) => (rArcs, rContinuum, rDiffuser, rFilter, rShutter).parTupled.flatMap {
+         (arcs, continuum, diffuser, filter, shutter) =>
+           Lamp.fromContinuumOrArcs(continuum, arcs.toList.flatten) match {
+             case Left(msg)   => Result.failure(msg)
+             case Right(lamp) => Result(Gcal(lamp, filter, diffuser, shutter))
+           }
+
+      }
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/StepConfigInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/StepConfigInput.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.all.*
+import edu.gemini.grackle.Result
+import lucuma.core.model.sequence.StepConfig
+import lucuma.odb.graphql.binding.*
+
+object StepConfigInput {
+
+  val Binding: Matcher[StepConfig] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        BooleanBinding.Option("bias", rBias),
+        BooleanBinding.Option("dark", rDark),
+        StepConfigGcalInput.Binding.Option("gcal", rGcal),
+        StepConfigScienceInput.Binding.Option("science", rScience)
+      ) => (rBias, rDark, rGcal, rScience).parTupled.flatMap {
+         case (bias, dark, gcal, science) =>
+           oneOrFail(
+             bias.ifM(StepConfig.Bias.some, none) -> "bias",
+             dark.ifM(StepConfig.Dark.some, none) -> "dark",
+             gcal                                 -> "gcal",
+             science                              -> "science"
+           )
+
+      }
+    }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/StepConfigScienceInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/StepConfigScienceInput.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import lucuma.core.model.sequence.StepConfig.Science
+import lucuma.odb.graphql.binding.*
+
+object StepConfigScienceInput {
+
+  val Binding: Matcher[Science] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        OffsetInput.Binding("offset", rOffset)
+      ) => rOffset.map(Science(_))
+    }
+
+}


### PR DESCRIPTION
Before Observe begins to execute a step, it records the complete configuration in the database.  There is an input per instrument to accomplish this.  For example, `RecordGmosNorthStepInput` and `RecordGmosSouthStepInput`.  This PR rejiggers the `input`s in the schema a bit and implements all the bindings.

The mutation implementation itself is pending, but this is already so long that it seemed appropriate to make a separate PR. I  may make further changes as the bindings are used.