### PR TITLE
itc `EffectField`

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4864,6 +4864,12 @@ type Observation {
 
   # Execution sequence and runtime artifacts
   execution: Execution!
+
+  """
+  The ITC result for this observation, assuming it has associated target(s)
+  and a selected observing mode.
+  """
+  itc: ItcResultSet
 }
 
 # ObservationId id formatted as `o-[1-9a-f][0-9a-f]*`
@@ -5282,15 +5288,18 @@ type Query {
   # Metadata for `enum FilterType`
   filterTypeMeta: [FilterTypeMeta!]!
 
-  # ITC execution results
+  """
+  ITC execution results.  DEPRECATED (use the `observation` query and select the
+  `itc` field instead).
+  """
   itc(
     programId:     ProgramId!
 
     observationId: ObservationId!
 
-    # Whether to use cached results (true) or ignore the cache and make a remote ITC call (false).
+    "Whether to use cached results (true) or ignore the cache and make a remote ITC call (false)."
     useCache: Boolean! = true
-  ): ItcResultSet
+  ): ItcResultSet @deprecated(reason: "use observation(observationId: \"o-111\") { itc {...} } instead")
 
   # Returns the observation with the given id, if any.
   observation(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -10,20 +10,10 @@ import cats.effect.std.Supervisor
 import cats.effect.{Unique => _, _}
 import cats.syntax.all._
 import com.github.vertical_blank.sqlformatter.SqlFormatter
-import edu.gemini.grackle.Cursor.Context
-import edu.gemini.grackle.Cursor.Env
-import edu.gemini.grackle.Query.EffectHandler
-import edu.gemini.grackle.Query.PossiblyRenamedSelect
-import edu.gemini.grackle.Query.Select
 import edu.gemini.grackle.QueryCompiler.SelectElaborator
 import edu.gemini.grackle._
 import edu.gemini.grackle.skunk.SkunkMapping
 import edu.gemini.grackle.skunk.SkunkMonitor
-import edu.gemini.grackle.sql.SqlMapping
-import edu.gemini.grackle.syntax.*
-import eu.timepit.refined.types.numeric.NonNegInt
-import eu.timepit.refined.types.numeric.PosDouble
-import fs2.Stream
 import fs2.concurrent.Topic
 import lucuma.core.model.User
 import lucuma.itc.client.ItcClient

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -10,10 +10,20 @@ import cats.effect.std.Supervisor
 import cats.effect.{Unique => _, _}
 import cats.syntax.all._
 import com.github.vertical_blank.sqlformatter.SqlFormatter
+import edu.gemini.grackle.Cursor.Context
+import edu.gemini.grackle.Cursor.Env
+import edu.gemini.grackle.Query.EffectHandler
+import edu.gemini.grackle.Query.PossiblyRenamedSelect
+import edu.gemini.grackle.Query.Select
 import edu.gemini.grackle.QueryCompiler.SelectElaborator
 import edu.gemini.grackle._
 import edu.gemini.grackle.skunk.SkunkMapping
 import edu.gemini.grackle.skunk.SkunkMonitor
+import edu.gemini.grackle.sql.SqlMapping
+import edu.gemini.grackle.syntax.*
+import eu.timepit.refined.types.numeric.NonNegInt
+import eu.timepit.refined.types.numeric.PosDouble
+import fs2.Stream
 import fs2.concurrent.Topic
 import lucuma.core.model.User
 import lucuma.itc.client.ItcClient

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -5,13 +5,31 @@ package lucuma.odb.graphql
 
 package mapping
 
+import cats.effect.Resource
+import cats.syntax.applicative.*
+import cats.syntax.eq.*
+import cats.syntax.foldable.*
+import cats.syntax.functor.*
+import cats.syntax.traverse.*
+import edu.gemini.grackle.Cursor
+import edu.gemini.grackle.Predicate._
 import edu.gemini.grackle.Query
 import edu.gemini.grackle.Query._
 import edu.gemini.grackle.Result
+import edu.gemini.grackle.ResultT
 import edu.gemini.grackle.TypeRef
 import edu.gemini.grackle.skunk.SkunkMapping
+import edu.gemini.grackle.syntax.*
+import io.circe.literal.*
+import io.circe.syntax.*
 import lucuma.core.model.ObsAttachment
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.itc.client.ItcClient
 import lucuma.odb.graphql.table.TimingWindowView
+import lucuma.odb.logic.Itc
+import lucuma.odb.service.Services
+import lucuma.odb.service.Services.Syntax.*
 
 import table.ObsAttachmentAssignmentTable
 import table.ObsAttachmentTable
@@ -25,6 +43,9 @@ trait ObservationMapping[F[_]]
      with TimingWindowView[F]
      with ObsAttachmentTable[F]
      with ObsAttachmentAssignmentTable[F] {
+
+  def itcClient: ItcClient[F]
+  def services: Resource[F, Services[F]]
 
   lazy val ObservationMapping: ObjectMapping =
     ObjectMapping(
@@ -49,7 +70,8 @@ trait ObservationMapping[F[_]]
         SqlObject("observingMode"),
         SqlField("instrument", ObservationView.Instrument),
         SqlObject("plannedTime"),
-        SqlObject("program", Join(ObservationView.ProgramId, ProgramTable.Id))
+        SqlObject("program", Join(ObservationView.ProgramId, ProgramTable.Id)),
+        EffectField("itc", itcQueryHandler, List("id", "programId"))
       )
     )
 
@@ -70,6 +92,7 @@ trait ObservationMapping[F[_]]
               )
             )
           )
+
         case Select("obsAttachments", Nil, child) =>
           Result(
             Select("obsAttachments", Nil,
@@ -78,5 +101,50 @@ trait ObservationMapping[F[_]]
           )
       }
     )
+
+  def itcQueryHandler: EffectHandler[F] =
+    new EffectHandler[F] {
+      private def extractIds(queries: List[(Query, Cursor)]): Result[List[(Program.Id, Observation.Id)]] =
+        queries.traverse { case (_, cursor) =>
+          for {
+            p <- cursor.fieldAs[Program.Id]("programId")
+            o <- cursor.fieldAs[Observation.Id]("id")
+          } yield (p, o)
+        }
+
+      private def callItc(pid: Program.Id, oid: Observation.Id): F[Result[(Observation.Id, Itc.ResultSet)]] =
+        services.useTransactionally {
+          itc(itcClient)
+            .lookup(pid, oid, useCache = true)
+            .map {
+              case Left(errors)     => Result.failure(errors.map(_.format).intercalate(", "))
+              case Right(resultSet) => (oid, resultSet).success
+            }
+        }
+
+      def runEffects(queries: List[(Query, Cursor)]): F[Result[List[(Query, Cursor)]]] = {
+        val children = queries.flatMap {
+          case (PossiblyRenamedSelect(Select(name, _, child), alias), parentCursor) =>
+            parentCursor.context.forField(name, alias).toList.map(ctx => (ctx, child, parentCursor))
+          case _ => Nil
+        }
+
+        val res = for {
+          ids <- ResultT(extractIds(queries).pure[F])
+          distinct = ids.distinct
+          itc <- distinct.traverse { case (pid, oid) => ResultT(callItc(pid, oid)) }
+        } yield
+
+          ids.flatMap { case (_, oid) => itc.find(_._1 === oid).map(_._2).toList }
+             .zip(children)
+             .map { case (itcResultSet, (ctx, child, parentCursor)) =>
+               val cursor: Cursor = CirceCursor(ctx, itcResultSet.asJson, Some(parentCursor), parentCursor.fullEnv)
+               (child, cursor)
+             }
+
+        res.value
+      }
+    }
+
 }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -12,7 +12,6 @@ import cats.syntax.foldable.*
 import cats.syntax.functor.*
 import cats.syntax.traverse.*
 import edu.gemini.grackle.Cursor
-import edu.gemini.grackle.Predicate._
 import edu.gemini.grackle.Query
 import edu.gemini.grackle.Query._
 import edu.gemini.grackle.Result

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -55,6 +55,50 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                 itc {
                   result {
                     targetId
+                  }
+                  all {
+                    targetId
+                  }
+                }
+              }
+            }
+          """,
+        expected = Right(
+          json"""
+            {
+               "observation": {
+                 "id": $oid,
+                 "itc": {
+                   "result": {
+                     "targetId": $tid
+                   },
+                   "all": [
+                     {
+                       "targetId": $tid
+                     }
+                   ]
+                 }
+               }
+            }
+          """
+        )
+      )
+    }
+  }
+
+  /*
+  test("success, one target") {
+    setup1.flatMap { case (_, oid, tid) =>
+      expect(
+        user = user,
+        query =
+          s"""
+            query {
+              observation(observationId: "$oid") {
+                id
+                itc {
+                  result {
+                    targetId
                     exposureTime {
                       seconds
                     }
@@ -355,4 +399,5 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
       )
     } yield r
   }
+ */
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -55,50 +55,6 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                 itc {
                   result {
                     targetId
-                  }
-                  all {
-                    targetId
-                  }
-                }
-              }
-            }
-          """,
-        expected = Right(
-          json"""
-            {
-               "observation": {
-                 "id": $oid,
-                 "itc": {
-                   "result": {
-                     "targetId": $tid
-                   },
-                   "all": [
-                     {
-                       "targetId": $tid
-                     }
-                   ]
-                 }
-               }
-            }
-          """
-        )
-      )
-    }
-  }
-
-  /*
-  test("success, one target") {
-    setup1.flatMap { case (_, oid, tid) =>
-      expect(
-        user = user,
-        query =
-          s"""
-            query {
-              observation(observationId: "$oid") {
-                id
-                itc {
-                  result {
-                    targetId
                     exposureTime {
                       seconds
                     }
@@ -141,18 +97,20 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
   }
 
   test("success, two targets") {
-    setup2.flatMap { case (pid, oid, tid0, tid1) =>
+    setup2.flatMap { case (_, oid, tid0, tid1) =>
       expect(
         user = user,
         query =
           s"""
             query {
-              itc(programId: "$pid", observationId: "$oid") {
-                result {
-                  targetId
-                }
-                all {
-                  targetId
+              observation(observationId: "$oid") {
+                itc {
+                  result {
+                    targetId
+                  }
+                  all {
+                    targetId
+                  }
                 }
               }
             }
@@ -160,18 +118,20 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
         expected = Right(
           json"""
             {
-               "itc": {
-                 "result": {
-                   "targetId": $tid1
-                 },
-                 "all": [
-                   {
-                     "targetId": $tid0
-                   },
-                   {
+               "observation": {
+                 "itc": {
+                   "result": {
                      "targetId": $tid1
-                   }
-                 ]
+                   },
+                   "all": [
+                     {
+                       "targetId": $tid0
+                     },
+                     {
+                       "targetId": $tid1
+                     }
+                   ]
+                 }
                }
             }
           """
@@ -179,6 +139,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
       )
     }
   }
+
 
   test("observation missing observingMode") {
     def createObservation(pid: Program.Id, tid: Target.Id): IO[Observation.Id] =
@@ -236,9 +197,11 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
         query =
           s"""
             query {
-              itc(programId: "$p", observationId: "$o") {
-                result {
-                  targetId
+              observation(observationId: "$o") {
+                itc {
+                  result {
+                    targetId
+                  }
                 }
               }
             }
@@ -312,9 +275,11 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
         query =
           s"""
             query {
-              itc(programId: "$p", observationId: "$o") {
-                result {
-                  targetId
+              observation(observationId: "$o") {
+                itc {
+                  result {
+                    targetId
+                  }
                 }
               }
             }
@@ -386,9 +351,11 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
         query =
           s"""
             query {
-              itc(programId: "$p", observationId: "$o") {
-                result {
-                  targetId
+              observation(observationId: "$o") {
+                itc {
+                  result {
+                    targetId
+                  }
                 }
               }
             }
@@ -399,5 +366,5 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
       )
     } yield r
   }
- */
+
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -44,23 +44,26 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
     }
 
   test("success, one target") {
-    setup1.flatMap { case (pid, oid, tid) =>
+    setup1.flatMap { case (_, oid, tid) =>
       expect(
         user = user,
         query =
           s"""
             query {
-              itc(programId: "$pid", observationId: "$oid") {
-                result {
-                  targetId
-                  exposureTime {
-                    seconds
+              observation(observationId: "$oid") {
+                id
+                itc {
+                  result {
+                    targetId
+                    exposureTime {
+                      seconds
+                    }
+                    exposures
+                    signalToNoise
                   }
-                  exposures
-                  signalToNoise
-                }
-                all {
-                  targetId
+                  all {
+                    targetId
+                  }
                 }
               }
             }
@@ -68,20 +71,23 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
         expected = Right(
           json"""
             {
-               "itc": {
-                 "result": {
-                   "targetId": $tid,
-                   "exposureTime": {
-                     "seconds": 10.000000
+               "observation": {
+                 "id": $oid,
+                 "itc": {
+                   "result": {
+                     "targetId": $tid,
+                     "exposureTime": {
+                       "seconds": 10.000000
+                     },
+                     "exposures": ${FakeItcResult.exposures.value},
+                     "signalToNoise": ${FakeItcResult.signalToNoise.toBigDecimal}
                    },
-                   "exposures": ${FakeItcResult.exposures.value},
-                   "signalToNoise": ${FakeItcResult.signalToNoise.toBigDecimal}
-                 },
-                 "all": [
-                   {
-                     "targetId": $tid
-                   }
-                 ]
+                   "all": [
+                     {
+                       "targetId": $tid
+                     }
+                   ]
+                 }
                }
             }
           """


### PR DESCRIPTION
Adds the `itc` query to the `observation`, leaving the top-level `itc` query for now but marking it `@deprecated`.  It will be removed when there has been sufficient time for Explore to adjust.

This was not a priority issue per se, but I wanted to apply the `EffectField` to a simple case because it will be needed elsewhere.  The `sequence` query will be moved to the observation in a future PR.