### PR TITLE
ITC `useCache` flag

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4869,7 +4869,11 @@ type Observation {
   The ITC result for this observation, assuming it has associated target(s)
   and a selected observing mode.
   """
-  itc: ItcResultSet
+  itc(
+    "Whether to use cached results (true) or ignore the cache and make a remote ITC call (false)."
+    useCache: Boolean = true
+  ): ItcResultSet
+
 }
 
 # ObservationId id formatted as `o-[1-9a-f][0-9a-f]*`

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -12,6 +12,7 @@ import cats.syntax.foldable.*
 import cats.syntax.functor.*
 import cats.syntax.traverse.*
 import edu.gemini.grackle.Cursor
+import edu.gemini.grackle.Cursor.Env
 import edu.gemini.grackle.Query
 import edu.gemini.grackle.Query._
 import edu.gemini.grackle.Result
@@ -25,6 +26,7 @@ import lucuma.core.model.ObsAttachment
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.itc.client.ItcClient
+import lucuma.odb.graphql.binding.BooleanBinding
 import lucuma.odb.graphql.table.TimingWindowView
 import lucuma.odb.logic.Itc
 import lucuma.odb.service.Services
@@ -42,6 +44,9 @@ trait ObservationMapping[F[_]]
      with TimingWindowView[F]
      with ObsAttachmentTable[F]
      with ObsAttachmentAssignmentTable[F] {
+
+  private val UseCacheParam   = "useCache"
+  private val UseCacheDefault = true
 
   def itcClient: ItcClient[F]
   def services: Resource[F, Services[F]]
@@ -98,23 +103,34 @@ trait ObservationMapping[F[_]]
               OrderBy(OrderSelections(List(OrderSelection[ObsAttachment.Id](ObsAttachmentType / "id"))), child)
             )
           )
+
+        case Select("itc", List(
+          BooleanBinding.Option("useCache", rUseCache)
+        ), child) =>
+          rUseCache.map { useCache =>
+            Environment(
+              Env(UseCacheParam -> useCache.getOrElse(UseCacheDefault)),
+              Select("itc", Nil, child)
+            )
+          }
       }
     )
 
   def itcQueryHandler: EffectHandler[F] =
     new EffectHandler[F] {
-      private def extractIds(queries: List[(Query, Cursor)]): Result[List[(Program.Id, Observation.Id)]] =
+      private def extractIds(queries: List[(Query, Cursor)]): Result[List[(Program.Id, Observation.Id, Boolean)]] =
         queries.traverse { case (_, cursor) =>
           for {
             p <- cursor.fieldAs[Program.Id]("programId")
             o <- cursor.fieldAs[Observation.Id]("id")
-          } yield (p, o)
+            c <- cursor.fullEnv.getR[Boolean](UseCacheParam)
+          } yield (p, o, c)
         }
 
-      private def callItc(pid: Program.Id, oid: Observation.Id): F[Result[(Observation.Id, Itc.ResultSet)]] =
+      private def callItc(pid: Program.Id, oid: Observation.Id, useCache: Boolean): F[Result[(Observation.Id, Itc.ResultSet)]] =
         services.useTransactionally {
           itc(itcClient)
-            .lookup(pid, oid, useCache = true)
+            .lookup(pid, oid, useCache)
             .map {
               case Left(errors)     => Result.failure(errors.map(_.format).intercalate(", "))
               case Right(resultSet) => (oid, resultSet).success
@@ -124,10 +140,10 @@ trait ObservationMapping[F[_]]
       def runEffects(queries: List[(Query, Cursor)]): F[Result[List[(Query, Cursor)]]] =
         (for {
           ids <- ResultT(extractIds(queries).pure[F])
-          itc <- ids.distinct.traverse { case (pid, oid) => ResultT(callItc(pid, oid)) }
+          itc <- ids.distinct.traverse { case (pid, oid, useCache) => ResultT(callItc(pid, oid, useCache)) }
         } yield
           ids
-            .flatMap { case (_, oid) => itc.find(_._1 === oid).map(_._2).toList }
+            .flatMap { case (_, oid, _) => itc.find(_._1 === oid).map(_._2).toList }
             .zip(queries)
             .map { case (itcResultSet, (child, parentCursor)) =>
               val itc: Json      = Json.fromFields(List("itc" -> itcResultSet.asJson))

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -142,19 +142,26 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
       SignalToNoise.unsafeFromBigDecimalExact(50.0)
     )
 
+  val FakeItcResultNoCache: IntegrationTime =
+    IntegrationTime(
+      11.secTimeSpan,
+      PosInt.unsafeFrom(7),
+      SignalToNoise.unsafeFromBigDecimalExact(50.0)
+    )
+
   private def itcClient: ItcClient[IO] =
     new ItcClient[IO] {
 
       override def imaging(input: ImagingIntegrationTimeInput, useCache: Boolean): IO[IntegrationTimeResult] =
         IntegrationTimeResult(
           FakeItcVersions,
-          NonEmptyList.one(FakeItcResult)
+          NonEmptyList.one(if (useCache) FakeItcResult else FakeItcResultNoCache)
         ).pure[IO]
 
       override def spectroscopy(input: SpectroscopyIntegrationTimeInput, useCache: Boolean): IO[IntegrationTimeResult] =
         IntegrationTimeResult(
           FakeItcVersions,
-          NonEmptyList.one(FakeItcResult)
+          NonEmptyList.one(if (useCache) FakeItcResult else FakeItcResultNoCache)
         ).pure[IO]
 
       def optimizedSpectroscopyGraph(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -96,6 +96,59 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
     }
   }
 
+  test("success, one target -- no cache") {
+    setup1.flatMap { case (_, oid, tid) =>
+      expect(
+        user = user,
+        query =
+          s"""
+            query {
+              observation(observationId: "$oid") {
+                id
+                itc(useCache: false) {
+                  result {
+                    targetId
+                    exposureTime {
+                      seconds
+                    }
+                    exposures
+                    signalToNoise
+                  }
+                  all {
+                    targetId
+                  }
+                }
+              }
+            }
+          """,
+        expected = Right(
+          json"""
+            {
+               "observation": {
+                 "id": $oid,
+                 "itc": {
+                   "result": {
+                     "targetId": $tid,
+                     "exposureTime": {
+                       "seconds": 11.000000
+                     },
+                     "exposures": ${FakeItcResultNoCache.exposures.value},
+                     "signalToNoise": ${FakeItcResultNoCache.signalToNoise.toBigDecimal}
+                   },
+                   "all": [
+                     {
+                       "targetId": $tid
+                     }
+                   ]
+                 }
+               }
+            }
+          """
+        )
+      )
+    }
+  }
+
   test("success, two targets") {
     setup2.flatMap { case (_, oid, tid0, tid1) =>
       expect(


### PR DESCRIPTION
Adds the `useCache` flag to the effect field version of the `itc` query.