### PR TITLE
Don't hold a transaction open while calling the ITC

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/Services.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/Services.scala
@@ -43,7 +43,7 @@ trait Services[F[_]]:
    * with `user` (see above) set in a transaction-local variable `lucuma.user` in the database,
    * available in PostgreSQL as `current_setting('lucuma.user', true)` 
    * 
-   * Within the pased block `fa` the current `Transaction` is implicit, as well as this `Services`
+   * Within the passed block `fa` the current `Transaction` is implicit, as well as this `Services`
    * instance. The purpose is as follows:
    *
    *   - When `Services` is `given` and `Services.Syntax.*` is imported, all members here are 
@@ -61,7 +61,7 @@ trait Services[F[_]]:
    */
   def transactionally[A](fa: (Transaction[F], Services[F]) ?=> F[A])(using NoTransaction[F]): F[A]
 
-  /** The `AllocationService`. */
+    /** The `AllocationService`. */
   def allocationService: AllocationService[F]
   
   /** The `AsterismService`. */

--- a/modules/service/src/main/scala/lucuma/odb/service/Services.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/Services.scala
@@ -61,7 +61,7 @@ trait Services[F[_]]:
    */
   def transactionally[A](fa: (Transaction[F], Services[F]) ?=> F[A])(using NoTransaction[F]): F[A]
 
-    /** The `AllocationService`. */
+  /** The `AllocationService`. */
   def allocationService: AllocationService[F]
   
   /** The `AsterismService`. */


### PR DESCRIPTION
The ITC lookup (and therefore also the sequence generation) were requiring a transaction while calling the ITC.  This PR rejiggers the implementation to only require a transaction while gathering the parameters.