### PR TITLE
mapping name cleanup

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -164,7 +164,7 @@ trait BaseMapping[F[_]]
   lazy val ProgramType                         = schema.ref("Program")
   lazy val ProgramUserRoleType                 = schema.ref("ProgramUserRole")
   lazy val ProperMotionDeclinationType         = schema.ref("ProperMotionDeclination")
-  lazy val ProperMotionRAType                  = schema.ref("ProperMotionRA")
+  lazy val ProperMotionRaType                  = schema.ref("ProperMotionRA")
   lazy val ProperMotionType                    = schema.ref("ProperMotion")
   lazy val ProposalAttachmentType              = schema.ref("ProposalAttachment")
   lazy val ProposalAttachmentTypeMetaType      = schema.ref("ProposalAttachmentTypeMeta")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -148,7 +148,7 @@ object OdbMapping {
           with ProgramUserMapping[F]
           with ProperMotionDeclinationMapping[F]
           with ProperMotionMapping[F]
-          with ProperMotionRAMapping[F]
+          with ProperMotionRaMapping[F]
           with ProposalMapping[F]
           with ProposalClassMapping[F]
           with ProposalAttachmentMapping[F]
@@ -274,7 +274,7 @@ object OdbMapping {
               ProgramUserMapping,
               ProperMotionDeclinationMapping,
               ProperMotionMapping,
-              ProperMotionRAMapping,
+              ProperMotionRaMapping,
               ProposalAttachmentMapping,
               ProposalAttachmentTypeMetaMapping,
               ProposalMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AddConditionsEntryResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AddConditionsEntryResultMapping.scala
@@ -9,7 +9,7 @@ import lucuma.odb.graphql.table.ChronConditionsEntryView
 
 trait AddConditionsEntryResultMapping[F[_]] extends ChronConditionsEntryView[F] {
 
-  lazy val AddConditionsEntryResultMapping =
+  lazy val AddConditionsEntryResultMapping: ObjectMapping =
     ObjectMapping(
       tpe = AddConditionsEntryResultType,
       fieldMappings = List(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CreateGroupResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CreateGroupResultMapping.scala
@@ -10,7 +10,7 @@ import edu.gemini.grackle.skunk.SkunkMapping
 import table.GroupView
 trait CreateGroupResultMapping[F[_]] extends GroupView[F] {
 
-  lazy val CreateGroupResultMapping =
+  lazy val CreateGroupResultMapping: ObjectMapping =
     ObjectMapping(
       tpe = CreateGroupResultType,
       fieldMappings = List(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProperMotionDeclinationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProperMotionDeclinationMapping.scala
@@ -11,18 +11,18 @@ import lucuma.core.math.Angle
 import table.TargetView
 import table.ProgramTable
 
-trait ProperMotionRAMapping[F[_]] extends ProgramTable[F] with TargetView[F] {
+trait ProperMotionDeclinationMapping[F[_]] extends ProgramTable[F] with TargetView[F] {
 
-  lazy val ProperMotionRAMapping =
+  lazy val ProperMotionDeclinationMapping: ObjectMapping =
     ObjectMapping(
-      tpe = ProperMotionRAType,
+      tpe = ProperMotionDeclinationType,
       fieldMappings = List(
         SqlField("synthetic_id", TargetView.Sidereal.ProperMotion.SyntheticId, key = true, hidden = true),
-        SqlField("value", TargetView.Sidereal.ProperMotion.Ra, hidden = true),
+        SqlField("value", TargetView.Sidereal.ProperMotion.Dec, hidden = true),
         FieldRef[Angle]("value").as("microarcsecondsPerYear", Angle.signedMicroarcseconds.get),
         FieldRef[Angle]("value").as("milliarcsecondsPerYear", Angle.signedDecimalMilliarcseconds.get),
       )
     )
 
-  }
+}
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProperMotionRaMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProperMotionRaMapping.scala
@@ -11,18 +11,18 @@ import lucuma.core.math.Angle
 import table.TargetView
 import table.ProgramTable
 
-trait ProperMotionDeclinationMapping[F[_]] extends ProgramTable[F] with TargetView[F] {
+trait ProperMotionRaMapping[F[_]] extends ProgramTable[F] with TargetView[F] {
 
-  lazy val ProperMotionDeclinationMapping =
+  lazy val ProperMotionRaMapping: ObjectMapping =
     ObjectMapping(
-      tpe = ProperMotionDeclinationType,
+      tpe = ProperMotionRaType,
       fieldMappings = List(
         SqlField("synthetic_id", TargetView.Sidereal.ProperMotion.SyntheticId, key = true, hidden = true),
-        SqlField("value", TargetView.Sidereal.ProperMotion.Dec, hidden = true),
+        SqlField("value", TargetView.Sidereal.ProperMotion.Ra, hidden = true),
         FieldRef[Angle]("value").as("microarcsecondsPerYear", Angle.signedMicroarcseconds.get),
         FieldRef[Angle]("value").as("milliarcsecondsPerYear", Angle.signedDecimalMilliarcseconds.get),
       )
     )
 
-  }
+}
 


### PR DESCRIPTION
There were a handful of `Mapping` traits for which the file didn't match the type.  No logic change.