### PR TITLE
Fix documentation and schema query parameter type

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -5223,10 +5223,11 @@ type Execution {
     The maximum size (number of atoms) of the `possibleFuture` in the sequences.
     If the projected future is longer, the size will be capped at this value.
     Use 0 if only interested in the `nextAtom`.  The maximum is 100.  Each
-    sequence has `hasMore` and `atomCount` fields that can be used to determine
-    whether and how many remaining atoms are yet to be executed.
+    sequence has a `hasMore` field that can be used to determine whether there
+    additional atoms beyond those returned in `possibleFuture`.  The total
+    projected atom count is available in the execution digest.
     """
-    futureLimit: PosInt = 25
+    futureLimit: NonNegInt = 25
 
   ): ExecutionConfig!
 


### PR DESCRIPTION
I noticed this small bug in the schema documentation, and actually the parameter type should have been `NonNegInt` instead of `PosInt`.

@toddburnside will this break anything in client land?  I can wait to fix it.