### PR TITLE
Program-wide PlannedTimeRange Improvements

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7020,7 +7020,7 @@ type Observation {
   The ITC result for this observation, assuming it has associated target(s)
   and a selected observing mode.
   """
-  itc: ItcResultSet
+  itc: ItcResultSet!
 
 }
 

--- a/modules/service/src/main/resources/db/migration/V0371__bytea_hash_type.sql
+++ b/modules/service/src/main/resources/db/migration/V0371__bytea_hash_type.sql
@@ -1,0 +1,9 @@
+TRUNCATE TABLE t_itc_result;
+
+ALTER TABLE t_itc_result
+  ALTER COLUMN c_hash TYPE bytea USING c_hash::bytea;
+
+TRUNCATE TABLE t_execution_digest;
+
+ALTER TABLE t_execution_digest
+  ALTER COLUMN c_hash TYPE bytea USING c_hash::bytea;

--- a/modules/service/src/main/scala/lucuma/odb/data/Md5Hash.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/Md5Hash.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+
+import cats.Eq
+import cats.syntax.eq.*
+import scodec.bits.ByteVector
+
+opaque type Md5Hash = ByteVector
+
+object Md5Hash {
+
+  def fromByteArray(bytes: Array[Byte]): Option[Md5Hash] =
+    Option.when(bytes.size === 16)(ByteVector(bytes))
+
+  def unsafeFromByteArray(bytes: Array[Byte]): Md5Hash =
+    fromByteArray(bytes).getOrElse(sys.error(s"Expected 16 byte array but was ${bytes.size} bytes"))
+
+  def fromByteVector(bv: ByteVector): Option[Md5Hash] =
+    Option.when(bv.size === 16)(bv)
+
+  extension (h: Md5Hash) {
+    def toHex: String =
+      h.toHex
+
+    def toByteArray: Array[Byte] =
+      h.toArray
+
+    def toByteVector: ByteVector =
+      h
+  }
+
+  given Eq[Md5Hash] =
+    Eq.instance[Md5Hash]((a, b) => a.toByteVector === b.toByteVector)
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
@@ -27,7 +27,6 @@ import lucuma.odb.json.all.query.given
 import lucuma.odb.logic.Generator
 import lucuma.odb.logic.PlannedTimeCalculator
 import lucuma.odb.sequence.util.CommitHash
-import lucuma.odb.service.ItcService
 import lucuma.odb.service.Services
 
 trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F] {
@@ -67,12 +66,7 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F] {
 
   extension (e: Generator.Error) {
     def toResult: Result[Json] =
-      e match {
-        case Generator.Error.ItcError(ItcService.Error.ObservationNotFound(_, _)) =>
-          Result(Json.Null)
-        case e: Generator.Error                                                   =>
-          Result.failure(e.format)
-      }
+      Result.failure(e.format)
   }
 
   private lazy val configHandler: EffectHandler[F] = {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -106,7 +106,7 @@ trait ObservationMapping[F[_]]
   def itcQueryHandler: EffectHandler[F] = {
     val readEnv: Env => Result[Unit] = _ => ().success
 
-    val calculate: (Program.Id, Observation.Id, Unit) => F[Result[Option[ItcService.AsterismResult]]] =
+    val calculate: (Program.Id, Observation.Id, Unit) => F[Result[ItcService.AsterismResult]] =
       (pid, oid, _) =>
         services.use { s =>
           s.itcService(itcClient)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -106,14 +106,14 @@ trait ObservationMapping[F[_]]
   def itcQueryHandler: EffectHandler[F] = {
     val readEnv: Env => Result[Unit] = _ => ().success
 
-    val calculate: (Program.Id, Observation.Id, Unit) => F[Result[ItcService.AsterismResult]] =
+    val calculate: (Program.Id, Observation.Id, Unit) => F[Result[Option[ItcService.AsterismResult]]] =
       (pid, oid, _) =>
         services.use { s =>
           s.itcService(itcClient)
            .lookup(pid, oid)
            .map {
              case Left(e)  => Result.failure(e.format)
-             case Right(s) => s.result.success
+             case Right(s) => s.success
            }
         }
 

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -53,11 +53,23 @@ import Generator.FutureLimit
 
 sealed trait Generator[F[_]] {
 
+  /**
+   * Looks up the parameters required to calculate the ExecutionDigest, performs
+   * the calculation, and caches the results if the observation was found.  If
+   * the observation is not completely defined (e.g., if missing the observing
+    * mode), an Error is produced.
+   */
   def digest(
     programId:     Program.Id,
     observationId: Observation.Id
   )(using NoTransaction[F]): F[Either[Error, Option[ExecutionDigest]]]
 
+  /**
+   * Calculates the ExecutionDigest given the AsterismResults from the ITC
+   * along with the GeneratorParams. This method always performs the calculation
+   * and does not attempt to use cached results nor call the ITC.  It will
+   * cache the calculation once performed.
+   */
   def calculateDigest(
     programId:      Program.Id,
     observationId:  Observation.Id,
@@ -65,6 +77,10 @@ sealed trait Generator[F[_]] {
     params:         GeneratorParams
   )(using NoTransaction[F]): F[Either[Error, ExecutionDigest]]
 
+  /**
+   * Generates the execution config if the observation is found and defined
+   * well enough to perform the calculation.
+   */
   def generate(
     programId:     Program.Id,
     observationId: Observation.Id,

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -30,6 +30,7 @@ import lucuma.core.model.sequence.Step
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.StepEstimate
 import lucuma.itc.client.ItcClient
+import lucuma.odb.data.Md5Hash
 import lucuma.odb.sequence.data.GeneratorParams
 import lucuma.odb.sequence.data.ProtoAtom
 import lucuma.odb.sequence.data.ProtoExecutionConfig
@@ -43,7 +44,6 @@ import lucuma.odb.service.Services
 import lucuma.odb.service.Services.Syntax.*
 
 import java.security.MessageDigest
-import java.util.HexFormat
 import java.util.UUID
 
 import Generator.FutureLimit
@@ -142,7 +142,7 @@ object Generator {
         val integrationTime: ItcService.TargetResult =
           itcRes.value.focus
 
-        val hash: String = {
+        val hash: Md5Hash = {
           val zero = 0.toByte
           val md5  = MessageDigest.getInstance("MD5")
 
@@ -157,7 +157,7 @@ object Generator {
           // Commit Hash
           md5.update(commitHash.toByteArray)
 
-          HexFormat.of.formatHex(md5.digest())
+          Md5Hash.unsafeFromByteArray(md5.digest())
         }
 
         def checkCache(using NoTransaction[F]): EitherT[F, Error, Option[ExecutionDigest]] =

--- a/modules/service/src/main/scala/lucuma/odb/logic/PlannedTimeRangeService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/PlannedTimeRangeService.scala
@@ -60,7 +60,7 @@ object PlannedTimeRangeService {
       for {
         p <- generatorParamsService.selectAll(pid)
         pʹ = p.collect { case (oid, Right(gp)) => (oid, gp) }
-        i <- itcService(itcClient).selectAllCachedResults(pid, pʹ)
+        i <- itcService(itcClient).selectAll(pid, pʹ)
         d <- executionDigestService.selectAll(pid)
         dʹ = d.map { case (oid, (_, digest)) => (oid, digest) }
       } yield pʹ.map { case (oid, gp) => (oid, ObservationData(gp, i.get(oid), dʹ.get(oid))) }

--- a/modules/service/src/main/scala/lucuma/odb/logic/PlannedTimeRangeService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/PlannedTimeRangeService.scala
@@ -29,9 +29,14 @@ import lucuma.odb.service.Services
 import lucuma.odb.service.Services.Syntax.*
 import skunk.Transaction
 
-
+/**
+ * A service that can estimate the PlannedTimeRange for a program.
+ */
 sealed trait PlannedTimeRangeService[F[_]] {
 
+  /**
+   * Estimates the program planned time for observations that are well defined.
+   */
   def estimateProgram(
     programId: Program.Id
   )(using NoTransaction[F]): F[Option[PlannedTimeRange]]

--- a/modules/service/src/main/scala/lucuma/odb/logic/PlannedTimeRangeService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/PlannedTimeRangeService.scala
@@ -1,0 +1,152 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.logic
+
+import cats.Order
+import cats.Order.catsKernelOrderingForOrder
+import cats.data.OptionT
+import cats.effect.Concurrent
+import cats.syntax.apply.*
+import cats.syntax.flatMap.*
+import cats.syntax.foldable.*
+import cats.syntax.functor.*
+import cats.syntax.traverse.*
+import eu.timepit.refined.types.numeric.NonNegShort
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.sequence.ExecutionDigest
+import lucuma.core.model.sequence.PlannedTime
+import lucuma.core.model.sequence.PlannedTimeRange
+import lucuma.itc.client.ItcClient
+import lucuma.odb.data.GroupTree
+import lucuma.odb.sequence.data.GeneratorParams
+import lucuma.odb.sequence.util.CommitHash
+import lucuma.odb.service.ItcService
+import lucuma.odb.service.ItcService.AsterismResult
+import lucuma.odb.service.NoTransaction
+import lucuma.odb.service.Services
+import lucuma.odb.service.Services.Syntax.*
+import skunk.Transaction
+
+
+sealed trait PlannedTimeRangeService[F[_]] {
+
+  def estimateProgram(
+    programId: Program.Id
+  )(using NoTransaction[F]): F[Option[PlannedTimeRange]]
+
+}
+
+object PlannedTimeRangeService {
+
+  private case class ObservationData(
+    generatorParams: GeneratorParams,
+    asterismResult:  Option[AsterismResult],
+    executionDigest: Option[ExecutionDigest]
+  ) {
+
+    def cachedFullPlannedTime: Option[PlannedTime] =
+      executionDigest.map(_.fullPlannedTime)
+
+  }
+
+  private object ObservationData {
+
+    def load[F[_]: Concurrent](
+      pid:       Program.Id,
+      itcClient: ItcClient[F]
+    )(using Services[F], Transaction[F]): F[Map[Observation.Id, ObservationData]] =
+      for {
+        p <- generatorParamsService.selectAll(pid)
+        pʹ = p.collect { case (oid, Right(gp)) => (oid, gp) }
+        i <- itcService(itcClient).selectAllCachedResults(pid, pʹ)
+        d <- executionDigestService.selectAll(pid)
+        dʹ = d.map { case (oid, (_, digest)) => (oid, digest) }
+      } yield pʹ.map { case (oid, gp) => (oid, ObservationData(gp, i.get(oid), dʹ.get(oid))) }
+
+  }
+
+  def instantiate[F[_]: Concurrent](
+    commitHash:   CommitHash,
+    itcClient:    ItcClient[F],
+    calculator:   PlannedTimeCalculator.ForInstrumentMode,
+  )(using Services[F]): PlannedTimeRangeService[F] =
+    new PlannedTimeRangeService[F] {
+
+      // PlannedTime Ordering that sorts longest to shortest.
+      val longestToShortest: Ordering[PlannedTime] =
+        catsKernelOrderingForOrder(Order.reverse(Order[PlannedTime]))
+
+      def combine(minRequired: Int, children: List[PlannedTimeRange]): Option[PlannedTimeRange] =
+        Option.when(children.size >= minRequired) {
+          PlannedTimeRange.from(
+            // Combines the first minRequired elements after sorting by ascending min PlannedTime
+            children.map(_.min).sorted.take(minRequired).combineAllOption.getOrElse(PlannedTime.Zero),
+            // Combines the first minRequired elements after sorting by descending max PlannedTime
+            children.map(_.max).sorted(longestToShortest).take(minRequired).combineAllOption.getOrElse(PlannedTime.Zero)
+          )
+        }
+
+      def leafRange(
+        pid: Program.Id,
+        oid: Observation.Id,
+        m:   Map[Observation.Id, ObservationData]
+      ): F[Option[PlannedTimeRange]] =
+        OptionT.fromOption(m.get(oid)).flatMap { data =>
+          OptionT
+            .fromOption(data.cachedFullPlannedTime)  // try the cache first
+            .orElse {
+              // ExecutionDigest not in the cache, we'll need to calculate it.
+              // For that we need the ITC results, which may be cached.  Use the
+              // cached ITC AsterismResult if available, else call remote ITC.
+              val asterismResult = OptionT.fromOption(data.asterismResult).orElseF {
+                 itcService(itcClient)
+                   .callRemote(pid, oid, data.generatorParams)
+                   .map(_.toOption)
+              }
+
+              // Calculate planned time using provided ITC result and params.
+              asterismResult.flatMapF { ar =>
+                generator(commitHash, itcClient, calculator)
+                  .calculateDigest(pid, oid, ar, data.generatorParams)
+                  .map(_.toOption.map(_.fullPlannedTime))
+              }
+            }
+            .map(PlannedTimeRange.single)
+        }.value
+
+
+      // If no minRequired, assume _all_ children are required.
+      def parentRange(
+        pid:         Program.Id,
+        minRequired: Option[NonNegShort],
+        children:    List[GroupTree.Child],
+        m:           Map[Observation.Id, ObservationData]
+      ): F[Option[PlannedTimeRange]] =
+        children
+          .traverse(plannedTimeRange(pid, _, m))
+          // combine after skipping any elements for which we cannot compute the planned time
+          .map(lst => combine(minRequired.fold(lst.size)(_.value.toInt), lst.flatMap(_.toList)))
+
+      def plannedTimeRange(
+        pid:  Program.Id,
+        root: GroupTree,
+        m:    Map[Observation.Id, ObservationData]
+      ): F[Option[PlannedTimeRange]] =
+        root match {
+          case GroupTree.Leaf(oid)                               => leafRange(pid, oid, m)
+          case GroupTree.Branch(_, min, _, children, _, _, _, _) => parentRange(pid, min, children, m)
+          case GroupTree.Root(_, children)                       => parentRange(pid, None, children, m)
+        }
+
+      override def estimateProgram(
+        pid: Program.Id
+      )(using NoTransaction[F]): F[Option[PlannedTimeRange]] =
+        services.transactionally {
+          (groupService.selectGroups(pid), ObservationData.load(pid, itcClient)).tupled
+        }.flatMap { case (tree, dataMap) =>
+          plannedTimeRange(pid, tree, dataMap)
+        }
+  }
+}

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionDigestService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionDigestService.scala
@@ -33,7 +33,7 @@ import scala.collection.immutable.SortedSet
 
 sealed trait ExecutionDigestService[F[_]] {
 
-  def select(
+  def selectOne(
     programId:     Program.Id,
     observationId: Observation.Id,
     hash:          String
@@ -56,7 +56,7 @@ object ExecutionDigestService {
 
   def instantiate[F[_]: Concurrent](using Services[F]): ExecutionDigestService[F] =
     new ExecutionDigestService[F] {
-      override def select(
+      override def selectOne(
         pid:  Program.Id,
         oid:  Observation.Id,
         hash: String
@@ -189,6 +189,7 @@ object ExecutionDigestService {
         SELECT
           c_hash,
           #$DigestColumns
+        FROM t_execution_digest
         WHERE
           c_program_id     = $program_id     AND
           c_observation_id = $observation_id
@@ -200,6 +201,7 @@ object ExecutionDigestService {
           c_observation_id,
           c_hash,
           #$DigestColumns
+        FROM t_execution_digest
         WHERE
           c_program_id = $program_id
       """.query(observation_id *: text *: execution_digest)

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -221,7 +221,7 @@ object ItcService {
         oid: Observation.Id
       )(using Transaction[F]): F[Either[Error, GeneratorParams]] =
         generatorParamsService
-          .select(pid, oid)
+          .selectOne(pid, oid)
           .map {
             case None                => ObservationNotFound(pid, oid).asLeft
             case Some(Left(errors))  => ObservationDefinitionError(errors).asLeft

--- a/modules/service/src/main/scala/lucuma/odb/service/Services.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/Services.scala
@@ -13,6 +13,7 @@ import lucuma.core.util.Gid
 import lucuma.itc.client.ItcClient
 import lucuma.odb.logic.Generator
 import lucuma.odb.logic.PlannedTimeCalculator
+import lucuma.odb.logic.PlannedTimeRangeService
 import lucuma.odb.sequence.util.CommitHash
 import natchez.Trace
 import skunk.Session
@@ -138,6 +139,8 @@ trait Services[F[_]]:
   /** Construct a `Generator`, given a `CommitHash` and an `ItcClient`.*/
   def generator(commitHash: CommitHash, itcClient: ItcClient[F], ptc: PlannedTimeCalculator.ForInstrumentMode): Generator[F]
 
+  /** Construct a `PlannedTimeRangeService`, given a `CommitHash` and an `ItcClient`.*/
+  def plannedTimeRangeService(commitHash: CommitHash, itcClient: ItcClient[F], ptc: PlannedTimeCalculator.ForInstrumentMode): PlannedTimeRangeService[F]
 
 
 object Services:
@@ -196,6 +199,7 @@ object Services:
       def obsAttachmentFileService(s3: S3FileService[F]) = ObsAttachmentFileService.instantiate(s3)
       def itcService(itcClient: ItcClient[F]) = ItcService.instantiate(itcClient)
       def generator(commitHash: CommitHash, itcClient: ItcClient[F], ptc: PlannedTimeCalculator.ForInstrumentMode) = Generator.instantiate(commitHash, itcClient, ptc)
+      def plannedTimeRangeService(commitHash: CommitHash, itcClient: ItcClient[F], ptc: PlannedTimeCalculator.ForInstrumentMode) = PlannedTimeRangeService.instantiate(commitHash, itcClient, ptc)
 
 
   /**
@@ -233,6 +237,7 @@ object Services:
     def visitService[F[_]](using Services[F]): VisitService[F] = summon[Services[F]].visitService
     def itcService[F[_]](client: ItcClient[F])(using Services[F]): ItcService[F] = summon[Services[F]].itcService(client)
     def generator[F[_]](commitHash: CommitHash, itcClient: ItcClient[F], ptc: PlannedTimeCalculator.ForInstrumentMode)(using Services[F]): Generator[F] = summon[Services[F]].generator(commitHash, itcClient, ptc)
+    def plannedTimeRangeService[F[_]](commitHash: CommitHash, itcClient: ItcClient[F], ptc: PlannedTimeCalculator.ForInstrumentMode)(using Services[F]): PlannedTimeRangeService[F] = summon[Services[F]].plannedTimeRangeService(commitHash, itcClient, ptc)
 
     extension [F[_]: MonadCancelThrow, A](s: Resource[F, Services[F]])
 

--- a/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
@@ -37,6 +37,7 @@ import lucuma.core.util.Uid
 import lucuma.odb.data.EditType
 import lucuma.odb.data.Existence
 import lucuma.odb.data.Extinction
+import lucuma.odb.data.Md5Hash
 import lucuma.odb.data.ObservingModeType
 import lucuma.odb.data.PosAngleConstraintMode
 import lucuma.odb.data.ProgramUserRole
@@ -223,6 +224,9 @@ trait Codecs {
 
   val int_percent: Codec[IntPercent] =
     int2.eimap(n => IntPercent.from(n))(_.value.toShort)
+
+  val md5_hash: Codec[Md5Hash] =
+    bytea.eimap(b => Md5Hash.fromByteArray(b).toRight(s"Expected an MD5 hash value but found ${b.size} bytes"))(_.toByteArray)
 
   val mos_pre_imaging: Codec[MosPreImaging] =
     bool.imap(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
@@ -88,13 +88,13 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
   }
 
   test("digest") {
-    val setup: IO[(Program.Id, Observation.Id, Target.Id)] =
+    val setup: IO[Observation.Id] =
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
         o <- createGmosNorthLongSlitObservationAs(user, p, t)
-      } yield (p, o, t)
-    setup.flatMap { case (_, oid, _) =>
+      } yield o
+    setup.flatMap { oid =>
       expect(
         user  = user,
         query =
@@ -262,14 +262,14 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
   }
 
   test("simple generation") {
-    val setup: IO[(Program.Id, Observation.Id, Target.Id)] =
+    val setup: IO[Observation.Id] =
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
         o <- createGmosNorthLongSlitObservationAs(user, p, t)
-      } yield (p, o, t)
+      } yield o
 
-    setup.flatMap { case (_, oid, _) =>
+    setup.flatMap { oid =>
       expect(
         user  = user,
         query =
@@ -457,14 +457,14 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
   }
 
   test("simple generation - limited future") {
-    val setup: IO[(Program.Id, Observation.Id, Target.Id)] =
+    val setup: IO[Observation.Id] =
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
         o <- createGmosNorthLongSlitObservationAs(user, p, t)
-      } yield (p, o, t)
+      } yield o
 
-    setup.flatMap { case (_, oid, _) =>
+    setup.flatMap { oid =>
       expect(
         user  = user,
         query =
@@ -552,14 +552,14 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
   }
 
   test("simple generation - too many future atoms") {
-    val setup: IO[(Program.Id, Observation.Id, Target.Id)] =
+    val setup: IO[(Program.Id, Observation.Id)] =
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
         o <- createGmosNorthLongSlitObservationAs(user, p, t)
-      } yield (p, o, t)
+      } yield (p, o)
 
-    setup.flatMap { case (pid, oid, _) =>
+    setup.flatMap { case (pid, oid) =>
       expect(
         user  = user,
         query =
@@ -587,7 +587,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
 
   test("explicit offsets") {
 
-    val setup: IO[(Program.Id, Observation.Id, Target.Id)] =
+    val setup: IO[Observation.Id] =
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
@@ -607,9 +607,9 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
             }
           """
         )
-      } yield (p, o, t)
+      } yield o
 
-    setup.flatMap { case (_, oid, _) =>
+    setup.flatMap { oid =>
       expect(
         user  = user,
         query =
@@ -819,7 +819,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
 
   test("explicit wavelength dithers") {
 
-    val setup: IO[(Program.Id, Observation.Id, Target.Id)] =
+    val setup: IO[Observation.Id] =
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
@@ -838,9 +838,9 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
             }
           """
         )
-      } yield (p, o, t)
+      } yield o
 
-    setup.flatMap { case (_, oid, _) =>
+    setup.flatMap { oid =>
       expect(
         user  = user,
         query =
@@ -1039,14 +1039,14 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
   }
 
   test("user cannot access program") {
-    val setup: IO[(Program.Id, Observation.Id, Target.Id)] =
+    val setup: IO[Observation.Id] =
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
         o <- createGmosNorthLongSlitObservationAs(user, p, t)
-      } yield (p, o, t)
+      } yield o
 
-    setup.flatMap { case (pid, oid, _) =>
+    setup.flatMap { oid =>
       expect(
         user  = pi,
         query =
@@ -1128,14 +1128,14 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
 
   test("planned time: config and detector estimates") {
 
-    val setup: IO[(Program.Id, Observation.Id, Target.Id)] =
+    val setup: IO[Observation.Id] =
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
         o <- createGmosNorthLongSlitObservationAs(user, p, t)
-      } yield (p, o, t)
+      } yield o
 
-    setup.flatMap { case (_, oid, _) =>
+    setup.flatMap { oid =>
       expect(
         user  = user,
         query =
@@ -1539,14 +1539,14 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
 
   test("planned time: observation level") {
 
-    val setup: IO[(Program.Id, Observation.Id, Target.Id)] =
+    val setup: IO[Observation.Id] =
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
         o <- createGmosNorthLongSlitObservationAs(user, p, t)
-      } yield (p, o, t)
+      } yield o
 
-    setup.flatMap { case (_, oid, _) =>
+    setup.flatMap { oid =>
       expect(
         user  = user,
         query =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
@@ -27,7 +27,6 @@ import lucuma.core.math.BoundedInterval
 import lucuma.core.math.Wavelength
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
-import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.core.model.sequence.StepConfig.Gcal
 import lucuma.core.util.TimeSpan

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -207,7 +207,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
             }
           """,
         expected = Left(List(
-            "ITC cannot be queried until the following parameters are defined: observing mode"
+            "ITC cannot be queried until the following parameters are defined: observing mode."
         ))
       )
     } yield r
@@ -285,7 +285,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
             }
           """,
         expected = Left(List(
-          "ITC cannot be queried until the following parameters are defined: target"
+          "ITC cannot be queried until the following parameters are defined: target."
         ))
       )
     } yield r
@@ -361,7 +361,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
             }
           """,
         expected = Left(List(
-          s"ITC cannot be queried until the following parameters are defined: (target $t) brightness measure, (target $t) radial velocity"
+          s"ITC cannot be queried until the following parameters are defined: (target t-104) brightness measure, (target t-104) radial velocity."
         ))
       )
     } yield r

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -361,7 +361,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
             }
           """,
         expected = Left(List(
-          s"ITC cannot be queried until the following parameters are defined: (target t-104) brightness measure, (target t-104) radial velocity."
+          s"ITC cannot be queried until the following parameters are defined: (target $t) brightness measure, (target $t) radial velocity."
         ))
       )
     } yield r


### PR DESCRIPTION
Improvements to the program-wide planned time calculation.  Most importantly, it calculates the program planned time by gathering up all parameters and potentially cached results in a single transaction, then performing ITC calls and digest calculations outside of the transaction where necessary.  In addition to not cycling so many transactions, it provides an answer that at least corresponds to a consistent program-wide planned time at some instant.

Also:

* Moves the code from `ExecutionMapping` into its own service because it had grown rather large.
* Adds an `Md5Hash` `opaque type`.
* Switches the hash type in the database from a `String` to a `bytea`.
