### PR TITLE
Program planned time range calculation update

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/logic/PlannedTimeRangeService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/PlannedTimeRangeService.scala
@@ -11,6 +11,7 @@ import cats.syntax.apply.*
 import cats.syntax.flatMap.*
 import cats.syntax.foldable.*
 import cats.syntax.functor.*
+import cats.syntax.functorFilter.*
 import cats.syntax.traverse.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import lucuma.core.enums.ObsStatus
@@ -133,7 +134,10 @@ object PlannedTimeRangeService {
         children
           .traverse(plannedTimeRange(pid, _, m))
           // combine after skipping any elements for which we cannot compute the planned time
-          .map(lst => combine(minRequired.fold(lst.size)(_.value.toInt), lst.flatMap(_.toList)))
+          .map { lst =>
+            val valid = lst.flattenOption
+            combine(minRequired.fold(valid.size)(_.value.toInt), valid)
+          }
 
       def plannedTimeRange(
         pid:  Program.Id,

--- a/modules/service/src/main/scala/lucuma/odb/logic/PlannedTimeRangeService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/PlannedTimeRangeService.scala
@@ -124,7 +124,6 @@ object PlannedTimeRangeService {
         }.value
 
 
-      // If no minRequired, assume _all_ children are required.
       def parentRange(
         pid:         Program.Id,
         minRequired: Option[NonNegShort],
@@ -133,9 +132,12 @@ object PlannedTimeRangeService {
       ): F[Option[PlannedTimeRange]] =
         children
           .traverse(plannedTimeRange(pid, _, m))
-          // combine after skipping any elements for which we cannot compute the planned time
+          // combine after skipping any elements for which we cannot compute the
+          // planned time
           .map { lst =>
             val valid = lst.flattenOption
+            // If no expicit `minRequired` is set, only count the complete and
+            // Approved (i.e., valid) observations.
             combine(minRequired.fold(valid.size)(_.value.toInt), valid)
           }
 

--- a/modules/service/src/main/scala/lucuma/odb/logic/PlannedTimeRangeService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/PlannedTimeRangeService.scala
@@ -13,6 +13,7 @@ import cats.syntax.foldable.*
 import cats.syntax.functor.*
 import cats.syntax.traverse.*
 import eu.timepit.refined.types.numeric.NonNegShort
+import lucuma.core.enums.ObsStatus
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.sequence.ExecutionDigest
@@ -63,7 +64,7 @@ object PlannedTimeRangeService {
       itcClient: ItcClient[F]
     )(using Services[F], Transaction[F]): F[Map[Observation.Id, ObservationData]] =
       for {
-        p <- generatorParamsService.selectAll(pid)
+        p <- generatorParamsService.selectAll(pid, ObsStatus.Approved)
         pʹ = p.collect { case (oid, Right(gp)) => (oid, gp) }
         i <- itcService(itcClient).selectAll(pid, pʹ)
         d <- executionDigestService.selectAll(pid)

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -18,6 +18,7 @@ import cats.syntax.functor.*
 import cats.syntax.option.*
 import cats.syntax.traverse.*
 import lucuma.core.enums.Band
+import lucuma.core.enums.ObsStatus
 import lucuma.core.math.BrightnessUnits.BrightnessMeasure
 import lucuma.core.math.BrightnessUnits.Integrated
 import lucuma.core.math.BrightnessUnits.Surface
@@ -30,6 +31,7 @@ import lucuma.core.model.Program
 import lucuma.core.model.SourceProfile
 import lucuma.core.model.Target
 import lucuma.core.model.User
+import lucuma.core.util.Enumerated
 import lucuma.itc.client.GmosFpu
 import lucuma.itc.client.InstrumentMode
 import lucuma.itc.client.SpectroscopyIntegrationTimeInput
@@ -61,6 +63,7 @@ trait GeneratorParamsService[F[_]] {
 
   def selectAll(
     programId: Program.Id,
+    minStatus: Option[ObsStatus] = None
   )(using Transaction[F]): F[Map[Observation.Id, EitherNel[Error, GeneratorParams]]]
 
 }
@@ -123,8 +126,9 @@ object GeneratorParamsService {
 
       override def selectAll(
         pid: Program.Id,
+        minStatus: Option[ObsStatus] = None
       )(using Transaction[F]): F[Map[Observation.Id, EitherNel[Error, GeneratorParams]]] =
-        doSelect(selectAllParams(pid))
+        doSelect(selectAllParams(pid, minStatus.getOrElse(Enumerated[ObsStatus].all.head)))
 
       private def doSelect(
         params: F[List[Params]]
@@ -149,9 +153,10 @@ object GeneratorParamsService {
           }
 
       private def selectAllParams(
-        pid: Program.Id
+        pid:       Program.Id,
+        minStatus: ObsStatus
       ): F[List[Params]] =
-        executeSelect(Statements.selectAllParams(user, pid))
+        executeSelect(Statements.selectAllParams(user, pid, minStatus))
 
       private def executeSelect(af: AppliedFragment): F[List[Params]] =
         session
@@ -340,7 +345,8 @@ object GeneratorParamsService {
 
     def selectAllParams(
       user:      User,
-      programId: Program.Id
+      programId: Program.Id,
+      minStatus: ObsStatus
     ): AppliedFragment =
       sql"""
         SELECT
@@ -349,8 +355,10 @@ object GeneratorParamsService {
         INNER JOIN t_observation ob ON gp.c_observation_id = ob.c_observation_id
         WHERE
       """(Void) |+|
-        sql"""gp.c_program_id = $program_id""".apply(programId) |+|
-        void""" AND ob.c_existence = 'present' """ |+|
+        sql"""gp.c_program_id = $program_id""".apply(programId)    |+|
+        void""" AND ob.c_existence = 'present' """                 |+|
+        sql""" AND ob.c_status >= $obs_status """.apply(minStatus) |+|
+        void""" AND ob.c_active_status = 'active' """              |+|
         existsUserAccess(user, programId).fold(AppliedFragment.empty) { af => void""" AND """ |+| af }
   }
 }

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -31,7 +31,6 @@ import lucuma.core.model.Program
 import lucuma.core.model.SourceProfile
 import lucuma.core.model.Target
 import lucuma.core.model.User
-import lucuma.core.util.Enumerated
 import lucuma.itc.client.GmosFpu
 import lucuma.itc.client.InstrumentMode
 import lucuma.itc.client.SpectroscopyIntegrationTimeInput
@@ -63,7 +62,7 @@ trait GeneratorParamsService[F[_]] {
 
   def selectAll(
     programId: Program.Id,
-    minStatus: Option[ObsStatus] = None
+    minStatus: ObsStatus = ObsStatus.New
   )(using Transaction[F]): F[Map[Observation.Id, EitherNel[Error, GeneratorParams]]]
 
 }
@@ -125,10 +124,10 @@ object GeneratorParamsService {
         doSelect(selectManyParams(pid, oids))
 
       override def selectAll(
-        pid: Program.Id,
-        minStatus: Option[ObsStatus] = None
+        pid:       Program.Id,
+        minStatus: ObsStatus
       )(using Transaction[F]): F[Map[Observation.Id, EitherNel[Error, GeneratorParams]]] =
-        doSelect(selectAllParams(pid, minStatus.getOrElse(Enumerated[ObsStatus].all.head)))
+        doSelect(selectAllParams(pid, minStatus))
 
       private def doSelect(
         params: F[List[Params]]

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
@@ -91,7 +91,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        o <- createGmosNorthLongSlitObservationAs(user, p, t)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield o
     setup.flatMap { oid =>
       expect(
@@ -265,7 +265,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        o <- createGmosNorthLongSlitObservationAs(user, p, t)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield o
 
     setup.flatMap { oid =>
@@ -460,7 +460,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        o <- createGmosNorthLongSlitObservationAs(user, p, t)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield o
 
     setup.flatMap { oid =>
@@ -555,7 +555,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        o <- createGmosNorthLongSlitObservationAs(user, p, t)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield (p, o)
 
     setup.flatMap { case (pid, oid) =>
@@ -1042,7 +1042,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        o <- createGmosNorthLongSlitObservationAs(user, p, t)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield o
 
     setup.flatMap { oid =>
@@ -1077,7 +1077,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        o <- createGmosNorthLongSlitObservationAs(user, p, t)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield (p, o)
 
     setup.flatMap { case (pid, oid) =>
@@ -1131,7 +1131,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        o <- createGmosNorthLongSlitObservationAs(user, p, t)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield o
 
     setup.flatMap { oid =>
@@ -1542,7 +1542,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        o <- createGmosNorthLongSlitObservationAs(user, p, t)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield o
 
     setup.flatMap { oid =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -28,7 +28,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
     for {
       p  <- createProgram
       ts <- (1 to targetCount).toList.traverse(_ => createTargetWithProfileAs(user, p))
-      o  <- createGmosNorthLongSlitObservationAs(user, p, ts*)
+      o  <- createGmosNorthLongSlitObservationAs(user, p, ts)
     } yield (p, o, ts)
 
   def setup1: IO[(Program.Id, Observation.Id, Target.Id)] =
@@ -345,7 +345,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
     for {
       p <- createProgram
       t <- createTarget(p)
-      o <- createGmosNorthLongSlitObservationAs(user, p, t)
+      o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       r <- expect(
         user = user,
         query =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programPlannedTime.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programPlannedTime.scala
@@ -24,6 +24,9 @@ import lucuma.core.enums.GmosNorthFpu
 import lucuma.core.enums.GmosNorthGrating
 import lucuma.core.enums.GmosXBinning
 import lucuma.core.enums.GmosYBinning
+import lucuma.core.enums.ObsActiveStatus.Inactive
+import lucuma.core.enums.ObsStatus.Approved
+import lucuma.core.enums.ObsStatus.New
 import lucuma.core.math.BoundedInterval
 import lucuma.core.math.Wavelength
 import lucuma.core.model.Group
@@ -133,7 +136,7 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        _ <- createGmosNorthLongSlitObservationAs(user, p, t)
+        _ <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield p
 
     setup.flatMap { pid =>
@@ -175,13 +178,85 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
 
   }
 
+  test("single complete, but 'New' observation") {
+    val setup: IO[Program.Id] =
+      for {
+        p <- createProgram
+        t <- createTargetWithProfileAs(user, p)
+        _ <- createGmosNorthLongSlitObservationAs(user, p, List(t), status = New)
+      } yield p
+
+    setup.flatMap { pid =>
+      expect(
+        user  = user,
+        query =
+          s"""
+             query {
+               program(programId: "$pid") {
+                 plannedTimeRange {
+                   minimum { total { seconds } }
+                   maximum { total { seconds } }
+                 }
+               }
+             }
+           """,
+        expected = Right(
+          json"""
+            {
+              "program": {
+                "plannedTimeRange": null
+              }
+            }
+          """
+        )
+      )
+    }
+
+  }
+
+  test("single complete, but 'Inactive' observation") {
+    val setup: IO[Program.Id] =
+      for {
+        p <- createProgram
+        t <- createTargetWithProfileAs(user, p)
+        _ <- createGmosNorthLongSlitObservationAs(user, p, List(t), status = Approved, activeStatus = Inactive)
+      } yield p
+
+    setup.flatMap { pid =>
+      expect(
+        user  = user,
+        query =
+          s"""
+             query {
+               program(programId: "$pid") {
+                 plannedTimeRange {
+                   minimum { total { seconds } }
+                   maximum { total { seconds } }
+                 }
+               }
+             }
+           """,
+        expected = Right(
+          json"""
+            {
+              "program": {
+                "plannedTimeRange": null
+              }
+            }
+          """
+        )
+      )
+    }
+
+  }
+
   test("two complete observations") {
     val setup: IO[Program.Id] =
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        _ <- createGmosNorthLongSlitObservationAs(user, p, t)
-        _ <- createGmosNorthLongSlitObservationAs(user, p, t)
+        _ <- createGmosNorthLongSlitObservationAs(user, p, List(t))
+        _ <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield p
 
     setup.flatMap { pid =>
@@ -227,7 +302,7 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        _ <- createGmosNorthLongSlitObservationAs(user, p, t)
+        _ <- createGmosNorthLongSlitObservationAs(user, p, List(t))
         _ <- createObservationWithNoModeAs(user, p, t)
       } yield p
 
@@ -286,7 +361,7 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
         g <- createGroupAs(user, p)
-        o <- createGmosNorthLongSlitObservationAs(user, p, t)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
         _ <- moveObsToGroup(p, g, o)
       } yield p
 
@@ -333,9 +408,9 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        _ <- createGmosNorthLongSlitObservationAs(user, p, t)
+        _ <- createGmosNorthLongSlitObservationAs(user, p, List(t))
         g <- createGroupAs(user, p)
-        o <- createGmosNorthLongSlitObservationAs(user, p, t)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
         _ <- moveObsToGroup(p, g, o)
       } yield p
 
@@ -383,7 +458,7 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
         g <- createGroupAs(user, p, minRequired = NonNegShort.unsafeFrom(1).some)
-        oShort <- createGmosNorthLongSlitObservationAs(user, p, t)
+        oShort <- createGmosNorthLongSlitObservationAs(user, p, List(t))
         oLong  <- createLongerGmosNorthLongSlitObservationAs(user, p, t)
         _ <- moveObsToGroup(p, g, oShort, oLong)
       } yield p
@@ -432,11 +507,11 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
         g0 <- createGroupAs(user, p, minRequired = NonNegShort.unsafeFrom(1).some)
-        oShort0 <- createGmosNorthLongSlitObservationAs(user, p, t)
+        oShort0 <- createGmosNorthLongSlitObservationAs(user, p, List(t))
         oLong0  <- createLongerGmosNorthLongSlitObservationAs(user, p, t)
         _ <- moveObsToGroup(p, g0, oShort0, oLong0)
         g1 <- createGroupAs(user, p, minRequired = NonNegShort.unsafeFrom(1).some)
-        oShort1 <- createGmosNorthLongSlitObservationAs(user, p, t)
+        oShort1 <- createGmosNorthLongSlitObservationAs(user, p, List(t))
         oLong1  <- createLongerGmosNorthLongSlitObservationAs(user, p, t)
         _ <- moveObsToGroup(p, g1, oShort1, oLong1)
       } yield p

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programPlannedTime.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programPlannedTime.scala
@@ -204,7 +204,18 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
           json"""
             {
               "program": {
-                "plannedTimeRange": null
+                "plannedTimeRange": {
+                  "minimum": {
+                    "total" : {
+                        "seconds" : 0.000000
+                    }
+                  },
+                  "maximum": {
+                    "total" : {
+                        "seconds" : 0.000000
+                    }
+                  }
+                }
               }
             }
           """
@@ -240,7 +251,18 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
           json"""
             {
               "program": {
-                "plannedTimeRange": null
+                "plannedTimeRange": {
+                  "minimum": {
+                    "total" : {
+                        "seconds" : 0.000000
+                    }
+                  },
+                  "maximum": {
+                    "total" : {
+                        "seconds" : 0.000000
+                    }
+                  }
+                }
               }
             }
           """
@@ -324,7 +346,18 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
           json"""
             {
               "program": {
-                "plannedTimeRange": null
+                 "plannedTimeRange": {
+                  "minimum": {
+                    "total" : {
+                        "seconds" : $ShortTime
+                    }
+                  },
+                  "maximum": {
+                    "total" : {
+                        "seconds" : $ShortTime
+                    }
+                  }
+                }
               }
             }
           """

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/smartgcal.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/smartgcal.scala
@@ -190,7 +190,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        o <- createGmosNorthLongSlitObservationAs(user, p, t)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield o
 
     // Should pick definition 2, with the 2 second exposure time based on the
@@ -420,7 +420,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
       for {
         p <- createProgram
         t <- createTargetWithProfileAs(user, p)
-        o <- createGmosSouthLongSlitObservationAs(user, p, t)
+        o <- createGmosSouthLongSlitObservationAs(user, p, List(t))
       } yield o
 
     // Should pick definition 2, with the 2 second exposure time based on the


### PR DESCRIPTION
After playing with it a bit, Andy recommended a couple of changes to the program planned time range calculation.  The main issue was that the presence of any incomplete observation could easily and often make it impossible to estimate the planned time range for the remainder of observations.  This was addressed in two ways:

1. Limit the calculation to only `active` and `approved` (or higher) observations.  Any others are ignored for the purpose of estimating the remaining time.
2. When the `minRequired` value of a group (or indeed the program as a whole) is not set, we only consider the complete, active and approved observations.  Previously `minRequired` would default to #children, resulting in the presence of even one incomplete child invalidating the calculation for a group (or program) as a whole.  Now `minRequired` defaults to the number of valid children only, which may even be `0`.

I suspect that this algorithm will evolve over time as we figure out what is needed.  In particular I think not having the program planned time range at TAC time will be an issue. It won't be calculated because presumably none of the observations will yet have `approved` status?