### PR TITLE
update cloneObservation to set asterism if requested

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CloneObservationInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CloneObservationInput.scala
@@ -5,14 +5,22 @@ package lucuma.odb.graphql
 
 package input
 
+import cats.data.NonEmptyList
 import cats.syntax.all.*
 import lucuma.core.model.Observation
+import lucuma.core.model.Target
+import lucuma.odb.data.Nullable
 import lucuma.odb.graphql.binding._
 
 final case class CloneObservationInput(
   observationId: Observation.Id,
   SET:           Option[ObservationPropertiesInput.Edit],
-)
+) {
+
+  def asterism: Nullable[NonEmptyList[Target.Id]] =
+    SET.fold(Nullable.Absent)(_.asterism)
+    
+}
 
 object CloneObservationInput {
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/634.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/634.scala
@@ -5,8 +5,8 @@ package lucuma.odb.graphql
 package issue.github
 
 import cats.syntax.all.*
-import io.circe.syntax.*
 import io.circe.literal.*
+import io.circe.syntax.*
 import lucuma.core.model.Target
 
 // https://github.com/gemini-hlsw/lucuma-odb/issues/634

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/634.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/634.scala
@@ -1,0 +1,88 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package issue.github
+
+import cats.syntax.all.*
+import io.circe.syntax.*
+import io.circe.literal.*
+import lucuma.core.model.Target
+
+// https://github.com/gemini-hlsw/lucuma-odb/issues/634
+class GitHub_634 extends OdbSuite {
+  val pi = TestUsers.Standard.pi(nextId, nextId)
+  val validUsers = List(pi)
+
+  test("observation clone with new asterism") {
+    createProgramAs(pi).flatMap { pid =>
+      createTargetAs(pi, pid).replicateA(3).map { 
+        case List(t1, t2, t3) => (t1, t2, t3)
+        case _                => fail("unpossible")
+      }.flatMap { (t1, t2, t3) =>
+        createObservationAs(pi, pid, t1, t2).flatMap { oid =>
+          expect(
+            user = pi,
+            query = s"""
+              mutation {
+                cloneObservation(
+                  input: {
+                    observationId: ${oid.asJson}
+                    SET: {
+                      targetEnvironment: {
+                          asterism: [ ${t3.asJson} ]
+                      }
+                    }
+                  }
+                ) {
+                  originalObservation {
+                    targetEnvironment {
+                      asterism {
+                        id
+                      }
+                    }
+                  }
+                  newObservation {
+                    targetEnvironment {
+                      asterism {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            """,
+            expected = Right(json"""
+              {
+                "cloneObservation" : {
+                  "originalObservation" : {
+                    "targetEnvironment" : {
+                      "asterism" : [
+                        {
+                          "id" : $t1
+                        },
+                        {
+                          "id" : $t2
+                        }
+                      ]
+                    }
+                  },
+                  "newObservation" : {
+                    "targetEnvironment" : {
+                      "asterism" : [
+                        {
+                          "id" : $t3
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            """) 
+          )
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Turns the observation service's `updateObservations` doesn't update the asterism, so I needed to add it to the `cloneObservation` mutation. This resolves #634 