### PR TITLE
tests for program edit access

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7341,6 +7341,11 @@ type Program {
   """
   plannedTimeRange: PlannedTimeRange
 
+  """
+  Allocated time.
+  """
+  allocations: [Allocation!]!
+
 }
 
 """

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
@@ -47,7 +47,8 @@ trait ProgramMapping[F[_]]
      with Predicates[F]
      with ProposalAttachmentTable[F]
      with ResultMapping[F]
-     with GroupElementView[F] {
+     with GroupElementView[F]
+     with AllocationTable[F] {
 
   def user: User
   def itcClient: ItcClient[F]
@@ -71,7 +72,8 @@ trait ProgramMapping[F[_]]
         SqlObject("allGroupElements", Join(ProgramTable.Id, GroupElementView.ProgramId)),
         SqlObject("obsAttachments", Join(ProgramTable.Id, ObsAttachmentTable.ProgramId)),
         SqlObject("proposalAttachments", Join(ProgramTable.Id, ProposalAttachmentTable.ProgramId)),
-        EffectField("plannedTimeRange", plannedTimeHandler, List("id"))
+        EffectField("plannedTimeRange", plannedTimeHandler, List("id")),
+        SqlObject("allocations", Join(ProgramTable.Id, AllocationTable.ProgramId)),
       )
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/AllocationPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/AllocationPredicates.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.predicate
+
+import edu.gemini.grackle.Path
+import lucuma.odb.data.Tag
+
+class AllocationPredicates(path: Path) {
+  lazy val partner = LeafPredicates[Tag](path / "partner")
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/LeafPredicate.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/LeafPredicate.scala
@@ -23,4 +23,7 @@ class LeafPredicates[A](path: Path) {
   def isNull(b: Boolean): Predicate =
     IsNull(path, b)
 
+  def contains(a: A)(using Eq[A]): Predicate =
+    Contains(path, Const(a))
+
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/ProgramPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/ProgramPredicates.scala
@@ -6,26 +6,36 @@ package lucuma.odb.graphql.predicate
 import edu.gemini.grackle.Path
 import edu.gemini.grackle.Predicate
 import edu.gemini.grackle.Predicate._
-import lucuma.core.model.Access._
 import lucuma.core.model.Program
 import lucuma.core.model.User
+import lucuma.core.model.GuestUser
+import lucuma.core.model.ServiceUser
+import lucuma.core.model.StandardUser
+import lucuma.core.model.StandardRole.Pi
+import lucuma.core.model.StandardRole.Ngo
+import lucuma.core.model.StandardRole.Staff
+import lucuma.core.model.StandardRole.Admin
+import lucuma.odb.data.Tag
 
 class ProgramPredicates(path: Path) {
 
-  lazy val existence = ExistencePredicates(path / "existence")
-  lazy val id        = LeafPredicates[Program.Id](path / "id")
-  lazy val piUserId  = LeafPredicates[User.Id](path / "piUserId")
+  lazy val existence   = ExistencePredicates(path / "existence")
+  lazy val id          = LeafPredicates[Program.Id](path / "id")
+  lazy val piUserId    = LeafPredicates[User.Id](path / "piUserId")
+  lazy val allocations = AllocationPredicates(path / "allocations")
 
   def isVisibleTo(user: User): Predicate =
-    user.role.access match {
-      case Guest | Pi =>
+    user match
+      case GuestUser(id)                    => piUserId.eql(user.id) // user is the PI
+      case ServiceUser(_, _)                => True
+      case StandardUser(_, Staff(_), _, _)  => True
+      case StandardUser(_, Admin(_), _, _)  => True
+      case StandardUser(_, Ngo(_, p), _, _) => allocations.partner.contains(Tag(p.tag)) // partner must have allocated time
+      case StandardUser(id, Pi(_), _, _)    => 
         Or(
           Contains(path / "users" / "userId", Const(user.id)), // user is linked, or
-          piUserId.eql(user.id)            // user is the PI
-        )
-      case Ngo => ???
-      case Staff | Admin | Service => True
-    }
+          piUserId.eql(user.id)                                // user is the PI
+        )          
 
   def isWritableBy(user: User): Predicate =
     isVisibleTo(user) // this is true for now

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updatePrograms.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updatePrograms.scala
@@ -11,8 +11,10 @@ import lucuma.core.model.Partner
 import lucuma.core.model.Program
 import lucuma.core.model.User
 import lucuma.odb.data.Existence
+import lucuma.odb.data.Tag
+import lucuma.core.syntax.timespan.*
 
-class updatePrograms extends OdbSuite {
+class updatePrograms extends OdbSuite(debug = true) {
 
   val pi       = TestUsers.Standard.pi(1, 101)
   val ngo      = TestUsers.Standard.ngo(2, 102, Partner.Ca)
@@ -20,8 +22,9 @@ class updatePrograms extends OdbSuite {
   val admin    = TestUsers.Standard.admin(4, 104)
   val guest    = TestUsers.guest(5)
   val service  = TestUsers.service(6)
+  val pi2      = TestUsers.Standard.pi(7, 105)
 
-  val validUsers = List(pi, ngo, staff, admin, guest, service).toList
+  val validUsers = List(pi, ngo, staff, admin, guest, service, pi2).toList
 
   test("edit name") {
     createProgramAs(pi).flatMap { pid =>
@@ -353,7 +356,7 @@ class updatePrograms extends OdbSuite {
                         percent: 70
                       }
                       {
-                        partner: KECK
+                        partner: CA
                         percent: 30
                       }
                     ]
@@ -398,7 +401,7 @@ class updatePrograms extends OdbSuite {
                           "percent" : 70
                         },
                         {
-                          "partner" : "KECK",
+                          "partner" : "CA",
                           "percent" : 30
                         }
                       ]
@@ -867,7 +870,7 @@ class updatePrograms extends OdbSuite {
                     toOActivation: RAPID
                     partnerSplits: [
                       {
-                        partner: KECK
+                        partner: CA
                         percent: 100
                       }
                     ]
@@ -910,7 +913,7 @@ class updatePrograms extends OdbSuite {
                       },
                       "partnerSplits" : [
                         {
-                          "partner" : "KECK",
+                          "partner" : "CA",
                           "percent" : 100
                         }
                       ]
@@ -924,7 +927,7 @@ class updatePrograms extends OdbSuite {
                       },
                       "partnerSplits" : [
                         {
-                          "partner" : "KECK",
+                          "partner" : "CA",
                           "percent" : 100
                         }
                       ]
@@ -933,6 +936,171 @@ class updatePrograms extends OdbSuite {
                 ]
               }
             }
+          """
+        )
+      )
+    }
+  }
+
+  test("[access control] pi/guest can't edit other people's programs") {
+    createUsers(pi2, guest) >> List(pi2, guest).traverse { u =>
+      createProgramAs(pi).flatMap { pid =>
+        expect(
+          user = u,
+          query = s"""
+            mutation {
+              updatePrograms(
+                input: {
+                  SET: {
+                    existence: DELETED
+                  }
+                  WHERE: {
+                    id: {
+                      EQ: "$pid"
+                    }
+                  }
+                }
+              ) {
+                programs {
+                  id
+                }
+              }
+            }
+          """,
+          expected = Right(
+            json"""
+            {
+              "updatePrograms": {
+                "programs": []
+              }
+            }
+            """
+          )
+        )
+      }
+    }
+  }
+
+  test("[access control] staff/admin/service can edit other people's programs") {
+    createUsers(staff, admin, service) >> List(staff, admin, service).traverse { u =>
+      createProgramAs(pi).flatMap { pid =>
+        expect(
+          user = u,
+          query = s"""
+            mutation {
+              updatePrograms(
+                input: {
+                  SET: {
+                    existence: DELETED
+                  }
+                  WHERE: {
+                    id: {
+                      EQ: "$pid"
+                    }
+                  }
+                }
+              ) {
+                programs {
+                  id
+                }
+              }
+            }
+          """,
+          expected = Right(
+            json"""
+            {
+              "updatePrograms": {
+                "programs": [
+                  {
+                    "id": $pid
+                  }
+                ]
+              }
+            }
+            """
+          )
+        )
+      }
+    }
+  }
+
+  test("[access control] ngo can't edit other people's programs without allocated time") {
+    createUsers(ngo) >>
+    createProgramAs(pi).flatMap { pid =>
+      setAllocationAs(admin, pid, Tag("US"), 42.hourTimeSpan) >> // ngo is canada!
+      expect(
+        user = ngo,
+        query = s"""
+          mutation {
+            updatePrograms(
+              input: {
+                SET: {
+                  name: "foo"
+                }
+                WHERE: {
+                  id: {
+                    EQ: "$pid"
+                  }
+                }
+              }
+            ) {
+              programs {
+                id
+              }
+            }
+          }
+        """,
+        expected = Right(
+          json"""
+          {
+            "updatePrograms": {
+              "programs": []
+            }
+          }
+          """
+        )
+      )
+    }
+  }
+
+
+  test("[access control] ngo can edit other people's programs with allocated time") {
+    createUsers(ngo, admin) >>
+    createProgramAs(pi).flatMap { pid =>
+      setAllocationAs(admin, pid, Tag("CA"), 42.hourTimeSpan) >>
+      expect(
+        user = ngo,
+        query = s"""
+          mutation {
+            updatePrograms(
+              input: {
+                SET: {
+                  name: "foo"
+                }
+                WHERE: {
+                  id: {
+                    EQ: "$pid"
+                  }
+                }
+              }
+            ) {
+              programs {
+                id
+              }
+            }
+          }
+        """,
+        expected = Right(
+          json"""
+          {
+            "updatePrograms": {
+              "programs": [ 
+                {
+                  "id": $pid 
+                }
+              ]
+            }
+          }
           """
         )
       )


### PR DESCRIPTION
This adds some tests for program edits (which for now include deletion). At this point anyone who can see the program can do anything. This implements access control for NGO roles, where you have access to programs if your partner has granted them time.

There is a disconnect between the model's `Partner` enum and the partner table in the database. I will circle back and fix that next.

This is in reference to #645 