### PR TITLE
WIP: static metadata endpoint

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -15,9 +15,11 @@ import edu.gemini.grackle.skunk.SkunkMonitor
 import fs2.io.net.Network
 import io.laserdisc.pure.s3.tagless.S3AsyncClientOp
 import lucuma.core.model.User
+import lucuma.graphql.routes.GrackleGraphQLService
 import lucuma.itc.client.ItcClient
 import lucuma.odb.graphql.GraphQLRoutes
 import lucuma.odb.graphql.ObsAttachmentRoutes
+import lucuma.odb.graphql.OdbMapping
 import lucuma.odb.graphql.ProposalAttachmentRoutes
 import lucuma.odb.graphql.enums.Enums
 import lucuma.odb.logic.PlannedTimeCalculator
@@ -44,8 +46,6 @@ import skunk.{Command => _, _}
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 
 import scala.concurrent.duration._
-import lucuma.odb.graphql.OdbMapping
-import lucuma.graphql.routes.GrackleGraphQLService
 
 object MainArgs {
   opaque type ResetDatabase = Boolean

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
@@ -26,14 +26,7 @@ import lucuma.odb.instances.given
 import lucuma.odb.service.Services
 
 trait QueryMapping[F[_]] extends Predicates[F] {
-  this: SkunkMapping[F]
-   with TargetMapping[F]
-   with ObsAttachmentTypeMetaMapping[F]
-   with FilterTypeMetaMapping[F]
-   with PartnerMetaMapping[F]
-   with ProgramMapping[F]
-   with ProposalAttachmentTypeMetaMapping[F]
-   with ObservationMapping[F] =>
+  this: SkunkMapping[F] =>
 
   // Resources defined in the final cake.
   def user: model.User

--- a/modules/service/src/test/scala/lucuma/odb/graphql/export/enumMetadata.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/export/enumMetadata.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package `export`
+
+import cats.effect.IO
+import org.http4s.client.JavaNetClientBuilder
+
+class enumMetadata extends OdbSuite {
+
+  val validUsers = Nil
+  val client = JavaNetClientBuilder[IO].create
+
+  test("enumMetadata") {
+    server.use { svr =>
+      client.expect[String](svr.baseUri / "export" / "enumMetadata").map { s =>
+        assert(s.startsWith("export const enumMetadata ='{"))
+      }
+    }
+  }
+
+}
+
+


### PR DESCRIPTION
This adds an unauthenticated endpoint at `/enum-metadata` that executes a static query for enum metadata.

```graphql
query {
  partnerMeta {
    tag
    shortName
    longName
    active
  }
  filterTypeMeta {
    tag
    shortName
    longName
  }
  obsAttachmentTypeMeta {
    tag
    shortName
    longName
    fileExtensions {
      fileExtension
    }
  }
  proposalAttachmentTypeMeta {
    tag
    shortName
    longName
  }
}
```

It's a simple HTTP `GET` that returns a javascript source file.

```
$ curl -i http://localhost:4082/export/enumMetadata
HTTP/1.1 200 OK
Content-Type: application/javascript
Vary: Origin
Date: Tue, 22 Aug 2023 18:53:16 GMT
Content-Length: 2028

export const enumMetadata ='{"data":{"obsAttachmentTypeMeta":[{"tag":"FINDER","shortName":"Finder",...
```

The intent here is that clients like Explore fetch this metadata at startup and use it to populate `Enumerated` instances for associated model traits.

@rpiaggio @toddburnside @armanbilge @cquiroz - wdyty?