### PR TITLE
treat json values as terminal

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GmosNorthStaticMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GmosNorthStaticMapping.scala
@@ -8,7 +8,7 @@
 
  trait GmosNorthStaticMapping[F[_]] extends GmosStaticTables[F] {
 
-   private lazy val mapping: ObjectMapping =
+   lazy val GmosNorthStaticMapping: ObjectMapping =
      ObjectMapping(
        tpe = GmosNorthStaticType,
        fieldMappings = List(
@@ -19,14 +19,4 @@
        )
      )
 
-   // The GmosNorthStatic type appears in the middle of a computed JSON result.
-   // In order to avoid finding this mapping in that case, we need to be
-   // explicit about when to use this mapping.
-   lazy val GmosNorthStaticMapping: TypeMapping =
-     SwitchMapping(
-       GmosNorthStaticType,
-       List(
-         GmosNorthVisitType / "static" -> mapping
-       )
-     )
  }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/util/MappingExtras.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/util/MappingExtras.scala
@@ -6,19 +6,19 @@ package lucuma.odb.graphql.util
 import cats.Eq
 import cats.kernel.Order
 import cats.syntax.all._
+import edu.gemini.grackle.Cursor
 import edu.gemini.grackle.Cursor.Context
 import edu.gemini.grackle.Mapping
 import edu.gemini.grackle.Path
+import edu.gemini.grackle.Result
 import edu.gemini.grackle.Type
+import edu.gemini.grackle.circe.CirceMappingLike
 import eu.timepit.refined.types.numeric.NonNegShort
 import io.circe.Encoder
+import io.circe.Json
 import org.tpolecat.sourcepos.SourcePos
 
 import scala.reflect.ClassTag
-import edu.gemini.grackle.Cursor
-import edu.gemini.grackle.Result
-import edu.gemini.grackle.circe.CirceMappingLike
-import io.circe.Json
 
 trait MappingExtras[F[_]] extends CirceMappingLike[F] {
 


### PR DESCRIPTION
This works around a behavior in Grackle by which JSON cursors can walk into non-JSON data, which is a cool feature but [so far] in Lucuma we just want to treat JSON results as opaque blobs and not worry about other existing mappings for types that might be encountered when zippering around. So this removes the need for the `SwitchMapping` in `GmosNorthStaticMapping` and in the work @toddburnside is doing with guide targets.