### PR TITLE
Select target on asterisms based on brightness

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,7 @@ val natchezVersion             = "0.3.1"
 val paigesVersion              = "0.4.3"
 val postgresVersion            = "42.6.0"
 val skunkVersion               = "0.6.0"
+val pprintVersion              = "0.8.1"
 val testcontainersScalaVersion = "0.40.14" // N.B. 0.40.15 causes java.lang.NoClassDefFoundError: munit/Test
 
 ThisBuild / tlBaseVersion      := "0.5"
@@ -123,6 +124,7 @@ lazy val service = project
       "org.tpolecat"   %% "natchez-log"                        % natchezVersion,
       "org.tpolecat"   %% "skunk-core"                         % skunkVersion,
       "org.tpolecat"   %% "skunk-circe"                        % skunkVersion,
+      "com.lihaoyi"    %% "pprint"                             % pprintVersion,
       "com.dimafeng"   %% "testcontainers-scala-munit"         % testcontainersScalaVersion % Test,
       "com.dimafeng"   %% "testcontainers-scala-localstack-v2" % testcontainersScalaVersion % Test,
       "com.dimafeng"   %% "testcontainers-scala-postgresql"    % testcontainersScalaVersion % Test,


### PR DESCRIPTION
explore and the odb differ on what target to select when an asterism is present
On explore we use the exposure time for the brightest target while on odb we are selecting the longest exposure time

This PR makes odb use the same logic as explore as requested at
https://app.shortcut.com/lucuma/story/2504/exposure-time-and-number-of-exposures-for-observations-of-asterisms#activity-2514