### PR TITLE
completed atom counts

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -271,7 +271,8 @@ object FMain extends MainParams {
       user     = config.user,
       database = database.getOrElse(config.database),
       password = config.password.some,
-      ssl      = SSL.Trusted.withFallback(true)
+      ssl      = SSL.Trusted.withFallback(true),
+      strategy = Strategy.SearchPath
     )
   }
 

--- a/modules/service/src/main/scala/lucuma/odb/service/GmosSequenceService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GmosSequenceService.scala
@@ -114,7 +114,7 @@ object GmosSequenceService {
     def encodeColumns(prefix: Option[String], columns: List[String]): String =
       columns.map(c => s"${prefix.foldMap(_ + ".")}$c").intercalate(",\n")
 
-    val GmosDynamicColumns: List[String] =
+    private val GmosDynamicColumns: List[String] =
       List(
         "c_exposure_time",
         "c_xbin",
@@ -133,7 +133,7 @@ object GmosSequenceService {
         "c_fpu_builtin"
       )
 
-    def insertGmosDynamic(site: String): Fragment[Void]  =
+    private def insertGmosDynamic(site: String): Fragment[Void]  =
       sql"""
         INSERT INTO t_gmos_#${site}_dynamic (
           c_step_id,
@@ -147,7 +147,7 @@ object GmosSequenceService {
     val InsertGmosSouthDynamic: Command[(Step.Id, DynamicConfig.GmosSouth)] =
       (insertGmosDynamic("south") ~> sql"SELECT $step_id, $gmos_south_dynamic").command
 
-    def selectGmosDynamic[A](site: String, decoderA: Decoder[A]): Query[Observation.Id, (Step.Id, A)] =
+    private def selectGmosDynamic[A](site: String, decoderA: Decoder[A]): Query[Observation.Id, (Step.Id, A)] =
       (sql"""
         SELECT
           s.c_step_id,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -395,4 +395,12 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
   def withSession[A](f: Session[IO] => IO[A]): IO[A] =
     Resource.eval(IO(sessionFixture())).use(f)
 
+  import lucuma.odb.service.Services
+  def withServices[A](u: User)(f: Services[IO] => IO[A]): IO[A] ={
+    Resource.eval(IO(sessionFixture())).use { s =>
+      f(Services.forUser(u)(s))
+    }
+}
+
+
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
@@ -571,7 +571,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
         o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield (p, o)
 
-    setup.flatMap { case (pid, oid) =>
+    setup.flatMap { case (_, oid) =>
       expect(
         user  = user,
         query =
@@ -1093,7 +1093,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
         o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       } yield (p, o)
 
-    setup.flatMap { case (pid, oid) =>
+    setup.flatMap { case (_, oid) =>
       expect(
         user  = user,
         query =
@@ -1788,7 +1788,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
 
   }
 
-  val SetupZeroStepsGmosNorth: IO[Observation.Id] =
+  private val SetupZeroStepsGmosNorth: IO[Observation.Id] =
     for {
       p <- createProgram
       t <- createTargetWithProfileAs(user, p)
@@ -1833,7 +1833,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
     }.map(m => assert(m.isEmpty))
   }
 
-  val NorthDynamicScience = GmosNorth(
+  private val NorthDynamicScience = GmosNorth(
     TimeSpan.unsafeFromMicroseconds(20_000_000L),
     GmosCcdMode(GmosXBinning.One, GmosYBinning.Two, GmosAmpCount.Twelve, GmosAmpGain.Low, GmosAmpReadMode.Slow),
     GmosDtax.Zero,
@@ -1843,12 +1843,12 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
     GmosFpuMask.Builtin(GmosNorthFpu.LongSlit_0_50).some
   )
 
-  val NorthDynamicFlat = NorthDynamicScience.copy(exposure = TimeSpan.unsafeFromMicroseconds(1_000_000L))
+  private val NorthDynamicFlat = NorthDynamicScience.copy(exposure = TimeSpan.unsafeFromMicroseconds(1_000_000L))
 
-  val Science = StepConfig.Science(Offset.Zero, GuideState.Enabled)
-  val Flat    = StepConfig.Gcal(Gcal.Lamp.fromContinuum(GcalContinuum.QuartzHalogen5W), GcalFilter.Gmos, GcalDiffuser.Ir, GcalShutter.Open)
+  private val Science = StepConfig.Science(Offset.Zero, GuideState.Enabled)
+  private val Flat    = StepConfig.Gcal(Gcal.Lamp.fromContinuum(GcalContinuum.QuartzHalogen5W), GcalFilter.Gmos, GcalDiffuser.Ir, GcalShutter.Open)
 
-  val SetupOneStepGmosNorth: IO[(Observation.Id, Step.Id)] = {
+  private val SetupOneStepGmosNorth: IO[(Observation.Id, Step.Id)] = {
     import lucuma.odb.json.all.transport.given
 
     for {
@@ -1856,7 +1856,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       t <- createTargetWithProfileAs(user, p)
       o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       v <- recordVisitAs(user, Instrument.GmosNorth, o)
-      a <- recordAtomAs(user, Instrument.GmosNorth, v, stepCount = 1)
+      a <- recordAtomAs(user, Instrument.GmosNorth, v)
       s <- recordStepAs(user, a, Instrument.GmosNorth, NorthDynamicScience, Science)
     } yield (o, s)
 }
@@ -1903,7 +1903,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
     }
   }
 
-  val SetupTwoStepsGmosNorth: IO[(Observation.Id, Step.Id, Step.Id)] = {
+  private val SetupTwoStepsGmosNorth: IO[(Observation.Id, Step.Id, Step.Id)] = {
     import lucuma.odb.json.all.transport.given
 
     for {


### PR DESCRIPTION
This PR contains updates to two services: `GmosSequenceService` and `SequenceService`.   They are not yet tied to anything in the API itself.

The goal is to read events and step configurations produced by Observe as it executes sequences into a format that can be easily matched against a generated sequence.  In particular, for each instrument we would read from the various tables (step and atom records, step events, etc.) to produce a map.  For example, for `GmosNorth`:

```
Map[List[(GmosNorth, StepConfig)], PosInt]
```

where the map key is interpreted as a completed atom configuration and the map value is the number of times said atom has been completed.  Using this information we can stream the generated sequence and remove completed atoms to leave only the remaining atoms.

While this would work, I believe, I am worried about what seems likely to be the heavy cost of calculating this map.  Suggestions welcome.
