### PR TITLE
Scala 3.3.1 + Library Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -102,7 +102,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,8 @@ val pprintVersion              = "0.8.1"
 val testcontainersScalaVersion = "0.40.14" // N.B. 0.40.15 causes java.lang.NoClassDefFoundError: munit/Test
 
 ThisBuild / tlBaseVersion      := "0.6"
-ThisBuild / scalaVersion       := "3.3.0"
-ThisBuild / crossScalaVersions := Seq("3.3.0")
+ThisBuild / scalaVersion       := "3.3.1"
+ThisBuild / crossScalaVersions := Seq("3.3.1")
 
 ThisBuild / Test / fork := false
 ThisBuild / Test / parallelExecution := false

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val http4sJdkHttpClientVersion = "0.9.0"
 val jwtVersion                 = "5.0.0"
 val logbackVersion             = "1.4.11"
 val log4catsVersion            = "2.6.0"
-val lucumaCatalogVersion       = "0.43.2"
+val lucumaCatalogVersion       = "0.43.3"
 val lucumaItcVersion           = "0.20.0"
 val lucumaCoreVersion          = "0.85.0"
 val lucumaGraphQLRoutesVersion = "0.6.6"
@@ -134,7 +134,7 @@ lazy val service = project
       "com.dimafeng"   %% "testcontainers-scala-postgresql"    % testcontainersScalaVersion % Test,
       // testcontainers-scala-localstack-v2 requires both v1 and v2 of the aws sdk
       "io.circe"       %% "circe-testing"                      % circeVersion               % Test,
-      "com.amazonaws"  %  "aws-java-sdk-core"                  % "1.12.543"                 % Test,
+      "com.amazonaws"  %  "aws-java-sdk-core"                  % "1.12.548"                 % Test,
       "edu.gemini"     %% "clue-http4s"                        % clueVersion                % Test,
       "org.scalameta"  %% "munit"                              % munitVersion               % Test,
       "org.scalameta"  %% "munit-scalacheck"                   % munitVersion               % Test,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentsSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentsSuite.scala
@@ -11,6 +11,7 @@ import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
 import fs2.text.utf8
 import lucuma.core.model.ObsAttachment
+import lucuma.core.model.User
 import org.http4s.*
 import org.http4s.client.Client
 import org.http4s.client.JavaNetClientBuilder
@@ -64,16 +65,16 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
         } yield nes
       }
 
-  val pi      = TestUsers.Standard.pi(1, 30)
-  val pi2     = TestUsers.Standard.pi(2, 30)
-  val service = TestUsers.service(3)
+  val pi: User      = TestUsers.Standard.pi(1, 30)
+  val pi2: User     = TestUsers.Standard.pi(2, 30)
+  val service: User = TestUsers.service(3)
 
-  val validUsers = List(pi, pi2, service)
+  val validUsers: List[User] = List(pi, pi2, service)
 
   def getViaPresignedUrl(url: NonEmptyString): Resource[IO, Response[IO]] =
-    server.flatMap { svr =>
-      var uri = Uri.unsafeFromString(url.value)
-      var request = Request[IO](
+    server.flatMap { _ =>
+      val uri = Uri.unsafeFromString(url.value)
+      val request = Request[IO](
         method = Method.GET,
         uri = uri,
       )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/ObsAttachmentsSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/ObsAttachmentsSuite.scala
@@ -64,8 +64,8 @@ abstract class ObsAttachmentsSuite extends AttachmentsSuite {
     attachmentId: ObsAttachment.Id
   ): Resource[IO, Response[IO]] =
     server.flatMap { svr =>
-      var uri     = svr.baseUri / "attachment" / "obs" / programId.toString / attachmentId.toString
-      var request = Request[IO](
+      val uri     = svr.baseUri / "attachment" / "obs" / programId.toString / attachmentId.toString
+      val request = Request[IO](
         method = Method.GET,
         uri = uri,
         headers = Headers(authHeader(user))
@@ -80,8 +80,8 @@ abstract class ObsAttachmentsSuite extends AttachmentsSuite {
     attachmentId: ObsAttachment.Id
   ): Resource[IO, Response[IO]] =
     server.flatMap { svr =>
-      var uri     = svr.baseUri / "attachment" / "obs" / "url" / programId.toString / attachmentId.toString
-      var request = Request[IO](
+      val uri     = svr.baseUri / "attachment" / "obs" / "url" / programId.toString / attachmentId.toString
+      val request = Request[IO](
         method = Method.GET,
         uri = uri,
         headers = Headers(authHeader(user))
@@ -96,8 +96,8 @@ abstract class ObsAttachmentsSuite extends AttachmentsSuite {
     attachmentId: ObsAttachment.Id
   ): Resource[IO, Response[IO]] =
     server.flatMap { svr =>
-      var uri     = svr.baseUri / "attachment" / "obs" / programId.toString / attachmentId.toString
-      var request = Request[IO](
+      val uri     = svr.baseUri / "attachment" / "obs" / programId.toString / attachmentId.toString
+      val request = Request[IO](
         method = Method.DELETE,
         uri = uri,
         headers = Headers(authHeader(user))

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/proposalAttachments.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/proposalAttachments.scala
@@ -146,8 +146,8 @@ class proposalAttachments extends AttachmentsSuite {
     ta:        TestAttachment
   ): Resource[IO, Response[IO]] =
     server.flatMap { svr =>
-      var uri     = svr.baseUri / "attachment" / "proposal" / programId.toString / ta.attachmentType
-      var request = Request[IO](
+      val uri     = svr.baseUri / "attachment" / "proposal" / programId.toString / ta.attachmentType
+      val request = Request[IO](
         method = Method.GET,
         uri = uri,
         headers = Headers(authHeader(user))
@@ -162,8 +162,8 @@ class proposalAttachments extends AttachmentsSuite {
     ta:        TestAttachment
   ): Resource[IO, Response[IO]] =
     server.flatMap { svr =>
-      var uri     = svr.baseUri / "attachment" / "proposal" / "url" / programId.toString / ta.attachmentType
-      var request = Request[IO](
+      val uri     = svr.baseUri / "attachment" / "proposal" / "url" / programId.toString / ta.attachmentType
+      val request = Request[IO](
         method = Method.GET,
         uri = uri,
         headers = Headers(authHeader(user))
@@ -178,8 +178,8 @@ class proposalAttachments extends AttachmentsSuite {
     ta:        TestAttachment
   ): Resource[IO, Response[IO]] =
     server.flatMap { svr =>
-      var uri     = svr.baseUri / "attachment" / "proposal" / programId.toString / ta.attachmentType
-      var request = Request[IO](
+      val uri     = svr.baseUri / "attachment" / "proposal" / programId.toString / ta.attachmentType
+      val request = Request[IO](
         method = Method.DELETE,
         uri = uri,
         headers = Headers(authHeader(user))
@@ -199,19 +199,19 @@ class proposalAttachments extends AttachmentsSuite {
     )
   }
 
-  val file1A           = TestAttachment("file1.pdf", "science", "A description".some, "Hopeful")
-  val file1B           = TestAttachment("file1.pdf", "science", none, "New contents")
-  val file1C           = TestAttachment("file1.pdf", "team", none, "Same name, different type")
-  val file1Empty       = TestAttachment("file1.pdf", "science", "Thing".some, "")
-  val file1InvalidType = TestAttachment("file1.pdf", "NotAType", none, "It'll never make it")
-  val file2            = TestAttachment("file2.pdf", "team", "Masked".some, "Zorro")
-  val fileWithPath     = TestAttachment("this/file.pdf", "science", none, "Doesn't matter")
-  val missingFileName  = TestAttachment("", "science", none, "Doesn't matter")
+  private val file1A           = TestAttachment("file1.pdf", "science", "A description".some, "Hopeful")
+  private val file1B           = TestAttachment("file1.pdf", "science", none, "New contents")
+  private val file1C           = TestAttachment("file1.pdf", "team", none, "Same name, different type")
+  private val file1Empty       = TestAttachment("file1.pdf", "science", "Thing".some, "")
+  private val file1InvalidType = TestAttachment("file1.pdf", "NotAType", none, "It'll never make it")
+  private val file2            = TestAttachment("file2.pdf", "team", "Masked".some, "Zorro")
+  private val fileWithPath     = TestAttachment("this/file.pdf", "science", none, "Doesn't matter")
+  private val missingFileName  = TestAttachment("", "science", none, "Doesn't matter")
   // same attachment type as file1A, but different name, etc.
-  val file3            = TestAttachment("different.pdf", "science", "Unmatching file name".some, "Something different")
-  val missingExtension = TestAttachment("file1", "science", "Missing extension".some, "Doesn't matter")
-  val emptyExtension =   TestAttachment("file1.", "team", "Empty extension".some, "Doesn't matter")
-  val invalidExtension =   TestAttachment("file1.pif", "science", "Invalid extension".some, "Doesn't matter")
+  private val file3            = TestAttachment("different.pdf", "science", "Unmatching file name".some, "Something different")
+  private val missingExtension = TestAttachment("file1", "science", "Missing extension".some, "Doesn't matter")
+  private val emptyExtension   = TestAttachment("file1.", "team", "Empty extension".some, "Doesn't matter")
+  private val invalidExtension = TestAttachment("file1.pif", "science", "Invalid extension".some, "Doesn't matter")
 
   val invalidExtensionMsg = "Invalid file. Must be a PDF file."
 
@@ -341,17 +341,15 @@ class proposalAttachments extends AttachmentsSuite {
 
   test("update with duplicate name is a BadRequest") {
     for {
-      pid    <- createProgramAs(pi)
-      _      <- insertAttachment(pi, pid, file1A).expectOk
-      path   <- getRemotePathFromDb(pid, file1A)
-      fileKey = awsConfig.fileKey(path)
-      _      <- insertAttachment(pi, pid, file2).expectOk
-      path2  <- getRemotePathFromDb(pid, file2)
-      fk2     = awsConfig.fileKey(path2)
-      _      <- assertAttachmentsGql(pi, pid, file2, file1A)
-      _      <- updateAttachment(pi, pid, file1C).withExpectation(Status.BadRequest, "Duplicate file name")
-      _      <- assertAttachmentsGql(pi, pid, file2, file1A)
-      _      <- getAttachment(pi, pid, file2).expectBody(file2.content)
+      pid <- createProgramAs(pi)
+      _   <- insertAttachment(pi, pid, file1A).expectOk
+      _   <- getRemotePathFromDb(pid, file1A)
+      _   <- insertAttachment(pi, pid, file2).expectOk
+      _   <- getRemotePathFromDb(pid, file2)
+      _   <- assertAttachmentsGql(pi, pid, file2, file1A)
+      _   <- updateAttachment(pi, pid, file1C).withExpectation(Status.BadRequest, "Duplicate file name")
+      _   <- assertAttachmentsGql(pi, pid, file2, file1A)
+      _   <- getAttachment(pi, pid, file2).expectBody(file2.content)
     } yield ()
   }
 
@@ -573,7 +571,6 @@ class proposalAttachments extends AttachmentsSuite {
     for {
       pid    <- createProgramAs(pi)
       _      <- insertAttachment(service, pid, file1A).expectOk
-      newDesc = "New description"
       newTa   = file1A.copy(description = none)
       _      <- updateAttachmentsGql(pi,
                                      pid,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("io.spray"           % "sbt-revolver"             % "0.10.0")
 addSbtPlugin("com.timushev.sbt"   % "sbt-updates"              % "0.6.4")
 addSbtPlugin("com.github.sbt"     % "sbt-native-packager"      % "1.9.16")
-addSbtPlugin("edu.gemini"         % "sbt-lucuma-lib"           % "0.11.5")
+addSbtPlugin("edu.gemini"         % "sbt-lucuma-lib"           % "0.11.7")


### PR DESCRIPTION
Updates to Scala 3.3.1, which required changing some `var`s to ` val`s.  Omnibus library updates.  Removed a few other gentle code warnings (unused values, missing parameter types on public `val`s).