### PR TITLE
Prevent 503's on attachment uploads

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/ObsAttachmentRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/ObsAttachmentRoutes.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.graphql
 
 import cats.effect._
+import cats.effect.implicits._
 import cats.effect.std.UUIDGen
 import cats.implicits._
 import eu.timepit.refined.types.string.NonEmptyString
@@ -97,6 +98,7 @@ object ObsAttachmentRoutes {
             s
               .insertAttachment(user, programId, typeTag, fileName, description, req.body)
               .flatMap(id => Ok(id.toString))
+              .guarantee(req.body.compile.drain)
               .recoverWith {
                 case EntityLimiter.EntityTooLarge(_) =>
                   BadRequest(s"File too large. Limit of $maxUploadMb MB")
@@ -113,6 +115,7 @@ object ObsAttachmentRoutes {
             s
               .updateAttachment(user, programId, attachmentId, fileName, description, req.body)
               .flatMap(_ => Ok())
+              .guarantee(req.body.compile.drain)
               .recoverWith {
                 case EntityLimiter.EntityTooLarge(_) =>
                   BadRequest(s"File too large. Limit of $maxUploadMb MB")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/ProposalAttachmentRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/ProposalAttachmentRoutes.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.graphql
 
 import cats.effect._
+import cats.effect.implicits._
 import cats.implicits._
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.model.Program
@@ -95,6 +96,7 @@ object ProposalAttachmentRoutes {
             s
               .insertAttachment(user, programId, attachmentType, fileName, description, req.body)
               .flatMap(_ => Ok())
+              .guarantee(req.body.compile.drain)
               .recoverWith {
                 case EntityLimiter.EntityTooLarge(_) =>
                   BadRequest(s"File too large. Limit of $maxUploadMb MB")
@@ -111,6 +113,7 @@ object ProposalAttachmentRoutes {
             s
               .updateAttachment(user, programId, attachmentType, fileName, description, req.body)
               .flatMap(_ => Ok())
+              .guarantee(req.body.compile.drain)
               .recoverWith {
                 case EntityLimiter.EntityTooLarge(_) =>
                   BadRequest(s"File too large. Limit of $maxUploadMb MB")


### PR DESCRIPTION
As noted in #528, Heroku has the unfortunate behavior of returning a 503 if you try to send a response before reading the entire body of a request. So, this PR always drains the request stream before responding.