### PR TITLE
t_step_record.c_completed

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0376__step_completed.sql
+++ b/modules/service/src/main/resources/db/migration/V0376__step_completed.sql
@@ -2,3 +2,38 @@
 -- Add a completion time that is set when the step is complete, but otherwise null
 ALTER TABLE t_step_record
   ADD COLUMN c_completed timestamp NULL;
+
+DROP VIEW v_step_record;
+
+-- A view that ties together all the step config tables, primarily to simplify
+-- mapping logic.
+CREATE VIEW v_step_record AS
+SELECT
+  s.c_step_id,
+  s.c_atom_id,
+  s.c_instrument,
+  s.c_step_type,
+  s.c_created,
+  s.c_completed,
+  g.c_gcal_continuum,
+  g.c_gcal_ar_arc,
+  g.c_gcal_cuar_arc,
+  g.c_gcal_thar_arc,
+  g.c_gcal_xe_arc,
+  g.c_gcal_filter,
+  g.c_gcal_diffuser,
+  g.c_gcal_shutter,
+  n.c_offset_p,
+  n.c_offset_q,
+  n.c_guide_state,
+  m.c_smart_gcal_type
+FROM
+  t_step_record s
+LEFT JOIN t_step_config_gcal g
+  ON g.c_step_id = s.c_step_id
+LEFT JOIN t_step_config_science n
+  ON n.c_step_id = s.c_step_id
+LEFT JOIN t_step_config_smart_gcal m
+  ON m.c_step_id = s.c_step_id
+ORDER BY
+  s.c_step_id;

--- a/modules/service/src/main/resources/db/migration/V0376__step_completed.sql
+++ b/modules/service/src/main/resources/db/migration/V0376__step_completed.sql
@@ -38,7 +38,7 @@ LEFT JOIN t_step_config_smart_gcal m
 ORDER BY
   s.c_step_id;
 
--- Deletes the observation's execution digest when one of its step is marked
+-- Deletes the observation's execution digest when one of its steps is marked
 -- complete.
 CREATE OR REPLACE FUNCTION delete_execution_digest()
   RETURNS TRIGGER AS $$

--- a/modules/service/src/main/resources/db/migration/V0376__step_completed.sql
+++ b/modules/service/src/main/resources/db/migration/V0376__step_completed.sql
@@ -1,0 +1,4 @@
+
+-- Add a completion time that is set when the step is complete, but otherwise null
+ALTER TABLE t_step_record
+  ADD COLUMN c_completed timestamp NULL;

--- a/modules/service/src/main/scala/lucuma/odb/data/Md5Hash.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/Md5Hash.scala
@@ -11,11 +11,13 @@ opaque type Md5Hash = ByteVector
 
 object Md5Hash {
 
+  val Zero: Md5Hash = unsafeFromByteArray(Array.fill(16)(0.toByte))
+
   def fromByteArray(bytes: Array[Byte]): Option[Md5Hash] =
     Option.when(bytes.size === 16)(ByteVector(bytes))
 
   def unsafeFromByteArray(bytes: Array[Byte]): Md5Hash =
-    fromByteArray(bytes).getOrElse(sys.error(s"Expected 16 byte array but was ${bytes.size} bytes"))
+    fromByteArray(bytes).getOrElse(sys.error(s"Expected 16 byte array but was ${bytes.length} bytes"))
 
   def fromByteVector(bv: ByteVector): Option[Md5Hash] =
     Option.when(bv.size === 16)(bv)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -354,7 +354,7 @@ trait MutationMapping[F[_]] extends Predicates[F] {
         Result.failure(s"Step id '$id' not found")
       case VisitNotFound(id)   =>
         Result.failure(s"Visit id '$id' not found")
-      case Success(eid)        =>
+      case Success(eid, _)     =>
         Result(Unique(Filter(predicates.id.eql(eid), child)))
     }
   }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/StepRecordTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/StepRecordTable.scala
@@ -28,6 +28,7 @@ trait StepRecordTable[F[_]] extends BaseMapping[F] {
     val AtomId: ColumnRef        = col("c_atom_id",        atom_id)
     val StepType: ColumnRef      = col("c_step_type",      step_type)
     val Created: ColumnRef       = col("c_created",        core_timestamp)
+    val Completed: ColumnRef     = col("c_completed",      core_timestamp.opt)
 
     object Gcal {
       val Continuum: ColumnRef = col("c_gcal_continuum", gcal_continuum)

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
@@ -139,7 +139,7 @@ object ExecutionEventService {
           e <- EitherT(insert).leftWiden[InsertEventResponse]
           (eid, time) = e
           _ <- EitherT.liftF(
-            Applicative[F].whenA(stepStage === StepStage.EndStep)(
+            Applicative[F].whenA(stepStage === StepStage.EndStep)(  // Simplistic we'll need to examine datasets as well
               services.sequenceService.setStepCompleted(stepId, time)
             )
           )

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
@@ -144,9 +144,7 @@ object ExecutionEventService {
           _ <- EitherT.liftF(
               // N.B. This is probably too simplistic. We'll need to examine
               // datasets as well I believe.
-//              Applicative[F].whenA(stepStage === StepStage.EndStep)(stepCompleteActions(time))
               stepCompleteActions(time).whenA(stepStage === StepStage.EndStep)
-//              Applicative[F].whenA(stepStage === StepStage.EndStep)(stepCompleteActions(time))
           )
         } yield Success(eid, time)).merge
       }

--- a/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
@@ -7,6 +7,7 @@ import cats.Applicative
 import cats.data.EitherT
 import cats.effect.Concurrent
 import cats.effect.std.UUIDGen
+import cats.syntax.either.*
 import cats.syntax.eq.*
 import cats.syntax.flatMap.*
 import cats.syntax.foldable.*
@@ -211,32 +212,12 @@ object SequenceService {
 
         for {
           ds <- foldStream(dynamicConfigs, Map.empty[Step.Id, D])((_, d) => d.some)
-          e   = Map.empty[Step.Id, (D, StepConfig)]
-          op  = (sid: Step.Id, sc: StepConfig) => ds.get(sid).tupleRight(sc)
-          g  <- foldQuery(Statements.SelectStepConfigGcalForObs,      e)(op)
-          s  <- foldQuery(Statements.SelectStepConfigScienceForObs,   g)(op)
-          m  <- foldQuery(Statements.SelectStepConfigSmartGcalForObs, s)(op)
-          bd <- biasAndDark(observationId)
-        } yield foldConfigs(bd, m)(op)
+          r  <- foldQuery(Statements.SelectStepConfigForObs, Map.empty[Step.Id, (D, StepConfig)]) { (sid, sc) =>
+            ds.get(sid).tupleRight(sc)
+          }
+        } yield r
 
       }
-
-      // Bias and Dark have no real configuration other than the instrument
-      // itself.  There's not a separate table for these like there is for gcal,
-      // science, and smart gcal.
-      private def biasAndDark(observationId: Observation.Id): F[List[(StepConfig, Set[Step.Id])]] =
-        session
-          .stream(Statements.SelectStepConfigBiasOrDarkForObs)(observationId, 1024)
-          .fold((Set.empty[Step.Id], Set.empty[Step.Id])) { case ((bias, dark), (s, stype)) =>
-            stype match {
-              case StepType.Bias => (bias + s, dark)
-              case StepType.Dark => (bias, dark + s)
-              case _             => (bias, dark)
-            }
-          }
-          .compile
-          .onlyOrError
-          .map { case (bias, dark) => List(StepConfig.Bias -> bias, StepConfig.Dark -> dark) }
 
       // Want a map from atom configuration to completed count that can be
       // matched against the generated atoms.
@@ -464,32 +445,8 @@ object SequenceService {
         WHERE """ ~> sql"""a.c_observation_id = $observation_id AND s.c_completed IS NOT NULL ORDER BY s.c_completed"""
       ).query(atom_id *: int2_nonneg *: step_id)
 
-    val SelectStepConfigBiasOrDarkForObs: Query[Observation.Id, (Step.Id, StepType)] =
-      (sql"""
-        SELECT
-          s.c_step_id,
-          s.c_step_type
-        FROM t_step_record s
-        INNER JOIN t_atom_record a on a.c_atom_id = s.c_atom_id
-        WHERE
-      """ ~> sql"""
-          a.c_observation_id = $observation_id AND
-          (s.c_step_type = 'bias' OR s.c_step_type = 'dark')
-      """).query(step_id *: step_type)
-
     def encodeColumns(prefix: Option[String], columns: List[String]): String =
       columns.map(c => s"${prefix.foldMap(_ + ".")}$c").intercalate(",\n")
-
-    private def selectStepConfigForObs[A](table: String, columns: List[String], decoderA: Decoder[A]): Query[Observation.Id, (Step.Id, A)] =
-      (sql"""
-        SELECT
-          s.c_step_id,
-          #${encodeColumns("c".some, columns)}
-        FROM #$table c
-        INNER JOIN t_step_record s ON s.c_step_id = c.c_step_id
-        INNER JOIN t_atom_record a ON a.c_atom_id = s.c_atom_id
-        WHERE """ ~> sql"""a.c_observation_id = $observation_id"""
-      ).query(step_id *: decoderA)
 
 // TODO: I would like to write the insert step config logic once, parameterized
 // by the table name, columns, and the encoder.  I think I'm being thwarted by
@@ -545,9 +502,6 @@ object SequenceService {
           $step_config_gcal
       """.command
 
-    val SelectStepConfigGcalForObs: Query[Observation.Id, (Step.Id, StepConfig.Gcal)] =
-      selectStepConfigForObs("t_step_config_gcal", StepConfigGcalColumns, step_config_gcal)
-
     private val StepConfigScienceColumns: List[String] =
       List(
         "c_offset_p",
@@ -563,9 +517,6 @@ object SequenceService {
           $step_config_science
       """.command
 
-    val SelectStepConfigScienceForObs: Query[Observation.Id, (Step.Id, StepConfig.Science)] =
-      selectStepConfigForObs("t_step_config_science", StepConfigScienceColumns, step_config_science)
-
     private val StepConfigSmartGcalColumns: List[String] =
       List(
         "c_smart_gcal_type"
@@ -578,8 +529,40 @@ object SequenceService {
           $step_config_smart_gcal
       """.command
 
-    val SelectStepConfigSmartGcalForObs: Query[Observation.Id, (Step.Id, StepConfig.SmartGcal)] =
-      selectStepConfigForObs("t_step_config_smart_gcal", StepConfigSmartGcalColumns, step_config_smart_gcal)
+    private val step_config: Codec[StepConfig] =
+      (
+        step_type               *:
+        step_config_gcal.opt    *:
+        step_config_science.opt *:
+        step_config_smart_gcal.opt
+      ).eimap { case stepType *: oGcal *: oScience *: oSmart *: EmptyTuple =>
+        stepType match {
+          case StepType.Bias      => StepConfig.Bias.asRight
+          case StepType.Dark      => StepConfig.Dark.asRight
+          case StepType.Gcal      => oGcal.toRight("Missing gcal step config definition")
+          case StepType.Science   => oScience.toRight("Missing science step config definition")
+          case StepType.SmartGcal => oSmart.toRight("Missing smart gcal step config definition")
+        }
+      } { stepConfig =>
+        stepConfig.stepType                        *:
+        StepConfig.gcal.getOption(stepConfig)      *:
+        StepConfig.science.getOption(stepConfig)   *:
+        StepConfig.smartGcal.getOption(stepConfig) *:
+        EmptyTuple
+      }
+
+    val SelectStepConfigForObs: Query[Observation.Id, (Step.Id, StepConfig)] =
+      (sql"""
+        SELECT
+          v.c_step_id,
+          v.c_step_type,
+          #${encodeColumns("v".some, StepConfigGcalColumns)},
+          #${encodeColumns("v".some, StepConfigScienceColumns)},
+          #${encodeColumns("v".some, StepConfigSmartGcalColumns)}
+        FROM v_step_record v
+        INNER JOIN t_atom_record a ON a.c_atom_id = v.c_atom_id
+        WHERE """ ~> sql"""a.c_observation_id = $observation_id"""
+      ).query(step_id *: step_config)
 
     val SetStepCompleted: Command[(Option[Timestamp], Step.Id)] =
       sql"""

--- a/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
@@ -535,7 +535,7 @@ object SequenceService {
         step_config_gcal.opt    *:
         step_config_science.opt *:
         step_config_smart_gcal.opt
-      ).eimap { case stepType *: oGcal *: oScience *: oSmart *: EmptyTuple =>
+      ).eimap { case (stepType, oGcal, oScience, oSmart) =>
         stepType match {
           case StepType.Bias      => StepConfig.Bias.asRight
           case StepType.Dark      => StepConfig.Dark.asRight
@@ -544,11 +544,11 @@ object SequenceService {
           case StepType.SmartGcal => oSmart.toRight("Missing smart gcal step config definition")
         }
       } { stepConfig =>
-        stepConfig.stepType                        *:
-        StepConfig.gcal.getOption(stepConfig)      *:
-        StepConfig.science.getOption(stepConfig)   *:
-        StepConfig.smartGcal.getOption(stepConfig) *:
-        EmptyTuple
+        (stepConfig.stepType,
+         StepConfig.gcal.getOption(stepConfig),
+         StepConfig.science.getOption(stepConfig),
+         StepConfig.smartGcal.getOption(stepConfig)
+        )
       }
 
     val SelectStepConfigForObs: Query[Observation.Id, (Step.Id, StepConfig)] =

--- a/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
@@ -461,8 +461,8 @@ object SequenceService {
           s.c_step_id
         FROM t_step_record s
         INNER JOIN t_atom_record a ON a.c_atom_id = s.c_atom_id
-        WHERE """ ~> sql"""a.c_observation_id = $observation_id ORDER BY s.c_created"""
-      ).query(atom_id *: int2_nonneg *: step_id)     // ORDER BY not quite correct, add a completion time set from events
+        WHERE """ ~> sql"""a.c_observation_id = $observation_id AND s.c_completed IS NOT NULL ORDER BY s.c_completed"""
+      ).query(atom_id *: int2_nonneg *: step_id)
 
     val SelectStepConfigBiasOrDarkForObs: Query[Observation.Id, (Step.Id, StepType)] =
       (sql"""

--- a/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
@@ -57,7 +57,7 @@ trait SequenceService[F[_]] {
 
   def setStepCompleted(
     stepId: Step.Id,
-    time:   Timestamp
+    time:   Option[Timestamp]
   )(using Transaction[F]): F[Unit]
 
   def insertAtomRecord(
@@ -309,7 +309,7 @@ object SequenceService {
 
       override def setStepCompleted(
         stepId: Step.Id,
-        time:   Timestamp
+        time:   Option[Timestamp]
       )(using Transaction[F]): F[Unit] =
         session.execute(Statements.SetStepComplete)(time, stepId).void
 
@@ -581,10 +581,10 @@ object SequenceService {
     val SelectStepConfigSmartGcalForObs: Query[Observation.Id, (Step.Id, StepConfig.SmartGcal)] =
       selectStepConfigForObs("t_step_config_smart_gcal", StepConfigSmartGcalColumns, step_config_smart_gcal)
 
-    val SetStepComplete: Command[(Timestamp, Step.Id)] =
+    val SetStepComplete: Command[(Option[Timestamp], Step.Id)] =
       sql"""
         UPDATE t_step_record
-           SET c_completed = $core_timestamp
+           SET c_completed = ${core_timestamp.opt}
          WHERE c_step_id = $step_id
       """.command
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
@@ -2003,15 +2003,13 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       } yield (p, o, s)
     }
 
-    val md5 = Md5Hash.unsafeFromByteArray(Array.fill(16)(0.toByte))
-
     val isEmpty = setup.flatMap { case (p, o, s) =>
       withServices(user) { services =>
         services.session.transaction.use { xa =>
           for {
-            _ <- services.executionDigestService.insertOrUpdate(p, o, md5, ExecutionDigest.Zero)(using xa)
+            _ <- services.executionDigestService.insertOrUpdate(p, o, Md5Hash.Zero, ExecutionDigest.Zero)(using xa)
             _ <- services.executionEventService.insertStepEvent(s, StepStage.EndStep)(using xa)
-            d <- services.executionDigestService.selectOne(p, o, md5)(using xa)
+            d <- services.executionDigestService.selectOne(p, o, Md5Hash.Zero)(using xa)
           } yield d.isEmpty
         }
       }


### PR DESCRIPTION
Adds a nullable `c_completed` `timestamp` column to `t_step_record` which is set when Observe events warrant it.  At the moment it simply sets the timestamp when we get an `END_STEP` event.  That will turn out to be too simplistic but it works as a starting point.

When a step is determined to be completed, we now also delete the cached execution digest (if any).  When the sequence digest is computed it will need to take into account that some steps are completed.  This prepares the way by clearing the cache.

