### PR TITLE
ExecutionDigest Input Hash

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -174,9 +174,10 @@ object Generator {
           md5.update(params.observingMode.hashBytes)
 
           // Integration Time
-          val ing = scienceIntegrationTime
-          md5.update(BigInt(ing.exposureTime.toMicroseconds).toByteArray.reverse.padTo(8, zero))
-          md5.update(BigInt(ing.exposures.value).toByteArray.reverse.padTo(4, zero))
+          List(acquisitionIntegrationTime, scienceIntegrationTime).foreach { ing =>
+            md5.update(BigInt(ing.exposureTime.toMicroseconds).toByteArray.reverse.padTo(8, zero))
+            md5.update(BigInt(ing.exposures.value).toByteArray.reverse.padTo(4, zero))
+          }
 
           // Commit Hash
           md5.update(commitHash.toByteArray)


### PR DESCRIPTION
When the acquisition ITC lookup was added, we forgot to add it to the `ExecutionDigest` computation input hash.