### PR TITLE
Filter Executed Atoms

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/ObservingMode.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/ObservingMode.scala
@@ -3,6 +3,8 @@
 
 package lucuma.odb.sequence
 
+import lucuma.odb.sequence.util.HashBytes
+
 /**
  * All observing mode options.
  */
@@ -10,18 +12,11 @@ type ObservingMode =
   gmos.longslit.Config.GmosNorth |
   gmos.longslit.Config.GmosSouth
 
-extension (m: ObservingMode) {
-
-  /**
-   * An array of bytes that corresponds to the observing mode for the purpose of
-   * producing a hash of all relevant sequence generation inputs.
-   */
-  def hashBytes: Array[Byte] =
-    m match {
+given HashBytes[ObservingMode] with {
+  def hashBytes(a: ObservingMode): Array[Byte] =
+    a match {
       case gn: gmos.longslit.Config.GmosNorth => gn.hashBytes
       case gs: gmos.longslit.Config.GmosSouth => gs.hashBytes
     }
-
 }
-
 

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/CompletedAtomMap.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/CompletedAtomMap.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence.data
+
+import cats.syntax.option.*
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.enums.SequenceType
+import lucuma.core.model.sequence.StepConfig
+
+
+opaque type CompletedAtomMap[D] = Map[CompletedAtomMap.Key[D], PosInt]
+
+object CompletedAtomMap {
+
+  type StepMatch[D] = (D, StepConfig)
+  type AtomMatch[D] = List[StepMatch[D]]
+
+  case class Key[D](
+    sequenceType: SequenceType,
+    atomMatch:    AtomMatch[D]
+  )
+
+  object Key {
+
+    def acquisition[D](steps: StepMatch[D]*): Key[D] =
+      Key(SequenceType.Acquisition, steps.toList)
+
+    def science[D](steps: StepMatch[D]*): Key[D] =
+      Key(SequenceType.Science, steps.toList)
+
+  }
+
+  def Empty[D]: CompletedAtomMap[D] =
+    Map.empty
+
+  def from[D](seq: (Key[D], PosInt)*): CompletedAtomMap[D] =
+    Map.from(seq)
+
+  extension [D](m: CompletedAtomMap[D]) {
+
+    def increment(k: Key[D]): CompletedAtomMap[D] =
+      m.updatedWith(k) {
+        case None    => PosInt.unsafeFrom(1).some
+        case Some(p) => PosInt.from(p.value + 1).toOption
+      }
+
+    def decrement(k: Key[D]): CompletedAtomMap[D] =
+      m.updatedWith(k)(_.flatMap(p => PosInt.from(p.value - 1).toOption))
+
+    def contains(k: Key[D]): Boolean =
+      m.contains(k)
+
+    def isEmpty: Boolean =
+      m.isEmpty
+
+    def toMap: Map[Key[D], PosInt] =
+      m
+
+  }
+
+}
+

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/CompletedAtomMap.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/CompletedAtomMap.scala
@@ -28,6 +28,12 @@ object CompletedAtomMap {
 
     def science[D](steps: StepMatch[D]*): Key[D] =
       Key(SequenceType.Science, steps.toList)
+      
+    def fromProtoAtom[D](
+      sequenceType: SequenceType,
+      atom:         ProtoAtom[ProtoStep[D]]
+    ): Key[D] =
+      Key(sequenceType, atom.steps.map(s => (s.value, s.stepConfig)).toList)
 
   }
 
@@ -44,6 +50,14 @@ object CompletedAtomMap {
         case None    => PosInt.unsafeFrom(1).some
         case Some(p) => PosInt.from(p.value + 1).toOption
       }
+      
+    def matchAtom(
+      s: SequenceType,
+      a: ProtoAtom[ProtoStep[D]]
+    ): (CompletedAtomMap[D], Boolean) = {
+      val k = Key.fromProtoAtom(s, a)
+      if (contains(k)) (decrement(k), true) else (m, false)
+    }
 
     def decrement(k: Key[D]): CompletedAtomMap[D] =
       m.updatedWith(k)(_.flatMap(p => PosInt.from(p.value - 1).toOption))

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/CompletedAtomMap.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/CompletedAtomMap.scala
@@ -8,7 +8,13 @@ import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.SequenceType
 import lucuma.core.model.sequence.StepConfig
 
-
+/**
+ * CompletedAtomMap associates atom configurations with a count of executed
+ * instances of the atom.  This is used to filter executed atoms when producing
+ * the sequence.
+ *
+ * @tparam D dynamic instrument configuration type
+ */
 opaque type CompletedAtomMap[D] = Map[CompletedAtomMap.Key[D], PosInt]
 
 object CompletedAtomMap {
@@ -51,14 +57,6 @@ object CompletedAtomMap {
         case Some(p) => PosInt.from(p.value + 1).toOption
       }
       
-    def matchAtom(
-      s: SequenceType,
-      a: ProtoAtom[ProtoStep[D]]
-    ): (CompletedAtomMap[D], Boolean) = {
-      val k = Key.fromProtoAtom(s, a)
-      if (contains(k)) (decrement(k), true) else (m, false)
-    }
-
     def decrement(k: Key[D]): CompletedAtomMap[D] =
       m.updatedWith(k)(_.flatMap(p => PosInt.from(p.value - 1).toOption))
 
@@ -71,7 +69,20 @@ object CompletedAtomMap {
     def toMap: Map[Key[D], PosInt] =
       m
 
+    /**
+     * Match the given `ProtoAtom[ProtoStep[D]]` against the completed atoms.
+     * If there is at least one matching completed atom, `true` is returned and
+     * a copy of the completed atom map with one fewer instance.  Otherwise
+     * `false` is returned along with this completed atom map.
+     */
+    def matchAtom(
+      s: SequenceType,
+      a: ProtoAtom[ProtoStep[D]]
+    ): (CompletedAtomMap[D], Boolean) = {
+      val k = Key.fromProtoAtom(s, a)
+      if (contains(k)) (decrement(k), true) else (m, false)
+    }
+
   }
 
 }
-

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/GeneratorParams.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/GeneratorParams.scala
@@ -59,6 +59,9 @@ object GeneratorParams {
   ): Array[Byte] = {
     val bld = scala.collection.mutable.ArrayBuilder.make[Byte]
 
+    given HashBytes[ImagingIntegrationTimeInput] = HashBytes.forJsonEncoder
+    given HashBytes[SpectroscopyIntegrationTimeInput] = HashBytes.forJsonEncoder
+
     itc.toList.foreach { case (tid, (imaging, spectroscopy)) =>
       bld.addAll(tid.hashBytes)
       bld.addAll(imaging.hashBytes)

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/GeneratorParams.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/GeneratorParams.scala
@@ -10,6 +10,8 @@ import cats.syntax.eq.*
 import lucuma.core.model.Target
 import lucuma.itc.client.ImagingIntegrationTimeInput
 import lucuma.itc.client.SpectroscopyIntegrationTimeInput
+import lucuma.odb.sequence.syntax.all.*
+import lucuma.odb.sequence.util.HashBytes
 
 enum GeneratorParams {
 
@@ -51,5 +53,27 @@ object GeneratorParams {
       case (s0@GmosSouthLongSlit(_, _), s1@GmosSouthLongSlit(_, _)) => s0 === s1
       case _                                                        => false
     }
+
+  private def itcBytes(
+    itc: NonEmptyList[(Target.Id, (ImagingIntegrationTimeInput, SpectroscopyIntegrationTimeInput))]
+  ): Array[Byte] = {
+    val bld = scala.collection.mutable.ArrayBuilder.make[Byte]
+
+    itc.toList.foreach { case (tid, (imaging, spectroscopy)) =>
+      bld.addAll(tid.hashBytes)
+      bld.addAll(imaging.hashBytes)
+      bld.addAll(spectroscopy.hashBytes)
+    }
+
+    bld.result()
+  }
+
+  given HashBytes[GeneratorParams] with {
+    def hashBytes(a: GeneratorParams): Array[Byte] =
+      a match {
+        case GmosNorthLongSlit(itc, mode) => Array.concat(itcBytes(itc), mode.hashBytes)
+        case GmosSouthLongSlit(itc, mode) => Array.concat(itcBytes(itc), mode.hashBytes)
+      }
+  }
 
 }

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/syntax/all.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/syntax/all.scala
@@ -1,0 +1,6 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence.syntax
+
+object all extends ToHashBytesOps

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/syntax/hash.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/syntax/hash.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence.syntax
+
+import lucuma.odb.sequence.util.HashBytes
+
+trait ToHashBytesOps {
+
+  extension [A: HashBytes](self: A) {
+    def hashBytes: Array[Byte] =
+      HashBytes[A].hashBytes(self)
+
+    def md5: Array[Byte] =
+      HashBytes[A].md5(self)
+  }
+
+}
+
+object hash extends ToHashBytesOps

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/CommitHash.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/CommitHash.scala
@@ -60,6 +60,11 @@ object CommitHash {
       }.getOrElse(0)
     }
 
+  given HashBytes[CommitHash] with {
+    def hashBytes(a: CommitHash): Array[Byte] =
+      a.toByteArray
+  }
+
   val FromString: Format[String, CommitHash] =
     Format(parse, _.format)
 

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/HashBytes.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/HashBytes.scala
@@ -11,6 +11,9 @@ import lucuma.core.util.Gid
 import java.nio.charset.StandardCharsets.UTF_8
 import java.security.MessageDigest
 
+/**
+ * Typeclass for producing an `Array[Byte]` that represents an object.
+ */
 trait HashBytes[A] {
 
   def hashBytes(a: A): Array[Byte]

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/HashBytes.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/HashBytes.scala
@@ -29,6 +29,12 @@ object HashBytes {
 
   def apply[A](using ev: HashBytes[A]): ev.type = ev
 
+  def forJsonEncoder[A: Encoder]: HashBytes[A] =
+    new HashBytes[A] {
+      def hashBytes(a: A): Array[Byte] =
+        Encoder[A].apply(a).spaces2.getBytes(UTF_8)
+    }
+
   private def toByteArray(b: BigInt, pad: Int): Array[Byte] =
     b.toByteArray.reverse.padTo(pad, 0.toByte)
 
@@ -70,8 +76,4 @@ object HashBytes {
       HashBytes[Long].hashBytes(a.toMicroseconds)
   }
 
-  given given_HashBytes_Json[A: Encoder]: HashBytes[A] with {
-    def hashBytes(a: A): Array[Byte] =
-      Encoder[A].apply(a).spaces2.getBytes(UTF_8)
-  }
 }

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/HashBytes.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/HashBytes.scala
@@ -7,12 +7,14 @@ import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.types.numeric.PosLong
 import io.circe.Encoder
 import lucuma.core.util.Gid
+import lucuma.core.util.TimeSpan
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.security.MessageDigest
 
 /**
- * Typeclass for producing an `Array[Byte]` that represents an object.
+ * Typeclass for producing an `Array[Byte]` that represents an object.  This is
+ * precursor to producing, say, an MD5 hash.
  */
 trait HashBytes[A] {
 
@@ -61,6 +63,11 @@ object HashBytes {
         HashBytes[Char].hashBytes(Gid[A].tag.value),
         HashBytes[PosLong].hashBytes(Gid[A].isoPosLong.get(a))
       )
+  }
+
+  given HashBytes[TimeSpan] with {
+    def hashBytes(a: TimeSpan): Array[Byte] =
+      HashBytes[Long].hashBytes(a.toMicroseconds)
   }
 
   given given_HashBytes_Json[A: Encoder]: HashBytes[A] with {

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/HashBytes.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/HashBytes.scala
@@ -1,0 +1,67 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence.util
+
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.numeric.PosLong
+import io.circe.Encoder
+import lucuma.core.util.Gid
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.security.MessageDigest
+
+trait HashBytes[A] {
+
+  def hashBytes(a: A): Array[Byte]
+
+  def md5(a: A): Array[Byte] =
+    MessageDigest.getInstance("MD5").digest(hashBytes(a))
+
+}
+
+object HashBytes {
+
+  def apply[A](using ev: HashBytes[A]): ev.type = ev
+
+  private def toByteArray(b: BigInt, pad: Int): Array[Byte] =
+    b.toByteArray.reverse.padTo(pad, 0.toByte)
+
+  given HashBytes[Long] with {
+    def hashBytes(a: Long): Array[Byte] =
+      toByteArray(BigInt(a), 8)
+  }
+
+  given HashBytes[PosLong] with {
+    def hashBytes(a: PosLong): Array[Byte] =
+      HashBytes[Long].hashBytes(a.value)
+  }
+
+  given HashBytes[Int] with {
+    def hashBytes(a: Int): Array[Byte] =
+      toByteArray(BigInt(a), 4)
+  }
+
+  given HashBytes[PosInt] with {
+    def hashBytes(a: PosInt): Array[Byte] =
+      HashBytes[Int].hashBytes(a.value)
+  }
+
+  given HashBytes[Char] with {
+    def hashBytes(a: Char): Array[Byte] =
+      toByteArray(BigInt(a), 2)
+  }
+
+  given given_HashBytes_Gid[A: Gid]: HashBytes[A] with {
+    def hashBytes(a: A): Array[Byte] =
+      Array.concat(
+        HashBytes[Char].hashBytes(Gid[A].tag.value),
+        HashBytes[PosLong].hashBytes(Gid[A].isoPosLong.get(a))
+      )
+  }
+
+  given given_HashBytes_Json[A: Encoder]: HashBytes[A] with {
+    def hashBytes(a: A): Array[Byte] =
+      Encoder[A].apply(a).spaces2.getBytes(UTF_8)
+  }
+}

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/SequenceIds.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/SequenceIds.scala
@@ -9,7 +9,7 @@ import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.Step
 import lucuma.core.util.Uid
 import lucuma.odb.sequence.data.GeneratorParams
-import lucuma.odb.sequence.util.CommitHash
+import lucuma.odb.sequence.syntax.hash.*
 
 import java.io.ByteArrayOutputStream
 import java.io.ObjectOutputStream
@@ -24,11 +24,9 @@ object SequenceIds {
     observationId: Observation.Id,
     params:        GeneratorParams
   ): UUID =
-    toUuid { s =>
-      s.write(commitHash.toByteArray)
-      s.writeObject(observationId)
-      s.writeObject(params)
-    }
+    UUID.nameUUIDFromBytes(
+      Array.concat(commitHash.hashBytes, observationId.hashBytes, params.hashBytes)
+    )
 
   def atomId(
     namespace:    UUID,
@@ -80,4 +78,5 @@ object SequenceIds {
       }
     )
   }
+
 }

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -158,7 +158,7 @@ object Generator {
       ) {
 
         def namespace: UUID =
-           SequenceIds.namespace(commitHash, oid, params)
+          SequenceIds.namespace(commitHash, oid, params)
 
         val acquisitionIntegrationTime: IntegrationTime =
           itcRes.acquisitionResult.focus.value

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -40,6 +40,7 @@ import lucuma.odb.sequence.data.ProtoAtom
 import lucuma.odb.sequence.data.ProtoExecutionConfig
 import lucuma.odb.sequence.data.ProtoStep
 import lucuma.odb.sequence.gmos
+import lucuma.odb.sequence.syntax.hash.*
 import lucuma.odb.sequence.util.CommitHash
 import lucuma.odb.sequence.util.SequenceIds
 import lucuma.odb.service.ItcService
@@ -171,20 +172,19 @@ object Generator {
           itcRes.scienceResult.focus.value
 
         val hash: Md5Hash = {
-          val zero = 0.toByte
-          val md5  = MessageDigest.getInstance("MD5")
+          val md5 = MessageDigest.getInstance("MD5")
 
           // Observing Mode
           md5.update(params.observingMode.hashBytes)
 
           // Integration Time
           List(acquisitionIntegrationTime, scienceIntegrationTime).foreach { ing =>
-            md5.update(BigInt(ing.exposureTime.toMicroseconds).toByteArray.reverse.padTo(8, zero))
-            md5.update(BigInt(ing.exposures.value).toByteArray.reverse.padTo(4, zero))
+            md5.update(ing.exposureTime.hashBytes)
+            md5.update(ing.exposures.hashBytes)
           }
 
           // Commit Hash
-          md5.update(commitHash.toByteArray)
+          md5.update(commitHash.hashBytes)
 
           Md5Hash.unsafeFromByteArray(md5.digest())
         }

--- a/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
@@ -448,32 +448,6 @@ object SequenceService {
     def encodeColumns(prefix: Option[String], columns: List[String]): String =
       columns.map(c => s"${prefix.foldMap(_ + ".")}$c").intercalate(",\n")
 
-// TODO: I would like to write the insert step config logic once, parameterized
-// by the table name, columns, and the encoder.  I think I'm being thwarted by
-// scala.quoted / macro issues?
-//
-//[error] /Users/swalker/dev/lucuma-odb/modules/core/shared/src/main/scala-3/syntax/StringContextOps.scala: Found:    skunk.Encoder[A]
-//[error] Required: skunk.Encoder[Nothing *: Nothing]
-//[error] one error found
-//[error] (service / Compile / compileIncremental) Compilation failed
-//
-// is there a way to get this method the context information that the macro is expecting?
-//
-//    def insertStepConfig[A: Type](table: String, columns: List[String], encoderA: Encoder[A]): Command[(Step.Id, A)] = {
-//      val f: Fragment[Void] = sql"""
-//        INSERT INTO #$table (
-//          c_step_id,
-//          #${encodeColumns(None, columns)}
-//        )"""
-//
-//      sql"""
-//        $f
-//        SELECT
-//          $step_id,
-//          $encoderA
-//      """.command
-//    }
-
     private def insertStepConfigFragment(table: String, columns: List[String]): Fragment[Void] =
       sql"""
         INSERT INTO #$table (
@@ -495,7 +469,6 @@ object SequenceService {
       )
 
     val InsertStepConfigGcal: Command[(Step.Id, StepConfig.Gcal)] =
-//      insertStepConfig[StepConfig.Gcal]("t_step_config_gcal", StepConfigGcalColumns, step_config_gcal)
       sql"""
         ${insertStepConfigFragment("t_step_config_gcal", StepConfigGcalColumns)} SELECT
           $step_id,
@@ -510,7 +483,6 @@ object SequenceService {
       )
 
     val InsertStepConfigScience: Command[(Step.Id, StepConfig.Science)] =
-//      insertStepConfig[StepConfig.Science]("t_step_config_science", StepConfigGcalColumns, step_config_science)
       sql"""
         ${insertStepConfigFragment("t_step_config_science", StepConfigScienceColumns)} SELECT
           $step_id,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/package.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/package.scala
@@ -9,7 +9,7 @@ import io.circe.Decoder
 package object graphql {
 
   implicit class ACursorOps(hc: ACursor) {
-    def downFields(fields: String*) = fields.foldLeft(hc)(_ downField _)
+    def downFields(fields: String*): ACursor = fields.foldLeft(hc)(_ downField _)
     def require[A: Decoder]: A = hc.as[A].fold(e => sys.error(e.message), identity)
   }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
@@ -28,7 +28,7 @@ trait ObservingModeSetupOperations extends DatabaseOperations { this: OdbSuite =
     createObservationWithModeAs(
       user,
       pid,
-      tids.toList,
+      tids,
       """
         gmosNorthLongSlit: {
           grating: R831_G5302,
@@ -53,7 +53,7 @@ trait ObservingModeSetupOperations extends DatabaseOperations { this: OdbSuite =
     createObservationWithModeAs(
       user,
       pid,
-      tids.toList,
+      tids,
       """
         gmosSouthLongSlit: {
           grating: R600_G5324,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
@@ -1856,20 +1856,33 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
     query(user, q).void
   }
 
-  private val GmosNorthScience = GmosNorth(
-    TimeSpan.unsafeFromMicroseconds(10_000_000L),
-    GmosCcdMode(GmosXBinning.One, GmosYBinning.Two, GmosAmpCount.Twelve, GmosAmpGain.Low, GmosAmpReadMode.Slow),
-    GmosDtax.Zero,
-    GmosRoi.FullFrame,
-    GmosGratingConfig.North(GmosNorthGrating.R831_G5302, GmosGratingOrder.One, Wavelength.decimalNanometers.unsafeGet(BigDecimal("500.0"))).some,
-    GmosNorthFilter.RPrime.some,
-    GmosFpuMask.Builtin(GmosNorthFpu.LongSlit_0_50).some
-  )
+  private val OneSecond      = TimeSpan.unsafeFromMicroseconds( 1_000_000L)
+  private val TenSeconds     = TimeSpan.unsafeFromMicroseconds(10_000_000L)
 
-  private val GmosNorthFlat = GmosNorthScience.copy(exposure = TimeSpan.unsafeFromMicroseconds(1_000_000L))
+  private val GmosNorthScience0: GmosNorth =
+    GmosNorth(
+      TenSeconds,
+      GmosCcdMode(GmosXBinning.One, GmosYBinning.Two, GmosAmpCount.Twelve, GmosAmpGain.Low, GmosAmpReadMode.Slow),
+      GmosDtax.Zero,
+      GmosRoi.FullFrame,
+      GmosGratingConfig.North(GmosNorthGrating.R831_G5302, GmosGratingOrder.One, Wavelength.decimalNanometers.unsafeGet(BigDecimal("500.0"))).some,
+      GmosNorthFilter.RPrime.some,
+      GmosFpuMask.Builtin(GmosNorthFpu.LongSlit_0_50).some
+    )
 
-  private val Science = StepConfig.Science(Offset.Zero, GuideState.Enabled)
-  private val Flat    = StepConfig.Gcal(Gcal.Lamp.fromContinuum(GcalContinuum.QuartzHalogen5W), GcalFilter.Gmos, GcalDiffuser.Ir, GcalShutter.Open)
+  private val GmosNorthScience5: GmosNorth =
+    GmosNorthScience0.copy(
+      gratingConfig = GmosNorthScience0.gratingConfig.map(_.copy(
+        wavelength = Wavelength.decimalNanometers.unsafeGet(BigDecimal("505.0"))
+      ))
+    )
+
+  private val GmosNorthFlat0 = GmosNorthScience0.copy(exposure = OneSecond)
+  private val GmosNorthFlat5 = GmosNorthScience5.copy(exposure = OneSecond)
+
+  private val Science00 = StepConfig.Science(Offset.Zero, GuideState.Enabled)
+  private val Science15 = StepConfig.Science(Offset.microarcseconds.reverseGet((0, 15_000_000L)), GuideState.Enabled)
+  private val Flat      = StepConfig.Gcal(Gcal.Lamp.fromContinuum(GcalContinuum.QuartzHalogen5W), GcalFilter.Gmos, GcalDiffuser.Ir, GcalShutter.Open)
 
   private val SetupOneStepGmosNorth: IO[(Observation.Id, Step.Id)] = {
     import lucuma.odb.json.all.transport.given
@@ -1880,7 +1893,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
       v <- recordVisitAs(user, Instrument.GmosNorth, o)
       a <- recordAtomAs(user, Instrument.GmosNorth, v)
-      s <- recordStepAs(user, a, Instrument.GmosNorth, GmosNorthScience, Science)
+      s <- recordStepAs(user, a, Instrument.GmosNorth, GmosNorthScience0, Science00)
       _ <- addEndStepEvent(s)
     } yield (o, s)
   }
@@ -1900,7 +1913,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
             .compile
             .toList
         }
-      }.map(lst => assertEquals(lst, List(s -> GmosNorthScience)))
+      }.map(lst => assertEquals(lst, List(s -> GmosNorthScience0)))
     }
   }
 
@@ -1913,7 +1926,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
             .selectGmosNorthSteps(o)(using xa)
         }
       }.map { m =>
-        assertEquals(m, Map(s -> (GmosNorthScience, Science)))
+        assertEquals(m, Map(s -> (GmosNorthScience0, Science00)))
       }
     }
   }
@@ -1929,7 +1942,101 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       }
     }
 
-    assertIO(m, scienceSingleAtom((GmosNorthScience, Science)))
+    assertIO(m, scienceSingleAtom((GmosNorthScience0, Science00)))
+  }
+
+  private val SetupTwoStepsGmosNorth: IO[(Observation.Id, Step.Id, Step.Id)] = {
+    import lucuma.odb.json.all.transport.given
+
+    for {
+      p <- createProgram
+      t <- createTargetWithProfileAs(user, p)
+      o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
+      v <- recordVisitAs(user, Instrument.GmosNorth, o)
+      a <- recordAtomAs(user, Instrument.GmosNorth, v, stepCount = 2)
+
+      sSci  <- recordStepAs(user, a, Instrument.GmosNorth, GmosNorthScience0, Science00)
+      _     <- addEndStepEvent(sSci)
+
+      sFlat <- recordStepAs(user, a, Instrument.GmosNorth, GmosNorthFlat0,    Flat)
+      _     <- addEndStepEvent(sFlat)
+
+    } yield (o, sSci, sFlat)
+  }
+
+  test("two gmos north dynamic steps - GmosSequenceService") {
+    SetupTwoStepsGmosNorth.flatMap { case (o, sSci, sFlat) =>
+      withServices(user) { services =>
+        services.session.transaction.use { xa =>
+          services
+            .gmosSequenceService
+            .selectGmosNorthDynamic(o)(using xa)
+            .compile
+            .toList
+            .map(_.toMap)
+        }
+      }.map { m =>
+        assertEquals(m, Map(sSci -> GmosNorthScience0, sFlat -> GmosNorthFlat0))
+      }
+    }
+  }
+
+  test("two gmos north dynamic steps - SequenceService steps") {
+    SetupTwoStepsGmosNorth.flatMap { case (o, sSci, sFlat) =>
+      withServices(user) { services =>
+        services.session.transaction.use { xa =>
+          services
+            .sequenceService
+            .selectGmosNorthSteps(o)(using xa)
+        }
+      }.map { m =>
+        assertEquals(m, Map(sSci -> (GmosNorthScience0, Science00), sFlat -> (GmosNorthFlat0, Flat)))
+      }
+    }
+  }
+
+  test("two gmos north dynamic steps - SequenceService atom counts") {
+    val m = SetupTwoStepsGmosNorth.flatMap { case (o, _, _) =>
+      withServices(user) { services =>
+        services.session.transaction.use { xa =>
+          services
+            .sequenceService
+            .selectGmosNorthCompletedAtomMap(o)(using xa)
+        }
+      }
+    }
+
+    assertIO(m, scienceSingleAtom((GmosNorthScience0, Science00), (GmosNorthFlat0, Flat)))
+  }
+
+  test("clear execution digest") {
+
+    val setup: IO[(Program.Id, Observation.Id, Step.Id)] = {
+      import lucuma.odb.json.all.transport.given
+
+      for {
+        p <- createProgram
+        t <- createTargetWithProfileAs(user, p)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
+        v <- recordVisitAs(user, Instrument.GmosNorth, o)
+        a <- recordAtomAs(user, Instrument.GmosNorth, v)
+        s <- recordStepAs(user, a, Instrument.GmosNorth, GmosNorthScience0, Science00)
+      } yield (p, o, s)
+    }
+
+    val isEmpty = setup.flatMap { case (p, o, s) =>
+      withServices(user) { services =>
+        services.session.transaction.use { xa =>
+          for {
+            _ <- services.executionDigestService.insertOrUpdate(p, o, Md5Hash.Zero, ExecutionDigest.Zero)(using xa)
+            _ <- services.executionEventService.insertStepEvent(s, StepStage.EndStep)(using xa)
+            d <- services.executionDigestService.selectOne(p, o, Md5Hash.Zero)(using xa)
+          } yield d.isEmpty
+        }
+      }
+    }
+
+    assertIOBoolean(isEmpty, "The execution digest should be removed")
   }
 
   def genGmosNorthSequence(oid: Observation.Id, futureLimit: Int): IO[List[Atom.Id]] =
@@ -1962,7 +2069,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
       n :: fs
     }
 
-  test("one gmos north dynamic step - Generator") {
+  test("execute the first step") {
 
     import lucuma.odb.json.all.transport.given
 
@@ -1972,114 +2079,100 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
         p      <- createProgram
         t      <- createTargetWithProfileAs(user, p)
         o      <- createGmosNorthLongSlitObservationAs(user, p, List(t))
-        before <- genGmosNorthSequence(o, 3)
+        before <- genGmosNorthSequence(o, 5)
         v      <- recordVisitAs(user, Instrument.GmosNorth, o)
         a0     <- recordAtomAs(user, Instrument.GmosNorth, v, stepCount = 2)
-        s0     <- recordStepAs(user, a0, Instrument.GmosNorth, GmosNorthScience, Science)
+        s0     <- recordStepAs(user, a0, Instrument.GmosNorth, GmosNorthScience0, Science00)
         _      <- addEndStepEvent(s0)
-        s1     <- recordStepAs(user, a0, Instrument.GmosNorth, GmosNorthFlat, Flat)
+        s1     <- recordStepAs(user, a0, Instrument.GmosNorth, GmosNorthFlat0, Flat)
         _      <- addEndStepEvent(s1)
-        after  <- genGmosNorthSequence(o, 2)
+        after  <- genGmosNorthSequence(o, 4)
       } yield (before, after)
 
-    // THe tail of before should equal after since the first atom has been executed.
+    // The tail of `before` should equal `after` since the first atom has been executed.
     val result = beforeAndAfter.map { case (before, after) => before.tail === after }
 
     assertIOBoolean(result)
   }
 
-  private val SetupTwoStepsGmosNorth: IO[(Observation.Id, Step.Id, Step.Id)] = {
+  test("execute the second step") {
+
     import lucuma.odb.json.all.transport.given
 
-    for {
-      p <- createProgram
-      t <- createTargetWithProfileAs(user, p)
-      o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
-      v <- recordVisitAs(user, Instrument.GmosNorth, o)
-      a <- recordAtomAs(user, Instrument.GmosNorth, v, stepCount = 2)
-
-      sSci  <- recordStepAs(user, a, Instrument.GmosNorth, GmosNorthScience, Science)
-      _     <- addEndStepEvent(sSci)
-
-      sFlat <- recordStepAs(user, a, Instrument.GmosNorth, GmosNorthFlat,    Flat)
-      _     <- addEndStepEvent(sFlat)
-
-    } yield (o, sSci, sFlat)
-  }
-
-  test("two gmos north dynamic steps - GmosSequenceService") {
-    SetupTwoStepsGmosNorth.flatMap { case (o, sSci, sFlat) =>
-      withServices(user) { services =>
-        services.session.transaction.use { xa =>
-          services
-            .gmosSequenceService
-            .selectGmosNorthDynamic(o)(using xa)
-            .compile
-            .toList
-            .map(_.toMap)
-        }
-      }.map { m =>
-        assertEquals(m, Map(sSci -> GmosNorthScience, sFlat -> GmosNorthFlat))
-      }
-    }
-  }
-
-  test("two gmos north dynamic steps - SequenceService steps") {
-    SetupTwoStepsGmosNorth.flatMap { case (o, sSci, sFlat) =>
-      withServices(user) { services =>
-        services.session.transaction.use { xa =>
-          services
-            .sequenceService
-            .selectGmosNorthSteps(o)(using xa)
-        }
-      }.map { m =>
-        assertEquals(m, Map(sSci -> (GmosNorthScience, Science), sFlat -> (GmosNorthFlat, Flat)))
-      }
-    }
-  }
-
-  test("two gmos north dynamic steps - SequenceService atom counts") {
-    val m = SetupTwoStepsGmosNorth.flatMap { case (o, _, _) =>
-      withServices(user) { services =>
-        services.session.transaction.use { xa =>
-          services
-            .sequenceService
-            .selectGmosNorthCompletedAtomMap(o)(using xa)
-        }
-      }
-    }
-
-    assertIO(m, scienceSingleAtom((GmosNorthScience, Science), (GmosNorthFlat, Flat)))
-  }
-
-  test("clear execution digest") {
-
-    val setup: IO[(Program.Id, Observation.Id, Step.Id)] = {
-      import lucuma.odb.json.all.transport.given
-
+    // Atom.Id list before and after recording the steps for the first atom.
+    val beforeAndAfter =
       for {
-        p <- createProgram
-        t <- createTargetWithProfileAs(user, p)
-        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
-        v <- recordVisitAs(user, Instrument.GmosNorth, o)
-        a <- recordAtomAs(user, Instrument.GmosNorth, v)
-        s <- recordStepAs(user, a, Instrument.GmosNorth, GmosNorthScience, Science)
-      } yield (p, o, s)
+        p      <- createProgram
+        t      <- createTargetWithProfileAs(user, p)
+        o      <- createGmosNorthLongSlitObservationAs(user, p, List(t))
+        before <- genGmosNorthSequence(o, 5)
+        v      <- recordVisitAs(user, Instrument.GmosNorth, o)
+        a0     <- recordAtomAs(user, Instrument.GmosNorth, v, stepCount = 2)
+        s0     <- recordStepAs(user, a0, Instrument.GmosNorth, GmosNorthFlat5, Flat)
+        _      <- addEndStepEvent(s0)
+        s1     <- recordStepAs(user, a0, Instrument.GmosNorth, GmosNorthScience5, Science15)
+        _      <- addEndStepEvent(s1)
+        after  <- genGmosNorthSequence(o, 4)
+      } yield (before, after)
+
+    // `after` should be the same as `before` with atom at index 1 removed, since
+    // the second atom was successfully executed.
+    val result = beforeAndAfter.map { case (before, after) =>
+      before.head :: before.tail.tail === after
     }
 
-    val isEmpty = setup.flatMap { case (p, o, s) =>
-      withServices(user) { services =>
-        services.session.transaction.use { xa =>
-          for {
-            _ <- services.executionDigestService.insertOrUpdate(p, o, Md5Hash.Zero, ExecutionDigest.Zero)(using xa)
-            _ <- services.executionEventService.insertStepEvent(s, StepStage.EndStep)(using xa)
-            d <- services.executionDigestService.selectOne(p, o, Md5Hash.Zero)(using xa)
-          } yield d.isEmpty
-        }
-      }
-    }
+    assertIOBoolean(result)
+  }
 
-    assertIOBoolean(isEmpty, "The execution digest should be removed")
+  test("incomplete atoms") {
+
+    import lucuma.odb.json.all.transport.given
+
+    // Atom.Id list before and after recording the steps for the first atom.
+    val beforeAndAfter =
+      for {
+        p      <- createProgram
+        t      <- createTargetWithProfileAs(user, p)
+        o      <- createGmosNorthLongSlitObservationAs(user, p, List(t))
+        before <- genGmosNorthSequence(o, 5)
+        v      <- recordVisitAs(user, Instrument.GmosNorth, o)
+        a0     <- recordAtomAs(user, Instrument.GmosNorth, v, stepCount = 2)
+        s0     <- recordStepAs(user, a0, Instrument.GmosNorth, GmosNorthScience0, Science00)
+        _      <- addEndStepEvent(s0)
+        a1     <- recordAtomAs(user, Instrument.GmosNorth, v, stepCount = 2)
+        s1     <- recordStepAs(user, a1, Instrument.GmosNorth, GmosNorthScience5, Science15)
+        _      <- addEndStepEvent(s1)
+        after  <- genGmosNorthSequence(o, 5)
+      } yield (before, after)
+
+    // No atoms have been completed, just the first steps of two different atoms
+    assertIOBoolean(beforeAndAfter.map { case (before, after) => before === after })
+  }
+
+  test("split atom") {
+
+    import lucuma.odb.json.all.transport.given
+
+    // Atom.Id list before and after recording the steps for the first atom.
+    val beforeAndAfter =
+      for {
+        p      <- createProgram
+        t      <- createTargetWithProfileAs(user, p)
+        o      <- createGmosNorthLongSlitObservationAs(user, p, List(t))
+        before <- genGmosNorthSequence(o, 5)
+        v      <- recordVisitAs(user, Instrument.GmosNorth, o)
+        a0     <- recordAtomAs(user, Instrument.GmosNorth, v, stepCount = 2)
+        s0     <- recordStepAs(user, a0, Instrument.GmosNorth, GmosNorthScience0, Science00)
+        _      <- addEndStepEvent(s0)
+        s1     <- recordStepAs(user, a0, Instrument.GmosNorth, GmosNorthFlat5, Flat)
+        _      <- addEndStepEvent(s1)
+        s2     <- recordStepAs(user, a0, Instrument.GmosNorth, GmosNorthFlat0, Flat)
+        _      <- addEndStepEvent(s2)
+        after  <- genGmosNorthSequence(o, 5)
+      } yield (before, after)
+
+    // The first atom is broken by another step, so nothing has been successfully completed
+    assertIOBoolean(beforeAndAfter.map { case (before, after) => before === after })
   }
 
 }


### PR DESCRIPTION
## Atom Filtering

The main thrust of this PR filters executed atoms from sequence generation.  Toward that end:

* `CompletedAtomMap` is promoted as a named (albeit `opaque`) type instead of the last PR’s raw `Map`.  Recall that it is a map from atom configuration to the number of executed atoms that match that configuration.  `CompletedAtomMap` contains an extension for matching against generated atoms.

* The match key in `CompletedAtomMap` is augmented with the sequence type so that acquisition and science atoms don’t count toward the completion of the opposite sequence type.

* Another complication is that the generated Atom IDs are based in part on the atom index of the generated sequence.  Since executed atoms are going to be filtered out, we need to zip the atom sequence with its index in order to keep from changing the atom ids of subsequent atoms.

## `HashBytes`

Along the way, I discovered that the “namespace” UUID used in creating atom and step IDs had a bug.  Namely, two identical `GeneratorParams` instances according to `Eq` would produce different namespace UUIDs.  This is presumably due to a difference in the way the objects are serialized.  Instead of writing the `GeneratorParams` to a `ByteArrayOutputStream` then, I added a `HashBytes` typeclass to explicitly convert implementing instances to an `Array[Byte]` that can be used to produce an `MD5` hash.