### PR TITLE
Reconcile modes

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/ObservingMode.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/ObservingMode.scala
@@ -3,6 +3,8 @@
 
 package lucuma.odb.sequence
 
+import cats.data.NonEmptyList
+import cats.syntax.option.*
 import lucuma.odb.sequence.util.HashBytes
 
 /**
@@ -12,11 +14,22 @@ type ObservingMode =
   gmos.longslit.Config.GmosNorth |
   gmos.longslit.Config.GmosSouth
 
-given HashBytes[ObservingMode] with {
-  def hashBytes(a: ObservingMode): Array[Byte] =
-    a match {
-      case gn: gmos.longslit.Config.GmosNorth => gn.hashBytes
-      case gs: gmos.longslit.Config.GmosSouth => gs.hashBytes
-    }
-}
+object ObservingMode {
 
+  def reconcile(modes: NonEmptyList[ObservingMode]): Option[ObservingMode] = {
+    modes.toList match {
+      case m :: Nil => m.some
+      case
+    }
+
+  }
+
+  given HashBytes[ObservingMode] with {
+    def hashBytes(a: ObservingMode): Array[Byte] =
+      a match {
+        case gn: gmos.longslit.Config.GmosNorth => gn.hashBytes
+        case gs: gmos.longslit.Config.GmosSouth => gs.hashBytes
+      }
+  }
+
+}

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/ObservingMode.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/ObservingMode.scala
@@ -17,8 +17,8 @@ object ObservingMode {
 
   def reconcile(modes: NonEmptyList[ObservingMode]): Option[ObservingMode] =
     modes.head match {
-        case gn: GmosNorth => GmosNorth.reconcile(gn, modes.tail)
-        case gs: GmosSouth => GmosSouth.reconcile(gs, modes.tail)
+      case gn: GmosNorth => GmosNorth.reconcile(gn, modes.tail)
+      case gs: GmosSouth => GmosSouth.reconcile(gs, modes.tail)
     }
 
   given HashBytes[ObservingMode] with {

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/ObservingMode.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/ObservingMode.scala
@@ -4,31 +4,28 @@
 package lucuma.odb.sequence
 
 import cats.data.NonEmptyList
-import cats.syntax.option.*
+import lucuma.odb.sequence.gmos.longslit.Config.GmosNorth
+import lucuma.odb.sequence.gmos.longslit.Config.GmosSouth
 import lucuma.odb.sequence.util.HashBytes
 
 /**
  * All observing mode options.
  */
-type ObservingMode =
-  gmos.longslit.Config.GmosNorth |
-  gmos.longslit.Config.GmosSouth
+type ObservingMode = GmosNorth | GmosSouth
 
 object ObservingMode {
 
-  def reconcile(modes: NonEmptyList[ObservingMode]): Option[ObservingMode] = {
-    modes.toList match {
-      case m :: Nil => m.some
-      case
+  def reconcile(modes: NonEmptyList[ObservingMode]): Option[ObservingMode] =
+    modes.head match {
+        case gn: GmosNorth => GmosNorth.reconcile(gn, modes.tail)
+        case gs: GmosSouth => GmosSouth.reconcile(gs, modes.tail)
     }
-
-  }
 
   given HashBytes[ObservingMode] with {
     def hashBytes(a: ObservingMode): Array[Byte] =
       a match {
-        case gn: gmos.longslit.Config.GmosNorth => gn.hashBytes
-        case gs: gmos.longslit.Config.GmosSouth => gs.hashBytes
+        case gn: GmosNorth => gn.hashBytes
+        case gs: GmosSouth => gs.hashBytes
       }
   }
 

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Config.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Config.scala
@@ -214,7 +214,7 @@ object Config {
         case None                                                  =>
           a.some
 
-        case Some(b@GmosNorth(_, _, _, _, _, _, _, _, _, _, _, _)) =>
+        case Some(b: GmosNorth) =>
           if (a === b)
             reconcile(a, modes.tail)
           else {
@@ -305,7 +305,7 @@ object Config {
         case None                                                  =>
           a.some
 
-        case Some(b@GmosSouth(_, _, _, _, _, _, _, _, _, _, _, _)) =>
+        case Some(b: GmosSouth) =>
           if (a === b)
             reconcile(a, modes.tail)
           else {

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Config.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Config.scala
@@ -4,6 +4,8 @@
 package lucuma.odb.sequence.gmos.longslit
 
 import cats.Eq
+import cats.syntax.option.*
+import cats.syntax.order.*
 import coulomb.*
 import eu.timepit.refined.types.numeric.PosDouble
 import eu.timepit.refined.types.numeric.PosInt
@@ -205,6 +207,14 @@ object Config {
         explicitWavelengthDithers,
         explicitSpatialOffsets
       )
+
+    def reconcile(a: GmosNorth, modes: List[ObservingMode]): Option[GmosNorth] =
+      modes match {
+        case Nil                                                             =>
+          a.some
+        case b @ GmosNorth(_, _, _, _, _, _, _, _, _, _, _, _, _, _) :: rest =>
+          a.xBin min b.
+      }
 
     given Eq[GmosNorth] =
       Eq.by { a => (

--- a/modules/service/src/main/scala/lucuma/odb/service/GmosLongSlitService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GmosLongSlitService.scala
@@ -96,7 +96,7 @@ trait GmosLongSlitService[F[_]] {
 
 object GmosLongSlitService {
 
-  val Sampling: PosDouble = PosDouble.unsafeFrom(2.0)
+  val Sampling: PosDouble = PosDouble.unsafeFrom(2.5)
 
   def instantiate[F[_]: Concurrent](using Services[F]): GmosLongSlitService[F] =
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import io.circe.syntax.*
 import lucuma.core.enums.ObsActiveStatus
 import lucuma.core.enums.ObsStatus
+import lucuma.core.math.Angle
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Target
@@ -205,6 +206,76 @@ trait ObservingModeSetupOperations extends DatabaseOperations { this: OdbSuite =
       _.hcursor.downFields("createTarget", "target", "id").require[Target.Id]
     )
 
+  def createTargetWithGaussianAs(
+    user: User,
+    pid:  Program.Id,
+    fwhm: Angle
+  ): IO[Target.Id] =
+    query(
+      user  = user,
+      query =
+      s"""
+         mutation {
+           createTarget(input: {
+             programId: ${pid.asJson},
+             SET: {
+               name: "V1647 Orionis"
+               sidereal: {
+                 ra: { hms: "05:46:13.137" },
+                 dec: { dms: "-00:06:04.89" },
+                 epoch: "J2000.0",
+                 properMotion: {
+                   ra: {
+                     milliarcsecondsPerYear: 0.918
+                   },
+                   dec: {
+                     milliarcsecondsPerYear: -1.057
+                   },
+                 },
+                 radialVelocity: {
+                   kilometersPerSecond: 27.58
+                 },
+                 parallax: {
+                   milliarcseconds: 2.422
+                 }
+               },
+               sourceProfile: {
+                 gaussian: {
+                   fwhm: {
+                     microarcseconds: ${fwhm.toMicroarcseconds}
+                   },
+                   spectralDefinition: {
+                     bandNormalized: {
+                       sed: {
+                         stellarLibrary: O5_V
+                       },
+                       brightnesses: [
+                         {
+                           band: J,
+                           value: 14.74,
+                           units: VEGA_MAGNITUDE
+                         },
+                         {
+                           band: V,
+                           value: 18.1,
+                           units: VEGA_MAGNITUDE
+                         }
+                       ]
+                     }
+                   }
+                 }
+               }
+             }
+           }) {
+             target {
+               id
+             }
+           }
+         }
+      """
+    ).map(
+      _.hcursor.downFields("createTarget", "target", "id").require[Target.Id]
+    )
 
 }
 


### PR DESCRIPTION
When there are multiple targets in an asterism, the computed observing mode configuration may differ across targets.  This happens for GMOS Long Slit, for example, because the source profile is used in calculating the object size which in turn is a parameter in the optimal binning calculation.  The current implementation throws up its hands when it encounters differing binning settings across targets.  Upon consultation, we learned that the proper way to handle this is to choose the minimum binning value of any of the targets.  This PR makes that change, but any other differences in the observing mode configuration derived from the various targets would continue to be rejected.

Note there will be additional updates to the binning calculation in future PRs based on new requirements, as soon as I can work out what they mean.