### PR TITLE
make the refined codec names more consistent

### DIFF
--- a/modules/service/src/main/scala/db/migration/SmartGcalTable.scala
+++ b/modules/service/src/main/scala/db/migration/SmartGcalTable.scala
@@ -91,7 +91,7 @@ object SmartGcalTable {
   def valueEncoder[A](using e: Encoder[A]): Encoder[SmartGcalValue[A]] =
     (
       step_config_gcal *:
-      pos_int          *:
+      int4_pos          *:
       gcal_baseline    *:
       e
     ).contramap[SmartGcalValue[A]] { v => (

--- a/modules/service/src/main/scala/db/migration/SmartGcalTable.scala
+++ b/modules/service/src/main/scala/db/migration/SmartGcalTable.scala
@@ -91,7 +91,7 @@ object SmartGcalTable {
   def valueEncoder[A](using e: Encoder[A]): Encoder[SmartGcalValue[A]] =
     (
       step_config_gcal *:
-      int4_pos          *:
+      int4_pos         *:
       gcal_baseline    *:
       e
     ).contramap[SmartGcalValue[A]] { v => (

--- a/modules/service/src/main/scala/db/migration/SmartGmosLoader.scala
+++ b/modules/service/src/main/scala/db/migration/SmartGmosLoader.scala
@@ -76,7 +76,7 @@ object SmartGmosLoader {
 
   def encoder[G, L, U](using k: Encoder[TableKey[G, L, U]], v: Encoder[SmartGcalValue.Legacy]): Encoder[TableRow[G, L, U]] =
     (
-      pos_long *:
+      int8_pos *:
       k        *:
       v
     ).contramap[TableRow[G, L, U]] { r => (

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/DatasetEventTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/DatasetEventTable.scala
@@ -8,7 +8,7 @@ import lucuma.odb.util.Codecs.core_timestamp
 import lucuma.odb.util.Codecs.dataset_stage
 import lucuma.odb.util.Codecs.execution_event_id
 import lucuma.odb.util.Codecs.int2_nonneg
-import lucuma.odb.util.Codecs.pos_int
+import lucuma.odb.util.Codecs.int4_pos
 import lucuma.odb.util.Codecs.site
 import lucuma.odb.util.Codecs.step_id
 import skunk.codec.temporal.date
@@ -29,7 +29,7 @@ trait DatasetEventTable[F[_]] extends BaseMapping[F] {
     object DatasetFilename {
       val FileSite: ColumnRef   = col("c_file_site",          site.opt)
       val FileDate: ColumnRef   = col("c_file_date",          date.opt)
-      val FileIndex: ColumnRef  = col("c_file_index",         pos_int.opt)
+      val FileIndex: ColumnRef  = col("c_file_index",         int4_pos.opt)
     }
   }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
@@ -88,7 +88,7 @@ trait ObservationView[F[_]] extends BaseMapping[F] {
             val Value: ColumnRef       = col("c_spec_focal_plane_angle",    angle_µas.embedded)
           }
 
-          val Resolution: ColumnRef         = col("c_spec_resolution",          pos_int.opt)          
+          val Resolution: ColumnRef         = col("c_spec_resolution",          int4_pos.opt)
           val SignalToNoise: ColumnRef      = col("c_spec_signal_to_noise",     signal_to_noise.opt)        
           val FocalPlane: ColumnRef         = col("c_spec_focal_plane",         focal_plane.opt)
           val Capability: ColumnRef         = col("c_spec_capability",          spectroscopy_capabilities.opt)

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -456,7 +456,7 @@ object ItcService {
 
   object Statements {
     private val integration_time: Codec[IntegrationTime] =
-      (time_span *: pos_int *: signal_to_noise).to[IntegrationTime]
+      (time_span *: int4_pos *: signal_to_noise).to[IntegrationTime]
 
     val UpdateItcVersion: Command[(
       Option[String],
@@ -541,18 +541,18 @@ object ItcService {
           $target_id,
           $md5_hash,
           $time_span,
-          $pos_int,
+          $int4_pos,
           $signal_to_noise,
           $time_span,
-          $pos_int,
+          $int4_pos,
           $signal_to_noise
         ON CONFLICT ON CONSTRAINT t_itc_result_pkey DO UPDATE
           SET c_hash                 = $md5_hash,
               c_sci_exposure_time    = $time_span,
-              c_sci_exposure_count   = $pos_int,
+              c_sci_exposure_count   = $int4_pos,
               c_sci_signal_to_noise  = $signal_to_noise,
               c_acq_exposure_time    = $time_span,
-              c_acq_exposure_count   = $pos_int,
+              c_acq_exposure_count   = $int4_pos,
               c_acq_signal_to_noise  = $signal_to_noise
       """.command
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -572,7 +572,7 @@ object ObservationService {
           ${hour_angle_range_value.opt},
           $science_mode,
           ${wavelength_pm.opt},
-          ${pos_int.opt},
+          ${int4_pos.opt},
           ${signal_to_noise.opt},
           ${wavelength_pm.opt},
           ${wavelength_pm.opt},
@@ -664,7 +664,7 @@ object ObservationService {
     def spectroscopyRequirementsUpdates(in: SpectroscopyScienceRequirementsInput): List[AppliedFragment] = {
 
       val upWavelength         = sql"c_spec_wavelength = ${wavelength_pm.opt}"
-      val upResolution         = sql"c_spec_resolution = ${pos_int.opt}"
+      val upResolution         = sql"c_spec_resolution = ${int4_pos.opt}"
       val upSignalToNoise      = sql"c_spec_signal_to_noise = ${signal_to_noise.opt}"
       val upSignalToNoiseAt    = sql"c_spec_signal_to_noise_at = ${wavelength_pm.opt}"
       val upWavelengthCoverage = sql"c_spec_wavelength_coverage = ${wavelength_pm.opt}"

--- a/modules/service/src/main/scala/lucuma/odb/service/SmartGcalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SmartGcalService.scala
@@ -114,7 +114,7 @@ object SmartGcalService {
         f: TimeSpan => D => D
       ): F[List[(D => D, Gcal)]] =
         session
-          .prepareR(af.fragment.query(step_config_gcal ~ pos_int ~ time_span))
+          .prepareR(af.fragment.query(step_config_gcal ~ int4_pos ~ time_span))
           .use(_.stream(af.argument, chunkSize = 16).compile.to(List))
           .map {
             _.flatMap { case ((gcal, count), exposureTime) =>
@@ -285,7 +285,7 @@ object SmartGcalService {
           $instrument,
           $int4,
           $step_config_gcal,
-          $pos_int,
+          $int4_pos,
           $gcal_baseline
       """
 
@@ -320,7 +320,7 @@ object SmartGcalService {
         ) SELECT
           $instrument,
           $int4,
-          $pos_long,
+          $int8_pos,
           ${gmos_north_grating.opt},
           ${gmos_north_filter.opt},
           ${gmos_north_fpu.opt},
@@ -363,7 +363,7 @@ object SmartGcalService {
         ) SELECT
           $instrument,
           $int4,
-          $pos_long,
+          $int8_pos,
           ${gmos_south_grating.opt},
           ${gmos_south_filter.opt},
           ${gmos_south_fpu.opt},

--- a/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
@@ -5,11 +5,14 @@ package lucuma.odb.util
 
 import cats.syntax.apply.*
 import cats.syntax.option.*
+import eu.timepit.refined.types.numeric.NonNegBigDecimal
 import eu.timepit.refined.types.numeric.NonNegInt
+import eu.timepit.refined.types.numeric.NonNegLong
 import eu.timepit.refined.types.numeric.NonNegShort
 import eu.timepit.refined.types.numeric.PosBigDecimal
 import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.types.numeric.PosLong
+import eu.timepit.refined.types.numeric.PosShort
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.*
 import lucuma.core.math.Angle
@@ -275,20 +278,29 @@ trait Codecs {
   val partner: Codec[Partner] =
     enumerated(Type.varchar)
 
-  val pos_big_decimal: Codec[PosBigDecimal] =
+  val numeric_nonneg: Codec[NonNegBigDecimal] =
+    numeric.eimap(NonNegBigDecimal.from)(_.value)
+
+  val numeric_pos: Codec[PosBigDecimal] =
     numeric.eimap(PosBigDecimal.from)(_.value)
-
-  val pos_int: Codec[PosInt] =
-    int4.eimap(PosInt.from)(_.value)
-
-  val pos_long: Codec[PosLong] =
-    int8.eimap(PosLong.from)(_.value)
 
   val int2_nonneg: Codec[NonNegShort] =
     int2.eimap(NonNegShort.from)(_.value)
 
+  val int2_pos: Codec[PosShort] =
+    int2.eimap(PosShort.from)(_.value)
+
   val int4_nonneg: Codec[NonNegInt] =
     int4.eimap(NonNegInt.from)(_.value)
+
+  val int4_pos: Codec[PosInt] =
+    int4.eimap(PosInt.from)(_.value)
+
+  val int8_nonneg: Codec[NonNegLong] =
+    int8.eimap(NonNegLong.from)(_.value)
+
+  val int8_pos: Codec[PosLong] =
+    int8.eimap(PosLong.from)(_.value)
 
   val program_id: Codec[Program.Id] =
     gid[Program.Id]
@@ -440,7 +452,7 @@ trait Codecs {
     (step_id *: int2_nonneg).to[Dataset.Id]
 
   val dataset_filename: Codec[Dataset.Filename] =
-    (site *: date *: pos_int).eimap { case (s, d, p) =>
+    (site *: date *: int4_pos).eimap { case (s, d, p) =>
       Dataset.Filename.from(s, d, p).toRight(s"Unsupported date: $d")
     } { f =>
       (f.site, f.localDate, f.index)


### PR DESCRIPTION
It bugged me that we had inconsistent naming for the skunk codecs related to `refined` types.  I think I introduced `pos_int` some time ago not knowing that the preferred form matches the underlying database type more closely.  At any rate we had `pos_int` and `int4_nonneg` and now it consistently matches `<database type>_<refinement>`:

* `int4_nonneg`
* `int4_pos`

etc.