### PR TITLE
add parent information to groups

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -6485,6 +6485,12 @@ type Group {
 
   id: GroupId!
 
+  "Id of this group's parent, or null if this group is at the top level."
+  parentId: GroupId
+
+  "Position of this group in its parent group (or at the top level)."
+  parentIndex: NonNegShort!
+
   "Optionally, a name"
   name: String
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GroupMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GroupMapping.scala
@@ -25,8 +25,8 @@ trait GroupMapping[F[_]] extends GroupView[F] with ProgramTable[F] with GroupEle
       tpe = GroupType,
       fieldMappings = List(
         SqlField("id", GroupView.Id, key = true),
-        SqlField("parentId", GroupView.ParentId, hidden = true),
-        SqlField("parentIndex", GroupView.ParentIndex, hidden = true),
+        SqlField("parentId", GroupView.ParentId),
+        SqlField("parentIndex", GroupView.ParentIndex),
         SqlField("name", GroupView.Name),
         SqlField("description", GroupView.Description),
         SqlField("minimumRequired", GroupView.MinRequired),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/GroupView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/GroupView.scala
@@ -15,7 +15,7 @@ trait GroupView[F[_]] extends BaseMapping[F] {
     val Id          = col("c_group_id", group_id)
     val ProgramId   = col("c_program_id", program_id)
     val ParentId    = col("c_parent_id", group_id.opt)
-    val ParentIndex = col("c_parent_index", int2)
+    val ParentIndex = col("c_parent_index", int2_nonneg)
     val Name        = col("c_name", text_nonempty.opt)
     val Description = col("c_description", text_nonempty.opt)
     val MinRequired = col("c_min_required", int2.opt)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -392,6 +392,13 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
       assertEquals(obt.map(_.spaces2), expected.map(_.spaces2))  // by comparing strings we get more useful errors
     }
 
+  def subscriptionExpectF(user: User, query: String, mutations: Either[List[(String, Option[JsonObject])], IO[Any]], expectedF: IO[List[Json]], variables: Option[JsonObject] = None) =
+    subscription(user, query, mutations, variables).flatMap { obt =>
+      expectedF.map { expected =>
+        assertEquals(obt.map(_.spaces2), expected.map(_.spaces2))  // by comparing strings we get more useful errors
+      }
+    }
+
   def withSession[A](f: Session[IO] => IO[A]): IO[A] =
     Resource.eval(IO(sessionFixture())).use(f)
 


### PR DESCRIPTION
Adds `parentId` and `parentIndex` to `type Group`. This just required adding them to the schema and exposing existing columns. Also added an improved test method for subscriptions. Resolves #439 