### PR TITLE
remove cached itc result when replacing a target with its clone

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/687.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/687.scala
@@ -1,0 +1,78 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package issue.github
+
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.model.Target
+import lucuma.odb.graphql.query.ObservingModeSetupOperations
+
+// https://github.com/gemini-hlsw/lucuma-odb/issues/687
+class GitHub_687 extends OdbSuite with ObservingModeSetupOperations {
+  val pi = TestUsers.Standard.pi(nextId, nextId)
+  val validUsers = List(pi)
+
+  test("clone target with replace_in, where obs has cached ITC results") {
+    for
+      pid <- createProgramAs(pi)
+      tid <- createTargetWithProfileAs(pi, pid)
+      o1  <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- expect(
+        user = pi,
+        query = s"""
+        query {
+          observation(observationId: ${o1.asJson}) {
+            itc {
+              science {
+                index
+              }
+            }
+          }
+        }
+        """,
+        expected = Right(
+          json"""
+            {
+              "observation" : {
+                "itc" : {
+                  "science" : {
+                    "index" : 0
+                  }
+                }
+              }
+            }
+          """
+        )
+      )
+      _   <- expect(
+        user = pi,
+        query = s"""
+          mutation {
+            cloneTarget(input: {
+              targetId: ${tid.asJson}
+              REPLACE_IN: [${o1.asJson}]
+            }) {
+              newTarget {
+                name
+              }
+            }
+          }
+        """,
+        expected = Right(
+          json"""
+            {
+              "cloneTarget" : {
+                "newTarget" : {
+                  "name" : "V1647 Orionis"
+                }
+              }
+            }
+          """
+        )
+      )
+    yield ()
+  }
+
+}


### PR DESCRIPTION
Resolves #687, which was triggered when a target is replaced with its own clone in an observation with cached ITC results. I'm deleting the ITC results in `TargetService` because you can't easily get ahold of an `ItcService` from there.