### PR TITLE
set dataset times on event reception

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/DatasetTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/DatasetTable.scala
@@ -36,7 +36,7 @@ trait DatasetTable[F[_]] extends BaseMapping[F] {
 
     object Time {
       val Start: ColumnRef     = col("c_start_time", core_timestamp.opt)
-      val End: ColumnRef       = col("c_start_time", core_timestamp.opt)
+      val End: ColumnRef       = col("c_end_time",   core_timestamp.opt)
     }
   }
 


### PR DESCRIPTION
The presence of a dataset end time (as recorded in the nullable `t_dataset.c_end_time` column) marks a completed dataset.  The dataset start and end times are inferred from dataset events.  We expect a number of events from Observe as it executes, but we need to know when it is really considered "done".  As it stands, the reception of an `EndWrite` dataset event that occurs sometime after a `StartObserve` dataset event will cause the end time to be set and hence mark the dataset as done.