### PR TITLE
Fixes skunk decode exception when observation has no configuration

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
@@ -513,4 +513,17 @@ class guideEnvironment extends OdbSuite with ObservingModeSetupOperations {
       expected = List(s"Error calling Gaia: 'No valid guide star candidates were returned for observation $oid.'").asLeft)
     }
   }
+
+  test("no configuration") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationWithNoModeAs(pi, p, t)
+      } yield o
+    setup.flatMap { oid =>
+      expect(pi, guideEnvironmentQuery(oid, aug3000),
+      expected = List(s"No configuration defined for observation $oid.").asLeft)
+    }
+  }
 }


### PR DESCRIPTION
I guess I must have thought that the decoder error message would be reported to the user, but it is not. Since not having a configuration is a common thing, the user needs a better error message than `An internal error of type DecodeException occurred`. 😆 