### PR TITLE
Use data from Generator in AGS

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
@@ -581,7 +581,7 @@ class guideEnvironment extends OdbSuite with ObservingModeSetupOperations {
       } yield o
     setup.flatMap { oid =>
       expect(pi, guideEnvironmentQuery(oid, aug3000),
-      expected = List(s"No configuration defined for observation $oid.").asLeft)
+      expected = List(s"Could not generate a sequence from the observation $oid: observing mode").asLeft)
     }
   }
 }


### PR DESCRIPTION
Adds `Generator.digestWithParmsAndHash()` for use by the `GuideEnvironmentService`. The hash is not needed quite yet, but guide star availability is also going to be cached. Since it depends on the digest, it seemed simpler to make use of the hash from the Generator as part of the hast for invalidating the cached GS availability. And, since the Generator was already getting the necessary configuration information, it seemed silly to get it again in the GuideEnvironmentService. 
