### PR TITLE
improve group events

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -3630,7 +3630,7 @@ input TargetEditInput {
 
 input GroupEditInput {
     """
-    Group ID
+    Group ID, or Null to watch top-level group(s), or omit to watch all groups.
     """
     groupId: GroupId
 
@@ -3686,10 +3686,13 @@ type GroupEdit {
   """
   editType: EditType!
 
+  "Assocated program"
+  program: Program!
+
   """
-  Edited object
+  Edited group, or null if it's the top-level group.
   """
-  value: Group!
+  value: Group
   id: Long! @deprecated(reason: "id is no longer computed; a constant value is returned")
 }
 

--- a/modules/service/src/main/resources/db/migration/V0379__obs_group_edit.sql
+++ b/modules/service/src/main/resources/db/migration/V0379__obs_group_edit.sql
@@ -1,0 +1,26 @@
+-- trigger for group edit event, when an observation is created or is moved
+CREATE OR REPLACE FUNCTION ch_obs_group_edit()
+  RETURNS trigger AS $$
+DECLARE
+BEGIN
+  -- notify old group, if any
+  IF (TG_OP = 'UPDATE' OR TG_OP = 'DELETE') THEN
+    PERFORM pg_notify('ch_group_edit', coalesce(OLD.c_group_id, 'null') || ',' || NEW.c_program_id || ',' || 'UPDATE');
+  END IF;
+  -- notify new group, if any
+  IF (TG_OP = 'INSERT' OR TG_OP = 'UPDATE' OR TG_OP = 'DELETE') THEN
+      PERFORM pg_notify('ch_group_edit', coalesce(NEW.c_group_id, 'null') || ',' || NEW.c_program_id || ',' || 'UPDATE');
+  END IF;
+  RETURN NEW; -- n.b. doesn't matter, it's an AFTER trigger
+END;
+$$ LANGUAGE plpgsql;
+
+-- call the trigger when an observation is added or deleted, or if the group columns are updated
+CREATE CONSTRAINT TRIGGER ch_obs_group_edit_trigger
+  AFTER INSERT
+     OR UPDATE OF c_group_id, c_group_index
+     OR DELETE 
+     ON t_observation
+  DEFERRABLE
+  FOR EACH ROW
+  EXECUTE PROCEDURE ch_obs_group_edit();

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GroupEditInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GroupEditInput.scala
@@ -7,10 +7,11 @@ package input
 import cats.syntax.apply.*
 import lucuma.core.model.Group
 import lucuma.core.model.Program
+import lucuma.odb.data.Nullable
 import lucuma.odb.graphql.binding.*
 
 final case class GroupEditInput(
-  groupId:   Option[Group.Id],
+  groupId:   Nullable[Group.Id],
   programId: Option[Program.Id]
 )
 
@@ -18,7 +19,7 @@ object GroupEditInput {
 
   val Binding = ObjectFieldsBinding.rmap {
     case List(
-      GroupIdBinding.Option("groupId", rGroupId),
+      GroupIdBinding.Nullable("groupId", rGroupId),
       ProgramIdBinding.Option("programId", rProgramId)
     ) =>
       (rGroupId, rProgramId).mapN(apply)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GroupEditMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GroupEditMapping.scala
@@ -8,19 +8,21 @@ package mapping
 import grackle.Result
 import lucuma.odb.data.EditType
 import lucuma.odb.graphql.table.GroupView
+import lucuma.odb.graphql.table.ProgramTable
 
 
-trait GroupEditMapping[F[_]] extends GroupView[F] {
+trait GroupEditMapping[F[_]] extends GroupView[F] with ProgramTable[F] {
 
   // N.B. env is populated by the subscription elaborator
   lazy val GroupEditMapping: ObjectMapping =
     ObjectMapping(
       tpe = GroupEditType,
       fieldMappings = List(
-        SqlField("synthetic-id", GroupView.Id, key = true, hidden = true),
+        SqlField("synthetic-id", ProgramTable.Id, key = true, hidden = true),
         CursorField("id", _ => Result(0L), List("synthetic-id")),
         CursorField("editType", _.envR[EditType]("editType"), List("synthetic-id")),
-        SqlObject("value")
+        SqlObject("program"),
+        SqlObject("value", Join(ProgramTable.Id, GroupView.ProgramId))
       )
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/GroupEditPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/GroupEditPredicates.scala
@@ -7,4 +7,5 @@ import grackle.Path
 
 class GroupEditPredicates(path: Path) {
   val value = GroupPredicates(path / "value")
+  val program = ProgramPredicates(path / "program")
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/LeafPredicate.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/LeafPredicate.scala
@@ -23,9 +23,4 @@ class LeafPredicates[A](path: Path) {
   def isNull(b: Boolean): Predicate =
     IsNull(path, b)
 
-  def notDistinctFrom(a: Option[A])(using Eq[A]): Predicate =
-    a match
-      case None => isNull(true)
-      case Some(value) => eql(value)
-
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/LeafPredicate.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/LeafPredicate.scala
@@ -23,4 +23,9 @@ class LeafPredicates[A](path: Path) {
   def isNull(b: Boolean): Predicate =
     IsNull(path, b)
 
+  def notDistinctFrom(a: Option[A])(using Eq[A]): Predicate =
+    a match
+      case None => isNull(true)
+      case Some(value) => eql(value)
+
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -745,4 +745,44 @@ trait DatabaseOperations { this: OdbSuite =>
     FMain.databasePoolResource[IO](databaseConfig).flatten
       .use(_.prepareR(af.fragment.query(target_id)).use(_.unique(af.argument)))
   }
+
+  def moveObservationAs(user: User, pid: Program.Id, oid: Observation.Id, gid: Option[Group.Id]): IO[Unit] =
+    expect(
+      user = user,
+      query = s"""
+        mutation {
+          updateObservations(input: {
+            programId: ${pid.asJson}
+            SET: {
+              groupId: ${gid.asJson}
+            }
+            WHERE: {
+              id: {
+                EQ: ${oid.asJson}
+              }
+            }
+          }) {
+            observations {
+              id
+              groupId
+            }
+          }
+        }
+      """,
+      expected = Right(
+        json"""
+          {
+            "updateObservations": {
+              "observations": [
+                {
+                  "id": $oid,
+                  "groupId": $gid
+                }
+              ]
+            }
+          }
+        """
+      )
+    )
+
 }


### PR DESCRIPTION
This changes the group event stream to trigger when the contents of a group change, so you get an event when an observation is created, and two events when an observation is moved.