### PR TITLE
Checklist and `interface`

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/Checklist.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/Checklist.scala
@@ -5,9 +5,10 @@ package lucuma.odb.graphql
 
 import cats.effect.IO
 import cats.syntax.all._
+import grackle.Field
 import grackle.ObjectType
 
-@munit.IgnoreSuite // comment this out if you want to run this. there's probably a better way to do this
+//@munit.IgnoreSuite // comment this out if you want to run this. there's probably a better way to do this
 class Checklist extends OdbSuite {
   val validUsers = Nil
 
@@ -56,26 +57,40 @@ class Checklist extends OdbSuite {
   def printObjectType(m: BaseMapping[IO], t: ObjectType): IO[Unit] =
     if JsonMappedTypes.contains(t.name) then
       IO.println(s"- [x] ${t.name} (via Json blob)")
-    else
-      m.typeMapping(t) match
-        case None    => IO.println(s"- [ ] ${t.name}")
-        case Some(om: m.ObjectMapping) =>
-          IO.println(s"- [x] ${t.name}") >>
-          t.fields.traverse_ { f =>
-            om.fieldMapping(f.name) match
-              case None => IO.println(s"  - [ ] ${f.name}")
-              case Some(_) => IO.println(s"  - [x] ${f.name}")
+    else {
+
+      def definedInInterface(f: Field): Option[String] =
+        t.interfaces.find { nt =>
+          m.typeMapping(nt).exists {
+            case om: m.ObjectMapping =>
+               om.fieldMapping(f.name).isDefined
+            case sm: m.SwitchMapping =>
+               sm.lookup.exists { case (p, om) =>
+                 om.fieldMapping(f.name).isDefined
+               }
+            case _                   =>
+               false
           }
+        }.map(_.name)
+
+      def printField(om: m.ObjectMapping, f: Field): IO[Unit] =
+        om.fieldMapping(f.name) match {
+          case None    => IO.println(s"  - ${definedInInterface(f).fold(s"[ ] ${f.name}")(n => s"[x] ${f.name} (via $n)")}")
+          case Some(_) => IO.println(s"  - [x] ${f.name}")
+        }
+
+      m.typeMapping(t) match
+        case None                      =>
+          IO.println(s"- [ ] ${t.name}")
+        case Some(om: m.ObjectMapping) =>
+          IO.println(s"- [x] ${t.name}") >> t.fields.traverse_ { f => printField(om, f) }
         case Some(sm: m.SwitchMapping) =>
           sm.lookup.traverse_ { (p, om) =>
             IO.println(s"- [x] ${t.name} (at ${p.path.mkString(s"${p.rootTpe}/", "/", "")})") >>
-            t.fields.traverse_ { f =>
-              om.fieldMapping(f.name) match
-                case None => IO.println(s"  - [ ] ${f.name}")
-                case Some(_) => IO.println(s"  - [x] ${f.name}")
-            }
+            t.fields.traverse_ { f => printField(om, f) }
           }
         case m => fail(s"Can't handle object mapping $m")
+  }
 
   def printChecklist(m: BaseMapping[IO]): IO[Unit] = {
     IO.println("\n\n# Schema Coverage") >>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/Checklist.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/Checklist.scala
@@ -8,7 +8,7 @@ import cats.syntax.all._
 import grackle.Field
 import grackle.ObjectType
 
-//@munit.IgnoreSuite // comment this out if you want to run this. there's probably a better way to do this
+@munit.IgnoreSuite // comment this out if you want to run this. there's probably a better way to do this
 class Checklist extends OdbSuite {
   val validUsers = Nil
 


### PR DESCRIPTION
The `Checklist` "test" is very useful for finding unmapped fields / types / errors in the schema.  Unfortunately it would show fields implemented in an interface as unmapped.  This PR, while admittedly destroying the erstwhile beauty of the `Checklist` code, takes into account interfaces.

For example, before the `instrument`, `observation`, etc. fields would be marked as unmapped.  Now they are shown as implemented along with the interface name in which they are implemented.

```
- [x] GmosNorthVisit
  - [x] id
  - [x] instrument (via Visit)
  - [x] observation (via Visit)
  - [x] created (via Visit)
  - [ ] startTime
  - [ ] endTime
  - [ ] duration
  - [x] atomRecords (via Visit)
  - [x] datasets (via Visit)
  - [x] events (via Visit)
  - [x] static
```