### PR TITLE
Remove unused ObservationEffectHandler effectHandler.fieldName

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
@@ -119,7 +119,7 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
         }
       }
 
-    effectHandler("config", readEnv, calculate)
+    effectHandler(readEnv, calculate)
   }
 
   private lazy val digestHandler: EffectHandler[F] = {
@@ -132,7 +132,7 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
         }
       }
 
-    effectHandler("digest", _ => ().success, calculate)
+    effectHandler(_ => ().success, calculate)
   }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationEffectHandler.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationEffectHandler.scala
@@ -23,7 +23,6 @@ import table.ObservationView
 trait ObservationEffectHandler[F[_]] extends ObservationView[F] {
 
   protected def effectHandler[E, R](
-    fieldName: String,
     readEnv:   Env => Result[E],
     calculate: (Program.Id, Observation.Id, E) => F[Result[R]]
   )(using Eq[E], io.circe.Encoder[R]): EffectHandler[F] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -111,7 +111,7 @@ trait ObservationMapping[F[_]]
            }
         }
 
-    effectHandler("itc", readEnv, calculate)
+    effectHandler(readEnv, calculate)
   }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
@@ -128,7 +128,7 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
             }
         }
 
-    effectHandler("guideEnvironments", readEnv, calculate)
+    effectHandler(readEnv, calculate)
   }
 
   def guideAvailabilityQueryHandler: EffectHandler[F] = {
@@ -149,7 +149,7 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
             }
         }
 
-    effectHandler("guideEnvironments", readEnv, calculate)
+    effectHandler(readEnv, calculate)
   }
 }
 


### PR DESCRIPTION
Unless someone knows a reason that the field name should exist...