### PR TITLE
Rename GuideEnvironmentService to GuideService

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
@@ -25,7 +25,7 @@ import lucuma.odb.graphql.predicate.Predicates
 import lucuma.odb.graphql.table.AsterismTargetTable
 import lucuma.odb.logic.PlannedTimeCalculator
 import lucuma.odb.sequence.util.CommitHash
-import lucuma.odb.service.GuideEnvironmentService
+import lucuma.odb.service.GuideService
 import lucuma.odb.service.Services
 import org.http4s.client.Client
 
@@ -117,11 +117,11 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
   def guideEnvironmentQueryHandler: EffectHandler[F] = {
     val readEnv: Env => Result[Timestamp] = _.getR[Timestamp](ObsTimeParam)
 
-    val calculate: (Program.Id, Observation.Id, Timestamp) => F[Result[List[GuideEnvironmentService.GuideEnvironment]]] =
+    val calculate: (Program.Id, Observation.Id, Timestamp) => F[Result[List[GuideService.GuideEnvironment]]] =
       (pid, oid, obsTime) =>
         services.use { s =>
-          s.guideEnvironmentService(httpClient, itcClient, commitHash, plannedTimeCalculator)
-            .get(pid, oid, obsTime)
+          s.guideService(httpClient, itcClient, commitHash, plannedTimeCalculator)
+            .getGuideEnvironment(pid, oid, obsTime)
             .map {
               case Left(e)  => Result.failure(e.format)
               case Right(s) => s.success
@@ -138,11 +138,11 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
         end   <- env.getR[Timestamp](AvailabilityEndParam)
       } yield (start, end)
 
-    val calculate: (Program.Id, Observation.Id, (Timestamp, Timestamp)) => F[Result[List[GuideEnvironmentService.AvailabilityPeriod]]] =
+    val calculate: (Program.Id, Observation.Id, (Timestamp, Timestamp)) => F[Result[List[GuideService.AvailabilityPeriod]]] =
       (pid, oid, period) =>
         services.use { s =>
-          s.guideEnvironmentService(httpClient, itcClient, commitHash, plannedTimeCalculator)
-            .availability(pid, oid, period._1, period._2)
+          s.guideService(httpClient, itcClient, commitHash, plannedTimeCalculator)
+            .getGuideAvailability(pid, oid, period._1, period._2)
             .map {
               case Left(e)  => Result.failure(e.format)
               case Right(s) => s.success

--- a/modules/service/src/main/scala/lucuma/odb/service/Services.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/Services.scala
@@ -146,8 +146,8 @@ trait Services[F[_]]:
   /** Construct a `PlannedTimeRangeService`, given a `CommitHash` and an `ItcClient`.*/
   def plannedTimeRangeService(commitHash: CommitHash, itcClient: ItcClient[F], ptc: PlannedTimeCalculator.ForInstrumentMode): PlannedTimeRangeService[F]
 
-  /** Construct a `GuideEnvironmentService`, given an http4s `Client`, an `ItcClient`, a `CommitHash` and a `PlannedTimeCalculator`. */
-  def guideEnvironmentService(httpClient: Client[F], itcClient: ItcClient[F], commitHash: CommitHash, ptc: PlannedTimeCalculator.ForInstrumentMode): GuideEnvironmentService[F]
+  /** Construct a `guideService`, given an http4s `Client`, an `ItcClient`, a `CommitHash` and a `PlannedTimeCalculator`. */
+  def guideService(httpClient: Client[F], itcClient: ItcClient[F], commitHash: CommitHash, ptc: PlannedTimeCalculator.ForInstrumentMode): GuideService[F]
   
 
 object Services:
@@ -208,7 +208,7 @@ object Services:
       def itcService(itcClient: ItcClient[F]) = ItcService.instantiate(itcClient)
       def generator(commitHash: CommitHash, itcClient: ItcClient[F], ptc: PlannedTimeCalculator.ForInstrumentMode) = Generator.instantiate(commitHash, itcClient, ptc)
       def plannedTimeRangeService(commitHash: CommitHash, itcClient: ItcClient[F], ptc: PlannedTimeCalculator.ForInstrumentMode) = PlannedTimeRangeService.instantiate(commitHash, itcClient, ptc)
-      def guideEnvironmentService(httpClient: Client[F], itcClient: ItcClient[F], commitHash: CommitHash, ptc: PlannedTimeCalculator.ForInstrumentMode) = GuideEnvironmentService.instantiate(httpClient, itcClient, commitHash, ptc)
+      def guideService(httpClient: Client[F], itcClient: ItcClient[F], commitHash: CommitHash, ptc: PlannedTimeCalculator.ForInstrumentMode) = GuideService.instantiate(httpClient, itcClient, commitHash, ptc)
 
 
   /**
@@ -248,7 +248,7 @@ object Services:
     def itcService[F[_]](client: ItcClient[F])(using Services[F]): ItcService[F] = summon[Services[F]].itcService(client)
     def generator[F[_]](commitHash: CommitHash, itcClient: ItcClient[F], ptc: PlannedTimeCalculator.ForInstrumentMode)(using Services[F]): Generator[F] = summon[Services[F]].generator(commitHash, itcClient, ptc)
     def plannedTimeRangeService[F[_]](commitHash: CommitHash, itcClient: ItcClient[F], ptc: PlannedTimeCalculator.ForInstrumentMode)(using Services[F]): PlannedTimeRangeService[F] = summon[Services[F]].plannedTimeRangeService(commitHash, itcClient, ptc)
-    def guideEnvironmentService[F[_]](httpClient: Client[F], itcClient: ItcClient[F], commitHash: CommitHash, ptc: PlannedTimeCalculator.ForInstrumentMode)(using Services[F]): GuideEnvironmentService[F] = summon[Services[F]].guideEnvironmentService(httpClient, itcClient, commitHash, ptc)
+    def guideService[F[_]](httpClient: Client[F], itcClient: ItcClient[F], commitHash: CommitHash, ptc: PlannedTimeCalculator.ForInstrumentMode)(using Services[F]): GuideService[F] = summon[Services[F]].guideService(httpClient, itcClient, commitHash, ptc)
 
     extension [F[_]: MonadCancelThrow, A](s: Resource[F, Services[F]])
 


### PR DESCRIPTION
It handles both `guideEnvironment` requests and `guideAvailability` requests, so this name makes more sense.

I didn't want to include the renaming in the previous PR because it sometimes makes diffs harder to read.