### PR TITLE
Execution Event Table

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0382__execution_events.sql
+++ b/modules/service/src/main/resources/db/migration/V0382__execution_events.sql
@@ -1,0 +1,51 @@
+
+
+-- Create an execution event table that matches the v_execution_event view
+-- which combines the three event tables: t_sequence_event, t_step_event
+-- and t_sequence_event.
+
+CREATE TABLE t_execution_event (
+  c_execution_event_id d_execution_event_id   PRIMARY KEY DEFAULT 'e-' || to_hex(nextval('s_execution_event_id')),
+  c_event_type         e_execution_event_type NOT NULL,
+  c_received           TIMESTAMP              NOT NULL DEFAULT now(),
+
+  -- FK references.  All events are associated with an obsevation and visit.
+  -- Step and dataset events have an associated step.  Dataset events refer to
+  -- a particular dataset.
+
+  c_observation_id     d_observation_id       NOT NULL REFERENCES t_observation (c_observation_id),
+  c_visit_id           d_visit_id             NOT NULL REFERENCES t_visit (c_visit_id),
+  c_step_id            d_step_id              NULL     REFERENCES t_step_record (c_step_id),
+  c_dataset_id         d_dataset_id           NULL     REFERENCES t_dataset (c_dataset_id),
+
+  c_sequence_command   e_sequence_command     NULL,
+  c_step_stage         e_step_stage           NULL,
+  c_dataset_stage      e_dataset_stage        NULL,
+
+  CONSTRAINT check_event_type_conditions CHECK (
+    CASE
+      WHEN c_event_type = 'sequence' THEN c_sequence_command IS NOT NULL
+      WHEN c_event_type = 'step'     THEN c_step_stage       IS NOT NULL AND c_step_id IS NOT NULL
+      WHEN c_event_type = 'dataset'  THEN c_dataset_stage    IS NOT NULL AND c_step_id IS NOT NULL AND c_dataset_id IS NOT NULL
+      ELSE FALSE
+    END
+  )
+
+);
+
+-- Copy the data from the view into the table.
+INSERT INTO t_execution_event
+  SELECT * FROM v_execution_event;
+
+-- Delete the view and the 3 tables it combines.
+DROP VIEW v_execution_event;
+DROP TABLE t_dataset_event;
+DROP TABLE t_step_event;
+DROP TABLE t_sequence_event;
+
+-- Time accounting is per visit so we'll need to select on visit_id.
+-- Also, we need to know all events that happened during the visit whether
+-- or not associated with that visit.
+
+CREATE INDEX execution_event_received_index ON t_execution_event (c_received);
+CREATE INDEX execution_event_id_index       ON t_execution_event (c_observation_id, c_visit_id);

--- a/modules/service/src/main/resources/db/migration/V0382__execution_events.sql
+++ b/modules/service/src/main/resources/db/migration/V0382__execution_events.sql
@@ -42,10 +42,3 @@ DROP VIEW v_execution_event;
 DROP TABLE t_dataset_event;
 DROP TABLE t_step_event;
 DROP TABLE t_sequence_event;
-
--- Time accounting is per visit so we'll need to select on visit_id.
--- Also, we need to know all events that happened during the visit whether
--- or not associated with that visit.
-
-CREATE INDEX execution_event_received_index ON t_execution_event (c_received);
-CREATE INDEX execution_event_id_index       ON t_execution_event (c_observation_id, c_visit_id);

--- a/modules/service/src/main/resources/db/migration/V0382__execution_events.sql
+++ b/modules/service/src/main/resources/db/migration/V0382__execution_events.sql
@@ -24,8 +24,8 @@ CREATE TABLE t_execution_event (
 
   CONSTRAINT check_event_type_conditions CHECK (
     CASE
-      WHEN c_event_type = 'sequence' THEN c_sequence_command IS NOT NULL
-      WHEN c_event_type = 'step'     THEN c_step_stage       IS NOT NULL AND c_step_id IS NOT NULL
+      WHEN c_event_type = 'sequence' THEN c_sequence_command IS NOT NULL AND c_step_ID IS NULL     AND c_dataset_id IS NULL
+      WHEN c_event_type = 'step'     THEN c_step_stage       IS NOT NULL AND c_step_id IS NOT NULL AND c_dataset_id IS NULL
       WHEN c_event_type = 'dataset'  THEN c_dataset_stage    IS NOT NULL AND c_step_id IS NOT NULL AND c_dataset_id IS NOT NULL
       ELSE FALSE
     END

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AddDatasetEventResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AddDatasetEventResultMapping.scala
@@ -4,15 +4,15 @@
 package lucuma.odb.graphql
 package mapping
 
-import table.ExecutionEventView
+import table.ExecutionEventTable
 
-trait AddDatasetEventResultMapping[F[_]] extends ExecutionEventView[F] {
+trait AddDatasetEventResultMapping[F[_]] extends ExecutionEventTable[F] {
 
   lazy val AddDatasetEventResultMapping: ObjectMapping =
     ObjectMapping(
       tpe = AddDatasetEventResultType,
       fieldMappings = List(
-        SqlField("id", ExecutionEventView.Id, key = true, hidden = true),
+        SqlField("id", ExecutionEventTable.Id, key = true, hidden = true),
         SqlObject("event")
       )
     )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AddSequenceEventResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AddSequenceEventResultMapping.scala
@@ -4,15 +4,15 @@
 package lucuma.odb.graphql
 package mapping
 
-import table.ExecutionEventView
+import table.ExecutionEventTable
 
-trait AddSequenceEventResultMapping[F[_]] extends ExecutionEventView[F] {
+trait AddSequenceEventResultMapping[F[_]] extends ExecutionEventTable[F] {
 
   lazy val AddSequenceEventResultMapping: ObjectMapping =
     ObjectMapping(
       tpe = AddSequenceEventResultType,
       fieldMappings = List(
-        SqlField("id", ExecutionEventView.Id, key = true, hidden = true),
+        SqlField("id", ExecutionEventTable.Id, key = true, hidden = true),
         SqlObject("event")
       )
     )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AddStepEventResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AddStepEventResultMapping.scala
@@ -4,15 +4,15 @@
 package lucuma.odb.graphql
 package mapping
 
-import table.ExecutionEventView
+import table.ExecutionEventTable
 
-trait AddStepEventResultMapping[F[_]] extends ExecutionEventView[F] {
+trait AddStepEventResultMapping[F[_]] extends ExecutionEventTable[F] {
 
   lazy val AddStepEventResultMapping: ObjectMapping =
     ObjectMapping(
       tpe = AddStepEventResultType,
       fieldMappings = List(
-        SqlField("id", ExecutionEventView.Id, key = true, hidden = true),
+        SqlField("id", ExecutionEventTable.Id, key = true, hidden = true),
         SqlObject("event")
       )
     )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionEventMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionEventMapping.scala
@@ -14,12 +14,12 @@ import grackle.Type
 import grackle.TypeRef
 
 import table.DatasetTable
-import table.ExecutionEventView
+import table.ExecutionEventTable
 import table.ObservationView
 import table.StepRecordTable
 import table.VisitTable
 
-trait ExecutionEventMapping[F[_]] extends ExecutionEventView[F]
+trait ExecutionEventMapping[F[_]] extends ExecutionEventTable[F]
                                      with DatasetTable[F]
                                      with ObservationView[F]
                                      with StepRecordTable[F]
@@ -30,11 +30,11 @@ trait ExecutionEventMapping[F[_]] extends ExecutionEventView[F]
       tpe           = ExecutionEventType,
       discriminator = executionEventTypeDiscriminator,
       fieldMappings = List(
-        SqlField("id",           ExecutionEventView.Id, key = true),
-        SqlObject("visit",       Join(ExecutionEventView.VisitId,       VisitTable.Id)),
-        SqlObject("observation", Join(ExecutionEventView.ObservationId, ObservationView.Id)),
-        SqlField("received",     ExecutionEventView.Received),
-        SqlField("eventType",    ExecutionEventView.EventType, discriminator = true)
+        SqlField("id",           ExecutionEventTable.Id, key = true),
+        SqlObject("visit",       Join(ExecutionEventTable.VisitId,       VisitTable.Id)),
+        SqlObject("observation", Join(ExecutionEventTable.ObservationId, ObservationView.Id)),
+        SqlField("received",     ExecutionEventTable.Received),
+        SqlField("eventType",    ExecutionEventTable.EventType, discriminator = true)
       )
     )
 
@@ -66,8 +66,8 @@ trait ExecutionEventMapping[F[_]] extends ExecutionEventView[F]
     ObjectMapping(
       tpe = SequenceEventType,
       fieldMappings = List(
-        SqlField("id",      ExecutionEventView.Id, key = true),
-        SqlField("command", ExecutionEventView.SequenceCommand)
+        SqlField("id",      ExecutionEventTable.Id, key = true),
+        SqlField("command", ExecutionEventTable.SequenceCommand)
       )
     )
 
@@ -75,9 +75,9 @@ trait ExecutionEventMapping[F[_]] extends ExecutionEventView[F]
     ObjectMapping(
       tpe = StepEventType,
       fieldMappings = List(
-        SqlField("id",        ExecutionEventView.Id, key = true),
-        SqlObject("step",     Join(ExecutionEventView.StepId, StepRecordTable.Id)),
-        SqlField("stepStage", ExecutionEventView.StepStage)
+        SqlField("id",        ExecutionEventTable.Id, key = true),
+        SqlObject("step",     Join(ExecutionEventTable.StepId, StepRecordTable.Id)),
+        SqlField("stepStage", ExecutionEventTable.StepStage)
       )
     )
 
@@ -85,9 +85,9 @@ trait ExecutionEventMapping[F[_]] extends ExecutionEventView[F]
     ObjectMapping(
       tpe = DatasetEventType,
       fieldMappings = List(
-        SqlField("id",           ExecutionEventView.Id, key = true),
-        SqlField("datasetStage", ExecutionEventView.DatasetStage),
-        SqlObject("dataset",     Join(ExecutionEventView.DatasetId, DatasetTable.Id))
+        SqlField("id",           ExecutionEventTable.Id, key = true),
+        SqlField("datasetStage", ExecutionEventTable.DatasetStage),
+        SqlObject("dataset",     Join(ExecutionEventTable.DatasetId, DatasetTable.Id))
       )
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionEventSelectResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionEventSelectResultMapping.scala
@@ -6,12 +6,12 @@ package mapping
 
 import table.DatasetTable
 import table.ObservationView
-import table.ExecutionEventView
+import table.ExecutionEventTable
 import table.StepRecordTable
 import table.VisitTable
 
 trait ExecutionEventSelectResultMapping[F[_]]
-  extends ExecutionEventView[F]
+  extends ExecutionEventTable[F]
      with DatasetTable[F]
      with LookupFrom[F]
      with ObservationView[F]
@@ -22,16 +22,16 @@ trait ExecutionEventSelectResultMapping[F[_]]
   lazy val ExecutionEventSelectResultMapping: TypeMapping = {
 
     val fromDataset: ObjectMapping =
-      nestedSelectResultMapping(ExecutionEventSelectResultType, DatasetTable.Id,    Join(DatasetTable.Id,    ExecutionEventView.DatasetId))
+      nestedSelectResultMapping(ExecutionEventSelectResultType, DatasetTable.Id,    Join(DatasetTable.Id,    ExecutionEventTable.DatasetId))
 
     val fromExecution: ObjectMapping =
-      nestedSelectResultMapping(ExecutionEventSelectResultType, ObservationView.Id, Join(ObservationView.Id, ExecutionEventView.ObservationId))
+      nestedSelectResultMapping(ExecutionEventSelectResultType, ObservationView.Id, Join(ObservationView.Id, ExecutionEventTable.ObservationId))
 
     val fromStepRecord: ObjectMapping =
-      nestedSelectResultMapping(ExecutionEventSelectResultType, StepRecordTable.Id, Join(StepRecordTable.Id, ExecutionEventView.StepId))
+      nestedSelectResultMapping(ExecutionEventSelectResultType, StepRecordTable.Id, Join(StepRecordTable.Id, ExecutionEventTable.StepId))
 
     val fromVisit: ObjectMapping =
-      nestedSelectResultMapping(ExecutionEventSelectResultType, VisitTable.Id,      Join(VisitTable.Id,      ExecutionEventView.VisitId))
+      nestedSelectResultMapping(ExecutionEventSelectResultType, VisitTable.Id,      Join(VisitTable.Id,      ExecutionEventTable.VisitId))
 
     SwitchMapping(
       ExecutionEventSelectResultType,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/VisitMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/VisitMapping.scala
@@ -23,13 +23,13 @@ import lucuma.odb.graphql.binding.NonNegIntBinding
 import lucuma.odb.graphql.binding.TimestampBinding
 import lucuma.odb.graphql.predicate.Predicates
 
-import table.ExecutionEventView
+import table.ExecutionEventTable
 import table.GmosStaticTables
 import table.ObservationView
 import table.VisitTable
 
 trait VisitMapping[F[_]] extends VisitTable[F]
-                            with ExecutionEventView[F]
+                            with ExecutionEventTable[F]
                             with GmosStaticTables[F]
                             with ObservationView[F]
                             with Predicates[F]

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ExecutionEventTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ExecutionEventTable.scala
@@ -15,9 +15,9 @@ import lucuma.odb.util.Codecs.step_id
 import lucuma.odb.util.Codecs.step_stage
 import lucuma.odb.util.Codecs.visit_id
 
-trait ExecutionEventView[F[_]] extends BaseMapping[F] {
+trait ExecutionEventTable[F[_]] extends BaseMapping[F] {
 
-  object ExecutionEventView extends TableDef("v_execution_event") {
+  object ExecutionEventTable extends TableDef("t_execution_event") {
     val Id: ColumnRef              = col("c_execution_event_id", execution_event_id)
     val EventType: ColumnRef       = col("c_event_type",         execution_event_type)
     val Received: ColumnRef        = col("c_received",           core_timestamp)


### PR DESCRIPTION
I have waffled on whether I wanted an execution event table per type (sequence, step, and dataset) with a shared key sequence and a view that combines them or else just a single wider table with nullable columns a check constraint.  I think I'll switch to a single table because for time accounting I'll need a couple of different indices on the events (by ids in one case and by timestamp in another).