### PR TITLE
Cache guide availability results

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0384__guide_availability.sql
+++ b/modules/service/src/main/resources/db/migration/V0384__guide_availability.sql
@@ -1,0 +1,25 @@
+-- GUIDE TARGET AVAILABILITY TABLES FOR CACHING
+
+create table t_guide_availability ( 
+  c_program_id              d_program_id      NOT NULL,
+  c_observation_id          d_observation_id  NOT NULL,
+  c_hash                    bytea             NOT NULL,
+
+  FOREIGN KEY (c_program_id, c_observation_id)
+    REFERENCES t_observation(c_program_id, c_observation_id)
+    ON DELETE CASCADE,
+  CONSTRAINT t_guide_availability_pkey PRIMARY KEY (c_program_id, c_observation_id)
+ );
+
+create table t_guide_availability_period ( 
+  c_program_id              d_program_id      NOT NULL,
+  c_observation_id          d_observation_id  NOT NULL,
+  c_start                   timestamp         NOT NULL,
+  c_end                     timestamp         NOT NULL,
+  c_angles                  d_angle_µas[]     NOT NULL,
+
+  FOREIGN KEY (c_program_id, c_observation_id)
+    REFERENCES t_guide_availability(c_program_id, c_observation_id)
+    ON DELETE CASCADE,
+  CONSTRAINT t_guide_availability_period_pkey PRIMARY KEY (c_program_id, c_observation_id, c_start)
+ );

--- a/modules/service/src/main/scala/lucuma/odb/data/ContiguousTimestampMap.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/ContiguousTimestampMap.scala
@@ -64,6 +64,9 @@ final case class ContiguousTimestampMap[A: Eq] private (
 object ContiguousTimestampMap {
   def empty[A: Eq]: ContiguousTimestampMap[A] = ContiguousTimestampMap(none, SortedMap.empty)
 
+  def single[A: Eq](period: TimestampInterval, a: A): ContiguousTimestampMap[A] =
+    ContiguousTimestampMap(period.some, SortedMap.from(List((period, a))))
+
   def fromList[A: Eq](list: List[(TimestampInterval, A)]): Option[ContiguousTimestampMap[A]] =
     list.sortBy(_._1).foldRight(empty.some){ case ((i, a), ectm) => ectm.flatMap(_.add(i, a)) }
 

--- a/modules/service/src/main/scala/lucuma/odb/data/ContiguousTimestampMap.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/ContiguousTimestampMap.scala
@@ -1,0 +1,77 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+
+import cats.Eq
+import cats.Order.*
+import cats.syntax.all.*
+import lucuma.core.util.TimestampInterval
+
+import scala.collection.immutable.SortedMap
+
+final case class ContiguousTimestampMap[A: Eq] private (
+  val coverage: Option[TimestampInterval],
+  val intervals:  SortedMap[TimestampInterval, A] 
+) {
+  import ContiguousTimestampMap.*
+
+  def add(interval: TimestampInterval, a: A): Option[ContiguousTimestampMap[A]] =
+    coverage.fold(ContiguousTimestampMap(interval.some, intervals + (interval -> a)).some) { cov =>
+      if (interval.abuts(cov)) {
+        val newCoverage   = cov.span(interval)
+        val fromIntervals = if (interval < cov) intervals.head else intervals.last
+
+        if (fromIntervals._2 === a)
+          ContiguousTimestampMap(newCoverage.some, intervals - fromIntervals._1 + (fromIntervals._1.span(interval) -> a)).some
+        else ContiguousTimestampMap(newCoverage.some, intervals + (interval -> a)).some
+      }
+      else none
+    }
+
+  def unsafeAdd(interval: TimestampInterval, a: A): ContiguousTimestampMap[A] = add(interval, a).get
+
+  def union(other: ContiguousTimestampMap[A]): Option[ContiguousTimestampMap[A]] =
+    (this.coverage, other.coverage) match {
+      case (Some(p1), Some(p2)) if (p1.abuts(p2)) => 
+        val (first, second) = if (p1 < p2) (this, other) else (other, this)
+        first.intervals.toList.foldRight(second){ case ((i, a), acc) => acc.unsafeAdd(i, a) }.some
+      case (Some(_), Some(_))                     =>  none
+      case (_, None)                              => this.some
+      case (None, _)                              => other.some
+    }
+
+  def slice(requestedPeriod: TimestampInterval): ContiguousTimestampMap[A] = {
+    coverage.fold(this){ cov =>
+      if (cov.intersects(requestedPeriod))
+        val newPeriods: List[(TimestampInterval, A)] =
+          intervals.toList.map((interval, a) => interval.intersection(requestedPeriod).map((_, a))).flatten 
+        ContiguousTimestampMap.fromList(newPeriods).get
+      else ContiguousTimestampMap.empty
+    }
+  }
+
+  // Given the requested time interval, we need to figure out what time intervals
+  // we need to create the entire requested period. This could be zero, one or 2 intervals.
+  def findMissingIntervals(requestedPeriod: TimestampInterval): List[TimestampInterval] = 
+    coverage.fold(List(requestedPeriod)){ cov =>
+      requestedPeriod.abutWith(cov).fold(requestedPeriod.minus(cov))(List(_))
+    }
+
+  def isEmpty: Boolean = coverage.isEmpty
+}
+
+object ContiguousTimestampMap {
+  def empty[A: Eq]: ContiguousTimestampMap[A] = ContiguousTimestampMap(none, SortedMap.empty)
+
+  def fromList[A: Eq](list: List[(TimestampInterval, A)]): Option[ContiguousTimestampMap[A]] =
+    list.sortBy(_._1).foldRight(empty.some){ case ((i, a), ectm) => ectm.flatMap(_.add(i, a)) }
+
+  extension (self: TimestampInterval)
+    // expand the interval to abut other if they don't intersect
+    def abutWith(other: TimestampInterval): Option[TimestampInterval] =
+      if (self.intersects(other)) none
+      else if (self.abuts(other)) self.some
+      else if (self < other) TimestampInterval.between(self.start, other.start).some
+      else TimestampInterval.between(other.end, self.end).some
+}

--- a/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
@@ -51,6 +51,7 @@ import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import lucuma.core.util.TimestampInterval
 import lucuma.itc.client.ItcClient
+import lucuma.itc.client.json.given
 import lucuma.odb.data.ContiguousTimestampMap
 import lucuma.odb.data.Md5Hash
 import lucuma.odb.data.PosAngleConstraintMode
@@ -59,6 +60,8 @@ import lucuma.odb.json.target
 import lucuma.odb.logic.Generator
 import lucuma.odb.logic.PlannedTimeCalculator
 import lucuma.odb.sequence.data.GeneratorParams
+import lucuma.odb.sequence.syntax.hash.*
+import lucuma.odb.sequence.util.HashBytes
 import lucuma.odb.sequence.util.CommitHash
 import lucuma.odb.util.Codecs.*
 import org.http4s.Header
@@ -66,14 +69,18 @@ import org.http4s.Headers
 import org.http4s.Method
 import org.http4s.Request
 import org.http4s.client.Client
-import skunk.AppliedFragment
-import skunk.Decoder
+import skunk.*
+import skunk.data.Arr
 import skunk.implicits.*
 
+import java.security.MessageDigest
+import java.time.Duration
 import java.time.temporal.ChronoUnit
 import scala.collection.immutable.SortedMap
 
 import Services.Syntax.*
+import lucuma.odb.service.GuideService.Statements.insertOrUpdateGuideAvailabilityHash
+import lucuma.odb.service.GuideService.Statements.insertManyAvailabilityPeriods
 
 trait GuideService[F[_]] {
   import GuideService.AvailabilityPeriod
@@ -93,6 +100,10 @@ object GuideService {
   // if any science target or guide star candidate moves more than this many milliarcseconds,
   // we consider it to potentially invalidate the availability.
   val invalidThreshold = 100.0
+
+  // The longest availability period we will calculate.
+  val maxAvailabilityPeriodDays = 200L
+  val maxAvailabilityPeriod = TimeSpan.unsafeFromDuration(Duration.ofDays(maxAvailabilityPeriodDays))
 
   given Order[Angle] = Angle.AngleOrder
 
@@ -167,6 +178,39 @@ object GuideService {
   ) {
     def wavelength: Either[Error, Wavelength] =
       optWavelength.toRight(Error.GeneralError(s"No wavelength defined for observation $id."))
+
+    private val AllAngles =
+      NonEmptyList.fromListUnsafe(
+        (0 until 360 by 10).map(a => Angle.fromDoubleDegrees(a.toDouble)).toList
+      )
+
+    val availabilityAngles: NonEmptyList[Angle] =
+      posAngleConstraint match 
+        case PosAngleConstraint.Fixed(a)               => NonEmptyList.of(a)
+        case PosAngleConstraint.AllowFlip(a)           => NonEmptyList.of(a, a.flip)
+        case PosAngleConstraint.ParallacticOverride(a) => NonEmptyList.of(a)
+        case PosAngleConstraint.AverageParallactic     => AllAngles
+        case PosAngleConstraint.Unbounded              => AllAngles
+
+    def hash(generatorHash: Md5Hash): Md5Hash = {
+      val md5 = MessageDigest.getInstance("MD5")
+
+      md5.update(generatorHash.toByteArray)
+
+      given HashBytes[ConstraintSet] = HashBytes.forJsonEncoder
+      md5.update(constraints.hashBytes)
+
+      given HashBytes[NonEmptyList[Angle]] = HashBytes.forJsonEncoder
+      md5.update(availabilityAngles.hashBytes)
+
+      given HashBytes[Option[Wavelength]] = HashBytes.forJsonEncoder
+      md5.update(optWavelength.hashBytes)
+
+      given Encoder[Coordinates] = deriveEncoder
+      md5.update(HashBytes.forJsonEncoder[Option[Coordinates]].hashBytes(explicitBase))
+
+      Md5Hash.unsafeFromByteArray(md5.digest())
+    }
   }
 
   private case class GeneratorInfo(
@@ -217,6 +261,75 @@ object GuideService {
             _.option(af.argument).map(_.toRight(Error.GeneralError(s"Observation $oid not found.")))
           )
       }
+
+      def getAvailabilityHash(pid: Program.Id, oid: Observation.Id)(using
+        NoTransaction[F]
+      ): F[Option[Md5Hash]] = {
+        val af = Statements.getGuideAvailabilityHash(user, pid, oid)
+        session
+          .prepareR(af.fragment.query(md5_hash))
+          .use(_.option(af.argument))
+      }
+
+      def insertOrUpdateAvailabilityHash(pid: Program.Id, oid: Observation.Id, hash: Md5Hash)(using
+        Transaction[F]
+      ): F[Unit] = {
+        val af = Statements.insertOrUpdateGuideAvailabilityHash(user, pid, oid, hash)
+        session
+          .prepareR(af.fragment.command)
+          .use(_.execute(af.argument).void)
+      }
+
+      def getAvailabilityPeriods(pid: Program.Id, oid: Observation.Id)(using
+        NoTransaction[F]
+      ): F[List[AvailabilityPeriod]] = {
+        val af = Statements.getAvailabilityPeriods(user, pid, oid)
+        session
+          .prepareR(af.fragment.query(Decoders.availability_period))
+          .use(_.stream(af.argument, chunkSize = 1024).compile.toList)
+      }
+
+      def insertAvailabilityPeriods(pid: Program.Id, oid: Observation.Id, aps: List[AvailabilityPeriod])(using
+        Transaction[F]
+      ): F[Unit] = {
+        val af = Statements.insertManyAvailabilityPeriods(user, pid, oid, aps)
+        session
+          .prepareR(af.fragment.command)
+          .use(_.execute(af.argument).void)
+      }
+
+      def deleteAvailabilityPeriods(pid: Program.Id, oid: Observation.Id)(using Transaction[F]): F[Unit] = {
+        val af = Statements.deleteAvailabilityPeriods(user, pid, oid)
+        session
+          .prepareR(af.fragment.command)
+          .use(_.execute(af.argument).void)
+      }
+
+      def getFromCacheOrEmpty(pid: Program.Id, oid: Observation.Id, newHash: Md5Hash)(
+        using NoTransaction[F]
+      ): F[ContiguousTimestampMap[List[Angle]]] =
+        getAvailabilityHash(pid, oid).flatMap(oldHash =>
+          if (oldHash.exists(_ === newHash))
+            getAvailabilityPeriods(pid, oid)
+              .map(l => 
+                // If for some reason the cache is invalid, we'll just ignore it
+                ContiguousTimestampMap.fromList(l.map(ap => (ap.period, ap.posAngles)))
+                  .getOrElse(ContiguousTimestampMap.empty[List[Angle]])
+              )
+          else ContiguousTimestampMap.empty[List[Angle]].pure[F]
+        )
+      
+      def cacheAvailability(
+        pid:          Program.Id,
+        oid:          Observation.Id,
+        hash:         Md5Hash,
+        availability: ContiguousTimestampMap[List[Angle]]
+      ): F[Unit] =
+        services.transactionally {
+          deleteAvailabilityPeriods(pid, oid) >>
+          insertOrUpdateAvailabilityHash(pid, oid, hash) >>
+          insertAvailabilityPeriods(pid, oid, availability.intervals.toList.map(AvailabilityPeriod.fromTuple))
+        }
 
       def getGaiaQuery(
         oid:             Observation.Id,
@@ -337,20 +450,6 @@ object GuideService {
           off <- offsets.getOrElse(NonEmptyList.of(Offset.Zero))
         } yield AgsPosition(pa, off)
 
-      private val AllAngles =
-        NonEmptyList.fromListUnsafe(
-          (0 until 360 by 10).map(a => Angle.fromDoubleDegrees(a.toDouble)).toList
-        )
-
-      def getAnglesForAvailability(posAngleConstraint: PosAngleConstraint): NonEmptyList[Angle] =
-        posAngleConstraint match 
-          case PosAngleConstraint.Fixed(a)               => NonEmptyList.of(a)
-          case PosAngleConstraint.AllowFlip(a)           => NonEmptyList.of(a, a.flip)
-          case PosAngleConstraint.ParallacticOverride(a) => NonEmptyList.of(a)
-          case PosAngleConstraint.AverageParallactic     => AllAngles
-          case PosAngleConstraint.Unbounded              => AllAngles
-        
-        
       def processCandidates(
         obsInfo:       ObservationInfo,
         wavelength:    Wavelength,
@@ -372,33 +471,60 @@ object GuideService {
           .sortUsablePositions
           .collect { case usable: AgsAnalysis.Usable => usable }
 
-      def buildAvailability(
-        start:      Timestamp,
-        end:        Timestamp,
+      def buildAvailabilityAndCache(
+        pid:             Program.Id,
+        requestedPeriod: TimestampInterval,
+        neededPeriods:   NonEmptyList[TimestampInterval],
+        obsInfo:         ObservationInfo,
+        genInfo:         GeneratorInfo,
+        currentAvail:    ContiguousTimestampMap[List[Angle]],
+        newHash:         Md5Hash
+      ): F[Either[Error, ContiguousTimestampMap[List[Angle]]]] = 
+        (for {
+          wavelength   <- EitherT.fromEither(obsInfo.wavelength)
+          asterism     <- EitherT(getAsterism(pid, obsInfo.id))
+          tracking      = ObjectTracking.fromAsterism(asterism)
+          candPeriod    = neededPeriods.tail.fold(neededPeriods.head)((a, b) => a.span(b))
+          candidates   <- EitherT(
+                           getCandidates(obsInfo.id, candPeriod.start, candPeriod.end, tracking, wavelength, obsInfo.constraints)
+                          )
+          positions     = getPositions(obsInfo.availabilityAngles, genInfo.offsets)
+          neededLists  <- EitherT.fromEither(
+                            neededPeriods.traverse(p => 
+                              buildAvailabilityList(p, obsInfo, genInfo, wavelength, asterism, tracking, candidates, positions)
+                            )
+                          )
+          availability <- EitherT.fromEither(
+                            neededLists.foldLeft(currentAvail.some)((acc, ele) => acc.flatMap(_.union(ele)))
+                              .toRight(Error.GeneralError("Error creating guide availability"))
+                          )
+          _            <- EitherT.right(cacheAvailability(pid, obsInfo.id, newHash, availability))
+        } yield availability).value
+
+      def buildAvailabilityList(
+        period:     TimestampInterval,
         obsInfo:    ObservationInfo,
         genInfo:    GeneratorInfo,
         wavelength: Wavelength,
         asterism:   NonEmptyList[Target],
         tracking:   ObjectTracking,
-        candidates: List[GuideStarCandidate]
-      ): Either[Error, List[AvailabilityPeriod]] = {
-        val angles    = getAnglesForAvailability(obsInfo.posAngleConstraint)
-        val positions = getPositions(angles, genInfo.offsets)
-
+        candidates: List[GuideStarCandidate],
+        positions:  NonEmptyList[AgsPosition]
+      ): Either[Error, ContiguousTimestampMap[List[Angle]]] = {
         @scala.annotation.tailrec
         def go(startTime: Timestamp, accum: ContiguousTimestampMap[List[Angle]]): Either[Error, ContiguousTimestampMap[List[Angle]]] = {
           val eap =
-            buildAvailabilityPeriod(startTime, end, obsInfo, genInfo, wavelength, asterism, tracking, candidates, positions, angles)
+            buildAvailabilityPeriod(startTime, period.end, obsInfo, genInfo, wavelength, asterism, tracking, candidates, positions)
           eap match
             case Left(error)                      => error.asLeft
-            case Right(ap) if ap.period.end < end => go(ap.period.end, accum.unsafeAdd(ap.period, ap.posAngles))
+            case Right(ap) if ap.period.end < period.end => go(ap.period.end, accum.unsafeAdd(ap.period, ap.posAngles))
             case Right(ap)                        => 
-              val newPeriod = TimestampInterval.between(ap.period.start, end)
+              val newPeriod = TimestampInterval.between(ap.period.start, period.end)
               accum.unsafeAdd(newPeriod, ap.posAngles).asRight
         }
         candidates match
-          case Nil => List(AvailabilityPeriod(start, end, List.empty)).asRight
-          case _   => go(start, ContiguousTimestampMap.empty[List[Angle]]).map(_.intervals.toList.map(AvailabilityPeriod.fromTuple))
+          case Nil => ContiguousTimestampMap.single(period, List.empty).asRight
+          case _   => go(period.start, ContiguousTimestampMap.empty[List[Angle]])
       }
 
       def buildAvailabilityPeriod(
@@ -411,7 +537,6 @@ object GuideService {
         tracking:   ObjectTracking,
         candidates: List[GuideStarCandidate],
         positions:  NonEmptyList[AgsPosition],
-        angles:     NonEmptyList[Angle]
       ): Either[Error, AvailabilityPeriod] =
         for {
           baseCoords      <- obsInfo.explicitBase
@@ -445,7 +570,7 @@ object GuideService {
                                wavelength,
                                baseCoords,
                                scienceCoords,
-                               angles,
+                               obsInfo.availabilityAngles,
                                positions,
                                genInfo.agsParams
                              )
@@ -539,23 +664,32 @@ object GuideService {
         NoTransaction[F]
       ): F[Either[Error, List[AvailabilityPeriod]]] =
         (for {
-          obsInfo      <- EitherT(getObservationInfo(pid, oid))
-          start         = period.start
-          end           = period.end
-          wavelength   <- EitherT.fromEither(obsInfo.wavelength)
-          asterism     <- EitherT(getAsterism(pid, oid))
-          genInfo      <- EitherT(getGeneratorInfo(pid, oid))
-          tracking      = ObjectTracking.fromAsterism(asterism)
-          candidates   <- EitherT(getCandidates(oid, period.start, period.end, tracking, wavelength, obsInfo.constraints))
-          availability <-
-            EitherT.fromEither(
-              buildAvailability(start, end, obsInfo, genInfo, wavelength, asterism, tracking, candidates)
-            )
+          _             <- EitherT.fromEither(
+                             if (period.boundedTimeSpan <= maxAvailabilityPeriod) ().asRight
+                             else Error.GeneralError(
+                              s"Period for guide availability cannot be greater than $maxAvailabilityPeriodDays days."
+                             ).asLeft
+                           )
+          obsInfo       <- EitherT(getObservationInfo(pid, oid))
+          genInfo       <- EitherT(getGeneratorInfo(pid, oid))
+          newHash        = obsInfo.hash(genInfo.hash)
+          currentAvail  <- EitherT.right(getFromCacheOrEmpty(pid, oid, newHash))
+          missingPeriods = currentAvail.findMissingIntervals(period)
+          // only happens if we have disjoint periods too far apart. If so, we'll just replace the existing
+          (neededPeriods, startAvail) = if (missingPeriods.exists(_.boundedTimeSpan > maxAvailabilityPeriod)) 
+                             (NonEmptyList.of(period).some, ContiguousTimestampMap.empty[List[Angle]])
+                           else (NonEmptyList.fromList(missingPeriods), currentAvail)
+          // if we don't need anything, then we already have what we need
+          fullAvail     <- neededPeriods.fold(EitherT.pure(startAvail))(nel =>
+                             EitherT(buildAvailabilityAndCache(pid, period, nel, obsInfo, genInfo, startAvail, newHash))
+                           )
+          availability   = fullAvail.slice(period).intervals.toList.map(AvailabilityPeriod.fromTuple)
         } yield availability).value
     }
 
   object Statements {
     import ProgramService.Statements.andWhereUserAccess
+    import ProgramService.Statements.whereUserAccess
 
     def getObservationInfo(user: User, pid: Program.Id, oid: Observation.Id): AppliedFragment =
       sql"""
@@ -575,8 +709,83 @@ object GuideService {
           obs.c_explicit_ra,
           obs.c_explicit_dec
         from t_observation obs
-        where obs.c_program_id = $program_id
+        where obs.c_program_id     = $program_id
           and obs.c_observation_id = $observation_id
+      """.apply(pid, oid) |+| andWhereUserAccess(user, pid)
+
+    def getGuideAvailabilityHash(user: User, pid: Program.Id, oid: Observation.Id): AppliedFragment = 
+      sql"""
+        select c_hash
+        from t_guide_availability
+        where c_program_id     = $program_id
+          and c_observation_id = $observation_id
+      """.apply(pid, oid) |+| andWhereUserAccess(user, pid)
+
+    def insertOrUpdateGuideAvailabilityHash(
+      user: User,
+      pid: Program.Id,
+      oid: Observation.Id,
+      hash: Md5Hash
+    ): AppliedFragment = 
+      sql"""
+        insert into t_guide_availability (
+          c_program_id,
+          c_observation_id,
+          c_hash
+        )
+        select
+          $program_id,
+          $observation_id,
+          $md5_hash
+      """.apply(pid, oid, hash) |+| 
+      whereUserAccess(user, pid) |+|
+      sql"""
+        on conflict on constraint t_guide_availability_pkey do update
+          set c_hash = $md5_hash
+      """.apply(hash)
+    
+    def getAvailabilityPeriods(user: User, pid: Program.Id, oid: Observation.Id): AppliedFragment =
+      sql"""
+        select
+          c_start,
+          c_end,
+          c_angles
+        from t_guide_availability_period
+        where c_program_id     = $program_id
+          and c_observation_id = $observation_id
+      """.apply(pid, oid) |+| andWhereUserAccess(user, pid)
+    
+    def insertManyAvailabilityPeriods(
+      user: User,
+      pid: Program.Id,
+      oid: Observation.Id,
+      periods: List[AvailabilityPeriod]): AppliedFragment = 
+      sql"""
+        insert into t_guide_availability_period (
+          c_program_id,
+          c_observation_id,
+          c_start,
+          c_end,
+          c_angles
+        ) values ${(
+          program_id *:
+          observation_id *:
+          core_timestamp *:
+          core_timestamp *:
+          Decoders.angle_µas_list
+        ).values.list(periods.length)}
+      """
+      .apply(
+        periods.map { ap =>
+          (pid, oid, ap.period.start, ap.period.end, ap.posAngles)
+        }
+      )
+
+    def deleteAvailabilityPeriods(user: User, pid: Program.Id, oid: Observation.Id): AppliedFragment =
+      sql"""
+        delete from t_guide_availability_period
+        where c_program_id     = $program_id
+          and c_observation_id = $observation_id
       """.apply(pid, oid) |+| andWhereUserAccess(user, pid)
   }
 
@@ -632,5 +841,13 @@ object GuideService {
             ObservationInfo(id, ConstraintSet(image, cloud, sky, water, elev), paConstraint, wavelength, explicitBase)
           )
       }
+
+    val angle_µas_list: Codec[List[Angle]] =
+      _angle_µas.imap(_.toList)(l => Arr.fromFoldable(l))
+
+    val availability_period: Codec[AvailabilityPeriod] =
+      (timestamp_interval *: angle_µas_list).imap((period, angles) =>
+        AvailabilityPeriod(period, angles)
+      )(ap => (ap.period, ap.posAngles))
   }
 }

--- a/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
@@ -61,8 +61,8 @@ import lucuma.odb.logic.Generator
 import lucuma.odb.logic.PlannedTimeCalculator
 import lucuma.odb.sequence.data.GeneratorParams
 import lucuma.odb.sequence.syntax.hash.*
-import lucuma.odb.sequence.util.HashBytes
 import lucuma.odb.sequence.util.CommitHash
+import lucuma.odb.sequence.util.HashBytes
 import lucuma.odb.util.Codecs.*
 import org.http4s.Header
 import org.http4s.Headers
@@ -79,8 +79,6 @@ import java.time.temporal.ChronoUnit
 import scala.collection.immutable.SortedMap
 
 import Services.Syntax.*
-import lucuma.odb.service.GuideService.Statements.insertOrUpdateGuideAvailabilityHash
-import lucuma.odb.service.GuideService.Statements.insertManyAvailabilityPeriods
 
 trait GuideService[F[_]] {
   import GuideService.AvailabilityPeriod

--- a/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
@@ -167,7 +167,7 @@ object GuideService {
     }
   }
 
-  private case class ObservationInfo(
+  case class ObservationInfo(
     id:                 Observation.Id,
     constraints:        ConstraintSet,
     posAngleConstraint: PosAngleConstraint,
@@ -198,6 +198,8 @@ object GuideService {
       given HashBytes[ConstraintSet] = HashBytes.forJsonEncoder
       md5.update(constraints.hashBytes)
 
+      // For our purposes, we don't care about the actual PosAngleConstraint, just what
+      // angles we need to check.
       given HashBytes[NonEmptyList[Angle]] = HashBytes.forJsonEncoder
       md5.update(availabilityAngles.hashBytes)
 

--- a/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
@@ -146,6 +146,13 @@ trait Codecs {
   val angle_µas: Codec[Angle] =
     int8.imap(Angle.microarcseconds.reverseGet)(Angle.microarcseconds.get)
 
+  val _angle_µas: Codec[Arr[Angle]] =
+    Codec.array(
+      a => Angle.microarcseconds.get(a).toString, 
+      safe(s => Angle.microarcseconds.reverseGet(s.toLong)),
+      Type("_d_angle_µas", List(Type("d_angle_µas")))
+    )
+
   val atom_id: Codec[Atom.Id] =
     uid[Atom.Id]
 

--- a/modules/service/src/test/scala/lucuma/odb/data/ContiguousTimestampMapSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/data/ContiguousTimestampMapSuite.scala
@@ -1,0 +1,183 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+
+import cats.syntax.all.*
+import lucuma.core.util.Timestamp
+import lucuma.core.util.TimestampInterval
+import munit.FunSuite
+
+class ContiguousTimestampMapSuite extends FunSuite {
+  private def timestamp(epochMilli: Long): Timestamp =
+    Timestamp.ofEpochMilli(epochMilli).get
+
+  private def interval(epochMilli0: Long, epochMilli1: Long): TimestampInterval =
+    TimestampInterval.between(timestamp(epochMilli0), timestamp(epochMilli1))
+
+  private def tuple(epochMilli0: Long, epochMilli1: Long, s: String): (TimestampInterval, String) =
+    (interval(epochMilli0, epochMilli1), s)
+
+  extension (ctm: ContiguousTimestampMap[String])
+    private def toTuple: Option[(Option[TimestampInterval], List[(TimestampInterval, String)])] =
+      ctm.some.toTuple
+
+  extension (ctm: Option[ContiguousTimestampMap[String]])
+    private def toTuple: Option[(Option[TimestampInterval], List[(TimestampInterval, String)])] =
+      ctm.map(c => (c.coverage, c.intervals.toList))
+
+  private def toCompare(epochMilli0: Long, epochMilli1: Long, is: (Long, Long, String)*): 
+    Option[(Option[TimestampInterval], List[(TimestampInterval, String)])] =
+      (interval(epochMilli0, epochMilli1).some, is.toList.map( (milli1, milli2, s) => (interval(milli1, milli2), s))).some
+
+  test("fromList") {
+    val ctm = 
+      ContiguousTimestampMap.fromList(
+        List(tuple(3, 5, "a"), tuple(1, 2, "b"), tuple(5, 7, "a"), tuple(2, 3, "c"))
+      )
+
+    assertEquals(ctm.toTuple, toCompare(1, 7, (1, 2, "b"), (2, 3, "c"), (3, 7, "a")))
+
+    val ctmNone = 
+      ContiguousTimestampMap.fromList(
+        List(tuple(3, 5, "a"), tuple(1, 2, "b"), tuple(5, 7, "a"))
+      )
+    assertEquals(ctmNone, None) 
+
+    val ctmEmpty = ContiguousTimestampMap.fromList(List.empty[(TimestampInterval, String)])
+    assert(ctmEmpty.exists(_.isEmpty), "Empty list makes empty map")
+  }
+
+  test("add") {
+    val ctm = 
+      ContiguousTimestampMap.fromList(
+        List(tuple(7, 11, "b"), tuple(5, 7, "a"))
+      ).get
+
+    assertEquals(ctm.add(interval(3, 5), "a").toTuple, toCompare(3, 11, (3, 7, "a"), (7, 11, "b")))
+    assertEquals(ctm.add(interval(3, 5), "_").toTuple, toCompare(3, 11, (3, 5, "_"), (5, 7, "a"), (7, 11, "b")))
+    assertEquals(ctm.add(interval(3, 5), "b").toTuple, toCompare(3, 11, (3, 5, "b"), (5, 7, "a"), (7, 11, "b")))
+    assertEquals(ctm.add(interval(11, 15), "b").toTuple, toCompare(5, 15, (5, 7, "a"), (7, 15, "b")))
+    assertEquals(ctm.add(interval(11, 15), "c").toTuple, toCompare(5, 15, (5, 7, "a"), (7, 11, "b"), (11, 15, "c")))
+    assertEquals(ctm.add(interval(11, 15), "a").toTuple, toCompare(5, 15, (5, 7, "a"), (7, 11, "b"), (11, 15, "a")))
+
+    assertEquals(ctm.add(interval(2, 4), "a"), None)
+    assertEquals(ctm.add(interval(2, 4), "_"), None)
+    assertEquals(ctm.add(interval(12, 14), "b"), None)
+    assertEquals(ctm.add(interval(12, 14), "c"), None)
+
+    assertEquals(
+      ContiguousTimestampMap.empty[String].add(interval(3, 5), "a").toTuple, 
+      toCompare(3, 5, (3, 5, "a"))
+    )
+  }
+
+  test("union") {
+    val ctm = 
+      ContiguousTimestampMap.fromList(
+        List(tuple(7, 11, "b"), tuple(5, 7, "a"))
+      ).get
+    val abutsSame = 
+      ContiguousTimestampMap.fromList(
+        List(tuple(11, 15, "b"), tuple(15, 17, "a"))
+      ).get
+    val abutsDiffers = 
+      ContiguousTimestampMap.fromList(
+        List(tuple(11, 15, "d"), tuple(15, 17, "a"))
+      ).get
+    val disjoint = 
+      ContiguousTimestampMap.fromList(
+        List(tuple(12, 15, "d"), tuple(15, 17, "a"))
+      ).get
+    val overlaps = 
+      ContiguousTimestampMap.fromList(
+        List(tuple(10, 15, "d"), tuple(15, 17, "a"))
+      ).get
+    val empty = ContiguousTimestampMap.empty[String]
+    
+    assertEquals(ctm.union(abutsSame).toTuple, toCompare(5, 17, (5, 7, "a"), (7, 15, "b"), (15, 17, "a"))) 
+    assertEquals(abutsSame.union(ctm).toTuple, toCompare(5, 17, (5, 7, "a"), (7, 15, "b"), (15, 17, "a"))) 
+    assertEquals(ctm.union(abutsDiffers).toTuple, toCompare(5, 17, (5, 7, "a"), (7, 11, "b"), (11, 15, "d"), (15, 17, "a"))) 
+    assertEquals(abutsDiffers.union(ctm).toTuple, toCompare(5, 17, (5, 7, "a"), (7, 11, "b"), (11, 15, "d"), (15, 17, "a"))) 
+
+    assertEquals(ctm.union(disjoint), None)
+    assertEquals(disjoint.union(ctm), None)
+    assertEquals(ctm.union(overlaps), None)
+    assertEquals(overlaps.union(ctm), None)
+
+    assertEquals(ctm.union(empty).toTuple, toCompare(5, 11, (5, 7, "a"), (7, 11, "b")))
+    assertEquals(empty.union(ctm).toTuple, toCompare(5, 11, (5, 7, "a"), (7, 11, "b")))
+  }
+
+  test("slice") {
+    val ctm = 
+      ContiguousTimestampMap.fromList(
+        List(tuple(7, 11, "b"), tuple(5, 7, "a"))
+      ).get
+
+    // superset
+    assertEquals(ctm.slice(interval(3, 15)).toTuple, ctm.toTuple)
+    assertEquals(ctm.slice(interval(5, 15)).toTuple, ctm.toTuple)
+    assertEquals(ctm.slice(interval(3, 11)).toTuple, ctm.toTuple)
+
+    // equals
+    assertEquals(ctm.slice(interval(5, 11)).toTuple, ctm.toTuple)
+
+    // upper partial
+    assertEquals(ctm.slice(interval(3, 9)).toTuple, toCompare(5, 9, (5, 7, "a"), (7, 9, "b")))
+    assertEquals(ctm.slice(interval(3, 7)).toTuple, toCompare(5, 7, (5, 7, "a")))
+    assertEquals(ctm.slice(interval(3, 6)).toTuple, toCompare(5, 6, (5, 6, "a")))
+
+    // lower partial
+    assertEquals(ctm.slice(interval(6, 19)).toTuple, toCompare(6, 11, (6, 7, "a"), (7, 11, "b")))
+    assertEquals(ctm.slice(interval(7, 19)).toTuple, toCompare(7, 11, (7, 11, "b")))
+    assertEquals(ctm.slice(interval(9, 19)).toTuple, toCompare(9, 11, (9, 11, "b")))
+
+    // abuts
+    assertEquals(ctm.slice(interval(3, 5)).toTuple, (None, Nil).some)
+    assertEquals(ctm.slice(interval(11, 19)).toTuple, (None, Nil).some)
+
+    // disjoint
+    assertEquals(ctm.slice(interval(1, 4)).toTuple, (None, Nil).some) 
+    assertEquals(ctm.slice(interval(12, 19)).toTuple, (None, Nil).some)
+  }
+
+  test("findMissingIntervals") {
+    val ctm = 
+      ContiguousTimestampMap.fromList(
+        List(tuple(7, 11, "b"), tuple(5, 7, "a"))
+      ).get
+
+    // superset
+    assertEquals(ctm.findMissingIntervals(interval(3, 15)), List(interval(3, 5), interval(11, 15)))
+    assertEquals(ctm.findMissingIntervals(interval(5, 15)), List(interval(11, 15)))
+    assertEquals(ctm.findMissingIntervals(interval(3, 11)), List(interval(3, 5)))
+
+    // equals
+    assertEquals(ctm.findMissingIntervals(interval(5, 11)), Nil)
+
+    // upper partial
+    assertEquals(ctm.findMissingIntervals(interval(3, 9)), List(interval(3, 5)))
+    assertEquals(ctm.findMissingIntervals(interval(3, 7)), List(interval(3, 5)))
+    assertEquals(ctm.findMissingIntervals(interval(3, 6)), List(interval(3, 5)))
+
+    // lower partial
+    assertEquals(ctm.findMissingIntervals(interval(6, 19)), List(interval(11, 19)))
+    assertEquals(ctm.findMissingIntervals(interval(7, 19)), List(interval(11, 19)))
+    assertEquals(ctm.findMissingIntervals(interval(9, 19)), List(interval(11, 19)))
+
+    // abuts
+    assertEquals(ctm.findMissingIntervals(interval(3, 5)), List(interval(3, 5)))
+    assertEquals(ctm.findMissingIntervals(interval(11, 19)), List(interval(11, 19)))
+
+    // disjoint
+    assertEquals(ctm.findMissingIntervals(interval(1, 4)), List(interval(1, 5)))
+    assertEquals(ctm.findMissingIntervals(interval(12, 19)), List(interval(11, 19)))
+
+    // empty
+    assertEquals(
+      ContiguousTimestampMap.empty[String].findMissingIntervals(interval(3, 9)),
+      List(interval(3, 9))
+    )
+  }
+}

--- a/modules/service/src/test/scala/lucuma/odb/data/Md5HashSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/data/Md5HashSuite.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+
+import cats.kernel.laws.discipline.EqTests
+import lucuma.odb.data.arb.ArbMd5Hash
+import munit.DisciplineSuite
+
+class Md5HashSuite extends DisciplineSuite {
+  import ArbMd5Hash.given
+
+  checkAll("Eq", EqTests[Md5Hash].eqv)  
+}

--- a/modules/service/src/test/scala/lucuma/odb/data/arb/ArbMd5Hash.scala
+++ b/modules/service/src/test/scala/lucuma/odb/data/arb/ArbMd5Hash.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+package arb
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbMd5Hash {
+  given Arbitrary[Md5Hash] =
+    Arbitrary {
+      for {
+        l <- Gen.listOfN(16, arbitrary[Byte])
+      } yield Md5Hash.unsafeFromByteArray(l.toArray)
+    }
+
+  given Cogen[Md5Hash] =
+    Cogen[Array[Byte]].contramap(_.toByteArray)
+}
+
+object ArbMd5Hash extends ArbMd5Hash

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideAvailability.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideAvailability.scala
@@ -50,7 +50,7 @@ class guideAvailability extends OdbSuite with ObservingModeSetupOperations {
   val successEnd   = "2024-02-28T00:00:00Z"
 
   val emptyStart   = "3025-10-31T00:00:00Z"
-  val emptyEnd     = "3026-10-31T01:00:00Z"
+  val emptyEnd     = "3025-12-31T01:00:00Z"
 
   override def dbInitialization: Option[Session[IO] => IO[Unit]] = Some { s =>
     val tableRow: TableRow.North =
@@ -280,7 +280,7 @@ class guideAvailability extends OdbSuite with ObservingModeSetupOperations {
           "guideAvailability": [
             {
               "start" : "3025-10-31 00:00:00",
-              "end" : "3026-10-31 01:00:00",
+              "end" : "3025-12-31 01:00:00",
               "posAngles" : [
               ]
             }
@@ -412,7 +412,7 @@ class guideAvailability extends OdbSuite with ObservingModeSetupOperations {
       } yield o
     setup.flatMap { oid =>
       expect(pi, guideAvailabilityQuery(oid, successStart, successEnd),
-      expected = List(s"No targets have been defined for observation $oid.").asLeft)
+      expected = List(s"Could not generate a sequence from the observation $oid: target").asLeft)
     }
   }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideAvailability.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideAvailability.scala
@@ -12,7 +12,7 @@ import eu.timepit.refined.types.numeric.PosLong
 import fs2.Stream
 import fs2.text.utf8
 import io.circe.Json
-import io.circe.literal.*
+import io.circe.syntax.*
 import lucuma.core.enums.GcalBaselineType
 import lucuma.core.enums.GcalContinuum
 import lucuma.core.enums.GcalDiffuser
@@ -25,11 +25,17 @@ import lucuma.core.enums.GmosNorthFpu
 import lucuma.core.enums.GmosNorthGrating
 import lucuma.core.enums.GmosXBinning
 import lucuma.core.enums.GmosYBinning
+import lucuma.core.math.Angle
 import lucuma.core.math.BoundedInterval
 import lucuma.core.math.Wavelength
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.StepConfig.Gcal
 import lucuma.core.util.TimeSpan
+import lucuma.core.util.Timestamp
+import lucuma.core.util.TimestampInterval
+import lucuma.odb.json.angle.query.given
+import lucuma.odb.service.GuideService
+import lucuma.odb.service.GuideService.AvailabilityPeriod
 import lucuma.odb.service.Services
 import lucuma.odb.smartgcal.data.Gmos.GratingConfigKey
 import lucuma.odb.smartgcal.data.Gmos.TableKey
@@ -46,11 +52,20 @@ class guideAvailability extends OdbSuite with ObservingModeSetupOperations {
   val pi         = TestUsers.Standard.pi(1, 30)
   val validUsers = List(pi)
 
-  val successStart = "2023-10-31T00:00:00Z"
-  val successEnd   = "2024-02-28T00:00:00Z"
+  val oct15_2023 = "2023-10-15T00:00:00Z"
+  val oct25_2023 = "2023-10-25T00:00:00Z"
+  val oct31_2023 = "2023-10-31T00:00:00Z"
+  val nov30_2023 = "2023-11-30T00:00:00Z"
+  val feb01_2024 = "2024-02-01T00:00:00Z"
+  val feb28_2024 = "2024-02-28T00:00:00Z"
+  val mar05_2024 = "2024-03-05T00:00:00Z"
+  val mar10_2024 = "2024-03-10T00:00:00Z"
 
   val emptyStart   = "3025-10-31T00:00:00Z"
   val emptyEnd     = "3025-12-31T01:00:00Z"
+
+  val earlyAngles = List(160, 170, 180, 190, 200, 250, 260, 270, 280, 290, 300, 310)
+  val laterAngles = earlyAngles.filter(_ =!= 250)
 
   override def dbInitialization: Option[Session[IO] => IO[Unit]] = Some { s =>
     val tableRow: TableRow.North =
@@ -198,7 +213,7 @@ class guideAvailability extends OdbSuite with ObservingModeSetupOperations {
   |            <![CDATA[SELECT TOP 100 source_id,ra,pmra,dec,pmdec,parallax,radial_velocity,phot_g_mean_mag,phot_rp_mean_mag 
   |     FROM gaiadr3.gaia_source_lite
   |     WHERE CONTAINS(POINT('ICRS',ra,dec),CIRCLE('ICRS', 86.55474, -0.10137, 0.08167))=1
-  |     and ((phot_rp_mean_mag < 17.228) or (phot_g_mean_mag < 17.228))
+  |     and ((phot_rp_mean_mag < 17.228) or (phot_g_mean_mag  17.228))
   |     and (ruwe < 1.4)
   |     ORDER BY phot_g_mean_mag
   |      ]]>
@@ -264,131 +279,58 @@ class guideAvailability extends OdbSuite with ObservingModeSetupOperations {
             guideAvailability(start: "$startTime", end: "$endTime") {
               start
               end
-              posAngles { degrees }
+              posAngles {
+                microarcseconds
+                microseconds
+                milliarcseconds
+                milliseconds
+                arcseconds
+                seconds
+                arcminutes
+                minutes
+                degrees
+                hours
+                dms
+                hms
+              }
             }
           }
         }
       }
     """
 
-  val emptyGuideAvailabilityResults =
-    json"""
-    {
-      "observation": {
-        "title": "V1647 Orionis",
-        "targetEnvironment": {
-          "guideAvailability": [
-            {
-              "start" : "3025-10-31 00:00:00",
-              "end" : "3025-12-31 01:00:00",
-              "posAngles" : [
-              ]
-            }
-          ]
-        }
-      }
-    }
-    """
+  def availabilityResult(title: String, periods: List[AvailabilityPeriod]): Json =
+    Json.obj(
+      "observation" -> Json.obj(
+        "title"            -> title.asJson,
+        "targetEnvironment" -> Json.obj(
+          "guideAvailability" -> Json.fromValues(
+            periods.map(ap =>
+              Json.obj(
+                "start"     -> ap.period.start.asJson,
+                "end"       -> ap.period.end.asJson,
+                "posAngles" -> ap.posAngles.asJson
+              )
+            )
+          )
+        )
+      )
+    )
 
-  val guideAvailabilityResults =
-    json"""
-    {
-      "observation": {
-        "title": "V1647 Orionis",
-        "targetEnvironment": {
-          "guideAvailability": [
-            {
-              "start" : "2023-10-31 00:00:00",
-              "end" : "2024-02-01 00:00:00",
-              "posAngles" : [
-                {
-                  "degrees" : 160.000000
-                },
-                {
-                  "degrees" : 170.000000
-                },
-                {
-                  "degrees" : 180.000000
-                },
-                {
-                  "degrees" : 190.000000
-                },
-                {
-                  "degrees" : 200.000000
-                },
-                {
-                  "degrees" : 250.000000
-                },
-                {
-                  "degrees" : 260.000000
-                },
-                {
-                  "degrees" : 270.000000
-                },
-                {
-                  "degrees" : 280.000000
-                },
-                {
-                  "degrees" : 290.000000
-                },
-                {
-                  "degrees" : 300.000000
-                },
-                {
-                  "degrees" : 310.000000
-                }
-              ]
-            },
-            {
-              "start" : "2024-02-01 00:00:00",
-              "end" : "2024-02-28 00:00:00",
-              "posAngles" : [
-                {
-                  "degrees" : 160.000000
-                },
-                {
-                  "degrees" : 170.000000
-                },
-                {
-                  "degrees" : 180.000000
-                },
-                {
-                  "degrees" : 190.000000
-                },
-                {
-                  "degrees" : 200.000000
-                },
-                {
-                  "degrees" : 260.000000
-                },
-                {
-                  "degrees" : 270.000000
-                },
-                {
-                  "degrees" : 280.000000
-                },
-                {
-                  "degrees" : 290.000000
-                },
-                {
-                  "degrees" : 300.000000
-                },
-                {
-                  "degrees" : 310.000000
-                }
-              ]
-            } 
-          ]
-        }
-      }
-    }
-    """
+  def makeAvailabilityPeriod(start: String, end: String, angles: List[Int]) =
+    AvailabilityPeriod(
+      TimestampInterval.between(
+        Timestamp.FromString.getOption(start).get,
+        Timestamp.FromString.getOption(end).get
+      ),
+      angles.map(i => Angle.fromBigDecimalDegrees(BigDecimal(i)))
+    )
 
   override def httpRequestHandler: Request[IO] => Resource[IO, Response[IO]] =
     req => {
       val respStr =
-        if (req.uri.renderString.contains("20-0.10137")) gaiaReponseString
-        else gaiaEmptyReponseString
+        if (req.uri.renderString.contains("20-0.10166")) gaiaEmptyReponseString
+        else gaiaReponseString
       Resource.eval(IO.pure(Response(body = Stream(respStr).through(utf8.encode))))
     }
 
@@ -399,8 +341,13 @@ class guideAvailability extends OdbSuite with ObservingModeSetupOperations {
         t <- createTargetWithProfileAs(pi, p)
         o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
       } yield o
+    val periods = List(
+      makeAvailabilityPeriod(oct31_2023, feb01_2024, earlyAngles),
+      makeAvailabilityPeriod(feb01_2024, feb28_2024, laterAngles)
+    )
+    val expected = availabilityResult("V1647 Orionis", periods).asRight
     setup.flatMap { oid =>
-      expect(pi, guideAvailabilityQuery(oid, successStart, successEnd), expected = guideAvailabilityResults.asRight)
+      expect(pi, guideAvailabilityQuery(oid, oct31_2023, feb28_2024), expected = expected)
     }
   }
 
@@ -411,7 +358,7 @@ class guideAvailability extends OdbSuite with ObservingModeSetupOperations {
         o <- createGmosNorthLongSlitObservationAs(pi, p, List.empty)
       } yield o
     setup.flatMap { oid =>
-      expect(pi, guideAvailabilityQuery(oid, successStart, successEnd),
+      expect(pi, guideAvailabilityQuery(oid, oct31_2023, feb28_2024),
       expected = List(s"Could not generate a sequence from the observation $oid: target").asLeft)
     }
   }
@@ -423,8 +370,12 @@ class guideAvailability extends OdbSuite with ObservingModeSetupOperations {
         t <- createTargetWithProfileAs(pi, p)
         o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
       } yield o
+    val periods = List(
+      makeAvailabilityPeriod(emptyStart, emptyEnd, List.empty)
+    )
+    val expected = availabilityResult("V1647 Orionis", periods).asRight
     setup.flatMap { oid =>
-      expect(pi, guideAvailabilityQuery(oid, emptyStart, emptyEnd), expected = emptyGuideAvailabilityResults.asRight)
+      expect(pi, guideAvailabilityQuery(oid, emptyStart, emptyEnd), expected = expected)
     }
   }
 
@@ -436,8 +387,253 @@ class guideAvailability extends OdbSuite with ObservingModeSetupOperations {
         o <- createObservationWithNoModeAs(pi, p, t)
       } yield o
     setup.flatMap { oid =>
-      expect(pi, guideAvailabilityQuery(oid, successStart, successEnd),
+      expect(pi, guideAvailabilityQuery(oid, oct31_2023, feb28_2024),
       expected = List(s"Could not generate a sequence from the observation $oid: observing mode").asLeft)
     }
   }
+
+  test("range too big") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationWithNoModeAs(pi, p, t)
+      } yield o
+    setup.flatMap { oid =>
+      expect(pi, guideAvailabilityQuery(oid, oct31_2023, emptyEnd),
+      expected = List(s"Period for guide availability cannot be greater than ${GuideService.maxAvailabilityPeriodDays} days.").asLeft)
+    }
+  }
+
+  // There isn't a lot of visibility into how the service is deciding what it needs to calculate
+  // based on what it already has, but we can make sure the various scenarios don't break things.
+  // Much of the decision behavior is encapsulated in ContiguousTimestampMap, which is well tested.
+
+  test("extends both ends") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      val periods1 = List(
+        makeAvailabilityPeriod(oct31_2023, feb01_2024, earlyAngles),
+        makeAvailabilityPeriod(feb01_2024, feb28_2024, laterAngles)
+      )
+      val expected1 = availabilityResult("V1647 Orionis", periods1).asRight
+      val one = expect(pi, guideAvailabilityQuery(oid, oct31_2023, feb28_2024), expected = expected1)
+
+      val periods2 = List(
+        makeAvailabilityPeriod(oct25_2023, feb01_2024, earlyAngles),
+        makeAvailabilityPeriod(feb01_2024, mar05_2024, laterAngles)
+      )
+      val expected2 = availabilityResult("V1647 Orionis", periods2).asRight
+      val two = expect(pi, guideAvailabilityQuery(oid, oct25_2023, mar05_2024), expected = expected2)
+
+      one >> two 
+    }
+  }
+
+  test("subset") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      val periods1 = List(
+        makeAvailabilityPeriod(oct31_2023, feb01_2024, earlyAngles),
+        makeAvailabilityPeriod(feb01_2024, feb28_2024, laterAngles)
+      )
+      val expected1 = availabilityResult("V1647 Orionis", periods1).asRight
+      val one = expect(pi, guideAvailabilityQuery(oid, oct31_2023, feb28_2024), expected = expected1)
+
+      val periods2 = List(
+        makeAvailabilityPeriod(nov30_2023, feb01_2024, earlyAngles)
+      )
+      val expected2 = availabilityResult("V1647 Orionis", periods2).asRight
+      val two = expect(pi, guideAvailabilityQuery(oid, nov30_2023, feb01_2024), expected = expected2)
+
+      one >> two 
+    }
+  }
+
+  test("disjoint in front") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      val periods1 = List(
+        makeAvailabilityPeriod(oct31_2023, feb01_2024, earlyAngles),
+        makeAvailabilityPeriod(feb01_2024, feb28_2024, laterAngles)
+      )
+      val expected1 = availabilityResult("V1647 Orionis", periods1).asRight
+      val one = expect(pi, guideAvailabilityQuery(oid, oct31_2023, feb28_2024), expected = expected1)
+
+      val periods2 = List(
+        makeAvailabilityPeriod(oct15_2023, oct25_2023, earlyAngles)
+      )
+      val expected2 = availabilityResult("V1647 Orionis", periods2).asRight
+      val two = expect(pi, guideAvailabilityQuery(oid, oct15_2023, oct25_2023), expected = expected2)
+
+      one >> two 
+    }
+  }
+
+  test("abuts in front") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      val periods1 = List(
+        makeAvailabilityPeriod(oct31_2023, feb01_2024, earlyAngles),
+        makeAvailabilityPeriod(feb01_2024, feb28_2024, laterAngles)
+      )
+      val expected1 = availabilityResult("V1647 Orionis", periods1).asRight
+      val one = expect(pi, guideAvailabilityQuery(oid, oct31_2023, feb28_2024), expected = expected1)
+
+      val periods2 = List(
+        makeAvailabilityPeriod(oct15_2023, oct31_2023, earlyAngles)
+      )
+      val expected2 = availabilityResult("V1647 Orionis", periods2).asRight
+      val two = expect(pi, guideAvailabilityQuery(oid, oct15_2023, oct31_2023), expected = expected2)
+
+      one >> two 
+    }
+  }
+
+  test("overlaps at front") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      val periods1 = List(
+        makeAvailabilityPeriod(oct31_2023, feb01_2024, earlyAngles),
+        makeAvailabilityPeriod(feb01_2024, feb28_2024, laterAngles)
+      )
+      val expected1 = availabilityResult("V1647 Orionis", periods1).asRight
+      val one = expect(pi, guideAvailabilityQuery(oid, oct31_2023, feb28_2024), expected = expected1)
+
+      val periods2 = List(
+        makeAvailabilityPeriod(oct15_2023, nov30_2023, earlyAngles)
+      )
+      val expected2 = availabilityResult("V1647 Orionis", periods2).asRight
+      val two = expect(pi, guideAvailabilityQuery(oid, oct15_2023, nov30_2023), expected = expected2)
+
+      one >> two 
+    }
+  }
+
+  test("disjoint at end") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      val periods1 = List(
+        makeAvailabilityPeriod(oct31_2023, feb01_2024, earlyAngles),
+        makeAvailabilityPeriod(feb01_2024, feb28_2024, laterAngles)
+      )
+      val expected1 = availabilityResult("V1647 Orionis", periods1).asRight
+      val one = expect(pi, guideAvailabilityQuery(oid, oct31_2023, feb28_2024), expected = expected1)
+
+      val periods2 = List(
+        makeAvailabilityPeriod(mar05_2024, mar10_2024, laterAngles)
+      )
+      val expected2 = availabilityResult("V1647 Orionis", periods2).asRight
+      val two = expect(pi, guideAvailabilityQuery(oid, mar05_2024, mar10_2024), expected = expected2)
+
+      one >> two 
+    }
+  }
+
+  test("abuts at end") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      val periods1 = List(
+        makeAvailabilityPeriod(oct31_2023, feb01_2024, earlyAngles),
+        makeAvailabilityPeriod(feb01_2024, feb28_2024, laterAngles)
+      )
+      val expected1 = availabilityResult("V1647 Orionis", periods1).asRight
+      val one = expect(pi, guideAvailabilityQuery(oid, oct31_2023, feb28_2024), expected = expected1)
+
+      val periods2 = List(
+        makeAvailabilityPeriod(feb28_2024, mar10_2024, laterAngles)
+      )
+      val expected2 = availabilityResult("V1647 Orionis", periods2).asRight
+      val two = expect(pi, guideAvailabilityQuery(oid, feb28_2024, mar10_2024), expected = expected2)
+
+      one >> two 
+    }
+  }
+
+  test("overlaps at end") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      val periods1 = List(
+        makeAvailabilityPeriod(oct31_2023, feb01_2024, earlyAngles),
+        makeAvailabilityPeriod(feb01_2024, feb28_2024, laterAngles)
+      )
+      val expected1 = availabilityResult("V1647 Orionis", periods1).asRight
+      val one = expect(pi, guideAvailabilityQuery(oid, oct31_2023, feb28_2024), expected = expected1)
+
+      val periods2 = List(
+        makeAvailabilityPeriod(nov30_2023, feb01_2024, earlyAngles),
+        makeAvailabilityPeriod(feb01_2024, mar05_2024, laterAngles)
+      )
+      val expected2 = availabilityResult("V1647 Orionis", periods2).asRight
+      val two = expect(pi, guideAvailabilityQuery(oid, nov30_2023, mar05_2024), expected = expected2)
+
+      one >> two 
+    }
+  }
+
+  test("disjoint and far away") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      val periods1 = List(
+        makeAvailabilityPeriod(oct31_2023, feb01_2024, earlyAngles),
+        makeAvailabilityPeriod(feb01_2024, feb28_2024, laterAngles)
+      )
+      val expected1 = availabilityResult("V1647 Orionis", periods1).asRight
+      val one = expect(pi, guideAvailabilityQuery(oid, oct31_2023, feb28_2024), expected = expected1)
+
+      val periods2 = List(
+        makeAvailabilityPeriod(emptyStart, emptyEnd, List.empty)
+      )
+      val expected2 = availabilityResult("V1647 Orionis", periods2).asRight
+      val two = expect(pi, guideAvailabilityQuery(oid, emptyStart, emptyEnd), expected = expected2)
+
+      one >> two 
+    }
+  }
+
 }

--- a/modules/service/src/test/scala/lucuma/odb/service/GuideServiceHashSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/GuideServiceHashSuite.scala
@@ -1,0 +1,150 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service
+
+import cats.syntax.all.*
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Wavelength
+import lucuma.core.math.arb.*
+import lucuma.core.model.ConstraintSet
+import lucuma.core.model.Observation
+import lucuma.core.model.PosAngleConstraint
+import lucuma.core.model.arb.*
+import lucuma.core.util.arb.*
+import lucuma.odb.data.Md5Hash
+import lucuma.odb.data.arb.ArbMd5Hash
+import lucuma.odb.service.GuideService.ObservationInfo
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop.*
+
+class GuideServiceHashSuite  extends ScalaCheckSuite {
+  import ArbConstraintSet.*
+  import ArbCoordinates.*
+  import ArbGid.* 
+  import ArbMd5Hash.given
+  import ArbPosAngleConstraint.*
+  import ArbWavelength.*
+
+  test("hashes equal for info equal with different Observation.Id") {
+    forAll { (
+      obsId1:  Observation.Id,
+      obsId2:  Observation.Id,
+      cs:      ConstraintSet,
+      pac:     PosAngleConstraint,
+      ow:      Option[Wavelength],
+      oc:      Option[Coordinates],
+      genHash: Md5Hash
+    ) =>
+      val obsInfo1 = ObservationInfo(obsId1, cs, pac, ow, oc)
+      val obsInfo2 = ObservationInfo(obsId2, cs, pac, ow, oc)
+      assertEquals(obsInfo1.hash(genHash), obsInfo2.hash(genHash))
+    }
+  }
+
+  test("hashes different for different generator hashes") {
+    forAll { (
+      obsId:    Observation.Id,
+      cs:       ConstraintSet,
+      pac:      PosAngleConstraint,
+      ow:       Option[Wavelength],
+      oc:       Option[Coordinates],
+      genHash1: Md5Hash,
+      genHash2: Md5Hash
+    ) =>
+      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc).hash(genHash1)
+      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc).hash(genHash2)
+
+      if (genHash1 === genHash2)
+        assertEquals(hash1, hash2)
+      else
+        assertNotEquals(hash1, hash2)
+    }
+  }
+
+  test("hashes different for different constraint sets") {
+    forAll { (
+      obsId:   Observation.Id,
+      cs1:     ConstraintSet,
+      cs2:     ConstraintSet,
+      pac:     PosAngleConstraint,
+      ow:      Option[Wavelength],
+      oc:      Option[Coordinates],
+      genHash: Md5Hash
+    ) =>
+      val hash1 = ObservationInfo(obsId, cs1, pac, ow, oc).hash(genHash)
+      val hash2 = ObservationInfo(obsId, cs2, pac, ow, oc).hash(genHash)
+
+      if (cs1 === cs2)
+        assertEquals(hash1, hash2)
+      else
+        assertNotEquals(hash1, hash2)
+    }
+  }
+
+  test("hashes different for different position angle constraints") {
+    forAll { (
+      obsId:   Observation.Id,
+      cs:      ConstraintSet,
+      pac1:    PosAngleConstraint,
+      pac2:    PosAngleConstraint,
+      ow:      Option[Wavelength],
+      oc:      Option[Coordinates],
+      genHash: Md5Hash
+    ) =>
+      val obsInfo1 = ObservationInfo(obsId, cs, pac1, ow, oc)
+      val obsInfo2 = ObservationInfo(obsId, cs, pac2, ow, oc)
+
+      val hash1 = obsInfo1.hash(genHash)
+      val hash2 = obsInfo2.hash(genHash)
+
+      // hash just depends on the angles we need to check. So, for example,
+      // unconstrained is the same as average parallactic
+      if (obsInfo1.availabilityAngles === obsInfo2.availabilityAngles)
+        assertEquals(hash1, hash2)
+      else
+        assertNotEquals(hash1, hash2)
+    }
+  }
+
+  test("hashes different for different wavelengths") {
+    forAll { (
+      obsId:   Observation.Id,
+      cs:      ConstraintSet,
+      pac:     PosAngleConstraint,
+      ow1:     Option[Wavelength],
+      ow2:     Option[Wavelength],
+      oc:      Option[Coordinates],
+      genHash: Md5Hash
+    ) =>
+      val hash1 = ObservationInfo(obsId, cs, pac, ow1, oc).hash(genHash)
+      val hash2 = ObservationInfo(obsId, cs, pac, ow2, oc).hash(genHash)
+
+      if (ow1 === ow2)
+        assertEquals(hash1, hash2)
+      else
+        assertNotEquals(hash1, hash2)
+    }
+  }
+
+  test("hashes different for different explicit base coordinates") {
+    forAll { (
+      obsId:   Observation.Id,
+      cs:      ConstraintSet,
+      pac:     PosAngleConstraint,
+      ow:      Option[Wavelength],
+      oc1:     Option[Coordinates],
+      oc2:     Option[Coordinates],
+      genHash: Md5Hash
+    ) =>
+      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc1).hash(genHash)
+      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc2).hash(genHash)
+
+      if (oc1 === oc2)
+        assertEquals(hash1, hash2)
+      else
+        assertNotEquals(hash1, hash2)
+    }
+  }
+
+}


### PR DESCRIPTION
The implementation avoids recalculating anything that it already has in the cache. So, if you request a subset of what is in the cache, it does nothing. If you request something that overlaps or abuts, it only calculates what is missing. If the request is completely disjoint, it will fill in the intermediate time as well, as long as the gap is not too large.

Most of the decision making for what will be calculated is encapsulated in the `ContiguousTimestampMap`. I don't know if this will be generally useful elsewhere, but it seemed better to extract it for testing, and it was easy to generalize it.