### PR TITLE
Make digest and config optional

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -5183,11 +5183,15 @@ type Execution {
 
   """
   Calculations dependent on the sequence, such as planned time and offsets.
+  If a sequence cannot be generated for this observation, `null` is returned
+  along with warning messages.
   """
-  digest: ExecutionDigest!
+  digest: ExecutionDigest
 
   """
-  Full execution config, including acquisition and science sequences.
+  Full execution config, including acquisition and science sequences.  If a
+  sequence cannot be generated for this observation, `null` is returned along
+  with warning messages.
   """
   config(
 
@@ -5201,7 +5205,7 @@ type Execution {
     """
     futureLimit: NonNegInt = 25
 
-  ): ExecutionConfig!
+  ): ExecutionConfig
 
   "Executed (or at least partially executed) atom records, across all visits."
   atomRecords(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
@@ -103,7 +103,7 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
 
   extension (e: Generator.Error) {
     def toResult: Result[Json] =
-      Result.failure(e.format)
+      Result.warning(e.format, Json.Null)
   }
 
   private lazy val configHandler: EffectHandler[F] = {


### PR DESCRIPTION
The `ExecutionDigest` and `ExecutionConfig` are currently required with a bang `!`. If the observation is not fully specified, these fail because we cannot generate its sequence.  This PR makes `execution / digest`  and `execution / config` both optional, while preserving any errors in the top-level error channel.  Is this a good idea?

  For example the query

```
             query {
               program(programId: "p-123") {
                 observations {
                   matches {
                     id
                     execution {
                       digest {
                         setup {
                           full { seconds }
                         }
                       }
                     }
                   }
                 }
               }
             }
```

might produce

 ```
            {
              "program": {
                "observations": {
                  "matches": [
                    {
                      "id": "o-123",
                      "execution": {
                        "digest": null
                      }
                    },
                    {
                      "id": "o-124",
                      "execution": {
                        "digest": {
                          "setup" : {
                            "full" : {
                              "seconds" : 960.000000
                            }
                          }
                        }
                      }
                    }
                  ]
                }
              }
            }
```

along with the error

```
Could not generate a sequence from the observation o-123: observing mode
```