### PR TITLE
Default Proposal ToO Activation to None.

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -3047,7 +3047,7 @@ input ProposalInput {
   category: TacCategory
 
   """
-  The toOActivation field is required when creating a new instance of proposal, but optional when editing
+  The toOActivation field is optional. If not specified when creating a proposal, it defaults to `NONE'.
   """
   toOActivation: ToOActivation
 
@@ -7690,7 +7690,7 @@ type Proposal {
   """
   Target of Opportunity activation
   """
-  toOActivation: ToOActivation
+  toOActivation: ToOActivation!
 
   """
   Abstract

--- a/modules/service/src/main/resources/db/migration/V0835__default-proposal-TOO-Activation.sql
+++ b/modules/service/src/main/resources/db/migration/V0835__default-proposal-TOO-Activation.sql
@@ -1,0 +1,6 @@
+-- Update the proposal table to default to 'none'
+
+ALTER TABLE t_proposal 
+  ALTER COLUMN c_too_activation TYPE e_too_activation USING (coalesce(c_too_activation, 'none')),
+  ALTER COLUMN c_too_activation SET DEFAULT 'none',
+  ALTER COLUMN c_too_activation SET NOT NULL;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ProposalTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ProposalTable.scala
@@ -15,7 +15,7 @@ trait ProposalTable[F[_]] extends BaseMapping[F] {
     val Title           = col("c_title", text_nonempty.opt)
     val Abstrakt        = col("c_abstract", text_nonempty.opt)
     val Category        = col("c_category", tag.opt)
-    val TooActivation   = col("c_too_activation", too_activation.opt)
+    val TooActivation   = col("c_too_activation", too_activation)
     val Clazz           = col("c_class", tag)
     val MinPercent      = col("c_min_percent", int_percent)
     val MinPercentTotal = col("c_min_percent_total", int_percent.embedded)


### PR DESCRIPTION
The `ToOActivation` field in the Proposal was optional in the API query. Although the GraphQL documentation stated that it was mandatory on creation, it was nullable in the database. Furthermore, it is not optional in the `Proposal` class in lucuma core, which is what Explore uses. This PR makes it not nullable in the database and defaults it to `none` which is a reasonable default value.