### PR TITLE
Fix constraints for the proposal class.

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0836__fix_proposal_class_constraints.sql
+++ b/modules/service/src/main/resources/db/migration/V0836__fix_proposal_class_constraints.sql
@@ -1,0 +1,17 @@
+-- Fix the constraints on the proposal class.
+
+-- We shouldn't have any of these, but just in case...
+update t_proposal
+   set c_class = 'queue',
+       c_min_percent_total = null,
+       c_total_time = null
+ where (c_class = 'intensive' or c_class = 'large_program')
+   and (c_min_percent_total is null or c_total_time is null);
+
+alter table t_proposal
+  drop constraint t_proposal_check,
+  drop constraint t_proposal_check1,
+   add constraint t_proposal_check_min_total 
+           check((c_min_percent_total is not null) = (c_class = 'intensive' or c_class = 'large_program')),
+   add constraint t_proposal_check_total
+           check((c_total_time is not null) = (c_class = 'intensive' or c_class = 'large_program'));

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -355,6 +355,7 @@ object OdbMapping {
                 MutationElaborator,
                 ObservationElaborator,
                 ProgramElaborator,
+                ProposalElaborator,
                 StepRecordElaborator,
                 SubscriptionElaborator,
                 TargetEnvironmentElaborator,

--- a/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
@@ -118,7 +118,11 @@ object ProposalService {
       val proposalClassUpdates: List[AppliedFragment] =
         SET.proposalClass.toList.flatMap {
           case Left(ta) =>
-              ta.minPercentTime.map(sql"c_min_percent = $int_percent").toList
+            List(
+              ta.minPercentTime.map(sql"c_min_percent = $int_percent"),
+              void"c_min_percent_total = null".some,
+              void"c_total_time = null".some,
+            ).flatten
           case Right(tb) =>
             List(
               tb.minPercentTime.map(sql"c_min_percent = $int_percent"),

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createProgram.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createProgram.scala
@@ -254,12 +254,12 @@ class createProgram extends OdbSuite {
                     "toOActivation" : "NONE",
                     "partnerSplits" : [
                       {
-                        "partner" : "CA",
-                        "percent" : 30
-                      },
-                      {
                         "partner" : "US",
                         "percent" : 70
+                      },
+                      {
+                        "partner" : "CA",
+                        "percent" : 30
                       }
                     ]
                   }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updatePrograms.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updatePrograms.scala
@@ -200,7 +200,7 @@ class updatePrograms extends OdbSuite {
     }
   }
 
-  test("edit proposal (add)") {
+  test("edit proposal (add type A)") {
     createProgramAs(pi).flatMap { pid =>
       expect(
         user = pi,
@@ -271,6 +271,119 @@ class updatePrograms extends OdbSuite {
                         {
                           "partner" : "US",
                           "percent" : 100
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          """)
+      )
+    }
+  }
+
+  test("edit proposal (add type B)") {
+    createProgramAs(pi).flatMap { pid =>
+      expect(
+        user = pi,
+        query = s"""
+          mutation {
+            updatePrograms(
+              input: {
+                SET: {
+                  proposal: {
+                    title: "new title"
+                    proposalClass: {
+                      largeProgram: {
+                        minPercentTime: 50
+                        minPercentTotalTime: 60
+                        totalTime: {
+                          hours: 0.5
+                        }
+                      }
+                    }
+                    category: GASEOUS_ASTROPHYSICS
+                    toOActivation: NONE
+                    partnerSplits: [
+                      {
+                        partner: CL
+                        percent: 10
+                      },
+                      {
+                        partner: UH
+                        percent: 80
+                      },
+                      {
+                        partner: BR
+                        percent: 10
+                      }
+                    ]
+                  }
+                }
+                WHERE: {
+                  id: {
+                    EQ: "$pid"
+                  }
+                }
+              }
+            ) {
+              programs {
+                id
+                proposal {
+                  title
+                  proposalClass {
+                    ... on LargeProgram {
+                      minPercentTime
+                      minPercentTotalTime
+                      totalTime {
+                        hours
+                        iso
+                      }
+                    }
+                  }
+                  category
+                  toOActivation
+                  partnerSplits {
+                    partner
+                    percent
+                  }
+                }
+              }
+            }
+          }
+        """,
+        expected =
+          Right(json"""
+            {
+              "updatePrograms" : {
+                "programs": [
+                  {
+                    "id" : $pid,
+                    "proposal" : {
+                      "title" : "new title",
+                      "proposalClass" : {
+                        "minPercentTime" : 50,
+                        "minPercentTotalTime" : 60,
+                        "totalTime" : {
+                          "hours" : 0.500000,
+                          "iso" : "PT30M"
+                        }
+                      },
+                      "category" : "GASEOUS_ASTROPHYSICS",
+                      "toOActivation" : "NONE",
+                      "partnerSplits" : [
+                        {
+                          "partner" : "UH",
+                          "percent" : 80
+                        },
+                        {
+                          "partner" : "BR",
+                          "percent" : 10
+                        },
+                        {
+                          "partner" : "CL",
+                          "percent" : 10
                         }
                       ]
                     }
@@ -631,6 +744,7 @@ class updatePrograms extends OdbSuite {
               input: {
                 SET: {
                   proposal: {
+                    category: EXOPLANET_ATMOSPHERES_ACTIVITY
                     proposalClass: {
                       queue: {
                         minPercentTime: 50
@@ -701,6 +815,7 @@ class updatePrograms extends OdbSuite {
               programs {
                 id
                 proposal {
+                  category
                   proposalClass {
                     ... on Intensive {
                       minPercentTime
@@ -724,6 +839,7 @@ class updatePrograms extends OdbSuite {
                   {
                     "id" : $pid,
                     "proposal" : {
+                      "category" : "EXOPLANET_ATMOSPHERES_ACTIVITY",
                       "proposalClass" : {
                         "minPercentTime" : 40,
                         "minPercentTotalTime" : 10,


### PR DESCRIPTION
The constraints for  `c_min_percent_total` and `c_total_time` checked the values of the `c_category` problem instead of the `c_class` column, leading to odd constraints that weren't caught by the tests.

This changes the constraints and also adds/updates some tests that would have failed with the previous constraints. 

In addition, adding a new test caused the `edit proposal (non-class properties` test to fail because the order of the partner splits changed, so an elaborator was added to make the order of the partner splits deterministic.