### PR TITLE
Switch obs status used for time calculations from Approve to Included

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/logic/TimeEstimateService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/TimeEstimateService.scala
@@ -65,7 +65,7 @@ object TimeEstimateService {
       itcClient: ItcClient[F]
     )(using Services[F], Transaction[F]): F[Map[Observation.Id, ObservationData]] =
       for {
-        p <- generatorParamsService.selectAll(pid, ObsStatus.Approved)
+        p <- generatorParamsService.selectAll(pid, ObsStatus.Included)
         pʹ = p.collect { case (oid, Right(gp)) => (oid, gp) }
         i <- itcService(itcClient).selectAll(pid, pʹ)
         d <- executionDigestService.selectAll(pid)


### PR DESCRIPTION
This is based on a discussion with Andy. The proposal needs the time for observations in the `Included` status and above.