### PR TITLE
Step QA State

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -1726,8 +1726,13 @@ type GmosNorthStepRecord implements StepRecord {
   "The observe class of this step."
   observeClass: ObserveClass!
 
-  "Step QA state based on a combination of dataset QA states."
-  stepQaState: StepQaState
+  """
+  QA state based on a combination of dataset QA states.  The worst QA state is
+  taken as the overall step QA state.  For example, one FAIL dataset will
+  result in the step having a FAIL QA state.  Unset QA states are ignored, but
+  if none are set the result will be null.
+  """
+  qaState: DatasetQaState
 
   "Datasets associated with this step."
   datasets(
@@ -2250,8 +2255,13 @@ type GmosSouthStepRecord implements StepRecord {
   "The observe class of this step."
   observeClass: ObserveClass!
 
-  "Step QA state based on a combination of dataset QA states."
-  stepQaState: StepQaState
+  """
+  QA state based on a combination of dataset QA states.  The worst QA state is
+  taken as the overall step QA state.  For example, one FAIL dataset will
+  result in the step having a FAIL QA state.  Unset QA states are ignored, but
+  if none are set the result will be null.
+  """
+  qaState: DatasetQaState
 
   "Datasets associated with this step."
   datasets(
@@ -3565,21 +3575,6 @@ input StepConfigSmartGcalInput {
   Smart Gcal type
   """
   smartGcalType: SmartGcalType!
-}
-
-"""
-Step QA State
-"""
-enum StepQaState {
-  """
-  StepQaState Pass
-  """
-  PASS
-
-  """
-  StepQaState Fail
-  """
-  FAIL
 }
 
 """
@@ -9017,8 +9012,13 @@ interface StepRecord {
   "The observe class of this step."
   observeClass: ObserveClass!
 
-  "Step QA state based on a combination of dataset QA states."
-  stepQaState: StepQaState
+  """
+  QA state based on a combination of dataset QA states.  The worst QA state is
+  taken as the overall step QA state.  For example, one FAIL dataset will
+  result in the step having a FAIL QA state.  Unset QA states are ignored, but
+  if none are set the result will be null.
+  """
+  qaState: DatasetQaState
 
   "Datasets associated with this step."
   datasets(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionStepRecords.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionStepRecords.scala
@@ -1,0 +1,128 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package query
+
+import cats.syntax.either.*
+import cats.syntax.option.*
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.enums.DatasetQaState
+import lucuma.core.model.User
+import lucuma.odb.data.ObservingModeType
+
+class executionStepRecords extends OdbSuite with ExecutionQuerySetupOperations {
+  import ExecutionQuerySetupOperations.ObservationNode
+
+  val pi      = TestUsers.Standard.pi(1, 30)
+  val pi2     = TestUsers.Standard.pi(2, 32)
+  val service = TestUsers.service(3)
+
+  val mode    = ObservingModeType.GmosNorthLongSlit
+
+  val validUsers = List(pi, pi2, service).toList
+
+  def qaQuery(on: ObservationNode): String =
+    s"""
+      query {
+        observation(observationId: "${on.id}") {
+          execution {
+            atomRecords {
+              matches {
+                steps {
+                  matches {
+                    qaState
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+  def qaExpected(qa: Option[DatasetQaState]): Either[List[String], Json] =
+    json"""
+      {
+        "observation": {
+          "execution": {
+            "atomRecords": {
+              "matches": [
+                {
+                  "steps": {
+                    "matches": [
+                      {
+                        "qaState": ${qa.asJson}
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """.asRight
+
+
+  test("qaState - unset") {
+    recordAll(pi, mode, offset = 0, datasetCount = 2).flatMap { on =>
+      expect(pi, qaQuery(on), qaExpected(none))
+    }
+  }
+
+  test("qaState - one set") {
+    for {
+      on <- recordAll(pi, mode, offset = 10, datasetCount = 2)
+      _  <- setQaState(pi, DatasetQaState.Usable, s"${DatasetFilenamePrefix}0011.fits")
+      _  <- expect(pi, qaQuery(on), qaExpected(DatasetQaState.Usable.some))
+    } yield ()
+  }
+
+  test("qaState - two set") {
+    for {
+      on <- recordAll(pi, mode, offset = 20, datasetCount = 2)
+      _  <- setQaState(pi, DatasetQaState.Pass,   s"${DatasetFilenamePrefix}0021.fits")
+      _  <- setQaState(pi, DatasetQaState.Usable, s"${DatasetFilenamePrefix}0022.fits")
+      _  <- expect(pi, qaQuery(on), qaExpected(DatasetQaState.Usable.some))
+    } yield ()
+  }
+
+  test("qaState - two steps, two set") {
+    val expected = json"""
+      {
+        "observation": {
+          "execution": {
+            "atomRecords": {
+              "matches": [
+                {
+                  "steps": {
+                    "matches": [
+                      {
+                        "qaState": "USABLE"
+                      },
+                      {
+                        "qaState": "FAIL"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      """.asRight
+
+    for {
+      on <- recordAll(pi, mode, offset = 30, stepCount = 2, datasetCount = 2)
+      _  <- setQaState(pi, DatasetQaState.Pass,   s"${DatasetFilenamePrefix}0031.fits")
+      _  <- setQaState(pi, DatasetQaState.Usable, s"${DatasetFilenamePrefix}0032.fits")
+      _  <- setQaState(pi, DatasetQaState.Fail,   s"${DatasetFilenamePrefix}0033.fits")
+      _  <- setQaState(pi, DatasetQaState.Pass,   s"${DatasetFilenamePrefix}0034.fits")
+      _  <- expect(pi, qaQuery(on), expected)
+    } yield ()
+  }
+}


### PR DESCRIPTION
Adds a missing field definition, for overall step QA state.  It is a rollup of all the step's dataset's QA states.  There was a specific, `StepQaState` type for this but I couldn't remember why.  I removed it and just return the worst `DatasetQaState` for the step.  For example, if any dataset is marked `FAIL` the step QA state will also be `FAIL`.