### PR TITLE
Query -> events

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val skunkVersion               = "0.6.2"
 val pprintVersion              = "0.8.1"
 val testcontainersScalaVersion = "0.40.14" // N.B. 0.40.15 causes java.lang.NoClassDefFoundError: munit/Test
 
-ThisBuild / tlBaseVersion      := "0.9"
+ThisBuild / tlBaseVersion      := "0.10"
 ThisBuild / scalaVersion       := "3.3.1"
 ThisBuild / crossScalaVersions := Seq("3.3.1")
 

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7951,7 +7951,7 @@ type Query {
   """
   Selects the first `LIMIT` matching execution events based on the provided `WHERE` parameter, if any.
   """
-  executionEvents(
+  events(
     """
     Filters the selection of execution events
     """
@@ -10162,36 +10162,35 @@ input WhereDataset {
   qaState: WhereOptionEqQaState
 }
 
-"""
-DatasetEvent filter options.
-"""
-input WhereDatasetEvent {
-  """
-  Matches on the step id.
-  """
-  stepId: WhereEqStepId
+
+input WhereEqExecutionEventType {
 
   """
-  Matches on the dataset index within the step.
+  Matches if the property is exactly the supplied value.
   """
-  index: WhereOrderPosShort
+  EQ: ExecutionEventType
 
   """
-  Matches on the dataset stage.
+  Matches if the property is not the supplied value.
   """
-  stage: WhereOrderDatasetStage
+  NEQ: ExecutionEventType
 
   """
-  Matches on the dataset filename.
+  Matches if the property value is any of the supplied options.
   """
-  filename: WhereOptionString
+  IN: [ExecutionEventType!]
+
+  """
+  Matches if the property value is none of the supplied values.
+  """
+  NIN: [ExecutionEventType!]
+
 }
 
 """
 Filters on equality (or not) of the property value and the supplied criteria.
 All supplied criteria must match, but usually only one is selected.  E.g.
 'EQ = "Foo"' will match when the property value is "FOO".
-
 """
 input WhereEqPartner {
   """
@@ -10274,7 +10273,6 @@ input WhereEqProposalStatus {
 Filters on equality (or not) of the property value and the supplied criteria.
 All supplied criteria must match, but usually only one is selected.  E.g.
 'EQ = "Foo"' will match when the property value is "FOO".
-
 """
 input WhereEqStepId {
   """
@@ -10359,54 +10357,53 @@ ExecutionEvent filter options.
 """
 input WhereExecutionEvent {
   """
-  A list of nested execution event filters that all must match in order for the AND group as a whole to match.
+  A list of nested execution event filters that all must match in order for the
+  AND group as a whole to match.
   """
   AND: [WhereExecutionEvent!]
 
   """
-  A list of nested execution event filters where any one match causes the entire OR group as a whole to match.
+  A list of nested execution event filters where any one match causes the
+  entire OR group as a whole to match.
   """
   OR: [WhereExecutionEvent!]
 
   """
-  A nested execution event filter that must not match in order for the NOT itself to match.
+  A nested execution event filter that must not match in order for the NOT
+  itself to match.
   """
   NOT: WhereExecutionEvent
 
-  """
-  Matches on the execution event id
-  """
+  "Matches on the execution event id"
   id: WhereOrderExecutionEventId
 
-  """
-  Matches on the visit id
-  """
+  "Matches on the visit id"
   visitId: WhereEqVisitId
 
-  """
-  Matches on observation id
-  """
+  "Matches on observation id"
   observationId: WhereOrderObservationId
 
-  """
-  Matches on event reception time
-  """
+  "Matches on event reception time"
   received: WhereOrderTimestamp
 
-  """
-  Matches sequence events only
-  """
-  sequenceEvent: WhereSequenceEvent
+  "Matches on execution event type"
+  eventType: WhereEqExecutionEventType
 
-  """
-  Matches step events only
-  """
-  stepEvent: WhereStepEvent
+  "Matches the sequence command type, for sequence events."
+  sequenceCommand: WhereOrderSequenceCommand
 
-  """
-  Matches dataset events only
-  """
-  datasetEvent: WhereDatasetEvent
+  "Matches on the step id, for step and dataset events."
+  stepId: WhereEqStepId
+
+  "Matches on the step stage, for step events."
+  stepStage: WhereOrderStepStage
+
+  "Matches on the dataset id, for dataset events."
+  datasetId: WhereOrderDatasetId
+
+  "Matches on the dataset stage, for dataset events."
+  datasetStage: WhereOrderDatasetStage
+
 }
 
 """
@@ -11427,36 +11424,6 @@ input WhereProposalPartners {
   Matching based on whether the proposal is a joint (i.e., multi-partner) proposal.
   """
   isJoint: Boolean
-}
-
-"""
-SequenceEvent filter options.
-"""
-input WhereSequenceEvent {
-  """
-  Matches the sequence command type
-  """
-  command: WhereOrderSequenceCommand
-}
-
-"""
-StepEvent filter options.
-"""
-input WhereStepEvent {
-  """
-  Matches on the step id.
-  """
-  stepId: WhereEqStepId
-
-  """
-  Matches on the sequence type
-  """
-  sequenceType: WhereOrderSequenceType
-
-  """
-  Matches on the step stage
-  """
-  stage: WhereOrderStepStage
 }
 
 """

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereExecutionEvent.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereExecutionEvent.scala
@@ -1,0 +1,77 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import grackle.Path
+import grackle.Predicate
+import grackle.Predicate.*
+import lucuma.core.enums.DatasetStage
+import lucuma.core.enums.SequenceCommand
+import lucuma.core.enums.StepStage
+import lucuma.core.model.ExecutionEvent
+import lucuma.core.model.Observation
+import lucuma.core.model.Visit
+import lucuma.core.model.sequence.Dataset
+import lucuma.core.model.sequence.Step
+import lucuma.core.util.Timestamp
+import lucuma.odb.data.ExecutionEventType
+import lucuma.odb.graphql.binding.*
+
+object WhereExecutionEvent {
+
+  def binding(path: Path): Matcher[Predicate] = {
+    val WhereExecutionEventIdBinding   = WhereOrder.binding[ExecutionEvent.Id](path / "id", ExecutionEventIdBinding)
+    val WhereVisitIdBinding            = WhereEq.binding[Visit.Id](path / "visit" / "id", VisitIdBinding)
+    val WhereObservationIdBinding      = WhereOrder.binding[Observation.Id](path / "observation" / "id", ObservationIdBinding)
+    val WhereTimestampBinding          = WhereOrder.binding[Timestamp](path / "received", TimestampBinding)
+    val WhereExecutionEventTypeBinding = WhereEq.binding(path / "eventType", enumeratedBinding[ExecutionEventType])
+
+    val WhereSequenceCommandBinding    = WhereOrder.binding(path / "_sequenceCommand", enumeratedBinding[SequenceCommand])
+    val WhereStepIdBinding             = WhereEq.binding(path / "_stepId", uidBinding[Step.Id]("step"))
+    val WhereStepStageBinding          = WhereOrder.binding(path / "_stepStage", enumeratedBinding[StepStage])
+    val WhereDatasetIdBinding          = WhereOrder.binding(path / "_datasetId", gidBinding[Dataset.Id]("dataset"))
+    val WhereDatasetStageBinding       = WhereOrder.binding(path / "_datasetStage", enumeratedBinding[DatasetStage])
+
+    lazy val WhereExecutionEventBinding = binding(path)
+
+    ObjectFieldsBinding.rmap {
+      case List(
+        WhereExecutionEventBinding.List.Option("AND", rAND),
+        WhereExecutionEventBinding.List.Option("OR", rOR),
+        WhereExecutionEventBinding.Option("NOT", rNOT),
+        WhereExecutionEventIdBinding.Option("id", rId),
+        WhereVisitIdBinding.Option("visitId", rVisitId),
+        WhereObservationIdBinding.Option("observationId", rObservationId),
+        WhereTimestampBinding.Option("received", rReceived),
+        WhereExecutionEventTypeBinding.Option("eventType", rEventType),
+        WhereSequenceCommandBinding.Option("sequenceCommand", rSequenceCommand),
+        WhereStepIdBinding.Option("stepId", rStepId),
+        WhereStepStageBinding.Option("stepStage", rStepStage),
+        WhereDatasetIdBinding.Option("datasetId", rDatasetId),
+        WhereDatasetStageBinding.Option("datasetStage", rDatasetStage)
+
+      ) => (rAND, rOR, rNOT, rId, rVisitId, rObservationId, rReceived, rEventType, rSequenceCommand, rStepId, rStepStage, rDatasetId, rDatasetStage).parMapN {
+        (AND, OR, NOT, id, vid, oid, received, eventType, sequenceCommand, stepId, stepStage, datasetId, datasetStage) =>
+          and(List(
+            AND.map(and),
+            OR.map(or),
+            NOT.map(Not(_)),
+            id,
+            vid,
+            oid,
+            received,
+            eventType,
+            sequenceCommand,
+            stepId,
+            stepStage,
+            datasetId,
+            datasetStage
+          ).flatten)
+      }
+    }
+  }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereOrder.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereOrder.scala
@@ -13,9 +13,6 @@ import lucuma.odb.graphql.binding._
 
 object WhereOrder {
 
-  // def SimpleBinding[A: Order](name: String, binding: Matcher[A]): Matcher[Predicate] =
-  //   Binding[A](UniquePath[A](List(name)), binding)
-
   def binding[A: Order](path: Path, binding: Matcher[A]): Matcher[Predicate] =
     ObjectFieldsBinding.rmap {
       case List(
@@ -42,23 +39,5 @@ object WhereOrder {
             ).flatten)
         }
     }
-
-  // val ObservationId: Matcher[Predicate] =
-  //   ObservationIdWithPath("id")
-
-  // def ObservationIdWithPath(head: String, tail: String*): Matcher[Predicate] =
-  //   Binding(UniquePath[Observation.Id](head :: tail.toList), ObservationIdBinding)
-
-  // val ProgramId: Matcher[Predicate] =
-  //   ProgramIdWithPath("id")
-
-  // def ProgramIdWithPath(head: String, tail: String*): Matcher[Predicate] =
-  //   Binding(UniquePath[Program.Id](head :: tail.toList), ProgramIdBinding)
-
-  // val TargetId: Matcher[Predicate] =
-  //   TargetIdWithPath("id")
-
-  // def TargetIdWithPath(head: String, tail: String*): Matcher[Predicate] =
-  //   Binding(UniquePath[Target.Id](head :: tail.toList), TargetIdBinding)
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionEventMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionEventMapping.scala
@@ -34,7 +34,17 @@ trait ExecutionEventMapping[F[_]] extends ExecutionEventTable[F]
         SqlObject("visit",       Join(ExecutionEventTable.VisitId,       VisitTable.Id)),
         SqlObject("observation", Join(ExecutionEventTable.ObservationId, ObservationView.Id)),
         SqlField("received",     ExecutionEventTable.Received),
-        SqlField("eventType",    ExecutionEventTable.EventType, discriminator = true)
+        SqlField("eventType",    ExecutionEventTable.EventType, discriminator = true),
+
+        // Hidden fields used in the WhereExecutionEvent predicate.  There
+        // appears to be no good way to create a predicate that matches on a
+        // particular interface implementation so this is the best we can do.
+        // We can match on fields that appear in the ExecutionEventTable.
+        SqlField("_sequenceCommand", ExecutionEventTable.SequenceCommand, hidden = true),
+        SqlField("_stepId",          ExecutionEventTable.StepId,          hidden = true),
+        SqlField("_stepStage",       ExecutionEventTable.StepStage,       hidden = true),
+        SqlField("_datasetId",       ExecutionEventTable.DatasetId,       hidden = true),
+        SqlField("_datasetStage",    ExecutionEventTable.DatasetStage,    hidden = true)
       )
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionEventSelectResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionEventSelectResultMapping.scala
@@ -27,6 +27,9 @@ trait ExecutionEventSelectResultMapping[F[_]]
     val fromExecution: ObjectMapping =
       nestedSelectResultMapping(ExecutionEventSelectResultType, ObservationView.Id, Join(ObservationView.Id, ExecutionEventTable.ObservationId))
 
+    val fromQuery: ObjectMapping =
+      topLevelSelectResultMapping(ExecutionEventSelectResultType)
+
     val fromStepRecord: ObjectMapping =
       nestedSelectResultMapping(ExecutionEventSelectResultType, StepRecordView.Id, Join(StepRecordView.Id, ExecutionEventTable.StepId))
 
@@ -37,7 +40,8 @@ trait ExecutionEventSelectResultMapping[F[_]]
       ExecutionEventSelectResultType,
       List(
         DatasetType   / "events" -> fromDataset,
-        ExecutionType / "events" -> fromExecution
+        ExecutionType / "events" -> fromExecution,
+        QueryType / "events" -> fromQuery
       ) ++
       lookupFromStepRecord(fromStepRecord, "events") ++
       lookupFromVisit(fromVisit, "events")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
@@ -34,6 +34,7 @@ import lucuma.core.model.sequence.Step
 import lucuma.core.model.sequence.TimeChargeCorrection
 import lucuma.core.util.Timestamp
 import lucuma.odb.data.EditType
+import lucuma.odb.data.ExecutionEventType
 import lucuma.odb.data.Existence
 import lucuma.odb.data.Extinction
 import lucuma.odb.data.ObservingModeType
@@ -68,7 +69,7 @@ trait LeafMappings[F[_]] extends BaseMapping[F] {
       LeafMapping[EphemerisKeyType](EphemerisKeyTypeType),
       LeafMapping[Epoch](EpochStringType),
       LeafMapping[ExecutionEvent.Id](ExecutionEventIdType),
-      LeafMapping[Tag](ExecutionEventTypeType),
+      LeafMapping[ExecutionEventType](ExecutionEventTypeType),
       LeafMapping[Existence](ExistenceType),
       LeafMapping[Extinction](ExtinctionType),
       LeafMapping[Tag](FilterTypeType),

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionEvents.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionEvents.scala
@@ -8,9 +8,16 @@ import cats.syntax.either.*
 import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
+import lucuma.core.enums.DatasetStage
+import lucuma.core.enums.SequenceCommand
+import lucuma.core.enums.StepStage
 import lucuma.core.model.ExecutionEvent
+import lucuma.core.model.ExecutionEvent.DatasetEvent
+import lucuma.core.model.ExecutionEvent.SequenceEvent
+import lucuma.core.model.ExecutionEvent.StepEvent
 import lucuma.core.model.User
 import lucuma.core.model.Visit
+import lucuma.core.util.Timestamp
 import lucuma.odb.data.ObservingModeType
 
 class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
@@ -29,7 +36,7 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
         query {
           observation(observationId: "${on.id}") {
             execution {
-              events() {
+              events {
                 matches {
                   id
                 }
@@ -63,7 +70,7 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
         query {
           observation(observationId: "${on.id}") {
             execution {
-              events() {
+              events {
                 matches {
                   id
                   observation {
@@ -103,4 +110,399 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
     }
   }
 
+  test("query -> events (no WHERE, only visible to pi2)") {
+    recordAll(pi2, mode, offset = 200, stepCount = 2).flatMap { on =>
+      val q = s"""
+        query {
+          events {
+            matches {
+              id
+            }
+          }
+        }
+      """
+
+      val events = on.allEvents.map(e => Json.obj("id" -> e.id.asJson))
+
+      val e = json"""
+      {
+        "events": {
+          "matches": $events
+        }
+      }
+      """.asRight
+
+      expect(pi2, q, e)
+    }
+  }
+
+  test("query -> events (WHERE observationId)") {
+    recordAll(pi, mode, offset = 300, stepCount = 2).flatMap { on =>
+      val q = s"""
+        query {
+          events(
+            WHERE: {
+              observationId: {
+                EQ: "${on.id}"
+              }
+            }
+          ) {
+            matches {
+              id
+            }
+          }
+        }
+      """
+
+      val events = on.allEvents.map(e => Json.obj("id" -> e.id.asJson))
+
+      val e = json"""
+      {
+        "events": {
+          "matches": $events
+        }
+      }
+      """.asRight
+
+      expect(pi, q, e)
+    }
+  }
+
+  test("query -> events (WHERE observationId + eventType)") {
+    recordAll(pi, mode, offset = 400, stepCount = 2).flatMap { on =>
+      val q = s"""
+        query {
+          events(
+            WHERE: {
+              observationId: {
+                EQ: "${on.id}"
+              },
+              eventType: {
+                EQ: SEQUENCE
+              }
+            }
+          ) {
+            matches {
+              id
+            }
+          }
+        }
+      """
+
+      val events: List[Json] =
+         on.allEvents.collect { case SequenceEvent(id, _, _, _, _) => Json.obj("id" -> id.asJson) }
+
+      val e = json"""
+      {
+        "events": {
+          "matches": $events
+        }
+      }
+      """.asRight
+
+      expect(pi, q, e)
+    }
+  }
+
+  test("query -> events (WHERE observationId + received)") {
+    recordAll(pi, mode, offset = 500).flatMap { on =>
+      val start: Timestamp = on.allEvents.head.received
+      val end: Timestamp   = on.allEvents.last.received
+
+      val q = s"""
+        query {
+          events(
+            WHERE: {
+              observationId: {
+                EQ: "${on.id}"
+              },
+              received: {
+                GT: "$start",
+                LT: "$end"
+              }
+            }
+          ) {
+            matches {
+              id
+            }
+          }
+        }
+      """
+
+      val events: List[Json] =
+         on.allEvents.tail.init.map(e => Json.obj("id" -> e.id.asJson))
+
+      val e = json"""
+      {
+        "events": {
+          "matches": $events
+        }
+      }
+      """.asRight
+
+      expect(pi, q, e)
+    }
+  }
+
+  test("query -> events (WHERE visitId)") {
+    recordAll(pi, mode, offset = 600, visitCount = 2).flatMap { on =>
+      val q = s"""
+        query {
+          events(
+            WHERE: {
+              visitId: {
+                EQ: "${on.visits.head.id}"
+              }
+            }
+          ) {
+            matches {
+              id
+            }
+          }
+        }
+      """
+
+      val events: List[Json] =
+         on.visits.head.allEvents.map(e => Json.obj("id" -> e.id.asJson))
+
+      val e = json"""
+      {
+        "events": {
+          "matches": $events
+        }
+      }
+      """.asRight
+
+      expect(pi, q, e)
+    }
+  }
+
+  test("query -> events (WHERE id)") {
+    recordAll(pi, mode, offset = 700).flatMap { on =>
+      val q = s"""
+        query {
+          events(
+            WHERE: {
+              id: {
+                EQ: "${on.allEvents.head.id}"
+              }
+            }
+          ) {
+            matches {
+              id
+            }
+          }
+        }
+      """
+
+      val events: List[Json] =
+         List(Json.obj("id" -> on.allEvents.head.id.asJson))
+
+      val e = json"""
+      {
+        "events": {
+          "matches": $events
+        }
+      }
+      """.asRight
+
+      expect(pi, q, e)
+    }
+  }
+
+  test("query -> events (WHERE observationId + sequenceEvent command)") {
+    recordAll(pi, mode, offset = 800, stepCount = 2).flatMap { on =>
+      val q = s"""
+        query {
+          events(
+            WHERE: {
+              observationId: {
+                EQ: "${on.id}"
+              },
+              sequenceCommand: {
+                EQ: START
+              }
+            }
+          ) {
+            matches {
+              id
+            }
+          }
+        }
+      """
+
+      val events: List[Json] =
+         on.allEvents.collect { case SequenceEvent(id, _, _, _, SequenceCommand.Start) => Json.obj("id" -> id.asJson) }
+
+      val e = json"""
+      {
+        "events": {
+          "matches": $events
+        }
+      }
+      """.asRight
+
+      expect(pi, q, e)
+    }
+  }
+
+  test("query -> events (WHERE observationId + stepEvent stepId)") {
+    recordAll(pi, mode, offset = 900, stepCount = 2).flatMap { on =>
+      val sid = on.visits.head.atoms.head.steps.head.id
+
+      val q = s"""
+        query {
+          events(
+            WHERE: {
+              observationId: {
+                EQ: "${on.id}"
+              },
+              eventType: {
+                EQ: STEP
+              },
+              stepId: {
+                EQ: "$sid"
+              }
+            }
+          ) {
+            matches {
+              id
+              ... on StepEvent {
+                step {
+                  id
+                }
+              }
+            }
+          }
+        }
+      """
+
+      val events: List[Json] =
+         on.allEvents.collect { case StepEvent(id, _, _, _, `sid`, _) =>
+           Json.obj(
+             "id" -> id.asJson,
+             "step" -> Json.obj(
+               "id" -> sid.asJson
+             )
+           )
+         }
+
+      val e = json"""
+      {
+        "events": {
+          "matches": $events
+        }
+      }
+      """.asRight
+
+      expect(pi, q, e)
+    }
+  }
+
+  test("query -> events (WHERE observationId + stepEvent stepStage)") {
+    recordAll(pi, mode, offset = 1000, stepCount = 2).flatMap { on =>
+      val q = s"""
+        query {
+          events(
+            WHERE: {
+              observationId: {
+                EQ: "${on.id}"
+              },
+              stepStage: {
+                EQ: END_STEP
+              }
+            }
+          ) {
+            matches {
+              id
+            }
+          }
+        }
+      """
+
+      val events: List[Json] =
+         on.allEvents.collect { case StepEvent(id, _, _, _, _, StepStage.EndStep) => Json.obj("id" -> id.asJson) }
+
+      val e = json"""
+      {
+        "events": {
+          "matches": $events
+        }
+      }
+      """.asRight
+
+      expect(pi, q, e)
+    }
+  }
+
+  test("query -> events (WHERE datasetId)") {
+    recordAll(pi, mode, offset = 1100, stepCount = 2).flatMap { on =>
+      val dids = on.visits.head.atoms.head.steps.head.allDatasets
+      val q = s"""
+        query {
+          events(
+            WHERE: {
+              datasetId: {
+                IN: ${dids.map(id => s"\"${id.toString}\"").mkString("[", ", ", "]")}
+              }
+            }
+          ) {
+            matches {
+              id
+            }
+          }
+        }
+      """
+
+      val didsContains = dids.toSet
+      val events: List[Json] =
+         on.allEvents.collect { case DatasetEvent(id, _, _, _, _, did, _) if didsContains(did) => Json.obj("id" -> id.asJson) }
+
+      val e = json"""
+      {
+        "events": {
+          "matches": $events
+        }
+      }
+      """.asRight
+
+      expect(pi, q, e)
+    }
+  }
+
+  test("query -> events (WHERE observationId + datasetStage)") {
+    recordAll(pi, mode, offset = 1200, stepCount = 2).flatMap { on =>
+      val q = s"""
+        query {
+          events(
+            WHERE: {
+              observationId: {
+                EQ: "${on.id}"
+              },
+              datasetStage: {
+                EQ: END_WRITE
+              }
+            }
+          ) {
+            matches {
+              id
+            }
+          }
+        }
+      """
+
+      val events: List[Json] =
+         on.allEvents.collect { case DatasetEvent(id, _, _, _, _, _, DatasetStage.EndWrite) => Json.obj("id" -> id.asJson) }
+
+      val e = json"""
+      {
+        "events": {
+          "matches": $events
+        }
+      }
+      """.asRight
+
+      expect(pi, q, e)
+    }
+  }
 }


### PR DESCRIPTION
`ExecutionEvent` top-level query.  It can match on observation id, step id, dataset id, timestamp, etc. but is hampered by lack of interface support in Grackle.  I could not, for example, add a predicate for dataset filename for dataset events because those would require matching on `DatasetEvent` in particular or perhaps adding a hidden `SqlObject` (which is not supported).