### PR TITLE
Short Cut 2429: Unify updateObservations and updateTargets inputs

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -10429,6 +10429,11 @@ input WhereObservation {
   id: WhereOrderObservationId
 
   """
+  Matches the id of the associated program.
+  """
+  programId: WhereOrderProgramId
+
+  """
   Matches the subtitle of the observation.
   """
   subtitle: WhereOptionString

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4128,11 +4128,6 @@ Observation selection and update description.  Use `SET` to specify the changes,
 input UpdateObservationsInput {
 
   """
-  The program whose observations will be updated.
-  """
-  programId: ProgramId!
-
-  """
   Describes the observation values to modify.
   """
   SET: ObservationPropertiesInput!

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateObservationsInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateObservationsInput.scala
@@ -10,13 +10,11 @@ import cats.syntax.parallel.*
 import eu.timepit.refined.types.numeric.NonNegInt
 import grackle.Path
 import grackle.Predicate
-import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.odb.data.Nullable
 import lucuma.odb.graphql.binding._
 
 final case class UpdateObservationsInput(
-  programId:      Program.Id,
   SET:            ObservationPropertiesInput.Edit,
   WHERE:          Option[Predicate],
   LIMIT:          Option[NonNegInt],
@@ -34,13 +32,12 @@ object UpdateObservationsInput {
     val WhereObservationBinding = WhereObservation.binding(path)
     ObjectFieldsBinding.rmap {
       case List(
-        ProgramIdBinding("programId", rPid),
         ObservationPropertiesInput.Edit.Binding("SET", rSET),
         WhereObservationBinding.Option("WHERE", rWHERE),
         NonNegIntBinding.Option("LIMIT", rLIMIT),
         BooleanBinding.Option("includeDeleted", rIncludeDeleted)
       ) =>
-        (rPid, rSET, rWHERE, rLIMIT, rIncludeDeleted).parMapN(apply)
+        (rSET, rWHERE, rLIMIT, rIncludeDeleted).parMapN(apply)
     }
   }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
@@ -12,6 +12,7 @@ import grackle.Predicate._
 import lucuma.core.enums.ObsActiveStatus
 import lucuma.core.enums.ObsStatus
 import lucuma.core.model.Observation
+import lucuma.core.model.Program
 import lucuma.odb.graphql.binding._
 
 object WhereObservation {
@@ -19,6 +20,7 @@ object WhereObservation {
   def binding(path: Path): Matcher[Predicate] = {
     val SubtitleBinding = WhereOptionString.binding(path / "subtitle")
     val WhereOrderObservationIdBinding = WhereOrder.binding[Observation.Id](path / "id", ObservationIdBinding)
+    val WhereOrderProgramIdBinding = WhereOrder.binding[Program.Id](path / "program" / "id", ProgramIdBinding)
     val StatusBinding = WhereOrder.binding(path / "status", enumeratedBinding[ObsStatus])
     val ActiveStatusBinding = WhereOrder.binding(path / "activeStatus", enumeratedBinding[ObsActiveStatus])
     lazy val WhereObservationBinding = binding(path)
@@ -28,16 +30,18 @@ object WhereObservation {
         WhereObservationBinding.List.Option("OR", rOR),
         WhereObservationBinding.Option("NOT", rNOT),
         WhereOrderObservationIdBinding.Option("id", rId),
+        WhereOrderProgramIdBinding.Option("programId", rPid),
         SubtitleBinding.Option("subtitle", rSubtitle),
         StatusBinding.Option("status", rStatus),
         ActiveStatusBinding.Option("activeStatus", rActiveStatus)
       ) =>
-        (rAND, rOR, rNOT, rId, rSubtitle, rStatus, rActiveStatus).parMapN { (AND, OR, NOT, id, subtitle, status, activeStatus) =>
+        (rAND, rOR, rNOT, rId, rPid, rSubtitle, rStatus, rActiveStatus).parMapN { (AND, OR, NOT, id, pid, subtitle, status, activeStatus) =>
           and(List(
             AND.map(and),
             OR.map(or),
             NOT.map(Not(_)),
             id,
+            pid,
             subtitle,
             status,
             activeStatus

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -912,13 +912,12 @@ trait DatabaseOperations { this: OdbSuite =>
       .use(_.prepareR(af.fragment.query(target_id)).use(_.unique(af.argument)))
   }
 
-  def moveObservationAs(user: User, pid: Program.Id, oid: Observation.Id, gid: Option[Group.Id]): IO[Unit] =
+  def moveObservationAs(user: User, oid: Observation.Id, gid: Option[Group.Id]): IO[Unit] =
     expect(
       user = user,
       query = s"""
         mutation {
           updateObservations(input: {
-            programId: ${pid.asJson}
             SET: {
               groupId: ${gid.asJson}
             }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/obsAttachmentsAssignments.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/obsAttachmentsAssignments.scala
@@ -83,7 +83,6 @@ class obsAttachmentsAssignments extends ObsAttachmentsSuite {
 
   def deleteObservation(
     user: User,
-    pid:  Program.Id,
     oid:  Observation.Id
   ): IO[Unit] =
     expect(
@@ -92,7 +91,6 @@ class obsAttachmentsAssignments extends ObsAttachmentsSuite {
         mutation {
           updateObservations(
             input: {
-              programId: ${pid.asJson}
               WHERE: {
                 id: {
                   EQ: ${oid.asJson}
@@ -122,7 +120,6 @@ class obsAttachmentsAssignments extends ObsAttachmentsSuite {
 
   def updateObservation(
     user:  User,
-    pid:   Program.Id,
     oid:   Observation.Id,
     input: UpdateInput
   ): IO[Unit] =
@@ -132,7 +129,6 @@ class obsAttachmentsAssignments extends ObsAttachmentsSuite {
         mutation {
           updateObservations(
             input: {
-              programId: ${pid.asJson}
               WHERE: {
                 id: {
                   EQ: ${oid.asJson}
@@ -232,7 +228,7 @@ class obsAttachmentsAssignments extends ObsAttachmentsSuite {
       pid <- createProgramAs(pi)
       oid <- createObservationAs(pi, pid)
       aid <- insertAttachment(pi, pid, file1).toAttachmentId
-      _   <- updateObservation(pi, pid, oid, updateFile1(aid))
+      _   <- updateObservation(pi, oid, updateFile1(aid))
     } yield ()
   }
 
@@ -242,7 +238,7 @@ class obsAttachmentsAssignments extends ObsAttachmentsSuite {
       aid <- insertAttachment(pi, pid, file1).toAttachmentId
       oid <- createObservation(pi, pid, (aid, file1))
       _   <- assertObservation(pi, pid, oid, (aid, file1))
-      _   <- updateObservation(pi, pid, oid, UpdateInput.Null)
+      _   <- updateObservation(pi, oid, UpdateInput.Null)
     } yield ()
   }
 
@@ -252,7 +248,7 @@ class obsAttachmentsAssignments extends ObsAttachmentsSuite {
       aid <- insertAttachment(pi, pid, file1).toAttachmentId
       oid <- createObservation(pi, pid, (aid, file1))
       _   <- assertObservation(pi, pid, oid, (aid, file1))
-      _   <- updateObservation(pi, pid, oid, updateEmpty)
+      _   <- updateObservation(pi, oid, updateEmpty)
     } yield ()
   }
 
@@ -261,8 +257,8 @@ class obsAttachmentsAssignments extends ObsAttachmentsSuite {
       pid <- createProgramAs(pi)
       oid <- createObservationAs(pi, pid)
       aid <- insertAttachment(pi, pid, file1).toAttachmentId
-      _   <- updateObservation(pi, pid, oid, updateFile1(aid))
-      _   <- updateObservation(pi, pid, oid, skipFile1(aid))
+      _   <- updateObservation(pi, oid, updateFile1(aid))
+      _   <- updateObservation(pi, oid, skipFile1(aid))
     } yield ()
   }
 
@@ -272,7 +268,7 @@ class obsAttachmentsAssignments extends ObsAttachmentsSuite {
       oid  <- createObservationAs(pi, pid)
       aid1 <- insertAttachment(pi, pid, file1).toAttachmentId
       aid2 <- insertAttachment(pi, pid, file2).toAttachmentId
-      _    <- updateObservation(pi, pid, oid, updateBothFiles(aid1, aid2))
+      _    <- updateObservation(pi, oid, updateBothFiles(aid1, aid2))
     } yield ()
   }
 
@@ -297,7 +293,7 @@ class obsAttachmentsAssignments extends ObsAttachmentsSuite {
       oid2 <- createObservation(pi, pid, (aid2, file2))
       _    <- assertObservation(pi, pid, oid1, (aid1, file1), (aid2, file2))
       _    <- assertObservation(pi, pid, oid2, (aid2, file2))
-      _    <- deleteObservation(pi, pid, oid1)
+      _    <- deleteObservation(pi, oid1)
     } yield ()
   }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
@@ -12,7 +12,6 @@ import io.circe.syntax.*
 import lucuma.core.enums.ObsActiveStatus
 import lucuma.core.enums.ObsStatus
 import lucuma.core.model.Observation
-import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.odb.data.Existence
 import lucuma.odb.data.ObservingModeType
@@ -225,13 +224,12 @@ class cloneObservation extends OdbSuite {
 
   test("cloned observation should always be present/new/active") {
 
-    def updateFields(pid: Program.Id, oid: Observation.Id): IO[Unit] =
+    def updateFields(oid: Observation.Id): IO[Unit] =
       expect(
         user = pi,
         query = s"""
           mutation {
             updateObservations(input: {
-              programId: ${pid.asJson}
               SET: {
                 existence: ${Existence.Deleted.tag.toUpperCase}
                 status: ${ObsStatus.Observed.tag.toUpperCase}
@@ -272,7 +270,7 @@ class cloneObservation extends OdbSuite {
       for
         pid <- createProgramAs(pi)
         oid <- createObservationAs(pi, pid)
-        _   <- updateFields(pid, oid)
+        _   <- updateFields(oid)
       yield oid
 
     setup.flatMap { oid =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programPlannedTime.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programPlannedTime.scala
@@ -371,14 +371,13 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
     }
   }
 
-  private def moveObsToGroup(pid: Program.Id, gid: Group.Id, oids: Observation.Id*): IO[Unit] =
+  private def moveObsToGroup(gid: Group.Id, oids: Observation.Id*): IO[Unit] =
     query(
       user = user,
       query = s"""
         mutation {
           updateObservations(
             input: {
-              programId: "$pid"
               SET: {
                 groupId: "$gid"
               }
@@ -400,7 +399,7 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
         t <- createTargetWithProfileAs(user, p)
         g <- createGroupAs(user, p)
         o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
-        _ <- moveObsToGroup(p, g, o)
+        _ <- moveObsToGroup(g, o)
       } yield p
 
     setup.flatMap { pid =>
@@ -449,7 +448,7 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
         _ <- createGmosNorthLongSlitObservationAs(user, p, List(t))
         g <- createGroupAs(user, p)
         o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
-        _ <- moveObsToGroup(p, g, o)
+        _ <- moveObsToGroup(g, o)
       } yield p
 
     setup.flatMap { pid =>
@@ -498,7 +497,7 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
         g <- createGroupAs(user, p, minRequired = NonNegShort.unsafeFrom(1).some)
         oShort <- createGmosNorthLongSlitObservationAs(user, p, List(t))
         oLong  <- createLongerGmosNorthLongSlitObservationAs(user, p, t)
-        _ <- moveObsToGroup(p, g, oShort, oLong)
+        _ <- moveObsToGroup(g, oShort, oLong)
       } yield p
 
     setup.flatMap { pid =>
@@ -547,7 +546,7 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
         g  <- createGroupAs(user, p, minRequired = NonNegShort.unsafeFrom(2).some)
         o1 <- createGmosNorthLongSlitObservationAs(user, p, List(t))
         o2 <- createObservationWithNoModeAs(user, p, t)
-        _  <- moveObsToGroup(p, g, o1, o2)
+        _  <- moveObsToGroup(g, o1, o2)
       } yield p
 
     setup.flatMap { pid =>
@@ -596,11 +595,11 @@ class programPlannedTime extends OdbSuite with ObservingModeSetupOperations {
         g0 <- createGroupAs(user, p, minRequired = NonNegShort.unsafeFrom(1).some)
         oShort0 <- createGmosNorthLongSlitObservationAs(user, p, List(t))
         oLong0  <- createLongerGmosNorthLongSlitObservationAs(user, p, t)
-        _ <- moveObsToGroup(p, g0, oShort0, oLong0)
+        _ <- moveObsToGroup(g0, oShort0, oLong0)
         g1 <- createGroupAs(user, p, minRequired = NonNegShort.unsafeFrom(1).some)
         oShort1 <- createGmosNorthLongSlitObservationAs(user, p, List(t))
         oLong1  <- createLongerGmosNorthLongSlitObservationAs(user, p, t)
-        _ <- moveObsToGroup(p, g1, oShort1, oLong1)
+        _ <- moveObsToGroup(g1, oShort1, oLong1)
       } yield p
 
     setup.flatMap { pid =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/timingWindows.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/timingWindows.scala
@@ -45,14 +45,13 @@ class timingWindows extends OdbSuite {
       json.hcursor.downFields("createObservation", "observation", "id").require[Observation.Id]
     }
 
-  def updateObservation(user: User,  pid: Program.Id, oid: Observation.Id, twisOpt: Option[String]): IO[Json] = 
+  def updateObservation(user: User,  oid: Observation.Id, twisOpt: Option[String]): IO[Json] =
     query(
       user = user,
       query =
         s"""
           mutation {
             updateObservations(input: {
-              programId: ${pid.asJson},
               WHERE: {
                 id: {
                   EQ: "$oid"
@@ -278,7 +277,7 @@ class timingWindows extends OdbSuite {
     List(pi).traverse { user =>
       createProgramAs(user).flatMap { pid =>
         createObservation(user, pid, TimingWindowsInput.some).flatMap{ obsId =>
-          updateObservation(user, pid, obsId, TimingWindowsInput2.some).assertEquals(TimingWindowsOutput2)
+          updateObservation(user, obsId, TimingWindowsInput2.some).assertEquals(TimingWindowsOutput2)
         }
       }
     }
@@ -288,7 +287,7 @@ class timingWindows extends OdbSuite {
     List(pi).traverse { user =>
       createProgramAs(user).flatMap { pid =>
         createObservation(user, pid, TimingWindowsInput.some).flatMap{ obsId =>
-          updateObservation(user, pid, obsId, "null".some).assertEquals(json"""{ "observations": [{ "timingWindows": [] }]}""")
+          updateObservation(user, obsId, "null".some).assertEquals(json"""{ "observations": [{ "timingWindows": [] }]}""")
         }
       }
     }
@@ -298,7 +297,7 @@ class timingWindows extends OdbSuite {
     List(pi).traverse { user =>
       createProgramAs(user).flatMap { pid =>
         createObservation(user, pid, TimingWindowsInput2.some).flatMap{ obsId =>
-          updateObservation(user, pid, obsId, none).assertEquals(TimingWindowsOutput2)
+          updateObservation(user, obsId, none).assertEquals(TimingWindowsOutput2)
         }
       }
     }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/SubscriptionUtils.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/SubscriptionUtils.scala
@@ -55,7 +55,7 @@ trait SubscriptionUtils { self: OdbSuite =>
         json.hcursor.downFields("createObservation", "observation", "id").require[Observation.Id]
       }
 
-  def updateObservation(user: User, subtitle: String, pid: Program.Id, oid: Observation.Id): IO[Unit] =
+  def updateObservation(user: User, subtitle: String, oid: Observation.Id): IO[Unit] =
     sleep >>
       query(
         user    = user,
@@ -63,7 +63,6 @@ trait SubscriptionUtils { self: OdbSuite =>
           s"""
             mutation {
               updateObservations(input: {
-                programId: "${pid.show}",
                 SET: {
                   subtitle: "${subtitle}"
                 },

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/groupEdit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/groupEdit.scala
@@ -431,7 +431,7 @@ class groupEdit extends OdbSuite {
               pid <- createProgramAs(pi)
               gid <- createGroupAs(pi, pid, None, None, None)
               oid <- createObservationAs(pi, pid)
-              _   <- moveObservationAs(pi, pid, oid, Some(gid))
+              _   <- moveObservationAs(pi, oid, Some(gid))
               _   <- d.complete((pid, gid))
             } yield ()
           ),
@@ -507,7 +507,7 @@ class groupEdit extends OdbSuite {
               pid <- createProgramAs(pi)
               gid <- createGroupAs(pi, pid, None, None, None)
               oid <- createObservationAs(pi, pid)
-              _   <- moveObservationAs(pi, pid, oid, Some(gid))
+              _   <- moveObservationAs(pi, oid, Some(gid))
               _   <- d.complete((pid, gid))
             } yield ()
           ),

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEdit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEdit.scala
@@ -135,8 +135,8 @@ class observationEdit extends OdbSuite with SubscriptionUtils {
         query     = subtitleSubscription(None, Some(oid1)),
         mutations =
           Right(
-            updateObservation(pi, "obs 0 - edit", pid, oid0) >>
-              updateObservation(pi, "obs 1 - edit", pid, oid1)
+            updateObservation(pi, "obs 0 - edit", oid0) >>
+              updateObservation(pi, "obs 1 - edit", oid1)
           ),
         expected  = List(updated("obs 1 - edit"))
       )


### PR DESCRIPTION
This fulfills a request from Andy to "make the input for updating observations and updating targets more similar, specifically either removing the requirement for a `ProgramId` or requiring it in both".  See [ShortCut Issue 2429](https://app.shortcut.com/lucuma/story/2429/normalize-updateobservationsinput-and-updatetargetsinput).

I'm not sure why I required the `ProgramId` for `updateObservations`.  There may have been a good reason (?) or it may more likely have simply been dumb.  At any rate, it feels onerous to require that so I removed it to match `updateTargets`.