### PR TITLE
execution permissions

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -18,8 +18,6 @@ import grackle.skunk.SkunkMonitor
 import lucuma.core.model.User
 import lucuma.itc.client.ItcClient
 import lucuma.odb.graphql.enums.Enums
-import lucuma.odb.graphql.mapping.CreateGroupResultMapping
-import lucuma.odb.graphql.mapping.UpdateObservationsResultMapping
 import lucuma.odb.graphql.mapping._
 import lucuma.odb.graphql.topic.GroupTopic
 import lucuma.odb.graphql.topic.ObservationTopic
@@ -37,8 +35,6 @@ import org.typelevel.log4cats.Logger
 
 import scala.io.AnsiColor
 import scala.io.Source
-
-import mapping.RedeemUserInvitationResultMapping
 
 object OdbMapping {
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionUserCheck.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionUserCheck.scala
@@ -4,9 +4,7 @@
 package lucuma.odb.service
 
 import cats.syntax.either.*
-import lucuma.core.model.Access.Admin
 import lucuma.core.model.Access.Service
-import lucuma.core.model.Access.Staff
 import lucuma.core.model.User
 
 import Services.Syntax.*
@@ -15,8 +13,8 @@ trait ExecutionUserCheck {
 
   def checkUser[F[_], A](f: User => A)(using Services[F]): Either[A, Unit] =
     user.role.access match {
-      case Admin | Service | Staff => ().asRight
-      case _                       => /*f(user).asLeft*/ ().asRight // for now
+      case Service => ().asRight // TODO: should specifically be the observe service user, whose name should be passed in the app config
+      case _       => f(user).asLeft
     }
 
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addDatasetEvent.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addDatasetEvent.scala
@@ -24,9 +24,9 @@ import lucuma.odb.data.ObservingModeType
 class addDatasetEvent extends OdbSuite {
 
   val mode: ObservingModeType = ObservingModeType.GmosNorthLongSlit
-  val staff: User = TestUsers.Standard.staff(nextId, nextId)
+  val service: User = TestUsers.service(nextId)
 
-  override lazy val validUsers: List[User] = List(staff)
+  override lazy val validUsers: List[User] = List(service)
 
   private def recordDataset(
     mode: ObservingModeType,
@@ -78,7 +78,7 @@ class addDatasetEvent extends OdbSuite {
 
     addDatasetEventTest(
       mode,
-      staff,
+      service,
       "N18630101S0001.fits",
       did => query(did),
       (oid, did) => json"""
@@ -123,7 +123,7 @@ class addDatasetEvent extends OdbSuite {
 
     addDatasetEventTest(
       mode,
-      staff,
+      service,
       "N18630101S0002.fits",
       did => query(did),
       (oid, did) => json"""
@@ -164,7 +164,7 @@ class addDatasetEvent extends OdbSuite {
 
     addDatasetEventTest(
       mode,
-      staff,
+      service,
       "N18630101S0003.fits",
       _ => query,
       (_, _) => s"Dataset 'd-1863' not found".asLeft
@@ -174,7 +174,7 @@ class addDatasetEvent extends OdbSuite {
 
   private def addEvent(did: Dataset.Id, stage: DatasetStage): IO[Timestamp] =
     query(
-      staff,
+      service,
       s"""
         mutation {
           addDatasetEvent(input: {
@@ -193,7 +193,7 @@ class addDatasetEvent extends OdbSuite {
 
   private def timestamps(did: Dataset.Id): IO[Option[TimestampInterval]] =
     query(
-      staff,
+      service,
       s"""
         query {
           dataset(datasetId: "$did") {
@@ -220,7 +220,7 @@ class addDatasetEvent extends OdbSuite {
       }
 
     for {
-      ids <- recordDataset(mode, staff, file)
+      ids <- recordDataset(mode, service, file)
       (oid, did) = ids
       es  <- stages.toList.traverse(addEvent(did, _))
       ex   = expected(es).mapN { (s, e) => TimestampInterval.between(s, e) }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addSequenceEvent.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addSequenceEvent.scala
@@ -16,9 +16,9 @@ import lucuma.odb.data.ObservingModeType
 
 class addSequenceEvent extends OdbSuite {
 
-  val staff: User = TestUsers.Standard.staff(nextId, nextId)
+  val service: User = TestUsers.service(nextId)
 
-  override lazy val validUsers: List[User] = List(staff)
+  override lazy val validUsers: List[User] = List(service)
 
   private def recordVisit(
     mode: ObservingModeType,
@@ -65,7 +65,7 @@ class addSequenceEvent extends OdbSuite {
 
     addSequenceEventTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       vid => query(vid),
       (oid, vid) => json"""
       {
@@ -107,7 +107,7 @@ class addSequenceEvent extends OdbSuite {
 
     addSequenceEventTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       _ => query,
       (_, _) => s"Visit 'v-42' not found".asLeft
     )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addStepEvent.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addStepEvent.scala
@@ -17,9 +17,9 @@ import lucuma.odb.data.ObservingModeType
 
 class addStepEvent extends OdbSuite {
 
-  val staff: User = TestUsers.Standard.staff(nextId, nextId)
+  val service: User = TestUsers.service(nextId)
 
-  override lazy val validUsers: List[User] = List(staff)
+  override lazy val validUsers: List[User] = List(service)
 
   private def recordStep(
     mode: ObservingModeType,
@@ -69,7 +69,7 @@ class addStepEvent extends OdbSuite {
 
     addStepEventTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       sid => query(sid),
       (oid, sid) => json"""
       {
@@ -109,7 +109,7 @@ class addStepEvent extends OdbSuite {
 
     addStepEventTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       _ => query,
       (_, _) => s"Step 's-cfebc981-db7e-4c35-964d-6b19aa5ed2d7' not found".asLeft
     )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordAtom.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordAtom.scala
@@ -18,9 +18,9 @@ import lucuma.odb.data.ObservingModeType
 
 class recordAtom extends OdbSuite {
 
-  val staff: User = TestUsers.Standard.staff(nextId, nextId)
+  val service: User = TestUsers.service(nextId)
 
-  override lazy val validUsers: List[User] = List(staff)
+  override lazy val validUsers: List[User] = List(service)
 
   private def recordVisit(
     mode: ObservingModeType,
@@ -47,7 +47,7 @@ class recordAtom extends OdbSuite {
   test("recordAtom - GmosNorth") {
     recordAtomTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       vid => s"""
         mutation {
           recordAtom(input: {
@@ -93,7 +93,7 @@ class recordAtom extends OdbSuite {
   test("recordAtom - GmosSouth") {
     recordAtomTest(
       ObservingModeType.GmosSouthLongSlit,
-      staff,
+      service,
       vid => s"""
         mutation {
           recordAtom(input: {
@@ -139,7 +139,7 @@ class recordAtom extends OdbSuite {
   test("recordStep - mix up") {
     recordAtomTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       vid => s"""
         mutation {
           recordAtom(input: {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordDataset.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordDataset.scala
@@ -20,9 +20,9 @@ import lucuma.odb.data.ObservingModeType
 
 class recordDataset extends OdbSuite {
 
-  val staff: User = TestUsers.Standard.staff(nextId, nextId)
+  val service: User = TestUsers.service(nextId)
 
-  override lazy val validUsers: List[User] = List(staff)
+  override lazy val validUsers: List[User] = List(service)
 
   private def setup(
     mode: ObservingModeType,
@@ -51,7 +51,7 @@ class recordDataset extends OdbSuite {
   test("recordDataset") {
     recordDatasetTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       sid => s"""
         mutation {
           recordDataset(input: {
@@ -97,7 +97,7 @@ class recordDataset extends OdbSuite {
   test("recordDataset - init QA state") {
     recordDatasetTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       sid => s"""
         mutation {
           recordDataset(input: {
@@ -144,7 +144,7 @@ class recordDataset extends OdbSuite {
   test("recordDataset - reused filename") {
     recordDatasetTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       sid => s"""
         mutation {
           recordDataset(input: {
@@ -165,7 +165,7 @@ class recordDataset extends OdbSuite {
   test("recordDataset - unkown step id") {
     recordDatasetTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       sid => s"""
         mutation {
           recordDataset(input: {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordStep.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordStep.scala
@@ -21,9 +21,9 @@ import lucuma.odb.data.ObservingModeType
 
 class recordStep extends OdbSuite {
 
-  val staff: User = TestUsers.Standard.staff(nextId, nextId)
+  val service: User = TestUsers.service(nextId)
 
-  override lazy val validUsers: List[User] = List(staff)
+  override lazy val validUsers: List[User] = List(service)
 
   private def recordVisitAndAtom(
     mode: ObservingModeType,
@@ -51,7 +51,7 @@ class recordStep extends OdbSuite {
   test("recordStep - GmosNorth") {
     recordStepTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       aid => s"""
         mutation {
           recordGmosNorthStep(input: {
@@ -136,7 +136,7 @@ class recordStep extends OdbSuite {
   test("recordStep - GmosSouth") {
     recordStepTest(
       ObservingModeType.GmosSouthLongSlit,
-      staff,
+      service,
       aid => s"""
         mutation {
           recordGmosSouthStep(input: {
@@ -221,7 +221,7 @@ class recordStep extends OdbSuite {
   test("recordStep - mix up") {
     recordStepTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       aid => s"""
         mutation {
           recordGmosSouthStep(input: {
@@ -268,7 +268,7 @@ class recordStep extends OdbSuite {
 
     recordStepTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       aid => s"""
         mutation {
           recordGmosNorthStep(input: {
@@ -332,7 +332,7 @@ class recordStep extends OdbSuite {
 
     recordStepTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       aid => s"""
         mutation {
           recordGmosNorthStep(input: {
@@ -398,7 +398,7 @@ class recordStep extends OdbSuite {
 
     recordStepTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       aid => s"""
         mutation {
           recordGmosNorthStep(input: {
@@ -457,7 +457,7 @@ class recordStep extends OdbSuite {
 
     recordStepTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       aid => s"""
         mutation {
           recordGmosNorthStep(input: {
@@ -498,7 +498,7 @@ class recordStep extends OdbSuite {
 
     recordStepTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       aid => s"""
         mutation {
           recordGmosNorthStep(input: {
@@ -544,7 +544,7 @@ class recordStep extends OdbSuite {
 
     recordStepTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       aid => s"""
         mutation {
           recordGmosNorthStep(input: {
@@ -588,7 +588,7 @@ class recordStep extends OdbSuite {
   test("recordStep - stepConfig Science") {
     recordStepTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       aid => s"""
         mutation {
           recordGmosNorthStep(input: {
@@ -651,7 +651,7 @@ class recordStep extends OdbSuite {
 
     recordStepTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       aid => s"""
         mutation {
           recordGmosNorthStep(input: {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordVisit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordVisit.scala
@@ -14,9 +14,9 @@ import lucuma.odb.data.ObservingModeType
 
 class recordVisit extends OdbSuite {
 
-  val staff: User = TestUsers.Standard.staff(nextId, nextId)
+  val service: User = TestUsers.service(nextId)
 
-  override lazy val validUsers: List[User] = List(staff)
+  override lazy val validUsers: List[User] = List(service)
 
   private def recordVisitTest(
     mode:     ObservingModeType,
@@ -35,7 +35,7 @@ class recordVisit extends OdbSuite {
 
     recordVisitTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       oid => s"""
         mutation {
           recordGmosNorthVisit(input: {
@@ -75,7 +75,7 @@ class recordVisit extends OdbSuite {
 
     recordVisitTest(
       ObservingModeType.GmosSouthLongSlit,
-      staff,
+      service,
       oid => s"""
         mutation {
           recordGmosSouthVisit(input: {
@@ -115,7 +115,7 @@ class recordVisit extends OdbSuite {
 
     recordVisitTest(
       ObservingModeType.GmosNorthLongSlit,
-      staff,
+      service,
       oid => s"""
         mutation {
           recordGmosSouthVisit(input: {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateDatasets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateDatasets.scala
@@ -22,7 +22,7 @@ class updateDatasets extends OdbSuite with query.DatasetSetupOperations {
   val validUsers = List(pi, pi2, service).toList
 
   test("updateDatasets") {
-    recordDatasets(mode, pi, 0, 2, 3).flatMap {
+    recordDatasets(mode, pi, service, 0, 2, 3).flatMap {
       case (_, _) =>
         val q = s"""
           mutation {
@@ -97,7 +97,7 @@ class updateDatasets extends OdbSuite with query.DatasetSetupOperations {
   }
 
   test("updateDatasets - subset select") {
-    recordDatasets(mode, pi, 6, 2, 3).flatMap {
+    recordDatasets(mode, pi, service, 6, 2, 3).flatMap {
       case (_, _) =>
         val q = s"""
           mutation {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/DatasetSetupOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/DatasetSetupOperations.scala
@@ -19,6 +19,7 @@ trait DatasetSetupOperations extends DatabaseOperations { this: OdbSuite =>
   def recordDatasets(
     mode: ObservingModeType,
     user: User,
+    service: User,
     offset: Int = 0,
     stepCount: Int = 3,
     datasetsPerStep: Int = 2
@@ -26,12 +27,12 @@ trait DatasetSetupOperations extends DatabaseOperations { this: OdbSuite =>
     for {
       pid <- createProgramAs(user)
       oid <- createObservationAs(user, pid, mode.some)
-      vid <- recordVisitAs(user, mode.instrument, oid)
-      aid <- recordAtomAs(user, mode.instrument, vid)
+      vid <- recordVisitAs(service, mode.instrument, oid)
+      aid <- recordAtomAs(service, mode.instrument, vid)
       ids <- (0 until stepCount).toList.traverse { x =>
-        recordStepAs(user, mode.instrument, aid).flatMap { sid =>
+        recordStepAs(service, mode.instrument, aid).flatMap { sid =>
           (0 until datasetsPerStep).toList.traverse { y =>
-            recordDatasetAs(user, sid, f"N18630101S${offset + x * datasetsPerStep + y + 1}%04d.fits")
+            recordDatasetAs(service, sid, f"N18630101S${offset + x * datasetsPerStep + y + 1}%04d.fits")
           }.tupleLeft(sid)
         }
       }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionQuerySetupOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionQuerySetupOperations.scala
@@ -119,6 +119,7 @@ trait ExecutionQuerySetupOperations extends DatabaseOperations { this: OdbSuite 
 
   def recordAll(
     user: User,
+    serviceUser: User, // user who actually creates the observing events
     mode: ObservingModeType,
     offset: Int       = 0,
     visitCount: Int   = 1,
@@ -130,7 +131,7 @@ trait ExecutionQuerySetupOperations extends DatabaseOperations { this: OdbSuite 
     for {
       pid   <- createProgramAs(user)
       oid   <- createObservationAs(user, pid, mode.some)
-      vs    <- (0 until setup.visitCount).toList.traverse { v => recordVisit(mode, setup, user, oid, v) }
+      vs    <- (0 until setup.visitCount).toList.traverse { v => recordVisit(mode, setup, serviceUser, oid, v) }
     } yield ObservationNode(oid, vs)
   }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/dataset.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/dataset.scala
@@ -24,7 +24,7 @@ class dataset extends OdbSuite with DatasetSetupOperations {
   val validUsers = List(pi, pi2, service).toList
 
   test("pi can select thier own dataset") {
-    recordDatasets(ObservingModeType.GmosNorthLongSlit, pi, 0, 1, 1).flatMap {
+    recordDatasets(ObservingModeType.GmosNorthLongSlit, pi, service, 0, 1, 1).flatMap {
       case (oid, List((_, List(did)))) =>
         val q = s"""
           query {
@@ -50,7 +50,7 @@ class dataset extends OdbSuite with DatasetSetupOperations {
   }
 
   test("empty interval when not complete") {
-    recordDatasets(ObservingModeType.GmosNorthLongSlit, pi, 100, 1, 1).flatMap {
+    recordDatasets(ObservingModeType.GmosNorthLongSlit, pi, service, 100, 1, 1).flatMap {
       case (oid, List((_, List(did)))) =>
         val q = s"""
           query {
@@ -79,10 +79,10 @@ class dataset extends OdbSuite with DatasetSetupOperations {
 
   test("dataset interval") {
     val f = for {
-      ds <- recordDatasets(ObservingModeType.GmosNorthLongSlit, pi, 200, 1, 1)
+      ds <- recordDatasets(ObservingModeType.GmosNorthLongSlit, pi, service, 200, 1, 1)
       (_, List((_, List(did)))) = ds
-      s  <- addDatasetEventAs(pi, did, DatasetStage.StartObserve)
-      e  <- addDatasetEventAs(pi, did, DatasetStage.EndWrite)
+      s  <- addDatasetEventAs(service, did, DatasetStage.StartObserve)
+      e  <- addDatasetEventAs(service, did, DatasetStage.EndWrite)
     } yield (did, TimestampInterval.between(s.received, e.received))
 
     f.flatMap { (did, inv) =>
@@ -117,7 +117,7 @@ class dataset extends OdbSuite with DatasetSetupOperations {
   }
 
   test("pi cannot select someone else's dataset") {
-    recordDatasets(ObservingModeType.GmosNorthLongSlit, pi, 300, 1, 1).flatMap {
+    recordDatasets(ObservingModeType.GmosNorthLongSlit, pi, service, 300, 1, 1).flatMap {
       case (oid, List((_, List(did)))) =>
         val q = s"""
           query {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/datasets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/datasets.scala
@@ -23,7 +23,7 @@ class datasets extends OdbSuite with DatasetSetupOperations {
   val validUsers = List(pi, pi2, service).toList
 
   test("simple datasets selection") {
-    recordDatasets(mode, pi, 0, 2, 3).flatMap {
+    recordDatasets(mode, pi, service, 0, 2, 3).flatMap {
       case (_, _) =>
         val q = s"""
           query {
@@ -55,7 +55,7 @@ class datasets extends OdbSuite with DatasetSetupOperations {
   }
 
   test("OFFSET, LIMIT, hasMore") {
-    recordDatasets(mode, pi, 6, 2, 3).flatMap {
+    recordDatasets(mode, pi, service, 6, 2, 3).flatMap {
       case (_, steps) =>
         val q = s"""
           query {
@@ -90,7 +90,7 @@ class datasets extends OdbSuite with DatasetSetupOperations {
   }
 
   test("dataset selection") {
-    recordDatasets(mode, pi, 12, 1, 3).flatMap {
+    recordDatasets(mode, pi, service, 12, 1, 3).flatMap {
       case (oid, List((_, List(_, did, _)))) =>
         val q = s"""
           query {
@@ -122,7 +122,7 @@ class datasets extends OdbSuite with DatasetSetupOperations {
   }
 
   test("observation selection") {
-    recordDatasets(mode, pi, 15, 1, 3).flatMap {
+    recordDatasets(mode, pi, service, 15, 1, 3).flatMap {
       case (oid, _) =>
         val q = s"""
           query {
@@ -151,7 +151,7 @@ class datasets extends OdbSuite with DatasetSetupOperations {
   }
 
   test("step selection") {
-    recordDatasets(mode, pi, 18, 1, 3).flatMap {
+    recordDatasets(mode, pi, service, 18, 1, 3).flatMap {
       case (oid, List((sid, _))) =>
         val q = s"""
           query {
@@ -184,7 +184,7 @@ class datasets extends OdbSuite with DatasetSetupOperations {
   }
 
   test("step and index selection") {
-    recordDatasets(mode, pi, 21, 1, 3).flatMap {
+    recordDatasets(mode, pi, service, 21, 1, 3).flatMap {
       case (oid, List((sid, _))) =>
         val q = s"""
           query {
@@ -217,7 +217,7 @@ class datasets extends OdbSuite with DatasetSetupOperations {
   }
 
   test("filename") {
-    recordDatasets(mode, pi, 24, 1, 3).flatMap {
+    recordDatasets(mode, pi, service, 24, 1, 3).flatMap {
       case (oid, List((sid, _))) =>
         val q = s"""
           query {
@@ -255,7 +255,7 @@ class datasets extends OdbSuite with DatasetSetupOperations {
   }
 
   test("qaState") {
-    recordDatasets(mode, pi, 27, 1, 3).flatMap {
+    recordDatasets(mode, pi, service, 27, 1, 3).flatMap {
       case (oid, List((sid, _))) =>
         val q = s"""
           query {
@@ -290,7 +290,7 @@ class datasets extends OdbSuite with DatasetSetupOperations {
   }
 
   test("pi cannot select someone else's dataset") {
-    recordDatasets(mode, pi, 30, 1, 1).flatMap {
+    recordDatasets(mode, pi, service, 30, 1, 1).flatMap {
       case _ =>
         val q = s"""
           query {
@@ -316,7 +316,7 @@ class datasets extends OdbSuite with DatasetSetupOperations {
   }
 
   test("query via `observation` -> `execution` -> `datasets`") {
-    recordDatasets(mode, pi, 31, 1, 3).flatMap {
+    recordDatasets(mode, pi, service, 31, 1, 3).flatMap {
       case (oid, _) =>
         val q = s"""
           query {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAtomRecords.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAtomRecords.scala
@@ -27,7 +27,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations {
   val validUsers = List(pi, pi2, service).toList
 
   test("observation -> execution -> atomRecords") {
-    recordAll(pi, mode, offset = 0, visitCount = 2, atomCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 0, visitCount = 2, atomCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -63,7 +63,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> atomRecords -> interval") {
-    recordAll(pi, mode, offset = 50, visitCount = 2, stepCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 50, visitCount = 2, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -118,7 +118,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> atomRecords -> steps") {
-    recordAll(pi, mode, offset = 100, visitCount = 2, stepCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 100, visitCount = 2, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -162,7 +162,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> atomRecords -> steps -> interval") {
-    recordAll(pi, mode, offset = 150, visitCount = 2, stepCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 150, visitCount = 2, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -229,7 +229,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> atomRecords -> steps -> datasets") {
-    recordAll(pi, mode, offset = 200, atomCount = 2, stepCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 200, atomCount = 2, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -285,7 +285,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> atomRecords -> steps -> events") {
-    recordAll(pi, mode, offset = 300).flatMap { on =>
+    recordAll(pi, service, mode, offset = 300).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -344,7 +344,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations {
     offset:       Int,
     matchesQuery: String
   ): IO[Unit] =
-    recordAll(pi, mode, offset = offset).flatMap { on =>
+    recordAll(pi, service, mode, offset = offset).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDatasets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDatasets.scala
@@ -23,7 +23,7 @@ class executionDatasets extends OdbSuite with ExecutionQuerySetupOperations {
   val validUsers = List(pi, pi2, service).toList
 
   test("observation -> execution -> datasets") {
-    recordAll(pi, mode, offset = 0, visitCount = 2, atomCount = 2, stepCount = 3, datasetCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 0, visitCount = 2, atomCount = 2, stepCount = 3, datasetCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -57,7 +57,7 @@ class executionDatasets extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> datasets -> events") {
-    recordAll(pi, mode, offset = 100, stepCount = 2, datasetCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 100, stepCount = 2, datasetCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -98,7 +98,7 @@ class executionDatasets extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> datasets -> observation") {
-    recordAll(pi, mode, offset = 200).flatMap { on =>
+    recordAll(pi, service, mode, offset = 200).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -134,7 +134,7 @@ class executionDatasets extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> datasets -> visit") {
-    recordAll(pi, mode, offset = 300, visitCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 300, visitCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionEvents.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionEvents.scala
@@ -24,7 +24,7 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
   val validUsers = List(pi, pi2, service).toList
 
   test("observation -> execution -> events") {
-    recordAll(pi, mode, offset = 0, visitCount = 2, atomCount = 2, stepCount = 3, datasetCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 0, visitCount = 2, atomCount = 2, stepCount = 3, datasetCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -58,7 +58,7 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> events (visit, observation)") {
-    recordAll(pi, mode, offset = 100).flatMap { on =>
+    recordAll(pi, service, mode, offset = 100).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionStepRecords.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionStepRecords.scala
@@ -68,14 +68,14 @@ class executionStepRecords extends OdbSuite with ExecutionQuerySetupOperations {
 
 
   test("qaState - unset") {
-    recordAll(pi, mode, offset = 0, datasetCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 0, datasetCount = 2).flatMap { on =>
       expect(pi, qaQuery(on), qaExpected(none))
     }
   }
 
   test("qaState - one set") {
     for {
-      on <- recordAll(pi, mode, offset = 10, datasetCount = 2)
+      on <- recordAll(pi, service, mode, offset = 10, datasetCount = 2)
       _  <- setQaState(pi, DatasetQaState.Usable, s"${DatasetFilenamePrefix}0011.fits")
       _  <- expect(pi, qaQuery(on), qaExpected(DatasetQaState.Usable.some))
     } yield ()
@@ -83,7 +83,7 @@ class executionStepRecords extends OdbSuite with ExecutionQuerySetupOperations {
 
   test("qaState - two set") {
     for {
-      on <- recordAll(pi, mode, offset = 20, datasetCount = 2)
+      on <- recordAll(pi, service, mode, offset = 20, datasetCount = 2)
       _  <- setQaState(pi, DatasetQaState.Pass,   s"${DatasetFilenamePrefix}0021.fits")
       _  <- setQaState(pi, DatasetQaState.Usable, s"${DatasetFilenamePrefix}0022.fits")
       _  <- expect(pi, qaQuery(on), qaExpected(DatasetQaState.Usable.some))
@@ -117,7 +117,7 @@ class executionStepRecords extends OdbSuite with ExecutionQuerySetupOperations {
       """.asRight
 
     for {
-      on <- recordAll(pi, mode, offset = 30, stepCount = 2, datasetCount = 2)
+      on <- recordAll(pi, service, mode, offset = 30, stepCount = 2, datasetCount = 2)
       _  <- setQaState(pi, DatasetQaState.Pass,   s"${DatasetFilenamePrefix}0031.fits")
       _  <- setQaState(pi, DatasetQaState.Usable, s"${DatasetFilenamePrefix}0032.fits")
       _  <- setQaState(pi, DatasetQaState.Fail,   s"${DatasetFilenamePrefix}0033.fits")

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionVisits.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionVisits.scala
@@ -27,7 +27,7 @@ class executionVisits extends OdbSuite with ExecutionQuerySetupOperations {
   val validUsers = List(pi, pi2, service).toList
 
   test("observation -> execution -> visits") {
-    recordAll(pi, mode, offset = 0, visitCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 0, visitCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -61,7 +61,7 @@ class executionVisits extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> visits -> datasets") {
-    recordAll(pi, mode, offset = 100, visitCount = 2, stepCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 100, visitCount = 2, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -105,7 +105,7 @@ class executionVisits extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> visits -> events") {
-    recordAll(pi, mode, offset = 200, visitCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 200, visitCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -149,7 +149,7 @@ class executionVisits extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> visits -> atomRecords") {
-    recordAll(pi, mode, offset = 300, visitCount = 2, atomCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 300, visitCount = 2, atomCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -196,7 +196,7 @@ class executionVisits extends OdbSuite with ExecutionQuerySetupOperations {
     offset:       Int,
     matchesQuery: String
   ): IO[Unit] =
-    recordAll(pi, mode, offset = offset).flatMap { on =>
+    recordAll(pi, service, mode, offset = offset).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -272,7 +272,7 @@ class executionVisits extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> excution -> visits -> interval") {
-    recordAll(pi, mode, offset = 550, visitCount = 2, atomCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 550, visitCount = 2, atomCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {


### PR DESCRIPTION
This implements `ExecutionUserCheck#checkUser`, disallowing execution event writes from non-service users. Everything else is just adjustments in the tests to accommodate this.