### PR TITLE
*Group with ProgramReference

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -8148,13 +8148,17 @@ type Query {
   # ): TargetEnvironmentGroupSelectResult!
 
   """
-  Observations grouped by commonly held targets
+  Observations grouped by commonly held targets.  Specify one of programId or
+  programReference.  If both are set, both must match.  If neither are set,
+  nothing will match.
   """
   targetGroup(
-    """
-    Program ID
-    """
-    programId: ProgramId!
+
+    "Program ID"
+    programId: ProgramId
+
+    "Program Reference"
+    programReference: ProgramReference
 
     """
     Filters the selection of observations.

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4874,6 +4874,11 @@ type ConstraintSetGroup {
   Commonly held value across the observations
   """
   constraintSet: ConstraintSet!
+
+  """
+  Link back to program.
+  """
+  program: Program!
 }
 
 """
@@ -7923,13 +7928,17 @@ type Query {
   obsAttachmentTypeMeta: [ObsAttachmentTypeMeta!]!
 
   """
-  Observations grouped by commonly held constraints
+  Observations grouped by commonly held constraints. Specify one of programId or
+  programReference.  If both are set, both must match.  If neither are set,
+  nothing will match.
   """
   constraintSetGroup(
-    """
-    Program ID
-    """
-    programId: ProgramId!
+
+    "Program ID"
+    programId: ProgramId
+
+    "Program reference"
+    programReference: ProgramReference
 
     """
     Filters the selection of observations.

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7901,10 +7901,12 @@ type Query {
   Observations grouped by commonly held science asterisms
   """
   asterismGroup(
-    """
-    Program ID
-    """
-    programId: ProgramId!
+
+    "Program ID"
+    programId: ProgramId
+
+    "Program reference"
+    programReference: ProgramReference
 
     """
     Filters the selection of observations.

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -9548,10 +9548,9 @@ type TargetGroup {
   target: Target!
 
   """
-  Link back to program, temporary, to avoid some mapping issues.
-  Please don't use this in API calls.
+  Link back to program.
   """
-  program: Program! @deprecated
+  program: Program!
 
 }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConstraintSetGroupMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConstraintSetGroupMapping.scala
@@ -18,11 +18,13 @@ import lucuma.odb.graphql.predicate.Predicates
 import lucuma.odb.graphql.table.ConstraintSetGroupView
 
 import table.ObservationView
+import table.ProgramTable
 import binding._
 
 trait ConstraintSetGroupMapping[F[_]]
   extends ConstraintSetGroupView[F]
      with ObservationView[F]
+     with ProgramTable[F]
      with Predicates[F] {
 
   lazy val ConstraintSetGroupMapping =
@@ -30,7 +32,7 @@ trait ConstraintSetGroupMapping[F[_]]
       tpe = ConstraintSetGroupType,
       fieldMappings = List(
         SqlField("key", ConstraintSetGroupView.ConstraintSetKey, key = true, hidden = true),
-        SqlField("programId", ConstraintSetGroupView.ProgramId),
+        SqlObject("program", Join(ConstraintSetGroupView.ProgramId, ProgramTable.Id)),
         SqlObject("observations", Join(ConstraintSetGroupView.ConstraintSetKey, ObservationView.ConstraintSet.Key)),
         SqlObject("constraintSet", Join(ConstraintSetGroupView.ObservationId, ObservationView.Id)),
       )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/ConstraintSetGroupPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/ConstraintSetGroupPredicates.scala
@@ -4,9 +4,8 @@
 package lucuma.odb.graphql.predicate
 
 import grackle.Path
-import lucuma.core.model.Program
 
 class ConstraintSetGroupPredicates(path: Path) {
-  val programId = LeafPredicates[Program.Id](path / "programId")
+  val program      = ProgramPredicates(path / "program")
   val observations = ObservationSelectResultPredicates(path / "observations")
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/constraintSetGroup.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/constraintSetGroup.scala
@@ -13,6 +13,7 @@ import lucuma.core.enums.ImageQuality
 import lucuma.core.enums.SkyBackground
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
+import lucuma.core.model.Semester
 import lucuma.core.model.User
 
 class constraintSetGroup extends OdbSuite {
@@ -118,5 +119,79 @@ class constraintSetGroup extends OdbSuite {
     }
   }
 
+  test("should be able to use a program reference") {
+    List(pi).traverse { user =>
+      createProgramAs(user).flatMap { pid =>
+        def create2(iq: ImageQuality, sb: SkyBackground) = createObservation(user, pid, iq, sb).replicateA(2)
+        (
+          create2(ImageQuality.OnePointFive, SkyBackground.Bright),
+          create2(ImageQuality.PointOne, SkyBackground.Bright),
+          create2(ImageQuality.PointOne, SkyBackground.Dark)
+        ).parTupled.flatMap { (g1, g2, g3) =>
+          addProposal(user, pid) *>
+          submitProposal(user, pid, Semester.unsafeFromString("2025A").some) *>
+          expect(
+            user = user,
+            query =
+              s"""
+              query {
+                constraintSetGroup(programReference: "G-2025A-0001") {
+                  matches {
+                    constraintSet {
+                      imageQuality
+                      skyBackground
+                    }
+                    observations {
+                      matches {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+              """,
+            expected = Right(
+              // N.B. the ordering of groups is based on the concatenation of all the components so it's deterministic
+              json"""
+                {
+                  "constraintSetGroup" : {
+                    "matches" : [
+                      {
+                        "constraintSet" : {
+                          "imageQuality" : "ONE_POINT_FIVE",
+                          "skyBackground" : "BRIGHT"
+                        },
+                        "observations" : {
+                          "matches" : ${g1.map { id => Json.obj("id" -> id.asJson) }.asJson }
+                        }
+                      },
+                      {
+                        "constraintSet" : {
+                          "imageQuality" : "POINT_ONE",
+                          "skyBackground" : "BRIGHT"
+                        },
+                        "observations" : {
+                          "matches" : ${g2.map { id => Json.obj("id" -> id.asJson) }.asJson }
+                        }
+                      },
+                      {
+                        "constraintSet" : {
+                          "imageQuality" : "POINT_ONE",
+                          "skyBackground" : "DARK"
+                        },
+                        "observations" : {
+                          "matches" : ${g3.map { id => Json.obj("id" -> id.asJson) }.asJson }
+                        }
+                      }
+                    ]
+                  }
+                }
+              """
+            )
+          )
+        }
+      }
+    }
+  }
 
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/targetGroup.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/targetGroup.scala
@@ -11,6 +11,7 @@ import io.circe.literal._
 import io.circe.syntax._
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
+import lucuma.core.model.Semester
 import lucuma.core.model.Target
 
 class targetGroup extends OdbSuite {
@@ -179,4 +180,125 @@ class targetGroup extends OdbSuite {
     }
   }
 
+  test("should work with a program reference") {
+    List(pi).traverse { user =>
+      for {
+        pid  <- createProgramAs(user)
+        _    <- addProposal(user, pid)
+        _    <- submitProposal(user, pid, Semester.unsafeFromString("2025A").some)
+        tids <- createTargetAs(user, pid).replicateA(3)
+        oid1 <- createObservationAs(user, pid, tids(0), tids(1))
+        oid2 <- createObservationAs(user, pid, tids(1), tids(2))
+        _  <- expect(
+          user = user,
+          query =
+            s"""
+              query {
+                targetGroup(programReference: "G-2025A-0001") {
+                  matches {
+                    observations {
+                      matches {
+                        id
+                      }
+                    }
+                    target {
+                      id
+                    }
+                  }
+                }
+              }
+            """,
+          expected = Right(
+            json"""
+              {
+                "targetGroup" : {
+                  "matches" : [
+                    {
+                      "observations" : {
+                        "matches" : [
+                          {
+                            "id" : $oid1
+                          }
+                        ]
+                      },
+                      "target" : {
+                        "id" : ${tids(0)}
+                      }
+                    },
+                    {
+                      "observations" : {
+                        "matches" : [
+                          {
+                            "id" : $oid1
+                          },
+                          {
+                            "id" : $oid2
+                          }
+                        ]
+                      },
+                      "target" : {
+                        "id" : ${tids(1)}
+                      }
+                    },
+                    {
+                      "observations" : {
+                        "matches" : [
+                          {
+                            "id" : $oid2
+                          }
+                        ]
+                      },
+                      "target" : {
+                        "id" : ${tids(2)}
+                      }
+                    }
+                  ]
+                }
+              }
+            """
+          )
+        )
+      } yield ()
+    }
+  }
+
+  test("should handle missing program id and reference") {
+    List(pi).traverse { user =>
+      for {
+        pid  <- createProgramAs(user)
+        tids <- createTargetAs(user, pid).replicateA(2)
+        oid1 <- createObservationAs(user, pid, tids(0), tids(1))
+        _  <- expect(
+          user = user,
+          query =
+            s"""
+              query {
+                targetGroup {
+                  matches {
+                    observations {
+                      matches {
+                        id
+                      }
+                    }
+                    target {
+                      id
+                    }
+                  }
+                }
+              }
+            """,
+          expected = Right(
+            json"""
+              {
+                "targetGroup" : {
+                  "matches" : [
+                  ]
+                }
+              }
+            """
+          )
+        )
+      } yield ()
+    }
+  }
 }


### PR DESCRIPTION
Updates the `asterismGroup`, `constraintSetGroup`, and `targetGroup` queries to accept either a program id (as they do currently) or a program reference.  This depends on having a `program` field in the corresponding group element.  It uses this to create the predicate which matches the program.  Of the three:

* __`TargetGroup`__ already had a `program` field but it was marked `deprecated` and the comment said it shouldn't be used?  

```
  Link back to program, temporary, to avoid some mapping issues.
  Please don't use this in API calls.
```

* __`AsterismGroup`__ already had a `program` field with neither `deprecated` nor other admonitions of any kind.
* __`ConstraintGroup`__ had just a `programId` which I turned into `program`.

So, is this not kosher for some reason?  I believe I saw that the latest Grackle has support for hidden `SqlObject`s in the mappings that we might use if necessary?