### PR TITLE
Issue with `EffectField` in `interface`

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/StepRecordMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/StepRecordMapping.scala
@@ -137,7 +137,9 @@ trait StepRecordMapping[F[_]] extends StepRecordView[F]
       tpe = GmosNorthStepRecordType,
       fieldMappings = List(
         SqlField("id", StepRecordView.Id, key = true),
-        SqlObject("instrumentConfig", Join(StepRecordView.Id, GmosNorthDynamicTable.Id))
+        SqlObject("instrumentConfig", Join(StepRecordView.Id, GmosNorthDynamicTable.Id)),
+        EffectField("interval",  intervalHandler, List("id")),
+        EffectField("qaState", qaStateHandler, List("id")),
       )
     )
 
@@ -146,7 +148,9 @@ trait StepRecordMapping[F[_]] extends StepRecordView[F]
       tpe = GmosSouthStepRecordType,
       fieldMappings = List(
         SqlField("id", StepRecordView.Id, key = true),
-        SqlObject("instrumentConfig", Join(StepRecordView.Id, GmosSouthDynamicTable.Id))
+        SqlObject("instrumentConfig", Join(StepRecordView.Id, GmosSouthDynamicTable.Id)),
+        EffectField("interval",  intervalHandler, List("id")),
+        EffectField("qaState", qaStateHandler, List("id")),
       )
     )
 


### PR DESCRIPTION
This is a workaround for a Grackle issue which I plan to report.  Namely an `EffectField` mapping in an interface type works fine unless you access it as part of a fragment.  For example, the `interval` field is defined in the `StepRecord` interface:

```
  lazy val StepRecordMapping: ObjectMapping =
    SqlInterfaceMapping(
      tpe           = StepRecordType,
      discriminator = stepRecordTypeDiscriminator,
      fieldMappings = List(
        SqlField("id",           StepRecordView.Id, key = true),
...
        EffectField("interval",  intervalHandler, List("id")),
...
      )
    )
```

 so this works fine:

```
                  steps {
                    matches {
                      interval {
                        start
                        end
                      }
                    }
                  }
```
`GmosNorthStepRecord` implements the `StepRecord` interface so this should work as well:
```
                  steps {
                    matches {
                      ... on GmosNorthStepRecord {
                        interval {
                          start
                          end
                        }
                      }
                    }
                  }
```
but does not.  The workaround is to redefine the `EffectField` mapping in the interface and in each implementation.  