### PR TITLE
Scala 3.4 + syntax tweaks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,8 +32,8 @@ val pprintVersion              = "0.8.1"
 val testcontainersScalaVersion = "0.40.14" // N.B. 0.40.15 causes java.lang.NoClassDefFoundError: munit/Test
 
 ThisBuild / tlBaseVersion      := "0.11"
-ThisBuild / scalaVersion       := "3.3.1"
-ThisBuild / crossScalaVersions := Seq("3.3.1")
+ThisBuild / scalaVersion       := "3.4.0"
+ThisBuild / crossScalaVersions := Seq("3.4.0")
 
 ThisBuild / Test / fork := false
 ThisBuild / Test / parallelExecution := false

--- a/modules/schema/src/main/scala/lucuma/odb/json/numeric.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/numeric.scala
@@ -14,9 +14,6 @@ import io.circe.syntax._
 
 trait NumericCodec {
 
-  given Codec[PosBigDecimal] =
-    Codec[BigDecimal].iemap(PosBigDecimal.from)(_.value)
-
   given Codec[BigDecimal] with {
     def apply(d: BigDecimal): Json =
       d.bigDecimal.toPlainString.asJson
@@ -28,6 +25,9 @@ trait NumericCodec {
         }
       }
   }
+
+  given Codec[PosBigDecimal] =
+    Codec[BigDecimal].iemap(PosBigDecimal.from)(_.value)
 
 }
 

--- a/modules/schema/src/main/scala/lucuma/odb/json/sourceprofile.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/sourceprofile.scala
@@ -58,38 +58,6 @@ trait SourceProfileCodec {
   import numeric.given
   import wavelength.decoder.given
 
-  // SpectralDefinition[T]
-  given [T](using Enumerated[Units Of Brightness[T]], Enumerated[Units Of LineFlux[T]], Enumerated[Units Of FluxDensityContinuum[T]]): Decoder[SpectralDefinition[T]] =
-    Decoder.instance { c =>
-      c.downField("bandNormalized").as[BandNormalized[T]] orElse
-        c.downField("emissionLines").as[EmissionLines[T]]
-    }
-
-  given [T](using Encoder[Wavelength], Enumerated[Units Of Brightness[T]], Enumerated[Units Of LineFlux[T]], Enumerated[Units Of FluxDensityContinuum[T]]): Encoder[SpectralDefinition[T]] =
-    Encoder.instance { (sd: SpectralDefinition[T]) =>
-      Json.obj(
-        sd match {
-          case bn: BandNormalized[T] => "bandNormalized" -> bn.asJson
-          case el: EmissionLines[T]  => "emissionLines"  -> el.asJson
-        }
-      )
-    }
-
-  given Decoder[SourceProfile.Gaussian] =
-    Decoder.instance { c =>
-      for {
-        f <- c.downField("fwhm").as[Angle]
-        s <- Decoder[SpectralDefinition[Integrated]].apply(c)
-      } yield SourceProfile.Gaussian(f, s)
-    }
-
-  given (using Encoder[Angle], Encoder[Wavelength]): Encoder[SourceProfile.Gaussian] =
-    Encoder.instance { (g: SourceProfile.Gaussian) =>
-      g.spectralDefinition
-       .asJson
-       .mapObject(_.add("fwhm", g.fwhm.asJson))
-    }
-
   private def refinedBigDecimalCodec[V](
     name:           String,
     range:          String,
@@ -326,6 +294,38 @@ trait SourceProfileCodec {
       } yield EmissionLine(w, f)
 
   }
+
+  // SpectralDefinition[T]
+  given [T](using Enumerated[Units Of Brightness[T]], Enumerated[Units Of LineFlux[T]], Enumerated[Units Of FluxDensityContinuum[T]]): Decoder[SpectralDefinition[T]] =
+    Decoder.instance { c =>
+      c.downField("bandNormalized").as[BandNormalized[T]] orElse
+        c.downField("emissionLines").as[EmissionLines[T]]
+    }
+
+  given [T](using Encoder[Wavelength], Enumerated[Units Of Brightness[T]], Enumerated[Units Of LineFlux[T]], Enumerated[Units Of FluxDensityContinuum[T]]): Encoder[SpectralDefinition[T]] =
+    Encoder.instance { (sd: SpectralDefinition[T]) =>
+      Json.obj(
+        sd match {
+          case bn: BandNormalized[T] => "bandNormalized" -> bn.asJson
+          case el: EmissionLines[T]  => "emissionLines"  -> el.asJson
+        }
+      )
+    }
+
+  given Decoder[SourceProfile.Gaussian] =
+    Decoder.instance { c =>
+      for {
+        f <- c.downField("fwhm").as[Angle]
+        s <- Decoder[SpectralDefinition[Integrated]].apply(c)
+      } yield SourceProfile.Gaussian(f, s)
+    }
+
+  given (using Encoder[Angle], Encoder[Wavelength]): Encoder[SourceProfile.Gaussian] =
+    Encoder.instance { (g: SourceProfile.Gaussian) =>
+      g.spectralDefinition
+       .asJson
+       .mapObject(_.add("fwhm", g.fwhm.asJson))
+    }
 
   // type SourceProfile
   given Decoder[SourceProfile] =

--- a/modules/service/src/main/scala/lucuma/odb/data/Nullable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/Nullable.scala
@@ -47,12 +47,12 @@ object Nullable {
   case object Absent               extends Nullable[Nothing]
   case class  NonNull[A](value: A) extends Nullable[A]
 
-  implicit val NullableInstances: Monad[Nullable] with SemigroupK[Nullable] =
+  implicit val NullableInstances: Monad[Nullable] & SemigroupK[Nullable] =
     new Monad[Nullable] with SemigroupK[Nullable] {
       override def map[A, B](fa: Nullable[A])(fab: A => B): Nullable[B] = fa.map(fab)
       def flatMap[A, B](fa: Nullable[A])(f: A => Nullable[B]): Nullable[B] = fa.flatMap(f)
       def pure[A](x: A): Nullable[A] = NonNull(x)
-      def combineK[A](x: Nullable[A], y: Nullable[A]): Nullable[A] = x orElse y
+      def combineK[A](x: Nullable[A], y: Nullable[A]): Nullable[A] = x.orElse(y)
       @tailrec def tailRecM[A, B](a: A)(f: A => Nullable[Either[A,B]]): Nullable[B] =
         f(a) match {
           case Absent                => Absent

--- a/modules/service/src/main/scala/lucuma/odb/data/Tag.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/Tag.scala
@@ -14,7 +14,7 @@ import lucuma.core.syntax.string._
 final case class Tag(value: String)
 object Tag {
 
-  implicit val TagCirceCodec: Encoder[Tag] with Decoder[Tag] =
+  implicit val TagCirceCodec: Encoder[Tag] & Decoder[Tag] =
     new Encoder[Tag] with Decoder[Tag] {
       def apply(c: HCursor) = c.as[String].map(s => Tag(s.toLowerCase))
       def apply(a: Tag) = Json.fromString(a.value.toScreamingSnakeCase)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/GaussianInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/GaussianInput.scala
@@ -40,6 +40,6 @@ object GaussianInput {
     }
 
   val CreateOrEditBinding =
-    CreateBinding or EditBinding
+    CreateBinding.or(EditBinding)
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/SpectralDefinitionInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/SpectralDefinitionInput.scala
@@ -41,7 +41,7 @@ object SpectralDefinitionInput {
       )
 
     val CreateOrEditBinding =
-      CreateBinding or EditBinding
+      CreateBinding.or(EditBinding)
 
   }
 
@@ -60,7 +60,7 @@ object SpectralDefinitionInput {
       )
 
     val CreateOrEditBinding =
-      CreateBinding or EditBinding
+      CreateBinding.or(EditBinding)
 
   }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/UnnormalizedSedInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/UnnormalizedSedInput.scala
@@ -59,7 +59,7 @@ object UnnormalizedSedInput {
           case (None, None, None, None, None, None, None, None, None, Some(v)) =>
             v match {
               case Nil => Result.failure("fluxDensities cannot be empty")
-              case h :: t => Result(UnnormalizedSED.UserDefined(NonEmptyMap.of(h, t: _*)))
+              case h :: t => Result(UnnormalizedSED.UserDefined(NonEmptyMap.of(h, t*)))
             }
 
           case _ =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ResultMapping.scala
@@ -96,7 +96,7 @@ trait ResultMapping[F[_]] extends BaseMapping[F] {
     ObjectMapping(
       tpe = tpe,
       fieldMappings = List(
-        SqlObject(collectionField, joins: _*),
+        SqlObject(collectionField, joins*),
         CursorField("hasMore", ResultMapping.hasMore(collectionField)),
         SqlField("<key>", parentKeyColumn, key = (parentKeyColumn ne root.bogus), hidden = true)
       )
@@ -106,7 +106,7 @@ trait ResultMapping[F[_]] extends BaseMapping[F] {
     resultMapping(tpe, "matches", root.bogus)
 
   def nestedSelectResultMapping(tpe: Type, parentKeyColumn: ColumnRef, joins: Join*): ObjectMapping =
-    resultMapping(tpe, "matches", parentKeyColumn, joins: _*)
+    resultMapping(tpe, "matches", parentKeyColumn, joins*)
 
   def updateResultMapping(tpe: Type, collectionField: String): ObjectMapping =
     resultMapping(tpe, collectionField, root.bogus)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
@@ -38,7 +38,7 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
      with AsterismTargetTable[F]
      with ObservationView[F]
      with Predicates[F]
-     with TargetView[F] { this: SkunkMapping[F] with TargetMapping[F] =>
+     with TargetView[F] { this: SkunkMapping[F] & TargetMapping[F] =>
 
   def itcClient: ItcClient[F]
   def httpClient: Client[F]

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TimeSpanMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TimeSpanMapping.scala
@@ -66,7 +66,7 @@ trait TimeSpanMapping[F[_]] extends AllocationTable[F]
     ObjectMapping(
       tpe = TimeSpanType,
       fieldMappings =
-        keyFields(keys: _*) ++ List(
+        keyFields(keys*) ++ List(
         SqlField("value", data, hidden = true),
         valueAs("microseconds")(Format.fromPrism(TimeSpan.FromMicroseconds)),
         valueAs("milliseconds")(TimeSpan.FromMilliseconds),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/util/PrettyPrinter.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/util/PrettyPrinter.scala
@@ -44,7 +44,7 @@ object PrettyPrinter {
     char('"') + text(s) + char('"')
 
   def obj(name: String, ps: (String, Doc)*): Doc =
-    obj(name, ps.map(prop): _*)
+    obj(name, ps.map(prop)*)
 
   def obj(name: String, vs: Doc*)(using DummyImplicit): Doc =
     elems(vs.toList).tightBracketBy(text(name) + Paren.Open, Paren.Close)
@@ -63,7 +63,7 @@ object PrettyPrinter {
       case Empty                           => text("Empty")
       case Environment(e, child)           => obj("Environment", "env" -> env(e), "child" -> query(child))
       case Filter(pred, child)             => obj("Filter", "pred" -> predicate(pred), "child" -> query(child))
-      case Group(queries)                  => obj("Group", queries.map(query):_*)
+      case Group(queries)                  => obj("Group", queries.map(query)*)
       case Introspect(schema, child)       => obj("Introspect", "schema" -> str("<schema>"), "child" -> query(child))
       case Limit(num, child)               => obj("Limit", "num" -> str(num), "child" -> query(child))
       case Narrow(subtpe, child)           => obj("Narrow", "subtpe" -> str(subtpe), "child" -> query(child))
@@ -72,18 +72,18 @@ object PrettyPrinter {
       case Select(name, alias, child) =>
         var props = List("name" -> quoted(name)) ++ alias.foldMap(a => List("alias" -> quoted(a)))
         if child != Query.Empty then props :+= "child" -> query(child)
-        if props.length == 1 then obj("Select", props.head._2) else obj("Select", props: _*)
+        if props.length == 1 then obj("Select", props.head._2) else obj("Select", props*)
       case TransformCursor(f, child)       => obj("TransformCursor", "f" -> text("<function>"), "child" -> query(child))
       case Unique(child)                   => obj("Unique", query(child))
       case UntypedFragmentSpread(name, ds) => obj("UntypedFragmentSpread", "directives" -> directives(ds))
       case UntypedInlineFragment(tpnme, ds, child) => 
         val ps = tpnme.foldMap(n => List("tpnme" -> quoted(n))) :+ ("directives" -> directives(ds)) :+ ("child" -> query(child))
-        obj("UntypedInlineFragment", ps:_*)
+        obj("UntypedInlineFragment", ps*)
       case UntypedSelect(name, alias, args, ds, child) =>
         var props = List("name" -> quoted(name)) ++ alias.foldMap(a => List("alias" -> quoted(a)))
         if args.nonEmpty then props = props :+ ("args" -> elems(args.map(binding)).tightBracketBy(Bracket.Open, Bracket.Close))
         if child != Query.Empty then props :+= "child" -> query(child)
-        if props.length == 1 then obj("Select", props.head._2) else obj("Select", props: _*)
+        if props.length == 1 then obj("Select", props.head._2) else obj("Select", props*)
 
   def env(e: Env): Doc =
     e match
@@ -99,7 +99,6 @@ object PrettyPrinter {
   def predicate(pred: Predicate): Doc =
     pred match
       case Predicate.And(x, y)             => obj("And", predicate(x), predicate(y))
-      case Predicate.AndB(x, y)            => obj("AndB", term(x), term(y))
       case Predicate.Contains(a, as)       => obj("Contains", term(a), term(as))
       case Predicate.Eql(x, y)             => obj("Eql", term(x), term(y))
       case Predicate.False                 => text("False")
@@ -112,9 +111,7 @@ object PrettyPrinter {
       case Predicate.Matches(x, r)         => obj("Matches", term(x), str(r))
       case Predicate.NEql(x, y)            => obj("NEql", term(x), term(y))
       case Predicate.Not(x)                => obj("Not", predicate(x))
-      case Predicate.NotB(x)               => obj("NotB", term(x))
       case Predicate.Or(x, y)              => obj("Or", predicate(x), predicate(y))
-      case Predicate.OrB(x, y)             => obj("OrB", term(x), term(y))
       case Predicate.StartsWith(x, prefix) => obj("StartsWith", term(x), quoted(prefix))
       case Predicate.True                  => text("True")
       case p                               => text(s"<Predicate:${p.getClass.getSimpleName}>")
@@ -122,8 +119,8 @@ object PrettyPrinter {
   def term[A](t: Term[A]): Doc =
     t match
       case p: Predicate => predicate(p) // Predicate <: Term[Boolean]
-      case PathTerm.ListPath(ss) => obj("ListPath", ss.map(quoted): _*)
-      case PathTerm.UniquePath(ss) => obj("UniquePath", ss.map(quoted): _*)
+      case PathTerm.ListPath(ss) => obj("ListPath", ss.map(quoted)*)
+      case PathTerm.UniquePath(ss) => obj("UniquePath", ss.map(quoted)*)
       case Predicate.Const(a: String) => obj("Const", quoted(a))
       case Predicate.Const(a) => obj("Const", str(a))
       case Predicate.ToLowerCase(x) => obj("ToLowerCase", term(x))

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -190,7 +190,7 @@ trait DatabaseOperations { this: OdbSuite =>
 
 
   def createObservationAs(user: User, pid: Program.Id, tids: Target.Id*): IO[Observation.Id] =
-    createObservationAs(user, pid, None, tids: _*)
+    createObservationAs(user, pid, None, tids*)
 
   private def scienceRequirementsObject(observingMode: ObservingModeType): String =
     observingMode match

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -254,7 +254,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
     for {
       sbe <- Resource.eval(JdkWSClient.simple[IO].map(Http4sWebSocketBackend[IO](_)))
       uri  = (svr.baseUri / "ws").copy(scheme = Some(Http4sUri.Scheme.unsafeFromString("ws")))
-      sc  <- Resource.eval(Http4sWebSocketClient.of[IO, Nothing](uri)(Async[IO], Logger[IO], sbe))
+      sc  <- Resource.eval(Http4sWebSocketClient.of[IO, Nothing](uri)(using Async[IO], Logger[IO], sbe))
       ps   = Map("Authorization" -> Json.fromString(s"Bearer ${Gid[User.Id].fromString.reverseGet(user.id)}"))
       _   <- Resource.make(sc.connect() *> sc.initialize(ps))(_ => sc.terminate() *> sc.disconnect())
     } yield sc

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/proposalAttachments.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/proposalAttachments.scala
@@ -51,7 +51,7 @@ class proposalAttachments extends AttachmentsSuite {
         """,
       expected = Right(
         Json.obj(
-          "program" -> expected(expectedTas: _*)
+          "program" -> expected(expectedTas*)
         )
       )
     )
@@ -86,7 +86,7 @@ class proposalAttachments extends AttachmentsSuite {
       """,
       expected = Right(
         Json.obj(
-          "updateProposalAttachments" -> expected(expectedTas: _*)
+          "updateProposalAttachments" -> expected(expectedTas*)
         )
       )
     )


### PR DESCRIPTION
Dependencies require 3.4, which was causing an issue.

```
[error] error while loading user,
[error] error while loading user,
[error] class file lucuma/sso/client/codec/user.class is broken, reading aborted with class dotty.tools.tasty.UnpickleException
[error] TASTy signature has wrong version.
[error]  expected: {majorVersion: 28, minorVersion: 3}
[error]  found   : {majorVersion: 28, minorVersion: 4}
[error] 
[error] This TASTy file was produced by a more recent, forwards incompatible release.
[error] To read this TASTy file, please upgrade your tooling.
[error] The TASTy file was produced by Scala 3.4.0.
[error] class file lucuma/sso/client/codec/user.class is broken, reading aborted with class dotty.tools.tasty.UnpickleException
[error] TASTy signature has wrong version.
[error]  expected: {majorVersion: 28, minorVersion: 3}
[error]  found   : {majorVersion: 28, minorVersion: 4}
[error] 
[error] This TASTy file was produced by a more recent, forwards incompatible release.
[error] To read this TASTy file, please upgrade your tooling.
```