### PR TITLE
Fix empty interval issue

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/TimeAccountingState.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TimeAccountingState.scala
@@ -150,8 +150,9 @@ sealed class TimeAccountingState private (val toMap: SortedMap[TimestampInterval
    * Returns the set of `Atom.Id` that are associated with state intervals which
    * intersect with `interval`.
    */
-  def atomsIn(interval: TimestampInterval): SortedSet[Atom.Id] =
-    between(interval).allAtoms
+  def atomsIntersecting(interval: TimestampInterval): SortedSet[Atom.Id] =
+    if (interval.nonEmpty) between(interval).allAtoms
+    else SortedSet.from(contextAt(interval.start).flatMap(_.step).map(_.atomId))
 
   /**
    * The minimal interval containing all the given atoms, if any.
@@ -183,7 +184,7 @@ sealed class TimeAccountingState private (val toMap: SortedMap[TimestampInterval
    *         intersect
    */
   def partitionOnAtomBoundary(interval: TimestampInterval): (TimeAccountingState, TimeAccountingState) = {
-    val intervalʹ = intervalContaining(atomsIn(interval)).getOrElse(interval).span(interval)
+    val intervalʹ = intervalContaining(atomsIntersecting(interval)).getOrElse(interval).span(interval)
     (between(intervalʹ), excluding(intervalʹ))
   }
 

--- a/modules/service/src/test/scala/lucuma/odb/service/TimeAccountingStateSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/TimeAccountingStateSuite.scala
@@ -175,10 +175,10 @@ final class TimeAccountingStateSuite extends ScalaCheckSuite {
     }
   }
 
-  test("atomsIn") {
+  test("atomsIntersecting") {
     forAll { (d: TestData) =>
       assertEquals(
-        d.state.atomsIn(d.interval),
+        d.state.atomsIntersecting(d.interval),
         d.state.toList.foldLeft(SortedSet.empty[Atom.Id]) { case (s, (interval, ctx)) =>
           ctx.step.fold(s) { step =>
             if (interval.intersects(d.interval)) s + step.atomId else s
@@ -203,7 +203,7 @@ final class TimeAccountingStateSuite extends ScalaCheckSuite {
     forAll { (d: TestData) =>
       val s  = d.state
       val i  = d.interval
-      val as = s.atomsIn(i)
+      val as = s.atomsIntersecting(i)
       val iʹ = s.intervalContaining(as).getOrElse(i)
       as.subsetOf(s.between(iʹ).allAtoms)
     }


### PR DESCRIPTION
Fixes #1016.  The state `between` an empty interval is empty and yet an empty interval may intersect with a `TimeAccountingState` interval associated with an atom.