### PR TITLE
Test case

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val skunkVersion               = "0.6.3"
 val pprintVersion              = "0.8.1"
 val testcontainersScalaVersion = "0.40.14" // N.B. 0.40.15 causes java.lang.NoClassDefFoundError: munit/Test
 
-ThisBuild / tlBaseVersion      := "0.11"
+ThisBuild / tlBaseVersion      := "0.12"
 ThisBuild / scalaVersion       := "3.4.0"
 ThisBuild / crossScalaVersions := Seq("3.4.0")
 

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -1418,24 +1418,19 @@ GMOS North Execution Config
 type GmosNorthExecutionConfig implements ExecutionConfig {
 
   """
-  Bogus field that makes the structure of this instrument distinct from the others.
-  """
-  gmosNorth: Boolean! @deprecated
-
-  """
   GMOS North static configuration
   """
-  static: GmosNorthStatic!
+  gmosNorthStatic: GmosNorthStatic!
 
   """
   GMOS North acquisition execution
   """
-  acquisition: GmosNorthExecutionSequence
+  gmosNorthAcquisition: GmosNorthExecutionSequence
 
   """
   GMOS North science execution
   """
-  science: GmosNorthExecutionSequence
+  gmosNorthScience: GmosNorthExecutionSequence
 
   """
   Instrument type
@@ -1945,24 +1940,19 @@ GMOS South Execution Config
 type GmosSouthExecutionConfig implements ExecutionConfig {
 
   """
-  Bogus field that makes the structure of this instrument distinct from the others.
-  """
-  gmosSouth: Boolean! @deprecated
-
-  """
   GMOS South static configuration
   """
-  static: GmosSouthStatic!
+  gmosSouthStatic: GmosSouthStatic!
 
   """
   GMOS South acquisition execution
   """
-  acquisition: GmosSouthExecutionSequence
+  gmosSouthAcquisition: GmosSouthExecutionSequence
 
   """
   GMOS South science execution
   """
-  science: GmosSouthExecutionSequence
+  gmosSouthScience: GmosSouthExecutionSequence
 
   """
   Instrument type

--- a/modules/schema/src/test/scala/lucuma/odb/json/SequenceSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/json/SequenceSuite.scala
@@ -7,22 +7,18 @@ import io.circe.testing.ArbitraryInstances
 import io.circe.testing.CodecTests
 import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.Dataset
-import lucuma.core.model.sequence.ExecutionConfig
 import lucuma.core.model.sequence.ExecutionSequence
 import lucuma.core.model.sequence.InstrumentExecutionConfig
 import lucuma.core.model.sequence.SequenceDigest
 import lucuma.core.model.sequence.Step
 import lucuma.core.model.sequence.arb.ArbAtom
 import lucuma.core.model.sequence.arb.ArbDataset
-import lucuma.core.model.sequence.arb.ArbExecutionConfig
 import lucuma.core.model.sequence.arb.ArbExecutionSequence
 import lucuma.core.model.sequence.arb.ArbInstrumentExecutionConfig
 import lucuma.core.model.sequence.arb.ArbSequenceDigest
 import lucuma.core.model.sequence.arb.ArbStep
 import lucuma.core.model.sequence.gmos.DynamicConfig
-import lucuma.core.model.sequence.gmos.StaticConfig
 import lucuma.core.model.sequence.gmos.arb.ArbDynamicConfig
-import lucuma.core.model.sequence.gmos.arb.ArbStaticConfig
 import lucuma.core.util.arb.ArbGid
 import munit.DisciplineSuite
 
@@ -33,10 +29,8 @@ class SequenceSuite extends DisciplineSuite with ArbitraryInstances {
   import ArbDynamicConfig._
   import ArbGid.*
   import ArbInstrumentExecutionConfig.given
-  import ArbExecutionConfig.given
   import ArbExecutionSequence.given
   import ArbSequenceDigest.given
-  import ArbStaticConfig._
   import ArbStep.given
 
   import offset.query.given
@@ -51,7 +45,9 @@ class SequenceSuite extends DisciplineSuite with ArbitraryInstances {
   checkAll("Step[GmosNorth]",              CodecTests[Step[DynamicConfig.GmosNorth]].codec)
   checkAll("Atom[GmosNorth]",              CodecTests[Atom[DynamicConfig.GmosNorth]].codec)
   checkAll("ExecutionSequence[GmosNorth]", CodecTests[ExecutionSequence[DynamicConfig.GmosNorth]].codec)
-  checkAll("ExecutionConfig[GmosNorth]",   CodecTests[ExecutionConfig[StaticConfig.GmosNorth, DynamicConfig.GmosNorth]].codec)
-  checkAll("InstrumentExecutionConfig",    CodecTests[InstrumentExecutionConfig].codec)
+
+  checkAll("InstrumentExecutionConfig.GmosNorth", CodecTests[InstrumentExecutionConfig.GmosNorth].codec)
+  checkAll("InstrumentExecutionConfig.GmosSouth", CodecTests[InstrumentExecutionConfig.GmosSouth].codec)
+  checkAll("InstrumentExecutionConfig",           CodecTests[InstrumentExecutionConfig].codec)
 
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/1023.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/1023.scala
@@ -106,7 +106,7 @@ class GitHub_1023 extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config(futureLimit: 100) {
                      ... on GmosNorthExecutionConfig {
-                       static {
+                       gmosNorthStatic {
                          stageMode
                          detector
                        }
@@ -122,7 +122,7 @@ class GitHub_1023 extends OdbSuite with ObservingModeSetupOperations {
               "observation" : {
                 "execution" : {
                   "config" : {
-                    "static" : {
+                    "gmosNorthStatic" : {
                       "stageMode" : "FOLLOW_XY",
                       "detector" : "HAMAMATSU"
                     }
@@ -154,13 +154,13 @@ class GitHub_1023 extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config(futureLimit: 100) {
                      ... on GmosNorthExecutionConfig {
-                       static {
+                       gmosNorthStatic {
                          stageMode
                          detector
                        }
                      }
                      ... on GmosSouthExecutionConfig {
-                       static {
+                       gmosSouthStatic {
                          stageMode
                          detector
                        }
@@ -176,7 +176,7 @@ class GitHub_1023 extends OdbSuite with ObservingModeSetupOperations {
               "observation" : {
                 "execution" : {
                   "config" : {
-                    "static" : {
+                    "gmosNorthStatic" : {
                       "stageMode" : "FOLLOW_XY",
                       "detector" : "HAMAMATSU"
                     }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/1023.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/1023.scala
@@ -7,9 +7,9 @@ package issue.github
 import cats.effect.IO
 import cats.syntax.either.*
 import cats.syntax.option.*
-import io.circe.literal.*
 import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.types.numeric.PosLong
+import io.circe.literal.*
 import lucuma.core.enums.GcalBaselineType
 import lucuma.core.enums.GcalContinuum
 import lucuma.core.enums.GcalDiffuser

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/1023.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/1023.scala
@@ -1,0 +1,191 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package issue.github
+
+import cats.effect.IO
+import cats.syntax.either.*
+import cats.syntax.option.*
+import io.circe.literal.*
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.numeric.PosLong
+import lucuma.core.enums.GcalBaselineType
+import lucuma.core.enums.GcalContinuum
+import lucuma.core.enums.GcalDiffuser
+import lucuma.core.enums.GcalFilter
+import lucuma.core.enums.GcalShutter
+import lucuma.core.enums.GmosAmpGain
+import lucuma.core.enums.GmosGratingOrder
+import lucuma.core.enums.GmosNorthFilter
+import lucuma.core.enums.GmosNorthFpu
+import lucuma.core.enums.GmosNorthGrating
+import lucuma.core.enums.GmosXBinning
+import lucuma.core.enums.GmosYBinning
+import lucuma.core.math.BoundedInterval
+import lucuma.core.math.Wavelength
+import lucuma.core.model.Observation
+import lucuma.core.model.Target
+import lucuma.core.model.User
+import lucuma.core.model.sequence.StepConfig.Gcal
+import lucuma.core.util.TimeSpan
+import lucuma.odb.graphql.enums.Enums
+import lucuma.odb.graphql.query.ObservingModeSetupOperations
+import lucuma.odb.service.Services
+import lucuma.odb.smartgcal.data.Gmos.GratingConfigKey
+import lucuma.odb.smartgcal.data.Gmos.TableKey
+import lucuma.odb.smartgcal.data.Gmos.TableRow
+import lucuma.odb.smartgcal.data.SmartGcalValue
+import lucuma.odb.smartgcal.data.SmartGcalValue.LegacyInstrumentConfig
+import natchez.Trace.Implicits.noop
+import skunk.Session
+
+
+class GitHub_1023 extends OdbSuite with ObservingModeSetupOperations {
+
+  val pi: User   = TestUsers.Standard.pi(1, 30)
+
+  override val validUsers: List[User] =
+    List(pi)
+
+  override def dbInitialization: Option[Session[IO] => IO[Unit]] = Some { s =>
+    val tableRow1: TableRow.North =
+      TableRow(
+        PosLong.unsafeFrom(1),
+        TableKey(
+          GratingConfigKey(
+            GmosNorthGrating.R831_G5302,
+            GmosGratingOrder.One,
+            BoundedInterval.unsafeOpenUpper(Wavelength.Min, Wavelength.Max)
+          ).some,
+          GmosNorthFilter.RPrime.some,
+          GmosNorthFpu.LongSlit_0_50.some,
+          GmosXBinning.One,
+          GmosYBinning.Two,
+          GmosAmpGain.Low
+        ),
+        SmartGcalValue(
+          Gcal(
+            Gcal.Lamp.fromContinuum(GcalContinuum.QuartzHalogen5W),
+            GcalFilter.Gmos,
+            GcalDiffuser.Ir,
+            GcalShutter.Open
+          ),
+          GcalBaselineType.Night,
+          PosInt.unsafeFrom(1),
+          LegacyInstrumentConfig(
+            TimeSpan.unsafeFromMicroseconds(1_000_000L)
+          )
+        )
+      )
+    Enums.load(s).flatMap { e =>
+      val services = Services.forUser(pi /* doesn't matter*/, e)(s)
+      services.transactionally {
+        services.smartGcalService.insertGmosNorth(1, tableRow1)
+      }
+    }
+  }
+
+
+  test("one inline fragment") {
+
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi, "Interface Issue")
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+
+    setup.flatMap { oid =>
+      expect(
+        user  = pi,
+        query =
+          s"""
+             query {
+               observation(observationId: "$oid") {
+                 execution {
+                   config(futureLimit: 100) {
+                     ... on GmosNorthExecutionConfig {
+                       static {
+                         stageMode
+                         detector
+                       }
+                     }
+                   }
+                 }
+               }
+             }
+          """,
+        expected =
+          json"""
+            {
+              "observation" : {
+                "execution" : {
+                  "config" : {
+                    "static" : {
+                      "stageMode" : "FOLLOW_XY",
+                      "detector" : "HAMAMATSU"
+                    }
+                  }
+                }
+              }
+            }
+          """.asRight
+        )
+    }
+  }
+
+  test("two inline fragments") {
+
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi, "Interface Issue")
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+
+    setup.flatMap { oid =>
+      expect(
+        user  = pi,
+        query =
+          s"""
+             query {
+               observation(observationId: "$oid") {
+                 execution {
+                   config(futureLimit: 100) {
+                     ... on GmosNorthExecutionConfig {
+                       static {
+                         stageMode
+                         detector
+                       }
+                     }
+                     ... on GmosSouthExecutionConfig {
+                       static {
+                         stageMode
+                         detector
+                       }
+                     }
+                   }
+                 }
+               }
+             }
+          """,
+        expected =
+          json"""
+            {
+              "observation" : {
+                "execution" : {
+                  "config" : {
+                    "static" : {
+                      "stageMode" : "FOLLOW_XY",
+                      "detector" : "HAMAMATSU"
+                    }
+                  }
+                }
+              }
+            }
+          """.asRight
+        )
+    }
+  }
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
@@ -500,7 +500,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config {
                      ... on GmosNorthExecutionConfig {
-                       static {
+                       gmosNorthStatic {
                          stageMode
                          detector
                          mosPreImaging
@@ -508,7 +508,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                            posA { p { microarcseconds } }
                          }
                        }
-                       acquisition {
+                       gmosNorthAcquisition {
                          nextAtom {
                            observeClass
                            steps {
@@ -567,13 +567,13 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
               "observation": {
                 "execution": {
                   "config": {
-                    "static": {
+                    "gmosNorthStatic": {
                       "stageMode": "FOLLOW_XY",
                       "detector": "HAMAMATSU",
                       "mosPreImaging": "IS_NOT_MOS_PRE_IMAGING",
                       "nodAndShuffle": null
                     },
-                    "acquisition": {
+                    "gmosNorthAcquisition": {
                       "nextAtom": {
                         "observeClass": "ACQUISITION",
                         "steps": [
@@ -695,7 +695,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config {
                      ... on GmosNorthExecutionConfig {
-                       static {
+                       gmosNorthStatic {
                          stageMode
                        }
                      }
@@ -738,7 +738,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config(futureLimit: 1) {
                      ... on GmosNorthExecutionConfig {
-                       science {
+                       gmosNorthScience {
                          nextAtom {
                            observeClass
                          }
@@ -770,7 +770,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
               "observation": {
                 "execution": {
                   "config": {
-                    "science": {
+                    "gmosNorthScience": {
                       "nextAtom": {
                         "observeClass": "SCIENCE"
                       },
@@ -833,7 +833,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config(futureLimit: 101) {
                      ... on GmosNorthExecutionConfig {
-                       science {
+                       gmosNorthScience {
                          possibleFuture {
                            observeClass
                          }
@@ -891,7 +891,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                    }
                    config {
                      ... on GmosNorthExecutionConfig {
-                       science {
+                       gmosNorthScience {
                          nextAtom {
                            description
                            steps {
@@ -947,7 +947,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                     }
                   },
                   "config": {
-                    "science": {
+                    "gmosNorthScience": {
                       "nextAtom": {
                         "description": "q -15.0″, λ 500.0 nm",
                         "steps": [
@@ -1116,7 +1116,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config {
                      ... on GmosNorthExecutionConfig {
-                       science {
+                       gmosNorthScience {
                          nextAtom {
                            description
                            steps {
@@ -1150,7 +1150,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
               "observation": {
                 "execution": {
                   "config": {
-                    "science": {
+                    "gmosNorthScience": {
                       "nextAtom": {
                         "description": "q 0.0″, λ 495.0 nm",
                         "steps": [
@@ -1357,7 +1357,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config {
                      ... on GmosSouthExecutionConfig {
-                       science {
+                       gmosSouthScience {
                          nextAtom {
                            steps {
                              instrumentConfig {
@@ -1499,7 +1499,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config {
                      ... on GmosNorthExecutionConfig {
-                       acquisition {
+                       gmosNorthAcquisition {
                          nextAtom {
                            ...gmosNorthAtomFields
                          }
@@ -1519,7 +1519,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
               "observation": {
                 "execution": {
                   "config": {
-                    "acquisition": {
+                    "gmosNorthAcquisition": {
                       "nextAtom": {
                          "steps": [
                           {
@@ -1853,7 +1853,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                    }
                    config {
                      ... on GmosNorthExecutionConfig {
-                       science {
+                       gmosNorthScience {
                          nextAtom {
                            ...gmosNorthAtomFields
                          }
@@ -1899,7 +1899,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                     }
                   },
                   "config" : {
-                    "science" : {
+                    "gmosNorthScience" : {
                       "nextAtom" : {
                         "steps" : [
                           {
@@ -2378,7 +2378,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
             execution {
               config(futureLimit: $futureLimit) {
                 ... on GmosNorthExecutionConfig {
-                  science {
+                  gmosNorthScience {
                     nextAtom {
                       id
                     }
@@ -2393,7 +2393,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
         }
       """
     ).map { json =>
-      val sci = json.hcursor.downFields("observation", "execution", "config", "science")
+      val sci = json.hcursor.downFields("observation", "execution", "config", "gmosNorthScience")
       val n   = sci.downFields("nextAtom", "id").require[Atom.Id]
       val fs  = sci.downFields("possibleFuture").values.toList.flatMap(_.toList.map(_.hcursor.downField("id").require[Atom.Id]))
       n :: fs
@@ -2537,7 +2537,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config {
                      ... on GmosNorthExecutionConfig {
-                       science {
+                       gmosNorthScience {
                          nextAtom {
                            steps {
                              instrumentConfig {
@@ -2561,7 +2561,7 @@ class execution extends OdbSuite with ObservingModeSetupOperations {
               "observation": {
                 "execution": {
                   "config": {
-                    "science": {
+                    "gmosNorthScience": {
                       "nextAtom": {
                         "steps": [
                           {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/smartgcal.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/smartgcal.scala
@@ -209,7 +209,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config {
                      ... on GmosNorthExecutionConfig {
-                       science {
+                       gmosNorthScience {
                          nextAtom {
                            steps {
                              instrumentConfig {
@@ -253,7 +253,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
               "observation": {
                 "execution": {
                   "config": {
-                    "science": {
+                    "gmosNorthScience": {
                       "nextAtom": {
                         "steps": [
                           {
@@ -439,7 +439,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config {
                      ... on GmosSouthExecutionConfig {
-                       science {
+                       gmosSouthScience {
                          nextAtom {
                            steps {
                              instrumentConfig {
@@ -468,7 +468,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
               "observation": {
                 "execution": {
                   "config": {
-                    "science": {
+                    "gmosSouthScience": {
                       "nextAtom": {
                         "steps": [
                           {
@@ -537,7 +537,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config {
                      ... on GmosNorthExecutionConfig {
-                       science {
+                       gmosNorthScience {
                          nextAtom {
                            steps {
                              instrumentConfig {
@@ -566,7 +566,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
               "observation": {
                 "execution": {
                   "config": {
-                    "science": {
+                    "gmosNorthScience": {
                       "nextAtom": {
                         "steps": [
                           {
@@ -644,7 +644,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config {
                      ... on GmosNorthExecutionConfig {
-                       science {
+                       gmosNorthScience {
                          nextAtom {
                            steps {
                              instrumentConfig {
@@ -673,7 +673,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
               "observation": {
                 "execution": {
                   "config": {
-                    "science": {
+                    "gmosNorthScience": {
                       "nextAtom": {
                         "steps": [
                           {
@@ -749,7 +749,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
                  execution {
                    config {
                      ... on GmosNorthExecutionConfig {
-                       science {
+                       gmosNorthScience {
                          nextAtom {
                            steps {
                              instrumentConfig {


### PR DESCRIPTION
Grackle 0.18.1 revealed that we were unknowingly taking advantage of a nonconformity of Grackle with respect to the GraphQL spec.  In particular, the path down to a leaf must always resolve to the same type regardless of the particular interface implementation (see #1023).  To make this possible, we can rename fields at a high level to introduce a distinguishing prefix.  That turns, for instance, 

* `execution` / `config` / `static` / `stageMode` into
*  `execution` / `config` / `gmosNorthStatic` / `stageMode` and
*  `execution` / `config` / `gmosSouthStatic` / `stageMode`.

For which a query might produce, for example:

```json
"execution": {
  "config": {
    "gmosNorthStatic": {
      "stageMode": "FOLLOW_XY"
    }
  }
}
```

but never the ambiguous

```json
"execution": {
  "config": {
    "static": {
      "stageMode": "FOLLOW_XY"
    }
  }
}
```