### PR TITLE
Remove unused input

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -11404,57 +11404,6 @@ input WhereOrderPosInt {
   LTE: PosInt
 }
 
-"""
-Filters on equality or order comparisons of the property.  All supplied
-criteria must match, but usually only one is selected.  E.g., 'GT = 2'
-for an integer property will match when the value is 3 or more.
-"""
-input WhereOptionOrderProgramReference {
-
-  "Matches if the ProgramReference is not defined."
-  IS_NULL: Boolean
-
-  """
-  Matches if the ProgramReference is exactly the supplied value.
-  """
-  EQ: ProgramReference
-
-  """
-  Matches if the ProgramReference is not the supplied value.
-  """
-  NEQ: ProgramReference
-
-  """
-  Matches if the ProgramReference is any of the supplied options.
-  """
-  IN: [ProgramReference!]
-
-  """
-  Matches if the ProgramReference is none of the supplied values.
-  """
-  NIN: [ProgramReference!]
-
-  """
-  Matches if the ProgramReference is ordered after (>) the supplied value.
-  """
-  GT: ProgramReference
-
-  """
-  Matches if the ProgramReference is ordered before (<) the supplied value.
-  """
-  LT: ProgramReference
-
-  """
-  Matches if the ProgramReference is ordered after or equal (>=) the supplied value.
-  """
-  GTE: ProgramReference
-
-  """
-  Matches if the ProgramReference is ordered before or equal (<=) the supplied value.
-  """
-  LTE: ProgramReference
-}
-
 input WhereProposalReference {
 
   "Matches if the proposal reference is not defined."


### PR DESCRIPTION
This is a bit of schema that is unused since #973 and should have been deleted (there is now instead `WhereProgramReference`).  Unfortunately it is breaking introspection because it is an input with fields that are not scalars or other inputs.