### PR TITLE
UpdateAsterismsInput

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -3754,27 +3754,24 @@ input UnnormalizedSedInput {
 
 """
 Input for bulk updating multiple observations.  Select observations
-with the 'WHERE' input and specify the changes in 'SET'.
-
+with the 'WHERE' input and specify the changes in 'SET'.  All the selected
+observations must be in the same program.
 """
 input UpdateAsterismsInput {
-  """
-  Program ID for the program whose asterism is to be edited.
-  """
-  programId: ProgramId!
-
   """
   Describes the values to modify.
   """
   SET: EditAsterismsPatchInput!
 
   """
-  Filters the observations to be updated according to those that match the given constraints.
+  Filters the observations to be updated according to those that match the
+  given constraints.  All must correspond to the same program.
   """
   WHERE: WhereObservation
 
   """
-  Caps the number of results returned to the given value (if additional observations match the WHERE clause they will be updated but not returned).
+  Caps the number of results returned to the given value (if additional
+  observations match the WHERE clause they will be updated but not returned).
   """
   LIMIT: NonNegInt
 
@@ -3782,7 +3779,9 @@ input UpdateAsterismsInput {
 }
 
 """
-The result of updating the selected observations, up to `LIMIT` or the maximum of (1000).  If `hasMore` is true, additional observations were modified and not included here.
+The result of updating the selected observations, up to `LIMIT` or the maximum
+of (1000).  If `hasMore` is true, additional observations were modified and not
+included here.
 """
 type UpdateAsterismsResult {
   """

--- a/modules/schema/src/main/scala/lucuma/odb/data/OdbError.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/OdbError.scala
@@ -41,7 +41,8 @@ enum OdbError:
   case InvitationError(invitationId: String, detail: Option[String] = None) // TODO: UserInvitation -> core, then we can have UserInvitation.Id here
   case InvalidProgram(programId: Program.Id, detail: Option[String] = None)       
   case InvalidObservation(observationId: Observation.Id, detail: Option[String] = None)   
-  case SequenceUnavailable(detail: Option[String] = None)  
+  case InvalidObservationList(observationIds: NonEmptyList[Observation.Id], detail: Option[String] = None)
+  case SequenceUnavailable(detail: Option[String] = None)
   case InvalidTarget(targetId: Target.Id, detail: Option[String] = None)        
   case InvalidTargetList(programId: Program.Id, targetIds: NonEmptyList[Target.Id], detail: Option[String] = None)    
   case InvalidVisit(visitId: Visit.Id, detail: Option[String] = None)         
@@ -58,24 +59,25 @@ object OdbError:
 
   // N.B. package-private to allow for Arb instance
   private[data] enum Tag(val value: String):
-    case InvalidArgument       extends Tag("invalid_argument")
-    case NoAction              extends Tag("no_action")
-    case NotAuthorized         extends Tag("not_authorized")
-    case InvitationError       extends Tag("invitation_error")
-    case InvalidProgram        extends Tag("invalid_program")
-    case InvalidObservation    extends Tag("invalid_observation")
-    case SequenceUnavailable   extends Tag("sequence_unavailable")
-    case InvalidTarget         extends Tag("invalid_target")
-    case InvalidTargetList     extends Tag("invalid_target_list")
-    case InvalidVisit          extends Tag("invalid_visit")
-    case InvalidStep           extends Tag("invalid_step")
-    case InvalidFilename       extends Tag("invalid_filename")
-    case InvalidAtom           extends Tag("invalid_atom")
-    case InvalidDataset        extends Tag("invalid_dataset")
-    case InvalidUser           extends Tag("invalid_user")
-    case UpdateFailed          extends Tag("update_failed")
-    case ItcError              extends Tag("itc_error")
-    case GuideEnvironmentError extends Tag("guide_environment_error")
+    case InvalidArgument        extends Tag("invalid_argument")
+    case NoAction               extends Tag("no_action")
+    case NotAuthorized          extends Tag("not_authorized")
+    case InvitationError        extends Tag("invitation_error")
+    case InvalidProgram         extends Tag("invalid_program")
+    case InvalidObservation     extends Tag("invalid_observation")
+    case InvalidObservationList extends Tag("invalid_observation_list")
+    case SequenceUnavailable    extends Tag("sequence_unavailable")
+    case InvalidTarget          extends Tag("invalid_target")
+    case InvalidTargetList      extends Tag("invalid_target_list")
+    case InvalidVisit           extends Tag("invalid_visit")
+    case InvalidStep            extends Tag("invalid_step")
+    case InvalidFilename        extends Tag("invalid_filename")
+    case InvalidAtom            extends Tag("invalid_atom")
+    case InvalidDataset         extends Tag("invalid_dataset")
+    case InvalidUser            extends Tag("invalid_user")
+    case UpdateFailed           extends Tag("update_failed")
+    case ItcError               extends Tag("itc_error")
+    case GuideEnvironmentError  extends Tag("guide_environment_error")
 
   private[data]  object Tag:
 
@@ -87,87 +89,91 @@ object OdbError:
 
   private def tag(e: OdbError): Tag =
     e match
-      case OdbError.InvalidArgument(_)         => Tag.InvalidArgument
-      case OdbError.NoAction(_)                => Tag.NoAction
-      case OdbError.NotAuthorized(_, _)        => Tag.NotAuthorized
-      case OdbError.InvitationError(_, _)      => Tag.InvitationError
-      case OdbError.InvalidProgram(_, _)       => Tag.InvalidProgram
-      case OdbError.InvalidObservation(_, _)   => Tag.InvalidObservation
-      case OdbError.SequenceUnavailable(_)     => Tag.SequenceUnavailable
-      case OdbError.InvalidTarget(_, _)        => Tag.InvalidTarget
-      case OdbError.InvalidTargetList(_, _, _) => Tag.InvalidTargetList
-      case OdbError.InvalidVisit(_, _)         => Tag.InvalidVisit
-      case OdbError.InvalidStep(_, _)          => Tag.InvalidStep
-      case OdbError.InvalidFilename(_, _)      => Tag.InvalidFilename
-      case OdbError.InvalidAtom(_, _)          => Tag.InvalidAtom
-      case OdbError.InvalidDataset(_, _)       => Tag.InvalidDataset
-      case OdbError.InvalidUser(_, _)          => Tag.InvalidUser
-      case OdbError.UpdateFailed(_)            => Tag.UpdateFailed
-      case OdbError.ItcError(_)                => Tag.ItcError
-      case OdbError.GuideEnvironmentError(_)   => Tag.GuideEnvironmentError
+      case OdbError.InvalidArgument(_)           => Tag.InvalidArgument
+      case OdbError.NoAction(_)                  => Tag.NoAction
+      case OdbError.NotAuthorized(_, _)          => Tag.NotAuthorized
+      case OdbError.InvitationError(_, _)        => Tag.InvitationError
+      case OdbError.InvalidProgram(_, _)         => Tag.InvalidProgram
+      case OdbError.InvalidObservation(_, _)     => Tag.InvalidObservation
+      case OdbError.InvalidObservationList(_, _) => Tag.InvalidObservationList
+      case OdbError.SequenceUnavailable(_)       => Tag.SequenceUnavailable
+      case OdbError.InvalidTarget(_, _)          => Tag.InvalidTarget
+      case OdbError.InvalidTargetList(_, _, _)   => Tag.InvalidTargetList
+      case OdbError.InvalidVisit(_, _)           => Tag.InvalidVisit
+      case OdbError.InvalidStep(_, _)            => Tag.InvalidStep
+      case OdbError.InvalidFilename(_, _)        => Tag.InvalidFilename
+      case OdbError.InvalidAtom(_, _)            => Tag.InvalidAtom
+      case OdbError.InvalidDataset(_, _)         => Tag.InvalidDataset
+      case OdbError.InvalidUser(_, _)            => Tag.InvalidUser
+      case OdbError.UpdateFailed(_)              => Tag.UpdateFailed
+      case OdbError.ItcError(_)                  => Tag.ItcError
+      case OdbError.GuideEnvironmentError(_)     => Tag.GuideEnvironmentError
 
   private def defaultMessage(e: OdbError): String =
     e match
-      case InvalidArgument(_)         => "The provided argument is not valid."
-      case NoAction(_)                => "No action was taken."
-      case NotAuthorized(u, _)        => s"User $u is not authorized to perform this operation."
-      case InvitationError(_, _)      => "Invitation operation could not be completed."
-      case InvalidProgram(p, _)       => s"Program $p does not exist, is not visible, or is ineligible for the requested operation."
-      case InvalidObservation(o, _)   => s"Observation $o does not exist, is not visible, or is ineligible for the requested operation."
-      case SequenceUnavailable(_)     => "Could not generate the requested sequence."
-      case InvalidTarget(t, _)        => s"Target $t does not exist, is not visible, or is ineligible for the requested operation."
-      case InvalidTargetList(p, ts, _) => s"Target(s) ${ts.toList.mkString(", ")} must exist and be associated with Program $p."
-      case InvalidVisit(v, _)         => s"Visit $v does not exist, is not visible, or is ineligible for the requested operation."
-      case InvalidStep(s, _)          => s"Step $s does not exist, is not visible, or is ineligible for the requested operation."
-      case InvalidFilename(n, _)      => s"Filename '$n' is invalid or already exists."
-      case InvalidAtom(a, _)          => s"Atom $a does not exist, is not visible, or is ineligible for the requested operation."
-      case InvalidDataset(d, _)       => s"Dataset $d does not exist, is not visible, or is ineligible for the requested operation."
-      case InvalidUser(u, _)          => s"User $u user does not exist, or is ineligible for the requested operation."
-      case UpdateFailed(_)            => "The specified operation could not be completed."
-      case ItcError(_)                => "The requested ITC operation could not be completed."
-      case GuideEnvironmentError(_)   => "The guide environment as configured is ineligible for the requested operation."
+      case InvalidArgument(_)            => "The provided argument is not valid."
+      case NoAction(_)                   => "No action was taken."
+      case NotAuthorized(u, _)           => s"User $u is not authorized to perform this operation."
+      case InvitationError(_, _)         => "Invitation operation could not be completed."
+      case InvalidProgram(p, _)          => s"Program $p does not exist, is not visible, or is ineligible for the requested operation."
+      case InvalidObservation(o, _)      => s"Observation $o does not exist, is not visible, or is ineligible for the requested operation."
+      case InvalidObservationList(os, _) => s"Observation(s) ${os.toList.mkString(", ")} must exist and be associated with the same program."
+      case SequenceUnavailable(_)        => "Could not generate the requested sequence."
+      case InvalidTarget(t, _)           => s"Target $t does not exist, is not visible, or is ineligible for the requested operation."
+      case InvalidTargetList(p, ts, _)   => s"Target(s) ${ts.toList.mkString(", ")} must exist and be associated with Program $p."
+      case InvalidVisit(v, _)            => s"Visit $v does not exist, is not visible, or is ineligible for the requested operation."
+      case InvalidStep(s, _)             => s"Step $s does not exist, is not visible, or is ineligible for the requested operation."
+      case InvalidFilename(n, _)         => s"Filename '$n' is invalid or already exists."
+      case InvalidAtom(a, _)             => s"Atom $a does not exist, is not visible, or is ineligible for the requested operation."
+      case InvalidDataset(d, _)          => s"Dataset $d does not exist, is not visible, or is ineligible for the requested operation."
+      case InvalidUser(u, _)             => s"User $u user does not exist, or is ineligible for the requested operation."
+      case UpdateFailed(_)               => "The specified operation could not be completed."
+      case ItcError(_)                   => "The requested ITC operation could not be completed."
+      case GuideEnvironmentError(_)      => "The guide environment as configured is ineligible for the requested operation."
 
   private def data(e: OdbError): JsonObject =
     e match
-      case InvalidArgument(_)          => JsonObject()
-      case NoAction(_)                 => JsonObject()
-      case NotAuthorized(u, _)         => JsonObject("userId" -> u.asJson)
-      case InvitationError(i, _)       => JsonObject("invitationId" -> i.asJson)
-      case InvalidProgram(p, _)        => JsonObject("programId" -> p.asJson)
-      case InvalidObservation(o, _)    => JsonObject("observationId" -> o.asJson)
-      case SequenceUnavailable(_)      => JsonObject()
-      case InvalidTarget(t, _)         => JsonObject("targetId" -> t.asJson)
-      case InvalidTargetList(p, ts, _) => JsonObject("programId" -> p.asJson, "targetIds" -> ts.asJson)
-      case InvalidVisit(v, _)          => JsonObject("visitId" -> v.asJson)
-      case InvalidStep(s, _)           => JsonObject("stepId" -> s.asJson)
-      case InvalidFilename(n, _)       => JsonObject("filename" -> n.asJson)
-      case InvalidAtom(a, _)           => JsonObject("atomId" -> a.asJson)
-      case InvalidDataset(d, _)        => JsonObject("datasetId" -> d.asJson)
-      case InvalidUser(u, _)           => JsonObject("userId" -> u.asJson)
-      case UpdateFailed(_)             => JsonObject()
-      case ItcError(_)                 => JsonObject()
-      case GuideEnvironmentError(_)    => JsonObject()
+      case InvalidArgument(_)            => JsonObject()
+      case NoAction(_)                   => JsonObject()
+      case NotAuthorized(u, _)           => JsonObject("userId" -> u.asJson)
+      case InvitationError(i, _)         => JsonObject("invitationId" -> i.asJson)
+      case InvalidProgram(p, _)          => JsonObject("programId" -> p.asJson)
+      case InvalidObservation(o, _)      => JsonObject("observationId" -> o.asJson)
+      case InvalidObservationList(os, _) => JsonObject("observationIds" -> os.asJson)
+      case SequenceUnavailable(_)        => JsonObject()
+      case InvalidTarget(t, _)           => JsonObject("targetId" -> t.asJson)
+      case InvalidTargetList(p, ts, _)   => JsonObject("programId" -> p.asJson, "targetIds" -> ts.asJson)
+      case InvalidVisit(v, _)            => JsonObject("visitId" -> v.asJson)
+      case InvalidStep(s, _)             => JsonObject("stepId" -> s.asJson)
+      case InvalidFilename(n, _)         => JsonObject("filename" -> n.asJson)
+      case InvalidAtom(a, _)             => JsonObject("atomId" -> a.asJson)
+      case InvalidDataset(d, _)          => JsonObject("datasetId" -> d.asJson)
+      case InvalidUser(u, _)             => JsonObject("userId" -> u.asJson)
+      case UpdateFailed(_)               => JsonObject()
+      case ItcError(_)                   => JsonObject()
+      case GuideEnvironmentError(_)      => JsonObject()
     
   private def decode(d: Tag, detail: Option[String], c: ACursor): Decoder.Result[OdbError] =
     d match
-      case Tag.InvalidArgument       => InvalidArgument(detail).asRight
-      case Tag.NoAction              => NoAction(detail).asRight      
-      case Tag.NotAuthorized         => c.downField("userId").as[User.Id].map(NotAuthorized(_, detail))
-      case Tag.InvitationError       => c.downField("invitationId").as[String].map(InvitationError(_, detail))
-      case Tag.InvalidProgram        => c.downField("programId").as[Program.Id].map(InvalidProgram(_, detail))
-      case Tag.InvalidObservation    => c.downField("observationId").as[Observation.Id].map(InvalidObservation(_, detail))
-      case Tag.SequenceUnavailable   => SequenceUnavailable(detail).asRight
-      case Tag.InvalidTarget         => c.downField("targetId").as[Target.Id].map(InvalidTarget(_, detail))
-      case Tag.InvalidTargetList     => (c.downField("programId").as[Program.Id], c.downField("targetIds").as[NonEmptyList[Target.Id]]).mapN(InvalidTargetList(_, _, detail))
-      case Tag.InvalidVisit          => c.downField("visitId").as[Visit.Id].map(InvalidVisit(_, detail))
-      case Tag.InvalidStep           => c.downField("stepId").as[Step.Id].map(InvalidStep(_, detail))
-      case Tag.InvalidFilename       => c.downField("filename").as[Filename].map(InvalidFilename(_, detail))
-      case Tag.InvalidAtom           => c.downField("atomId").as[Atom.Id].map(InvalidAtom(_, detail))
-      case Tag.InvalidDataset        => c.downField("datasetId").as[Dataset.Id].map(InvalidDataset(_, detail))
-      case Tag.InvalidUser           => c.downField("userId").as[User.Id].map(InvalidUser(_, detail))
-      case Tag.UpdateFailed          => UpdateFailed(detail).asRight
-      case Tag.ItcError              => ItcError(detail).asRight
-      case Tag.GuideEnvironmentError => GuideEnvironmentError(detail).asRight
+      case Tag.InvalidArgument        => InvalidArgument(detail).asRight
+      case Tag.NoAction               => NoAction(detail).asRight
+      case Tag.NotAuthorized          => c.downField("userId").as[User.Id].map(NotAuthorized(_, detail))
+      case Tag.InvitationError        => c.downField("invitationId").as[String].map(InvitationError(_, detail))
+      case Tag.InvalidProgram         => c.downField("programId").as[Program.Id].map(InvalidProgram(_, detail))
+      case Tag.InvalidObservation     => c.downField("observationId").as[Observation.Id].map(InvalidObservation(_, detail))
+      case Tag.InvalidObservationList => c.downField("observationIds").as[NonEmptyList[Observation.Id]].map(InvalidObservationList(_, detail))
+      case Tag.SequenceUnavailable    => SequenceUnavailable(detail).asRight
+      case Tag.InvalidTarget          => c.downField("targetId").as[Target.Id].map(InvalidTarget(_, detail))
+      case Tag.InvalidTargetList      => (c.downField("programId").as[Program.Id], c.downField("targetIds").as[NonEmptyList[Target.Id]]).mapN(InvalidTargetList(_, _, detail))
+      case Tag.InvalidVisit           => c.downField("visitId").as[Visit.Id].map(InvalidVisit(_, detail))
+      case Tag.InvalidStep            => c.downField("stepId").as[Step.Id].map(InvalidStep(_, detail))
+      case Tag.InvalidFilename        => c.downField("filename").as[Filename].map(InvalidFilename(_, detail))
+      case Tag.InvalidAtom            => c.downField("atomId").as[Atom.Id].map(InvalidAtom(_, detail))
+      case Tag.InvalidDataset         => c.downField("datasetId").as[Dataset.Id].map(InvalidDataset(_, detail))
+      case Tag.InvalidUser            => c.downField("userId").as[User.Id].map(InvalidUser(_, detail))
+      case Tag.UpdateFailed           => UpdateFailed(detail).asRight
+      case Tag.ItcError               => ItcError(detail).asRight
+      case Tag.GuideEnvironmentError  => GuideEnvironmentError(detail).asRight
     
   private object Field:
     private val Prefix = "odb_error"

--- a/modules/schema/src/test/scala/lucuma/odb/data/OdbErrorSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/data/OdbErrorSuite.scala
@@ -66,24 +66,25 @@ class OdbErrorSuite extends DisciplineSuite with ArbitraryInstances:
     Arbitrary:
       (arbitrary[OdbError.Tag], arbitrary[Option[String]]).tupled.flatMap: (tag, detail) =>
         tag match
-          case Tag.InvalidArgument       => OdbError.InvalidArgument(detail).pure[Gen]
-          case Tag.NoAction              => OdbError.NoAction(detail).pure[Gen]
-          case Tag.NotAuthorized         => arbitrary[User.Id].map(OdbError.NotAuthorized(_, detail))
-          case Tag.InvitationError       => arbitrary[String].map(OdbError.InvitationError(_, detail))
-          case Tag.InvalidProgram        => arbitrary[Program.Id].map(OdbError.InvalidProgram(_, detail))
-          case Tag.InvalidObservation    => arbitrary[Observation.Id].map(OdbError.InvalidObservation(_, detail))
-          case Tag.SequenceUnavailable   => OdbError.SequenceUnavailable(detail).pure[Gen]
-          case Tag.InvalidTarget         => arbitrary[Target.Id].map(OdbError.InvalidTarget(_, detail))
-          case Tag.InvalidTargetList     => (arbitrary[Program.Id], arbitrary[NonEmptyList[Target.Id]]).mapN(OdbError.InvalidTargetList(_, _, detail))
-          case Tag.InvalidVisit          => arbitrary[Visit.Id].map(OdbError.InvalidVisit(_, detail))
-          case Tag.InvalidStep           => arbitrary[Step.Id].map(OdbError.InvalidStep(_, detail))
-          case Tag.InvalidFilename       => arbitrary[Filename].map(OdbError.InvalidFilename(_, detail))
-          case Tag.InvalidAtom           => arbitrary[Atom.Id].map(OdbError.InvalidAtom(_, detail))
-          case Tag.InvalidDataset        => arbitrary[Dataset.Id].map(OdbError.InvalidDataset(_, detail))
-          case Tag.InvalidUser           => arbitrary[User.Id].map(OdbError.InvalidUser(_, detail))
-          case Tag.UpdateFailed          => OdbError.UpdateFailed(detail).pure[Gen]
-          case Tag.ItcError              => OdbError.ItcError(detail).pure[Gen]
-          case Tag.GuideEnvironmentError => OdbError.GuideEnvironmentError(detail).pure[Gen]
+          case Tag.InvalidArgument        => OdbError.InvalidArgument(detail).pure[Gen]
+          case Tag.NoAction               => OdbError.NoAction(detail).pure[Gen]
+          case Tag.NotAuthorized          => arbitrary[User.Id].map(OdbError.NotAuthorized(_, detail))
+          case Tag.InvitationError        => arbitrary[String].map(OdbError.InvitationError(_, detail))
+          case Tag.InvalidProgram         => arbitrary[Program.Id].map(OdbError.InvalidProgram(_, detail))
+          case Tag.InvalidObservation     => arbitrary[Observation.Id].map(OdbError.InvalidObservation(_, detail))
+          case Tag.InvalidObservationList => arbitrary[NonEmptyList[Observation.Id]].map(OdbError.InvalidObservationList(_, detail))
+          case Tag.SequenceUnavailable    => OdbError.SequenceUnavailable(detail).pure[Gen]
+          case Tag.InvalidTarget          => arbitrary[Target.Id].map(OdbError.InvalidTarget(_, detail))
+          case Tag.InvalidTargetList      => (arbitrary[Program.Id], arbitrary[NonEmptyList[Target.Id]]).mapN(OdbError.InvalidTargetList(_, _, detail))
+          case Tag.InvalidVisit           => arbitrary[Visit.Id].map(OdbError.InvalidVisit(_, detail))
+          case Tag.InvalidStep            => arbitrary[Step.Id].map(OdbError.InvalidStep(_, detail))
+          case Tag.InvalidFilename        => arbitrary[Filename].map(OdbError.InvalidFilename(_, detail))
+          case Tag.InvalidAtom            => arbitrary[Atom.Id].map(OdbError.InvalidAtom(_, detail))
+          case Tag.InvalidDataset         => arbitrary[Dataset.Id].map(OdbError.InvalidDataset(_, detail))
+          case Tag.InvalidUser            => arbitrary[User.Id].map(OdbError.InvalidUser(_, detail))
+          case Tag.UpdateFailed           => OdbError.UpdateFailed(detail).pure[Gen]
+          case Tag.ItcError               => OdbError.ItcError(detail).pure[Gen]
+          case Tag.GuideEnvironmentError  => OdbError.GuideEnvironmentError(detail).pure[Gen]
                       
   checkAll("OdbErrorCodec", CodecTests[OdbError].codec)
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateAsterismsInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateAsterismsInput.scala
@@ -8,7 +8,6 @@ import cats.syntax.parallel.*
 import eu.timepit.refined.types.numeric.NonNegInt
 import grackle.Path
 import grackle.Predicate
-import lucuma.core.model.Program
 import lucuma.odb.graphql.binding._
 
 
@@ -16,8 +15,6 @@ import lucuma.odb.graphql.binding._
 //# with the 'WHERE' input and specify the changes in 'SET'.
 //#
 //input UpdateAsterismsInput {
-//  # Program ID for the program whose asterism is to be edited.
-//  programId: ProgramId!
 //
 //  # Describes the values to modify.
 //  SET: EditAsterismsPatchInput!
@@ -30,7 +27,6 @@ import lucuma.odb.graphql.binding._
 //}
 
 final case class UpdateAsterismsInput(
-  programId:      Program.Id,
   SET:            EditAsterismsPatchInput,
   WHERE:          Option[Predicate],
   LIMIT:          Option[NonNegInt],
@@ -43,13 +39,12 @@ object UpdateAsterismsInput {
     val WhereObservationBinding = WhereObservation.binding(path)
     ObjectFieldsBinding.rmap {
       case List(
-        ProgramIdBinding("programId", rPid),
         EditAsterismsPatchInput.Binding("SET", rSET),
         WhereObservationBinding.Option("WHERE", rWHERE),
         NonNegIntBinding.Option("LIMIT", rLIMIT),
         BooleanBinding.Option("includeDeleted", rIncludeDeleted)
       ) =>
-        (rPid, rSET, rWHERE, rLIMIT, rIncludeDeleted).parMapN(apply)
+        (rSET, rWHERE, rLIMIT, rIncludeDeleted).parMapN(apply)
     }
   }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -674,7 +674,7 @@ trait MutationMapping[F[_]] extends Predicates[F] {
           NonEmptyList.fromList(oids).traverse { os =>
             val add = input.SET.ADD.flatMap(NonEmptyList.fromList)
             val del = input.SET.DELETE.flatMap(NonEmptyList.fromList)
-            asterismService.updateAsterism(input.programId, os, add, del)
+            asterismService.updateAsterism(os, add, del)
           }.map(_.getOrElse(Result.unit))
 
         for {

--- a/modules/service/src/main/scala/lucuma/odb/service/AsterismService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AsterismService.scala
@@ -98,6 +98,8 @@ object AsterismService {
 
     new AsterismService[F] {
 
+      // Selects the program id that is shared by all the given observations,
+      // or else fails.
       private def selectProgramId(
         observationIds: NonEmptyList[Observation.Id]
       ): F[Result[Program.Id]] = {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -496,7 +496,6 @@ trait DatabaseOperations { this: OdbSuite =>
 
   def updateAsterisms(
     user: User,
-    pid:  Program.Id,
     oids: List[Observation.Id],
     add:  List[Target.Id],
     del:  List[Target.Id],
@@ -508,7 +507,6 @@ trait DatabaseOperations { this: OdbSuite =>
         s"""
         mutation {
           updateAsterisms(input: {
-            programId: ${pid.asJson}
             SET: {
               ${
                  add match {


### PR DESCRIPTION
There is a collection of `updateFoo` mutations in the schema: `updateAsterisms`, `updateDatasets`, etc.  They all take a corresponding `UpdateFooInput` (e.g., `UpdateAsterismsInput`) which have a similar collection of fields:

* `SET` - what to change
* `WHERE` - which to change
* `LIMIT` - max result count to return
* `includeDeleted` - consider deleted observations, targets, etc.

A couple of these (`UpdateAsterismsInput` and `UpdateObsAttachmentsInput`) require an additional `programId` argument rather than using the `WHERE` clause to restrict the scope of the update.  I'd like to make it consistent across all these similar mutations.  Assuming you can filter on programs in the `WHERE` clause, this way you can also use program references or proposal references instead of just program ids.  In particular, for the asterism update:

```
WHERE: {
  program: { reference: { EQ: "G-2024A-0001-Q" }  }
}
```

The drawback of gaining consistency and making it possible to use references is that it becomes hidden that the update *requires* that all the observations passed by the `WHERE` filter have the same program.  If you try to update the asterism across programs you get an error message.  Still it *seems* worth it to me.

This PR updates `UpdateAsterismsInput` to remove the `programId` field.