### PR TITLE
UpdateObsAttachmentInput

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -9984,6 +9984,11 @@ input WhereObsAttachment {
   Matches whether the attachment has been checked or not
   """
   checked: Boolean
+
+  """
+  Matches the program containing the attachment.
+  """
+  program: WhereProgram
 }
 
 """

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -3801,11 +3801,6 @@ Obs Attachment selection and update description.  Use `SET` to specify the chang
 """
 input UpdateObsAttachmentsInput {
   """
-  Program ID for the program whose obs attachments are to be edited.
-  """
-  programId: ProgramId!
-
-  """
   Describes the obs attachment values to modify.
   """
   SET: ObsAttachmentPropertiesInput!

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateObsAttachmentsInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateObsAttachmentsInput.scala
@@ -9,11 +9,9 @@ import cats.syntax.parallel.*
 import eu.timepit.refined.types.numeric.NonNegInt
 import grackle.Path
 import grackle.Predicate
-import lucuma.core.model.Program
 import lucuma.odb.graphql.binding._
 
 case class UpdateObsAttachmentsInput(
-  programId: Program.Id,
   SET:       ObsAttachmentPropertiesInput.Edit,
   WHERE:     Option[Predicate],
   LIMIT:     Option[NonNegInt]
@@ -25,12 +23,11 @@ object UpdateObsAttachmentsInput {
     val WhereObsAttachmentBinding = WhereObsAttachment.binding(path)
     ObjectFieldsBinding.rmap {
       case List(
-        ProgramIdBinding("programId", rPid),
         ObsAttachmentPropertiesInput.EditBinding("SET", rSET),
         WhereObsAttachmentBinding.Option("WHERE", rWHERE),
         NonNegIntBinding.Option("LIMIT", rLIMIT)
       ) =>
-        (rPid, rSET, rWHERE, rLIMIT).parMapN(apply)
+        (rSET, rWHERE, rLIMIT).parMapN(apply)
     }
   }
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObsAttachment.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObsAttachment.scala
@@ -19,6 +19,7 @@ object WhereObsAttachment {
     val WhereFileNameBinding   = WhereString.binding(path / "fileName")
     val WhereDescriptionBinding   = WhereOptionString.binding(path / "description")
     val WhereAttachmentTypeBinding = WhereUnorderedTag.binding(path / "attachmentType", TagBinding)
+    val WhereProgramBinding = WhereProgram.binding(path / "program")
 
     lazy val WhereObsAttachmentBinding = binding(path)
     ObjectFieldsBinding.rmap {
@@ -30,10 +31,11 @@ object WhereObsAttachment {
             WhereFileNameBinding.Option("fileName", rFileName),
             WhereDescriptionBinding.Option("description", rDescription),
             WhereAttachmentTypeBinding.Option("attachmentType", rAttachmentType),
-            BooleanBinding.Option("checked", rChecked)
+            BooleanBinding.Option("checked", rChecked),
+            WhereProgramBinding.Option("program", rProgram)
           ) =>
-        (rAND, rOR, rNOT, rId, rFileName, rDescription, rAttachmentType, rChecked).parMapN { 
-          (AND, OR, NOT, id, name, desc, atType, checked) =>
+        (rAND, rOR, rNOT, rId, rFileName, rDescription, rAttachmentType, rChecked, rProgram).parMapN {
+          (AND, OR, NOT, id, name, desc, atType, checked, program) =>
             and(
               List(
                 AND.map(and),
@@ -43,7 +45,8 @@ object WhereObsAttachment {
                 name,
                 desc,
                 atType,
-                checked.map(b => Eql(path / "checked", Const(b)))
+                checked.map(b => Eql(path / "checked", Const(b))),
+                program
               ).flatten
             )
         }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -712,7 +712,6 @@ trait MutationMapping[F[_]] extends Predicates[F] {
     MutationField("updateObsAttachments", UpdateObsAttachmentsInput.binding(Path.from(ObsAttachmentType))) { (input, child) =>
       services.useTransactionally {
         val filterPredicate = and(List(
-          Predicates.obsAttachment.program.id.eql(input.programId),
           Predicates.obsAttachment.program.isWritableBy(user),
           input.WHERE.getOrElse(True)
         ))


### PR DESCRIPTION
This is a similar treatment as that described in #1035, but for `UpdateObsAttachmentInput`.  In this case, I needed to add the `WhereProgram` filter.  It now allows updating attachments in multiple programs, but you still need to have permission to update them.