### PR TITLE
remove OdbError construction from mapping layer

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -25,7 +25,6 @@ import grackle.Term
 import grackle.TypeRef
 import grackle.skunk.SkunkMapping
 import grackle.syntax.*
-import lucuma.core.model.Access
 import lucuma.core.model.Group
 import lucuma.core.model.ObsAttachment
 import lucuma.core.model.Observation
@@ -267,19 +266,11 @@ trait MutationMapping[F[_]] extends Predicates[F] {
   // Field definitions
 
   private lazy val AddConditionsEntry: MutationField =
-    MutationField("addConditionsEntry", ConditionsEntryInput.Binding) { (input, child) =>
-      if user.role.access < Access.Staff then {
-        OdbError.NotAuthorized(user.id, Some(s"This action is restricted to staff users.")).asFailureF
-      } else {
-        services.useTransactionally {
-          chronicleService.addConditionsEntry(input).map { id =>
-            Result(
-              Filter(Predicates.addConditionsEntyResult.conditionsEntry.id.eql(id), child)
-            )
-          }
-        }  
-      }
-    }
+    MutationField("addConditionsEntry", ConditionsEntryInput.Binding): (input, child) =>
+      services.useTransactionally:
+        ResultT(chronicleService.addConditionsEntry(input)).map: id =>
+            Filter(Predicates.addConditionsEntyResult.conditionsEntry.id.eql(id), child)
+          .value
 
   private lazy val AddTimeChargeCorrection: MutationField =
     MutationField("addTimeChargeCorrection", AddTimeChargeCorrectionInput.Binding) { (input, child) =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.graphql
 package mapping
 
+import cats.Functor
 import cats.data.Ior
 import cats.data.Nested
 import cats.data.NonEmptyList
@@ -85,7 +86,6 @@ import skunk.AppliedFragment
 import skunk.Transaction
 
 import scala.reflect.ClassTag
-import cats.Functor
 
 trait MutationMapping[F[_]] extends Predicates[F] {
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ChronicleService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ChronicleService.scala
@@ -5,7 +5,10 @@ package lucuma.odb.service
 
 import cats.effect.MonadCancelThrow
 import cats.syntax.all.*
+import grackle.Result
 import lucuma.core.model.Access
+import lucuma.odb.data.OdbError
+import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.graphql.input.ConditionsEntryInput
 import lucuma.odb.util.Codecs.*
 import skunk.*
@@ -13,9 +16,6 @@ import skunk.codec.all.*
 import skunk.syntax.all.*
 
 import Services.Syntax.*
-import lucuma.odb.data.OdbError
-import lucuma.odb.data.OdbErrorExtensions.*
-import grackle.Result
 
 trait ChronicleService[F[_]]:
   def addConditionsEntry(input: ConditionsEntryInput): F[Result[Long]]

--- a/modules/service/src/main/scala/lucuma/odb/service/GroupService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GroupService.scala
@@ -7,6 +7,7 @@ import cats.data.NonEmptyList
 import cats.effect.Concurrent
 import cats.syntax.all._
 import eu.timepit.refined.types.numeric.NonNegShort
+import grackle.Result
 import lucuma.core.model.Group
 import lucuma.core.model.Program
 import lucuma.odb.data.GroupTree
@@ -18,7 +19,6 @@ import skunk.codec.all.*
 import skunk.implicits._
 
 import Services.Syntax.*
-import grackle.Result
 
 trait GroupService[F[_]] {
   def createGroup(pid: Program.Id, SET: GroupPropertiesInput.Create)(using Transaction[F]): F[Group.Id]

--- a/modules/service/src/main/scala/lucuma/odb/service/ProgramService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProgramService.scala
@@ -32,6 +32,7 @@ import lucuma.odb.graphql.input.ProgramPropertiesInput
 import lucuma.odb.graphql.input.ProgramReferencePropertiesInput
 import lucuma.odb.service.ProgramService.LinkUserRequest.PartnerSupport
 import lucuma.odb.service.ProgramService.LinkUserRequest.StaffSupport
+import lucuma.odb.service.ProgramService.LinkUserResponse.Success
 import lucuma.odb.util.Codecs._
 import natchez.Trace
 import skunk._
@@ -39,7 +40,6 @@ import skunk.codec.all._
 import skunk.syntax.all._
 
 import Services.Syntax.*
-import lucuma.odb.service.ProgramService.LinkUserResponse.Success
 
 trait ProgramService[F[_]] {
 

--- a/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
@@ -18,6 +18,7 @@ import cats.syntax.option.*
 import cats.syntax.traverse.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import fs2.Stream
+import grackle.Result
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.SequenceType
@@ -35,6 +36,8 @@ import lucuma.core.model.sequence.gmos.StaticConfig.{GmosNorth => GmosNorthStati
 import lucuma.core.model.sequence.gmos.StaticConfig.{GmosSouth => GmosSouthStatic}
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
+import lucuma.odb.data.OdbError
+import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.logic.EstimatorState
 import lucuma.odb.logic.TimeEstimateCalculator
 import lucuma.odb.sequence.data.CompletedAtomMap
@@ -44,9 +47,6 @@ import skunk.*
 import skunk.implicits.*
 
 import Services.Syntax.*
-import grackle.Result
-import lucuma.odb.data.OdbError
-import lucuma.odb.data.OdbErrorExtensions.*
 
 trait SequenceService[F[_]] {
 

--- a/modules/service/src/main/scala/lucuma/odb/service/TargetService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TargetService.scala
@@ -28,6 +28,8 @@ import lucuma.core.model.StandardUser
 import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.odb.data.Nullable
+import lucuma.odb.data.OdbError
+import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.data.Tag
 import lucuma.odb.data.TargetRole
 import lucuma.odb.graphql.input.CatalogInfoInput
@@ -37,6 +39,8 @@ import lucuma.odb.graphql.input.TargetPropertiesInput
 import lucuma.odb.json.angle.query.given
 import lucuma.odb.json.sourceprofile.given
 import lucuma.odb.json.wavelength.query.given
+import lucuma.odb.service.TargetService.UpdateTargetsResponse.SourceProfileUpdatesFailed
+import lucuma.odb.service.TargetService.UpdateTargetsResponse.TrackingSwitchFailed
 import lucuma.odb.util.Codecs._
 import skunk.AppliedFragment
 import skunk.Encoder
@@ -48,10 +52,6 @@ import skunk.codec.all._
 import skunk.implicits._
 
 import Services.Syntax.*
-import lucuma.odb.data.OdbError
-import lucuma.odb.data.OdbErrorExtensions.*
-import lucuma.odb.service.TargetService.UpdateTargetsResponse.SourceProfileUpdatesFailed
-import lucuma.odb.service.TargetService.UpdateTargetsResponse.TrackingSwitchFailed
 
 trait TargetService[F[_]] {
   def createTarget(pid: Program.Id, input: TargetPropertiesInput.Create)(using Transaction[F]): F[Result[Target.Id]]


### PR DESCRIPTION
I have come to the conclusion that the mapping layer should be entirely mechanical; i.e., all business logic (including interpreting results and turning them into user errors) should live in the service layer. This will make service composition much safer because we won't need to worry about logic that's living somewhere else (an example of this is `cloneObservation`, which currently does *not* clone the asterism; instead it's done in two steps in the mapping logic), and in principle should make testing and automation easier because API and direct service calls will behave (and fail) the same way.

This PR gets us some of the way there by pushing error construction down into service calls (which now return `Result`s).  A side-effect is that some services now construct structured responses and then immediately turn them into `OdbError`s, which is harmless but dumb so I will remove this in a followup PR.
