### PR TITLE
ObservationReference (Take 2)

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7018,6 +7018,17 @@ type Observation {
   existence: Existence!
 
   """
+  Observation reference, if any (requires the existence of a reference for the
+  program itself).
+  """
+  reference: ObservationReference
+
+  """
+  Observation index, relative to other observations in the same program.
+  """
+  index: PosInt!
+
+  """
   Observation title generated from id and targets
   """
   title: String!
@@ -7144,6 +7155,29 @@ type ObservationSelectResult {
   """
   hasMore: Boolean!
 }
+
+"""
+Observation reference type, broken into its constituient parts and including
+a formatted label.
+"""
+type ObservationReference {
+
+  "Formatted observation reference label."
+  label:   ObservationReferenceLabel!
+
+  "The program reference."
+  program: ProgramReference!
+
+  "The observation index relative to its program."
+  index:   PosInt!
+}
+
+"""
+Observation reference, formatted according to the program type, suffixed with
+observation index. For example, G-2024B-1234-Q-0001 where G-2024B-1234-Q is
+the program reference label and the observation index is 1.
+"""
+scalar ObservationReferenceLabel
 
 """
 Each step in a sequence is tagged with an observe class which identifies its

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -327,11 +327,16 @@ input ClassicalInput {
 }
 
 """
-Describes an observation clone operation, making any edits in the `SET` parameter.  The observation status in the cloned observation defaults to NEW.
+Describes an observation clone operation, making any edits in the `SET`
+parameter.  The observation status in the cloned observation defaults to NEW.
+Identify the observation to clone by specifying either its id or reference.  If
+both are specified, they must refer to the same observation.  If neither is
+specified, nothing will be cloned.
 """
 input CloneObservationInput {
-  observationId: ObservationId!
-  SET: ObservationPropertiesInput
+  observationId:        ObservationId
+  observationReference: ObservationReferenceLabel
+  SET:                  ObservationPropertiesInput
 }
 
 """

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7865,13 +7865,19 @@ type Query {
   filterTypeMeta: [FilterTypeMeta!]!
 
   """
-  Returns the observation with the given id, if any.
+  Returns the observation with the given id or reference, if any.  Identify the
+  observation by specifying only one of observationId or observationReference.
+  If more than one is provided, all must match.  If neither are set, nothing
+  will match.
   """
   observation(
-    """
-    Observation ID
-    """
-    observationId: ObservationId!
+
+    "Specify to lookup the observation by its ID."
+    observationId: ObservationId
+
+    "Specify to lookup the observation by its reference."
+    observationReference: ObservationReferenceLabel
+
   ): Observation
 
   """

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -10425,6 +10425,11 @@ input WhereObservation {
   id: WhereOrderObservationId
 
   """
+  Matches the observation reference, if any.
+  """
+  reference: WhereObservationReference
+
+  """
   Matches the associated program.
   """
   program: WhereProgram
@@ -10445,6 +10450,21 @@ input WhereObservation {
   activeStatus: WhereOrderObsActiveStatus
 }
 
+input WhereObservationReference {
+
+  "Matches if the program reference is not defined."
+  IS_NULL: Boolean
+
+  "Matches the program reference label."
+  label: WhereString
+
+  "Matches the program reference."
+  program: WhereProgramReference
+
+  "Matches the observation index."
+  index: WhereOrderPosInt
+
+}
 
 input WhereGroup {
 

--- a/modules/service/src/main/resources/db/migration/V0847__observation_reference.sql
+++ b/modules/service/src/main/resources/db/migration/V0847__observation_reference.sql
@@ -1,0 +1,92 @@
+-- Add an index column to the observation table.
+ALTER TABLE t_observation
+  ADD COLUMN c_observation_index int4 CHECK (c_observation_index > 0),
+  ADD CONSTRAINT unique_observation_index_per_program UNIQUE (c_program_id, c_observation_index);
+
+-- A function to obtain the next observation number for a particular program.
+CREATE OR REPLACE FUNCTION next_observation_index(pid d_program_id)
+RETURNS INT
+AS $$
+DECLARE
+    sequence_name VARCHAR;
+BEGIN
+    sequence_name := CONCAT('s_', REPLACE(pid::text, '-', '')); -- a hyphen (as in p-123) will not work
+
+    BEGIN
+        EXECUTE 'CREATE SEQUENCE IF NOT EXISTS ' || sequence_name;
+    EXCEPTION WHEN unique_violation THEN
+        NULL; -- sequence exists, this was an attempt to create it in parallel
+    END;
+
+    RETURN nextval(sequence_name)::INT;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Update all existing observations so that they have an index defined.
+UPDATE t_observation
+  SET c_observation_index = next_observation_index(c_program_id);
+
+-- Make the index required.
+ALTER TABLE t_observation
+  ALTER COLUMN c_observation_index SET NOT NULL;
+
+-- Add a trigger that sets the observation index when a new observation is
+-- created.
+CREATE OR REPLACE FUNCTION set_observation_index()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.c_observation_index = next_observation_index(NEW.c_program_id);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_observation_index_trigger
+BEFORE INSERT ON t_observation
+FOR EACH ROW
+EXECUTE FUNCTION set_observation_index();
+
+-- Prevent the observation index from changing.
+CREATE OR REPLACE FUNCTION prevent_observation_index_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.c_observation_index != OLD.c_observation_index THEN
+    RAISE EXCEPTION 'The observation index (in column c_observation_index) cannot be updated once it is set';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER prevent_observation_index_update_trigger
+BEFORE UPDATE on t_observation
+FOR EACH ROW
+EXECUTE FUNCTION prevent_observation_index_update();
+
+
+-- Update the observation v to include the new column.
+-- Re-create this view to include the new index column.
+DROP VIEW v_observation;
+CREATE VIEW v_observation AS
+  SELECT o.*,
+  CASE WHEN c_explicit_ra              IS NOT NULL THEN c_observation_id END AS c_explicit_base_id,
+  CASE WHEN c_air_mass_min             IS NOT NULL THEN c_observation_id END AS c_air_mass_id,
+  CASE WHEN c_hour_angle_min           IS NOT NULL THEN c_observation_id END AS c_hour_angle_id,
+  CASE WHEN c_observing_mode_type      IS NOT NULL THEN c_observation_id END AS c_observing_mode_id,
+  CASE WHEN c_spec_wavelength          IS NOT NULL THEN c_observation_id END AS c_spec_wavelength_id,
+  CASE WHEN c_spec_signal_to_noise_at  IS NOT NULL THEN c_observation_id END AS c_spec_signal_to_noise_at_id,
+  CASE WHEN c_spec_wavelength_coverage IS NOT NULL THEN c_observation_id END AS c_spec_wavelength_coverage_id,
+  CASE WHEN c_spec_focal_plane_angle   IS NOT NULL THEN c_observation_id END AS c_spec_focal_plane_angle_id
+  FROM t_observation o;
+
+-- Create a view for the observation reference, including only observations with
+-- a defined reference.  This makes mapping the reference as optional easier.
+CREATE VIEW v_observation_reference AS
+  SELECT
+    o.c_observation_id,
+    o.c_program_id,
+    o.c_observation_index,
+    p.c_program_reference,
+    CONCAT(p.c_program_reference::text, '-', LPAD(o.c_observation_index::text, 4, '0')) AS c_observation_reference
+  FROM t_observation o
+  JOIN t_program p ON o.c_program_id = p.c_program_id
+  WHERE p.c_program_reference IS NOT NULL
+  ORDER BY c_observation_id;

--- a/modules/service/src/main/scala/lucuma/odb/data/ObservationReference.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/ObservationReference.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+
+import cats.Order
+import cats.parse.Parser
+import cats.parse.Parser.*
+import eu.timepit.refined.types.numeric.PosInt
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.syntax.*
+import lucuma.core.model.ProgramReference
+import lucuma.core.model.parser.ReferenceParsers
+import lucuma.core.optics.Format
+
+case class ObservationReference(
+  programReference: ProgramReference,
+  observationIndex: PosInt
+) {
+
+  /** Formatted observation reference String. */
+  def label: String =
+    f"${programReference.label}-$observationIndex%04d"
+
+}
+
+object ObservationReference {
+
+  object parse {
+    import ProgramReference.parse.programReference
+    import ReferenceParsers.*
+
+    val observation: Parser[ObservationReference] =
+      ((programReference <* dash) ~ index).map { (ref, index) =>
+        ObservationReference(ref, index)
+      }
+  }
+
+  given Order[ObservationReference] =
+    Order.by { a => (a.programReference, a.observationIndex.value) }
+
+  given Ordering[ObservationReference] =
+    Order[ObservationReference].toOrdering
+
+  val fromString: Format[String, ObservationReference] =
+    Format(s => parse.observation.parseAll(s).toOption, _.label)
+
+  given Decoder[ObservationReference] =
+    Decoder.decodeString.emap { s =>
+      fromString
+        .getOption(s)
+        .toRight(s"Could not parse '$s' as an ObservationReference.")
+    }
+
+  given Encoder[ObservationReference] =
+    Encoder.instance(_.label.asJson)
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -163,6 +163,8 @@ trait BaseMapping[F[_]]
   lazy val ObservationType                     = schema.ref("Observation")
   lazy val ObservingModeType                   = schema.ref("ObservingMode")
   lazy val ObservingModeTypeType               = schema.ref("ObservingModeType")
+  lazy val ObservationReferenceType            = schema.ref("ObservationReference")
+  lazy val ObservationReferenceLabelType       = schema.ref("ObservationReferenceLabel")
   lazy val ObservationSelectResultType         = schema.ref("ObservationSelectResult")
   lazy val ObserveClassType                    = schema.ref("ObserveClass")
   lazy val ObsStatusType                       = schema.ref("ObsStatus")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -139,6 +139,7 @@ object OdbMapping {
           with ObsAttachmentTypeMetaMapping[F]
           with ObservationEditMapping[F]
           with ObservationMapping[F]
+          with ObservationReferenceMapping[F]
           with ObservingModeMapping[F]
           with ObservationSelectResultMapping[F]
           with OffsetMapping[F]
@@ -293,8 +294,9 @@ object OdbMapping {
               ObsAttachmentTypeMetaMapping,
               ObservationEditMapping,
               ObservationMapping,
-              ObservingModeMapping,
+              ObservationReferenceMapping,
               ObservationSelectResultMapping,
+              ObservingModeMapping,
               OffsetMapping,
               OffsetPMapping,
               OffsetQMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/ObservationReferenceBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/ObservationReferenceBinding.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.odb.data.ObservationReference
+
+val ObservationReferenceBinding: Matcher[ObservationReference] =
+  StringBinding.emap { s =>
+    ObservationReference
+      .fromString
+      .getOption(s)
+      .toRight(s"'$s' cannot be parsed as a valid ObservationReference.")
+  }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CloneObservationInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CloneObservationInput.scala
@@ -10,11 +10,13 @@ import cats.syntax.all.*
 import lucuma.core.model.Observation
 import lucuma.core.model.Target
 import lucuma.odb.data.Nullable
+import lucuma.odb.data.ObservationReference
 import lucuma.odb.graphql.binding._
 
 final case class CloneObservationInput(
-  observationId: Observation.Id,
-  SET:           Option[ObservationPropertiesInput.Edit],
+  observationId:  Option[Observation.Id],
+  observationRef: Option[ObservationReference],
+  SET:            Option[ObservationPropertiesInput.Edit],
 ) {
 
   def asterism: Nullable[NonEmptyList[Target.Id]] =
@@ -27,10 +29,11 @@ object CloneObservationInput {
  val Binding: Matcher[CloneObservationInput] =
     ObjectFieldsBinding.rmap {
       case List(
-        ObservationIdBinding("observationId", rObservationId),
+        ObservationIdBinding.Option("observationId", rObservationId),
+        ObservationReferenceBinding.Option("observationReference", rObservationRef),
         ObservationPropertiesInput.Edit.Binding.Option("SET", rSET),
       ) =>
-        (rObservationId, rSET).mapN(CloneObservationInput.apply)
+        (rObservationId, rObservationRef, rSET).mapN(CloneObservationInput.apply)
     }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
@@ -19,6 +19,7 @@ object WhereObservation {
   def binding(path: Path): Matcher[Predicate] = {
     val SubtitleBinding = WhereOptionString.binding(path / "subtitle")
     val WhereOrderObservationIdBinding = WhereOrder.binding[Observation.Id](path / "id", ObservationIdBinding)
+    val WhereReferenceBinding = WhereObservationReference.binding(path / "reference")
     val WhereProgramBinding = WhereProgram.binding(path / "program")
     val StatusBinding = WhereOrder.binding(path / "status", enumeratedBinding[ObsStatus])
     val ActiveStatusBinding = WhereOrder.binding(path / "activeStatus", enumeratedBinding[ObsActiveStatus])
@@ -29,22 +30,25 @@ object WhereObservation {
         WhereObservationBinding.List.Option("OR", rOR),
         WhereObservationBinding.Option("NOT", rNOT),
         WhereOrderObservationIdBinding.Option("id", rId),
+        WhereReferenceBinding.Option("reference", rRef),
         WhereProgramBinding.Option("program", rProgram),
         SubtitleBinding.Option("subtitle", rSubtitle),
         StatusBinding.Option("status", rStatus),
         ActiveStatusBinding.Option("activeStatus", rActiveStatus)
       ) =>
-        (rAND, rOR, rNOT, rId, rProgram, rSubtitle, rStatus, rActiveStatus).parMapN { (AND, OR, NOT, id, program, subtitle, status, activeStatus) =>
-          and(List(
-            AND.map(and),
-            OR.map(or),
-            NOT.map(Not(_)),
-            id,
-            program,
-            subtitle,
-            status,
-            activeStatus
-          ).flatten)
+        (rAND, rOR, rNOT, rId, rRef, rProgram, rSubtitle, rStatus, rActiveStatus).parMapN {
+          (AND, OR, NOT, id, ref, program, subtitle, status, activeStatus) =>
+            and(List(
+              AND.map(and),
+              OR.map(or),
+              NOT.map(Not(_)),
+              id,
+              ref,
+              program,
+              subtitle,
+              status,
+              activeStatus
+            ).flatten)
         }
     }
   }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservationReference.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservationReference.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.input
+
+import cats.syntax.parallel.*
+import eu.timepit.refined.cats.given
+import eu.timepit.refined.types.numeric.PosInt
+import grackle.Path
+import grackle.Predicate
+import grackle.Predicate._
+import lucuma.odb.graphql.binding.BooleanBinding
+import lucuma.odb.graphql.binding.Matcher
+import lucuma.odb.graphql.binding.ObjectFieldsBinding
+import lucuma.odb.graphql.binding.PosIntBinding
+
+object WhereObservationReference {
+
+  def binding(path: Path): Matcher[Predicate] = {
+    // match proposal reference labels on the String value so we can do
+    // comparisons like 'LIKE: "G-2024A-0001-Q-000?"'.
+    val WhereLabel       = WhereString.binding(path / "labelString")
+    val WhereProgramRef  = WhereProgramReference.binding(path / "program")
+    val WhereIndex       = WhereOrder.binding[PosInt](path / "index", PosIntBinding)
+
+    ObjectFieldsBinding.rmap {
+      case List(
+        BooleanBinding.Option("IS_NULL", rIsNull),
+        WhereLabel.Option("label", rRef),
+        WhereProgramRef.Option("program", rProgram),
+        WhereIndex.Option("index", rIndex),
+      ) => (rIsNull, rRef, rProgram, rIndex).parMapN {
+        (isNull, ref, program, index) =>
+          and(List(
+            isNull.map(IsNull(path / "id", _)),
+            ref,
+            program,
+            index
+          ).flatten)
+      }
+    }
+  }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
@@ -41,6 +41,7 @@ import lucuma.odb.data.EditType
 import lucuma.odb.data.ExecutionEventType
 import lucuma.odb.data.Existence
 import lucuma.odb.data.Extinction
+import lucuma.odb.data.ObservationReference
 import lucuma.odb.data.ObservingModeType
 import lucuma.odb.data.PosAngleConstraintMode
 import lucuma.odb.data.ProgramUserRole
@@ -123,6 +124,7 @@ trait LeafMappings[F[_]] extends BaseMapping[F] {
       LeafMapping[Tag](ObsAttachmentTypeType),
       LeafMapping[ObservingModeType](ObservingModeTypeType),
       LeafMapping[Observation.Id](ObservationIdType),
+      LeafMapping[ObservationReference](ObservationReferenceLabelType),
       LeafMapping[ObserveClass](ObserveClassType),
       LeafMapping[ObsStatus](ObsStatusType),
       LeafMapping[Tag](PartnerType),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -236,10 +236,10 @@ trait MutationMapping[F[_]] extends Predicates[F] {
   private lazy val CloneObservation: MutationField =
     MutationField("cloneObservation", CloneObservationInput.Binding): (input, child) =>
       services.useTransactionally:
-        observationService.cloneObservation(input).nestMap: oid =>
+        observationService.cloneObservation(input).nestMap: ids =>
           Filter(And(
-            Predicates.cloneObservationResult.originalObservation.id.eql(input.observationId),
-            Predicates.cloneObservationResult.newObservation.id.eql(oid)
+            Predicates.cloneObservationResult.originalObservation.id.eql(ids.originalId),
+            Predicates.cloneObservationResult.newObservation.id.eql(ids.cloneId)
           ), child)
 
   private lazy val CloneTarget: MutationField =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -29,6 +29,7 @@ import lucuma.odb.service.Services
 
 import table.ObsAttachmentAssignmentTable
 import table.ObsAttachmentTable
+import table.ObservationReferenceView
 import table.ProgramTable
 import Services.Syntax.*
 
@@ -37,7 +38,8 @@ trait ObservationMapping[F[_]]
      with ProgramTable[F]
      with TimingWindowView[F]
      with ObsAttachmentTable[F]
-     with ObsAttachmentAssignmentTable[F] {
+     with ObsAttachmentAssignmentTable[F]
+     with ObservationReferenceView[F] {
 
   def itcClient: ItcClient[F]
   def services: Resource[F, Services[F]]
@@ -49,6 +51,8 @@ trait ObservationMapping[F[_]]
         SqlField("id", ObservationView.Id, key = true),
         SqlField("programId", ObservationView.ProgramId, hidden = true),
         SqlField("existence", ObservationView.Existence, hidden = true),
+        SqlObject("reference", Join(ObservationView.Id, ObservationReferenceView.Id)),
+        SqlField("index", ObservationView.ObservationIndex),
         SqlField("title", ObservationView.Title),
         SqlField("subtitle", ObservationView.Subtitle),
         SqlField("status", ObservationView.Status),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationReferenceMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationReferenceMapping.scala
@@ -20,7 +20,10 @@ trait ObservationReferenceMapping[F[_]]
         SqlField("id",       ObservationReferenceView.Id, key = true, hidden = true),
         SqlObject("program", Join(ObservationReferenceView.ProgramId, ProgramReferenceView.Id)),
         SqlField("index",    ObservationReferenceView.ObservationIndex),
-        SqlField("label",    ObservationReferenceView.ObservationReference)
+        SqlField("label",    ObservationReferenceView.ObservationReference),
+
+        // Used for WHERE clause matching
+        SqlField("labelString", ObservationReferenceView.ObservationReferenceString, hidden = true)
       )
     )
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationReferenceMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationReferenceMapping.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mapping
+
+import table.ObservationReferenceView
+import table.ProgramReferenceView
+
+
+trait ObservationReferenceMapping[F[_]]
+  extends BaseMapping[F]
+     with ObservationReferenceView[F]
+     with ProgramReferenceView[F] {
+
+  lazy val ObservationReferenceMapping: ObjectMapping =
+    ObjectMapping(
+      tpe = ObservationReferenceType,
+      fieldMappings = List(
+        SqlField("id",       ObservationReferenceView.Id, key = true, hidden = true),
+        SqlObject("program", Join(ObservationReferenceView.ProgramId, ProgramReferenceView.Id)),
+        SqlField("index",    ObservationReferenceView.ObservationIndex),
+        SqlField("label",    ObservationReferenceView.ObservationReference)
+      )
+    )
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/ObservationPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/ObservationPredicates.scala
@@ -5,9 +5,11 @@ package lucuma.odb.graphql.predicate
 
 import grackle.Path
 import lucuma.core.model.Observation
+import lucuma.odb.data.ObservationReference
 
 class ObservationPredicates(path: Path) {
-  lazy val existence = ExistencePredicates(path / "existence")
-  lazy val id        = LeafPredicates[Observation.Id](path / "id")
-  lazy val program   = new ProgramPredicates(path / "program")
+  lazy val existence      = ExistencePredicates(path / "existence")
+  lazy val id             = LeafPredicates[Observation.Id](path / "id")
+  lazy val program        = new ProgramPredicates(path / "program")
+  lazy val referenceLabel = LeafPredicates[ObservationReference](path / "reference" / "label")
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationReferenceView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationReferenceView.scala
@@ -18,7 +18,7 @@ trait ObservationReferenceView[F[_]] extends BaseMapping[F] {
     val ObservationIndex     = col("c_observation_index",     int4_pos)
     val ObservationReference = col("c_observation_reference", observation_reference)
 
-    // (To be) used in WhereObservationReference
+    // Used in WhereObservationReference
     val ObservationReferenceString = col("c_observation_reference", text)
   }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationReferenceView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationReferenceView.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package table
+
+import lucuma.odb.util.Codecs.int4_pos
+import lucuma.odb.util.Codecs.observation_id
+import lucuma.odb.util.Codecs.observation_reference
+import lucuma.odb.util.Codecs.program_id
+import skunk.codec.text.text
+
+trait ObservationReferenceView[F[_]] extends BaseMapping[F] {
+
+  object ObservationReferenceView extends TableDef("v_observation_reference") {
+    val Id                   = col("c_observation_id",        observation_id)
+    val ProgramId            = col("c_program_id",            program_id)
+    val ObservationIndex     = col("c_observation_index",     int4_pos)
+    val ObservationReference = col("c_observation_reference", observation_reference)
+
+    // (To be) used in WhereObservationReference
+    val ObservationReferenceString = col("c_observation_reference", text)
+  }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
@@ -14,12 +14,13 @@ trait ObservationView[F[_]] extends BaseMapping[F] {
     object ObservationView extends TableDef("v_observation") {
       val ProgramId: ColumnRef         = col("c_program_id",         program_id)
       val Id: ColumnRef                = col("c_observation_id",     observation_id)
+      val ObservationIndex: ColumnRef  = col("c_observation_index",     int4_pos)
       val Existence: ColumnRef         = col("c_existence",          existence)
       val Title: ColumnRef             = col("c_title",              text_nonempty)
       val Subtitle: ColumnRef          = col("c_subtitle",           text_nonempty.opt)
       val Instrument: ColumnRef        = col("c_instrument",         instrument.opt)
       val Status: ColumnRef            = col("c_status",             obs_status)
-      val ActiveStatus: ColumnRef      = col("c_active_status",      obs_active_status) 
+      val ActiveStatus: ColumnRef      = col("c_active_status",      obs_active_status)
       val VisualizationTime: ColumnRef = col("c_visualization_time", core_timestamp.opt)
       val AsterismGroup: ColumnRef     = col("c_asterism_group",     jsonb)
       val GroupId: ColumnRef           = col("c_group_id",           group_id.opt)
@@ -32,8 +33,8 @@ trait ObservationView[F[_]] extends BaseMapping[F] {
       }
 
       object PosAngleConstraint {
-        val Mode: ColumnRef            = col("c_pac_mode",  pac_mode.embedded)
-        val Angle: ColumnRef           = col("c_pac_angle", angle_µas.embedded)
+        val Mode: ColumnRef  = col("c_pac_mode",  pac_mode.embedded)
+        val Angle: ColumnRef = col("c_pac_angle", angle_µas.embedded)
       }
 
       object TargetEnvironment {
@@ -90,18 +91,16 @@ trait ObservationView[F[_]] extends BaseMapping[F] {
             val Value: ColumnRef       = col("c_spec_focal_plane_angle",    angle_µas.embedded)
           }
 
-          val Resolution: ColumnRef         = col("c_spec_resolution",          int4_pos.opt)
-          val SignalToNoise: ColumnRef      = col("c_spec_signal_to_noise",     signal_to_noise.opt)        
-          val FocalPlane: ColumnRef         = col("c_spec_focal_plane",         focal_plane.opt)
-          val Capability: ColumnRef         = col("c_spec_capability",          spectroscopy_capabilities.opt)
+          val Resolution: ColumnRef    = col("c_spec_resolution",          int4_pos.opt)
+          val SignalToNoise: ColumnRef = col("c_spec_signal_to_noise",     signal_to_noise.opt)
+          val FocalPlane: ColumnRef    = col("c_spec_focal_plane",         focal_plane.opt)
+          val Capability: ColumnRef    = col("c_spec_capability",          spectroscopy_capabilities.opt)
         }
       }
       
       object ObservingMode {
         val SyntheticId: ColumnRef = col("c_observing_mode_id", observation_id.embedded)
-        
         val ObservingModeType: ColumnRef = col("c_observing_mode_type", observing_mode_type.embedded)
-        
       }
 
     }

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -464,14 +464,10 @@ object ObservationService {
 
     val selectOid: Query[ObservationReference, Observation.Id] =
       sql"""
-        SELECT o.c_observation_id
-        FROM t_observation o
-        INNER JOIN t_program p ON p.c_program_id = o.c_program_id
-        WHERE p.c_program_reference = $program_reference
-          AND o.c_observation_index = $int4_pos
-      """.query(observation_id).contramap[ObservationReference] { ref =>
-        (ref.programReference, ref.observationIndex)
-      }
+        SELECT c_observation_id
+          FROM t_observation
+         WHERE c_observation_reference = $observation_reference
+      """.query(observation_id)
 
     import ProgramService.Statements.existsUserAccess
     import ProgramService.Statements.whereUserAccess

--- a/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
@@ -45,6 +45,7 @@ import lucuma.odb.data.ExecutionEventType
 import lucuma.odb.data.Existence
 import lucuma.odb.data.Extinction
 import lucuma.odb.data.Md5Hash
+import lucuma.odb.data.ObservationReference
 import lucuma.odb.data.ObservingModeType
 import lucuma.odb.data.PosAngleConstraintMode
 import lucuma.odb.data.ProgramUserRole
@@ -331,6 +332,12 @@ trait Codecs {
 
   val group_id: Codec[Group.Id] =
     gid[Group.Id]
+
+  val observation_reference: Codec[ObservationReference] =
+    text.eimap(
+      s => ObservationReference.fromString.getOption(s).toRight(s"Invalid observation reference: $s"))(
+      ObservationReference.fromString.reverseGet
+    )
 
   val proposal_reference: Codec[ProposalReference] =
     text.eimap(

--- a/modules/service/src/test/scala/lucuma/odb/data/ObservationReferenceSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/data/ObservationReferenceSuite.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+
+import cats.kernel.laws.discipline.*
+import lucuma.core.optics.laws.discipline.*
+import lucuma.odb.data.arb.ArbObservationReference
+
+final class ObservationReferenceSuite extends munit.DisciplineSuite {
+
+  import ArbObservationReference.given
+  import ArbObservationReference.observationReferenceStrings
+
+  checkAll("ObservationReference", OrderTests[ObservationReference].order)
+  checkAll("ObservationReference", FormatTests(ObservationReference.fromString).formatWith(observationReferenceStrings))
+}
+

--- a/modules/service/src/test/scala/lucuma/odb/data/arb/ArbObservationReference.scala
+++ b/modules/service/src/test/scala/lucuma/odb/data/arb/ArbObservationReference.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+package arb
+
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.model.ProgramReference
+import lucuma.core.model.arb.ArbProgramReference
+import lucuma.core.model.arb.ArbReference
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+
+trait ArbObservationReference extends ArbReference {
+
+  import ArbProgramReference.given
+
+  given Arbitrary[ObservationReference] =
+    Arbitrary {
+      for {
+        p <- arbitrary[ProgramReference]
+        n <- arbitraryIndex
+      } yield ObservationReference(p, PosInt.unsafeFrom(n))
+    }
+
+  given Cogen[ObservationReference] =
+    Cogen[(ProgramReference, Int)].contramap { a => (
+      a.programReference,
+      a.observationIndex.value
+    )}
+
+  val observationReferenceStrings: Gen[String] =
+    referenceStrings[ObservationReference](_.label)
+
+}
+
+object ArbObservationReference extends ArbObservationReference

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -127,6 +127,29 @@ trait DatabaseOperations { this: OdbSuite =>
         .liftTo[IO]
     }
 
+  def setProgramReference(user: User, pid: Program.Id, set: String): IO[Option[ProgramReference]] =
+    query(
+      user,
+      s"""
+        mutation {
+          setProgramReference(input: {
+            programId: "$pid"
+            SET: { $set }
+          }) {
+            reference { label }
+          }
+        }
+      """
+    ).flatMap {
+      _.hcursor
+       .downFields("setProgramReference", "reference", "label")
+       .success
+       .traverse(_.as[ProgramReference])
+       .leftMap(f => new RuntimeException(f.message))
+       .liftTo[IO]
+    }
+
+
   // For proposal tests where it doesn't matter what the proposal is, just that
   // there is one.
   def addProposal(user: User, pid: Program.Id): IO[Unit] =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/reference.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/reference.scala
@@ -5,14 +5,16 @@ package lucuma.odb.graphql
 package feature
 
 import cats.effect.IO
-import cats.syntax.all._
+import cats.syntax.all.*
 import io.circe.Json
-import io.circe.literal._
+import io.circe.literal.*
+import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.ProgramReference
 import lucuma.core.model.ProposalReference
 import lucuma.core.model.Semester
 import lucuma.core.model.User
+import lucuma.odb.data.ObservationReference
 
 
 class reference extends OdbSuite {
@@ -24,22 +26,37 @@ class reference extends OdbSuite {
 
   val validUsers = List(pi, guest, service, staff)
 
-  val sem2024A   = Semester.unsafeFromString("2024A")
-  val ref2024A1  = ProposalReference.fromString.unsafeGet("G-2024A-0001")
-  val ref2024A1Q = ProgramReference.fromString.unsafeGet("G-2024A-0001-Q")
-  val ref2024A1C = ProgramReference.fromString.unsafeGet("G-2024A-0001-C")
+  // Unsafe convenience for testing.
+  extension (s: String) {
+    def proposalReference: ProposalReference =
+      ProposalReference.fromString.unsafeGet(s)
 
-  val sem2024B   = Semester.unsafeFromString("2024B")
-  val ref2024B1  = ProposalReference.fromString.unsafeGet("G-2024B-0001")
-  val ref2024B2  = ProposalReference.fromString.unsafeGet("G-2024B-0002")
-  val ref2024B3  = ProposalReference.fromString.unsafeGet("G-2024B-0003")
+    def programReference: ProgramReference =
+      ProgramReference.fromString.unsafeGet(s)
 
-  val sem2025A   = Semester.unsafeFromString("2025A")
-  val ref2025A1  = ProposalReference.fromString.unsafeGet("G-2025A-0001")
+    def observationReference: ObservationReference =
+      ObservationReference.fromString.unsafeGet(s)
 
-  val sem2025B   = Semester.unsafeFromString("2025B")
-  val ref2025B1  = ProposalReference.fromString.unsafeGet("G-2025B-0001")
-  val ref2025B2  = ProposalReference.fromString.unsafeGet("G-2025B-0002")
+    def semester: Semester =
+      Semester.unsafeFromString(s)
+  }
+
+  val sem2024A   = "2024A".semester
+  val ref2024A1  = "G-2024A-0001".proposalReference
+  val ref2024A1Q = "G-2024A-0001-Q".programReference
+  val ref2024A1C = "G-2024A-0001-C".programReference
+
+  val sem2024B   = "2024B".semester
+  val ref2024B1  = "G-2024B-0001".proposalReference
+  val ref2024B2  = "G-2024B-0002".proposalReference
+  val ref2024B3  = "G-2024B-0003".proposalReference
+
+  val sem2025A   = "2025A".semester
+  val ref2025A1  = "G-2025A-0001".proposalReference
+
+  val sem2025B   = "2025B".semester
+  val ref2025B1  = "G-2025B-0001".proposalReference
+  val ref2025B2  = "G-2025B-0002".proposalReference
 
   def createProgramWithSemester(semester: String): IO[Program.Id] =
     query(pi,
@@ -239,7 +256,7 @@ class reference extends OdbSuite {
     )
   }
 
-  val ref2010A1 = ProposalReference.fromString.unsafeGet("G-2010A-0001")
+  val ref2010A1 = "G-2010A-0001".proposalReference
 
   // TODO: proposal status mutations
   // I think we want to remove semester as an independently settable property.
@@ -787,29 +804,29 @@ class reference extends OdbSuite {
 
   test("setProposalReference SCI, change subtype but index remains the same") {
     for {
-      pid <- fetchPid(pi, ProgramReference.fromString.unsafeGet("G-2025B-0001-Q"))
+      pid <- fetchPid(pi, "G-2025B-0001-Q".programReference)
       ref <- setProgramReference(pid, """science: { semester: "2025B", scienceSubtype: CLASSICAL }""")
     } yield assertEquals(ref, "G-2025B-0001-C".some)
   }
 
   test("setProposalReference SCI -> CAL -> SCI, index increases") {
     for {
-      pid <- fetchPid(pi, ProgramReference.fromString.unsafeGet("G-2025B-0001-C"))
+      pid <- fetchPid(pi, "G-2025B-0001-C".programReference)
       _   <- setProgramReference(pid, """calibration: { semester: "2025B", instrument: GMOS_SOUTH }""")
       ref <- setProgramReference(pid, """science: { semester: "2025B", scienceSubtype: QUEUE }""")
     } yield assertEquals(ref, "G-2025B-0002-Q".some)
   }
 
   // Program references created above
-  val ref25BCalGmosSouth01 = ProgramReference.fromString.unsafeGet("G-2025B-CAL-GMOSS-01")
-  val ref25BCalGmosNorth01 = ProgramReference.fromString.unsafeGet("G-2025B-CAL-GMOSN-01")
-  val ref25BEngGmosSouth01 = ProgramReference.fromString.unsafeGet("G-2025B-ENG-GMOSS-01")
-  val ref25BEngGmosSouth02 = ProgramReference.fromString.unsafeGet("G-2025B-ENG-GMOSS-02")
-  val refXplGmosSouth      = ProgramReference.fromString.unsafeGet("G-XPL-GMOSS")
-  val refLibGmosSouthFoo   = ProgramReference.fromString.unsafeGet("G-LIB-GMOSS-FOO")
-  val ref24ASci01C         = ProgramReference.fromString.unsafeGet("G-2024A-0001-C")
-  val ref24ASci02Q         = ProgramReference.fromString.unsafeGet("G-2024A-0002-Q")
-  val ref25BSci02Q         = ProgramReference.fromString.unsafeGet("G-2025B-0002-Q")
+  val ref25BCalGmosSouth01 = "G-2025B-CAL-GMOSS-01".programReference
+  val ref25BCalGmosNorth01 = "G-2025B-CAL-GMOSN-01".programReference
+  val ref25BEngGmosSouth01 = "G-2025B-ENG-GMOSS-01".programReference
+  val ref25BEngGmosSouth02 = "G-2025B-ENG-GMOSS-02".programReference
+  val refXplGmosSouth      = "G-XPL-GMOSS".programReference
+  val refLibGmosSouthFoo   = "G-LIB-GMOSS-FOO".programReference
+  val ref24ASci01C         = "G-2024A-0001-C".programReference
+  val ref24ASci02Q         = "G-2024A-0002-Q".programReference
+  val ref25BSci02Q         = "G-2025B-0002-Q".programReference
 
   test("select via WHERE program reference label LIKE") {
     assertIO(
@@ -866,4 +883,76 @@ class reference extends OdbSuite {
       List(ref24ASci01C)
     )
   }
+
+  def expectObservationReference(
+    oid: Observation.Id,
+    ref: ObservationReference
+  ): IO[Unit] =
+    expect(pi, s"""
+      query {
+        observation(observationId: "$oid") {
+          reference {
+            label
+            program { label }
+            index
+          }
+        }
+      }""",
+      json"""
+        {
+          "observation": {
+            "reference": {
+              "label": ${ref.label},
+              "program": {
+                "label": ${ref.programReference.label}
+              },
+              "index": ${ref.observationIndex.value}
+            }
+          }
+        }
+      """.asRight
+    )
+
+  def expectObservationIndex(
+    oid:   Observation.Id,
+    index: Int
+  ): IO[Unit] =
+    expect(pi,
+      s"""query { observation(observationId: "$oid") { index } }""",
+      json"""{ "observation": { "index": $index } }""".asRight
+    )
+
+  test("no observation reference") {
+    for {
+      pid <- createProgramAs(pi)
+      o   <- createObservationAs(pi, pid)
+      _   <- expect(pi, s"""query { observation(observationId: "$o") { reference { label } } }""", json"""{"observation":  { "reference":  null}}""".asRight)
+    } yield ()
+  }
+
+  test("observation reference SCI") {
+    for {
+      pid <- createProgramWithSemester("2025B")
+      _   <- addProposal(pi, pid)
+      _   <- acceptProposal(staff, pid)
+      ref <- setProgramReference(pid, """science: { semester: "2025B", scienceSubtype: QUEUE }""")
+      o   <- createObservationAs(pi, pid)
+      _   <- expectObservationReference(o, s"${ref.get}-0001".observationReference)
+      _   <- expectObservationIndex(o, 1)
+    } yield ()
+  }
+
+  test("observation reference ENG") {
+    for {
+      pid <- createProgramAs(pi)
+      ref <- setProgramReference(pid, """engineering: { semester: "2025B", instrument: GMOS_SOUTH }""")
+      o1  <- createObservationAs(pi, pid)
+      _   <- expectObservationReference(o1, s"${ref.get}-0001".observationReference)
+      _   <- expectObservationIndex(o1, 1)
+      o2  <- createObservationAs(pi, pid)
+      _   <- expectObservationReference(o2, s"${ref.get}-0002".observationReference)
+      _   <- expectObservationIndex(o2, 2)
+    } yield ()
+  }
+
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/reference.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/reference.scala
@@ -188,7 +188,7 @@ class reference extends OdbSuite {
     )
   }
 
-  test("lookup, no pid, no ref") {
+  test("lookup program, no pid, no ref") {
     expect(
       user  = pi,
       query = s"""
@@ -1023,6 +1023,46 @@ class reference extends OdbSuite {
            .size
         },
       1
+    )
+  }
+
+  test("lookup via observation ref") {
+    expect(
+      user  = pi,
+      query = s"""
+        query {
+          observation(observationReference: "G-2025B-ENG-GMOSS-02-0001") {
+            reference {
+              label
+              index
+              program { label }
+            }
+          }
+        }
+      """,
+      expected = Right(
+        json"""
+          {
+            "observation": {
+              "reference": {
+                "label": "G-2025B-ENG-GMOSS-02-0001",
+                "index": 1,
+                "program": {
+                  "label": "G-2025B-ENG-GMOSS-02"
+                }
+              }
+            }
+          }
+        """
+      )
+    )
+  }
+
+  test("lookup observation, no oid, no ref") {
+    expect(
+      user     = pi,
+      query    = s""" query { observation { reference { label } } } """,
+      expected = json"""{ "observation": null }""".asRight
     )
   }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/reference.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/reference.scala
@@ -1043,4 +1043,16 @@ class reference extends OdbSuite {
     )
   }
 
+  test("change program reference, updates observation reference") {
+    val pRef = "G-2025B-ENG-GMOSS-02".programReference
+    for {
+      pid <- fetchPid(pi, pRef)
+      ref <- setProgramReference(pi, pid, """calibration: { semester: "2025B", instrument: GMOS_SOUTH }""")
+      oref1 = s"${ref.get.label}-0001".observationReference
+      oref2 = s"${ref.get.label}-0002".observationReference
+      _  <- fetchOid(pi, oref1)
+      _  <- fetchOid(pi, oref2)
+    } yield ()
+  }
+
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
@@ -6,6 +6,7 @@ package mutation
 
 import cats.effect.IO
 import cats.syntax.all._
+import eu.timepit.refined.types.numeric.PosInt
 import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
@@ -14,6 +15,7 @@ import lucuma.core.enums.ObsStatus
 import lucuma.core.model.Observation
 import lucuma.core.model.Target
 import lucuma.odb.data.Existence
+import lucuma.odb.data.ObservationReference
 import lucuma.odb.data.ObservingModeType
 
 class cloneObservation extends OdbSuite {
@@ -351,4 +353,71 @@ class cloneObservation extends OdbSuite {
     }
   }
 
+  private def referenceTest(f: (Observation.Id, ObservationReference) => String): IO[Unit] =
+    for {
+      pid <- createProgramAs(pi)
+      ref <- setProgramReference(pi, pid, """calibration: { semester: "2025B", instrument: GMOS_SOUTH }""")
+      oref = ObservationReference(ref.get, PosInt.unsafeFrom(1))
+      oid <- createObservationAs(pi, pid)
+      jsn <- query(
+          user = pi,
+          query = s"""
+            mutation {
+              cloneObservation(input: {
+                ${f(oid, oref)}
+              }) {
+                originalObservation { id }
+                newObservation { id }
+              }
+            }
+          """
+        )
+    } yield {
+      assertEquals(
+        jsn.hcursor.downFields("cloneObservation", "originalObservation", "id").require[Observation.Id],
+        oid
+      )
+      assertNotEquals(
+        jsn.hcursor.downFields("cloneObservation", "newObservation", "id").require[Observation.Id],
+        oid
+      )
+    }
+
+  test("can specify the observation to clone using its reference") {
+    referenceTest { (oid, ref) =>
+      s"""
+         observationReference: ${ref.asJson}
+      """
+    }
+  }
+
+  test("can specify the observation to clone using both its id and reference") {
+    referenceTest { (oid, ref) =>
+      s"""
+         observationId: ${oid.asJson},
+         observationReference: ${ref.asJson}
+      """
+    }
+  }
+
+  test("fail if no ids are provided") {
+    for {
+      pid <- createProgramAs(pi)
+      ref <- setProgramReference(pi, pid, """calibration: { semester: "2025B", instrument: GMOS_SOUTH }""")
+      oref = ObservationReference(ref.get, PosInt.unsafeFrom(1))
+      oid <- createObservationAs(pi, pid)
+      _   <- expect(
+          user = pi,
+          query = s"""
+            mutation {
+              cloneObservation(input: {}) {
+                originalObservation { id }
+                newObservation { id }
+              }
+            }
+          """,
+          expected = List("One of observationId or observationReference must be provided.").asLeft
+        )
+    } yield ()
+  }
 }


### PR DESCRIPTION
This is a second attempt at observation reference, or more accurately an evolution from #1041.  Observation references consist of the corresponding program reference plus a unique (to the program) observation index.  The data migration:

* Adds an observation index which is kept by a program-specific `sequence`.
* Adds a copy of the program's `c_program_reference` in `t_observation`.  This is maintained in-sync explicitly via triggers.
* Adds a `GENERATED ALWAYS` observation reference label that combines the program reference and the index.

I'm hesitant to make the program reference part of a compound primary key for `t_program`, and then simply reference it as a foreign key in `t_observation`.  Maybe that is a more straightforward approach.  I don't have a ton of experience with this kind of thing but it just _feels wrong_ to make the primary key have a mutable, nullable and redundant component.  I can be easily persuaded to damn the torpedos and change this though.