### PR TITLE
Fix observation reference trigger comparison

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0849__observation_reference_bugfix.sql
+++ b/modules/service/src/main/resources/db/migration/V0849__observation_reference_bugfix.sql
@@ -1,0 +1,14 @@
+-- Fix the observation update trigger function from V0847.
+-- Needs to compare with IS DISTINCT FROM instead of <>.
+CREATE OR REPLACE FUNCTION update_program_reference_in_observation()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.c_program_reference IS DISTINCT FROM OLD.c_program_reference THEN
+    UPDATE t_observation
+    SET c_program_reference = NEW.c_program_reference
+    WHERE c_program_id = NEW.c_program_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/reference.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/reference.scala
@@ -1055,4 +1055,15 @@ class reference extends OdbSuite {
     } yield ()
   }
 
+  test("observation reference after observation creation") {
+    val pRef = "G-XPL-GMOSN".programReference
+    for {
+      pid <- createProgramAs(pi)
+      o1  <- createObservationAs(pi, pid)
+      o2  <- createObservationAs(pi, pid)
+      ref <- setProgramReference(pi, pid, """example: { instrument: GMOS_NORTH }""")
+      _   <- expectObservationReference(o1, s"${pRef.label}-0001".observationReference)
+      _   <- expectObservationReference(o2, s"${pRef.label}-0002".observationReference)
+    } yield ()
+  }
 }


### PR DESCRIPTION
When the program reference changes, a trigger updates the observations that correspond to the program.  Unfortunately the comparison was failing because it wasn't handling `null` correctly.  :-/ 