### PR TITLE
top-level group query

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -6412,6 +6412,9 @@ type Group {
   "Position of this group in its parent group (or at the top level)."
   parentIndex: NonNegShort!
 
+  "The program in which this group is found."
+  program: Program!
+
   "Optionally, a name"
   name: String
 
@@ -7908,6 +7911,13 @@ type Query {
   Metadata for `enum FilterType`
   """
   filterTypeMeta: [FilterTypeMeta!]!
+
+  """
+  Returns the group indicated by the given groupId, if found.
+  """
+  group(
+    groupId: GroupId!
+  ): Group
 
   """
   Returns the observation with the given id or reference, if any.  Identify the

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GroupMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GroupMapping.scala
@@ -54,6 +54,7 @@ trait GroupMapping[F[_]] extends GroupView[F] with ProgramTable[F] with GroupEle
         SqlObject("minimumInterval"),
         SqlObject("maximumInterval"),
         SqlObject("elements", Join(GroupView.Id, GroupElementView.GroupId)),
+        SqlObject("program", Join(GroupView.ProgramId, ProgramTable.Id)),
         EffectField("timeEstimateRange", timeEstimateHandler, List("id"))
       )
     )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/GroupPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/GroupPredicates.scala
@@ -9,4 +9,5 @@ import lucuma.core.model.Group
 class GroupPredicates(path: Path) {
   lazy val id       = LeafPredicates[Group.Id](path / "id")
   lazy val parentId = LeafPredicates[Group.Id](path / "parentId")
+  lazy val program  = ProgramPredicates(path / "program")
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/group.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/group.scala
@@ -28,7 +28,6 @@ class group extends OdbSuite {
      }
 
   test("can select a group by id") {
-
     for {
       pid <- createProgramAs(pi0)
       gex <- createGroupAs(pi0, pid)
@@ -36,7 +35,7 @@ class group extends OdbSuite {
     } yield assertEquals(gob, gex)
   }
 
-  test("group may not be found 2") {
+  test("group may not be found") {
     expect(pi0,
       s"""query { group(groupId: "${Group.Id.fromLong(42L).get}") { id } }""",
       json"""{ "group": null }""".asRight
@@ -52,6 +51,5 @@ class group extends OdbSuite {
                json"""{ "group": null }""".asRight
              )
     } yield ()
-
   }
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/group.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/group.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package query
+
+import cats.effect.IO
+import cats.syntax.either.*
+import io.circe.literal._
+import lucuma.core.model.Group
+
+class group extends OdbSuite {
+
+  val pi0 = TestUsers.Standard.pi(1, 30)
+  val pi1 = TestUsers.Standard.pi(2, 30)
+  val validUsers = List(pi0, pi1)
+
+  private def queryGroup(gid: Group.Id): IO[Group.Id] =
+    query(
+      pi0,
+      s"""query { group(groupId: "$gid") { id } }"""
+    ).flatMap {
+       _.hcursor
+        .downFields("group", "id")
+        .as[Group.Id]
+        .leftMap(f => new RuntimeException(f.message))
+        .liftTo[IO]
+     }
+
+  test("can select a group by id") {
+
+    for {
+      pid <- createProgramAs(pi0)
+      gex <- createGroupAs(pi0, pid)
+      gob <- queryGroup(gex)
+    } yield assertEquals(gob, gex)
+  }
+
+  test("group may not be found 2") {
+    expect(pi0,
+      s"""query { group(groupId: "${Group.Id.fromLong(42L).get}") { id } }""",
+      json"""{ "group": null }""".asRight
+    )
+  }
+
+  test("group may not be visible") {
+    for {
+      pid <- createProgramAs(pi0)
+      gid <- createGroupAs(pi0, pid)
+      _   <- expect(pi1,  // not visible to pi1
+               s"""query { group(groupId: "$gid") { id } }""",
+               json"""{ "group": null }""".asRight
+             )
+    } yield ()
+
+  }
+}


### PR DESCRIPTION
Implements #1057.  To do this, I needed to add `program: Program!` to the `Group` type in the schema.  This has been done for observations and targets, so it seems legitimate.  If anybody disagrees though, I believe the next Grackle release will allow us to mark the `program` field as hidden in `GroupMapping` and then remove this from the schema proper.