### PR TITLE
invitation recipient

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -12,6 +12,9 @@ enum FilterType { DUMMY }
 enum ProposalAttachmentType { DUMMY }
 enum ProposalStatus { DUMMY }
 
+"""Email address, matching ^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$"""
+scalar EmailAddress
+
 "DatasetEvent creation parameters."
 input AddDatasetEventInput {
 
@@ -2210,6 +2213,9 @@ input CreateUserInvitationInput {
   "The program to add a user to."
   programId: ProgramId!
 
+  "The recipient to whom the invitation should be sent."
+  recipientEmail: EmailAddress!
+
   "The role this user will play in the program."
   role: ProgramUserRole!
 
@@ -2248,6 +2254,9 @@ type UserInvitation {
 
   "User who issued the invitation."
   issuer: User!
+
+  "Recipient email address."
+  recipientEmail: EmailAddress!
 
   "User who redeemed the invitation, if any."
   redeemer: User

--- a/modules/service/src/main/resources/db/migration/V0854__invitation_recipient.sql
+++ b/modules/service/src/main/resources/db/migration/V0854__invitation_recipient.sql
@@ -1,0 +1,53 @@
+
+-- Add recipient email to user invitations.
+
+CREATE EXTENSION citext;
+CREATE DOMAIN d_email AS citext
+CHECK(
+  --  N.B. this is the same pattern used in the EmailAddress class; if we change one we need to change the other.
+  VALUE ~ '^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$'
+);
+
+-- wipe out any existing invitations (we don't care)
+DELETE FROM t_invitation;
+
+ALTER TABLE t_invitation ADD
+  c_recipient_email  d_email  not null;
+
+CREATE OR REPLACE FUNCTION insert_invitation(
+  p_issuer_id       d_user_id,                   
+  p_program_id      d_program_id,         
+  p_recipient_email d_email,       
+  p_role            e_program_user_role,         
+  p_support_type    e_program_user_support_type, 
+  p_support_partner d_tag                  
+) RETURNS text AS $$
+  DECLARE
+    invitation_key_id d_invitation_id := to_hex(nextval('s_invitation_id'::regclass));
+    invitation_key text := md5(random()::text) || md5(random()::text) ||  md5(random()::text);
+    invitation_key_hash text := md5(invitation_key);
+  BEGIN
+    INSERT INTO t_invitation (
+      c_invitation_id,
+      c_issuer_id,      
+      c_program_id,     
+      c_recipient_email,
+      c_role,           
+      c_support_type,   
+      c_support_partner,
+      c_key_hash
+    )
+    VALUES (
+      invitation_key_id,
+      p_issuer_id,      
+      p_program_id,     
+      p_recipient_email,
+      p_role,           
+      p_support_type,   
+      p_support_partner,
+      invitation_key_hash
+    );
+    return invitation_key_id || '.' || invitation_key;
+  END;
+$$ LANGUAGE plpgsql;
+

--- a/modules/service/src/main/scala/lucuma/odb/data/EmailAddress.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/EmailAddress.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+
+import io.circe.Encoder
+import monocle.Prism
+
+opaque type EmailAddress = String
+
+extension (self: EmailAddress) def value: String = self
+
+object EmailAddress:
+
+  // N.B. this is the same pattern used in the database constraint; if we change one we need to change the other.
+  private val Pat = """^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$""".r
+
+  def fromString: Prism[String, EmailAddress] =
+    Prism((s: String) => Option.when(Pat.matches(s))(s))(identity)
+
+  given Encoder[EmailAddress] =
+    Encoder.encodeString

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -70,6 +70,7 @@ trait BaseMapping[F[_]]
   lazy val DirectorsTimeType                   = schema.ref("DirectorsTime")
   lazy val DmsStringType                       = schema.ref("DmsString")
   lazy val EditTypeType                        = schema.ref("EditType")
+  lazy val EmailAddressType                    = schema.ref("EmailAddress")
   lazy val ElevationRangeType                  = schema.ref("ElevationRange")
   lazy val EngineeringProgramReferenceType     = schema.ref("EngineeringProgramReference")
   lazy val EphemerisKeyTypeType                = schema.ref("EphemerisKeyType")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/EmailAddressBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/EmailAddressBinding.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.odb.data.EmailAddress
+
+val EmailAddressBinding: Matcher[EmailAddress] =
+  StringBinding.emap: s =>
+    EmailAddress.fromString.getOption(s).toRight(s"Invalid email address: $s")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CreateUserInvitationInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CreateUserInvitationInput.scala
@@ -6,9 +6,11 @@ package lucuma.odb.graphql.input
 import cats.syntax.all.*
 import grackle.Result
 import lucuma.core.model.Program
+import lucuma.odb.data.EmailAddress
 import lucuma.odb.data.ProgramUserRole
 import lucuma.odb.data.ProgramUserSupportType
 import lucuma.odb.data.Tag
+import lucuma.odb.graphql.binding.EmailAddressBinding
 import lucuma.odb.graphql.binding.Matcher
 import lucuma.odb.graphql.binding.ObjectFieldsBinding
 import lucuma.odb.graphql.binding.ProgramIdBinding
@@ -21,27 +23,29 @@ import ProgramUserSupportType.*
 
 sealed abstract class CreateUserInvitationInput(val role: ProgramUserRole):
   def programId: Program.Id
+  def recipientEmail: EmailAddress
 
 object CreateUserInvitationInput:
 
   sealed abstract class Support(val supportType: ProgramUserSupportType) extends CreateUserInvitationInput(ProgramUserRole.Support)
 
-  final case class Coi(programId: Program.Id) extends CreateUserInvitationInput(ProgramUserRole.Coi)
-  final case class Observer(programId: Program.Id) extends CreateUserInvitationInput(ProgramUserRole.Observer)
-  final case class StaffSupport(programId: Program.Id) extends Support(ProgramUserSupportType.Staff)
-  final case class NgoSupportSupport(programId: Program.Id, supportPartner: Tag) extends Support(ProgramUserSupportType.Partner)
+  final case class Coi(programId: Program.Id, recipientEmail: EmailAddress) extends CreateUserInvitationInput(ProgramUserRole.Coi)
+  final case class Observer(programId: Program.Id, recipientEmail: EmailAddress) extends CreateUserInvitationInput(ProgramUserRole.Observer)
+  final case class StaffSupport(programId: Program.Id, recipientEmail: EmailAddress) extends Support(ProgramUserSupportType.Staff)
+  final case class NgoSupportSupport(programId: Program.Id, supportPartner: Tag, recipientEmail: EmailAddress) extends Support(ProgramUserSupportType.Partner)
 
   val Binding: Matcher[CreateUserInvitationInput] =
     ObjectFieldsBinding.rmap:
       case List(
         ProgramIdBinding("programId", rProgramId),
+        EmailAddressBinding("recipientEmail", rRecipientEmail),
         ProgramUserRoleBinding("role", rRole),
         ProgramUserSupportRoleTypeBinding.Option("supportType", rSupport),
         TagBinding.Option("supportPartner", rPartner)
       ) =>
-        (rProgramId, rRole, rSupport, rPartner).parTupled.flatMap:
-          case (pid, ProgramUserRole.Coi, None, None)                   => Result(Coi(pid))
-          case (pid, ProgramUserRole.Observer, None, None)              => Result(Observer(pid))
-          case (pid, ProgramUserRole.Support, Some(Staff), None)        => Result(StaffSupport(pid))
-          case (pid, ProgramUserRole.Support, Some(Partner), Some(tag)) => Result(NgoSupportSupport(pid, tag))
+        (rProgramId, rRecipientEmail, rRole, rSupport, rPartner).parTupled.flatMap:
+          case (pid, recip, ProgramUserRole.Coi, None, None)                   => Result(Coi(pid, recip))
+          case (pid, recip, ProgramUserRole.Observer, None, None)              => Result(Observer(pid, recip))
+          case (pid, recip, ProgramUserRole.Support, Some(Staff), None)        => Result(StaffSupport(pid, recip))
+          case (pid, recip, ProgramUserRole.Support, Some(Partner), Some(tag)) => Result(NgoSupportSupport(pid, tag, recip))
           case _                                                        => Matcher.validationFailure("Invalid combination of role, support type, and partner.")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
@@ -39,6 +39,7 @@ import lucuma.core.model.sequence.Step
 import lucuma.core.model.sequence.TimeChargeCorrection
 import lucuma.core.util.Timestamp
 import lucuma.odb.data.EditType
+import lucuma.odb.data.EmailAddress
 import lucuma.odb.data.ExecutionEventType
 import lucuma.odb.data.Existence
 import lucuma.odb.data.Extinction
@@ -76,6 +77,7 @@ trait LeafMappings[F[_]] extends BaseMapping[F] {
       LeafMapping[Dataset.Id](DatasetIdType),
       LeafMapping[DatasetStage](DatasetStageType),
       LeafMapping[EditType](EditTypeType),
+      LeafMapping[EmailAddress](EmailAddressType),
       LeafMapping[EphemerisKeyType](EphemerisKeyTypeType),
       LeafMapping[Epoch](EpochStringType),
       LeafMapping[ExecutionEvent.Id](ExecutionEventIdType),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/UserInvitationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/UserInvitationMapping.scala
@@ -19,6 +19,7 @@ trait UserInvitationMapping[F[_]] extends ProgramTable[F] with UserTable[F] with
         SqlField("status", UserInvitationTable.Status),
         SqlObject("issuer", Join(UserInvitationTable.IssuerId, UserTable.UserId)),
         SqlObject("program", Join(UserInvitationTable.ProgramId, ProgramTable.Id)),
+        SqlField("recipientEmail", UserInvitationTable.RecipientEmail),
         SqlField("role", UserInvitationTable.Role),
         SqlField("supportType", UserInvitationTable.SupportType),
         SqlField("supportPartner", UserInvitationTable.SupportPartner),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/UserInvitationTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/UserInvitationTable.scala
@@ -14,6 +14,7 @@ trait UserInvitationTable[F[_]] extends BaseMapping[F]:
     val Status         = col("c_status", user_invitation_status)
     val IssuerId       = col("c_issuer_id", user_id)
     val ProgramId      = col("c_program_id", program_id)
+    val RecipientEmail = col("c_recipient_email", email_address)
     val Role           = col("c_role", program_user_role)
     val SupportType    = col("c_support_type", program_user_support_type.opt)
     val SupportPartner = col("c_support_partner", tag.opt)

--- a/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
@@ -42,6 +42,7 @@ import lucuma.core.util.Timestamp
 import lucuma.core.util.TimestampInterval
 import lucuma.core.util.Uid
 import lucuma.odb.data.EditType
+import lucuma.odb.data.EmailAddress
 import lucuma.odb.data.ExecutionEventType
 import lucuma.odb.data.Existence
 import lucuma.odb.data.Extinction
@@ -75,18 +76,18 @@ trait Codecs {
   def enumerated[A](tpe: Type)(implicit ev: Enumerated[A]): Codec[A] =
     `enum`(ev.tag, ev.fromTag, tpe)
 
-  private def idCodecFromPrism[A](prism: Prism[String, A]): Codec[A] =
+  private def codecFromPrism[A](prism: Prism[String, A], tpe: Type): Codec[A] =
     Codec.simple(
       prism.reverseGet,
       s => prism.getOption(s).toRight(s"Invalid: $s"),
-      Type.varchar
+      tpe
     )
 
   def gid[A](implicit ev: Gid[A]): Codec[A] =
-    idCodecFromPrism(ev.fromString)
+    codecFromPrism(ev.fromString, Type.varchar)
 
   def uid[A](implicit ev: Uid[A]): Codec[A] =
-    idCodecFromPrism(ev.fromString)
+    codecFromPrism(ev.fromString, Type.varchar)
 
   final case class DomainCodec[A](domainName: String, codec: Codec[A]) extends Codec[A]:
     export codec.* // delegate everything!
@@ -611,6 +612,10 @@ trait Codecs {
 
   val user_invitation_status: Codec[UserInvitation.Status] =
     enumerated(Type("e_invitation_status"))
+
+  val email_address: Codec[EmailAddress] =
+    codecFromPrism(EmailAddress.fromString, Type("citext"))
+    
 
 }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -49,6 +49,7 @@ import lucuma.core.syntax.string.*
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import lucuma.odb.FMain
+import lucuma.odb.data.EmailAddress
 import lucuma.odb.data.Existence
 import lucuma.odb.data.ObservingModeType
 import lucuma.odb.data.ProgramUserRole
@@ -1180,7 +1181,8 @@ trait DatabaseOperations { this: OdbSuite =>
     pid: Program.Id, 
     role: ProgramUserRole = ProgramUserRole.Coi,
     supportType: Option[ProgramUserSupportType] = None,
-    supportPartner: Option[Tag] = None
+    supportPartner: Option[Tag] = None,
+    recipientEmail: EmailAddress = EmailAddress.fromString.getOption("bob@dobbs.com").get
   ): IO[UserInvitation] =
     query(
       user = user,
@@ -1189,6 +1191,7 @@ trait DatabaseOperations { this: OdbSuite =>
         createUserInvitation(
           input: {
             programId: "$pid"
+            recipientEmail: "$recipientEmail"
             role: ${role.tag.toUpperCase}
             ${supportType.map(_.tag.toUpperCase).foldMap(s => s"supportType: $s")}
             ${supportPartner.map(_.value.toUpperCase).foldMap(s => s"supportPartner: $s")}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createUserInvitation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createUserInvitation.scala
@@ -47,12 +47,14 @@ class createUserInvitation extends OdbSuite {
             createUserInvitation(
               input: {
                 programId: "$pid"
+                recipientEmail: "bob@dobbs.com"
                 role: ${pur.tag.toUpperCase}
               }
             ) {
               invitation {
                 status
                 issuer { id }
+                recipientEmail
                 redeemer { id }
                 program { id }
                 role
@@ -71,6 +73,7 @@ class createUserInvitation extends OdbSuite {
                     "issuer" : {
                       "id" : ${pi.id}
                     },
+                    "recipientEmail": "bob@dobbs.com",
                     "redeemer" : null,
                     "program" : {
                       "id" : $pid
@@ -97,6 +100,7 @@ class createUserInvitation extends OdbSuite {
           createUserInvitation(
             input: {
               programId: "$pid"
+              recipientEmail: "bob@dobbs.com"
               role: ${ProgramUserRole.Support.tag.toUpperCase}
               supportType: ${ProgramUserSupportType.Staff.tag.toUpperCase()}
             }
@@ -147,6 +151,7 @@ class createUserInvitation extends OdbSuite {
           createUserInvitation(
             input: {
               programId: "$pid"
+              recipientEmail: "bob@dobbs.com"
               role: ${ProgramUserRole.Support.tag.toUpperCase}
               supportType: ${ProgramUserSupportType.Partner.tag.toUpperCase()}
               supportPartner: CA
@@ -198,6 +203,7 @@ class createUserInvitation extends OdbSuite {
           createUserInvitation(
             input: {
               programId: "$pid"
+              recipientEmail: "bob@dobbs.com"
               role: ${ProgramUserRole.Support.tag.toUpperCase}
               supportType: ${ProgramUserSupportType.Partner.tag.toUpperCase()}
             }
@@ -223,6 +229,7 @@ class createUserInvitation extends OdbSuite {
         createUserInvitation(
           input: {
             programId: "p-ffff"
+            recipientEmail: "bob@dobbs.com"
             role: ${ProgramUserRole.Coi.tag.toUpperCase}
           }
         ) {
@@ -246,6 +253,7 @@ class createUserInvitation extends OdbSuite {
           createUserInvitation(
             input: {
               programId: "$pid"
+              recipientEmail: "bob@dobbs.com"
               role: ${ProgramUserRole.Coi.tag.toUpperCase}
             }
           ) {
@@ -269,6 +277,7 @@ class createUserInvitation extends OdbSuite {
           createUserInvitation(
             input: {
               programId: "$pid"
+              recipientEmail: "bob@dobbs.com"
               role: ${ProgramUserRole.Coi.tag.toUpperCase}
             }
           ) {
@@ -307,6 +316,7 @@ class createUserInvitation extends OdbSuite {
             createUserInvitation(
               input: {
                 programId: "$pid"
+                recipientEmail: "bob@dobbs.com"
                 role: SUPPORT
                 supportType: PARTNER
                 supportPartner: ${partner.tag.toUpperCase}


### PR DESCRIPTION
This adds `recipientEmail: EmailAddress!` to `type UserInvitation`, the idea being that once we have email hooked up we can email the key rather than returning it to the user to deliver by hand. The email address can also be used to disambiguate when revoking invitations.