### PR TITLE
Update regex for emails

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0855__recipient_email.sql
+++ b/modules/service/src/main/resources/db/migration/V0855__recipient_email.sql
@@ -1,9 +1,8 @@
 
 -- Update recipient email regex check
 
-ALTER DOMAIN d_email DROP CONSTRAINT;
-ALTER DOMAIN d_email ADD CONSTRAINT 
-CHECK(
+ALTER DOMAIN d_email DROP CONSTRAINT d_email_check;
+ALTER DOMAIN d_email ADD CONSTRAINT d_email_check CHECK(
   --  N.B. this is the same pattern used in the EmailAddress class; if we change one we need to change the other.
-  VALUE ~ '(?:[a-z0-9!#$%&'*+x\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])'
+  VALUE ~ '^[a-zA-Z0-9_+&-]+(?:.[a-zA-Z0-9_+&-]+)*@(?:[a-zA-Z0-9-]+.)+[a-zA-Z]{2,7}$'
 );

--- a/modules/service/src/main/resources/db/migration/V0855__recipient_email.sql
+++ b/modules/service/src/main/resources/db/migration/V0855__recipient_email.sql
@@ -1,0 +1,9 @@
+
+-- Update recipient email regex check
+
+ALTER DOMAIN d_email DROP CONSTRAINT;
+ALTER DOMAIN d_email ADD CONSTRAINT 
+CHECK(
+  --  N.B. this is the same pattern used in the EmailAddress class; if we change one we need to change the other.
+  VALUE ~ '(?:[a-z0-9!#$%&'*+x\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])'
+);

--- a/modules/service/src/main/scala/lucuma/odb/data/EmailAddress.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/EmailAddress.scala
@@ -13,7 +13,7 @@ extension (self: EmailAddress) def value: String = self
 object EmailAddress:
 
   // N.B. this is the same pattern used in the database constraint; if we change one we need to change the other.
-  private val Pat = """(?:[a-z0-9!#$%&'*+x\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""".r
+  private val Pat = """^[a-zA-Z0-9_+&-]+(?:.[a-zA-Z0-9_+&-]+)*@(?:[a-zA-Z0-9-]+.)+[a-zA-Z]{2,7}$""".r
 
   def fromString: Prism[String, EmailAddress] =
     Prism((s: String) => Option.when(Pat.matches(s))(s))(identity)

--- a/modules/service/src/main/scala/lucuma/odb/data/EmailAddress.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/EmailAddress.scala
@@ -13,7 +13,7 @@ extension (self: EmailAddress) def value: String = self
 object EmailAddress:
 
   // N.B. this is the same pattern used in the database constraint; if we change one we need to change the other.
-  private val Pat = """^\w+@[a-zA-Z_]+?\.[a-zA-Z]{2,3}$""".r
+  private val Pat = """(?:[a-z0-9!#$%&'*+x\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""".r
 
   def fromString: Prism[String, EmailAddress] =
     Prism((s: String) => Option.when(Pat.matches(s))(s))(identity)


### PR DESCRIPTION
The regex used for emails is not working if the email name has a dot.
I updated the regex based on this:
https://stackoverflow.com/questions/201323/how-can-i-validate-an-email-address-using-a-regular-expression