### PR TITLE
Require PiAccess for the proposal mutations

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -283,12 +283,11 @@ trait MutationMapping[F[_]] extends Predicates[F] {
     }
 
   private lazy val CreateProposal =
-    MutationField("createProposal", CreateProposalInput.Binding) { (input, child) =>
-      services.useTransactionally {
-        proposalService.createProposal(input).nestMap: pid =>
-          Unique(Filter(Predicates.createProposalResult.programId.eql(pid), child))
-      }
-  }
+    MutationField("createProposal", CreateProposalInput.Binding): (input, child) =>
+      services.useTransactionally:
+        requirePiAccess: 
+          proposalService.createProposal(input).nestMap: pid =>
+            Unique(Filter(Predicates.createProposalResult.programId.eql(pid), child))
 
   private lazy val CreateTarget =
     MutationField("createTarget", CreateTargetInput.Binding): (input, child) =>
@@ -469,8 +468,9 @@ trait MutationMapping[F[_]] extends Predicates[F] {
   private lazy val SetProposalStatus =
     MutationField("setProposalStatus", SetProposalStatusInput.Binding): (input, child) =>
       services.useTransactionally:
-        proposalService.setProposalStatus(input).nestMap: pid =>
-          Unique(Filter(Predicates.setProposalStatusResult.programId.eql(pid), child))
+        requirePiAccess:
+          proposalService.setProposalStatus(input).nestMap: pid =>
+            Unique(Filter(Predicates.setProposalStatusResult.programId.eql(pid), child))
 
   // An applied fragment that selects all observation ids that satisfy
   // `filterPredicate`
@@ -628,10 +628,10 @@ trait MutationMapping[F[_]] extends Predicates[F] {
 
   private lazy val UpdateProposal =
     MutationField("updateProposal", UpdateProposalInput.Binding) { (input, child) =>
-      services.useTransactionally {
-        proposalService.updateProposal(input).nestMap: pid =>
-          Unique(Filter(Predicates.updateProposalResult.programId.eql(pid), child))
-      }
+      services.useTransactionally:
+        requirePiAccess:
+          proposalService.updateProposal(input).nestMap: pid =>
+            Unique(Filter(Predicates.updateProposalResult.programId.eql(pid), child))
   }
 
   def targetResultSubquery(pids: List[Target.Id], limit: Option[NonNegInt], child: Query): Result[Query] =

--- a/modules/service/src/main/scala/lucuma/odb/service/Services.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/Services.scala
@@ -275,6 +275,10 @@ object Services:
     def guideService[F[_]](httpClient: Client[F], itcClient: ItcClient[F], commitHash: CommitHash, ptc: TimeEstimateCalculator.ForInstrumentMode)(using Services[F]): GuideService[F] = summon[Services[F]].guideService(httpClient, itcClient, commitHash, ptc)
     def userInvitationService[F[_]](using Services[F]): UserInvitationService[F] = summon[Services[F]].userInvitationService
     
+    def requirePiAccess[F[_], A](fa: Services.PiAccess ?=> F[Result[A]])(using Services[F], Applicative[F]): F[Result[A]] =
+      if user.role.access >= Access.Pi then fa(using ())
+      else OdbError.NotAuthorized(user.id).asFailureF
+
     def requireStaffAccess[F[_], A](fa: Services.StaffAccess ?=> F[Result[A]])(using Services[F], Applicative[F]): F[Result[A]] =
       if user.role.access >= Access.Staff then fa(using ())
       else OdbError.NotAuthorized(user.id).asFailureF

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatus.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatus.scala
@@ -77,8 +77,9 @@ class setProposalStatus extends OdbSuite {
   }
 
   test("edit proposal status (guests cannot submit proposals)") {
-    createProgramAs(guest).flatMap { pid =>
-      addProposal(guest, pid) >>
+    createProgramAs(pi).flatMap { pid =>
+      addProposal(pi, pid) >>
+      // the non-guest requirement gets caught before it even gets to the service.
       expect(
         user = guest,
         query = s"""
@@ -97,7 +98,7 @@ class setProposalStatus extends OdbSuite {
           }
         """,
         expected =
-          Left(List(UpdateProposalError.NotAuthorizedNewProposalStatus(pid, guest, Tag("submitted")).message))
+          Left(List(OdbError.NotAuthorized(guest.id).message))
       )
     }
   }


### PR DESCRIPTION
Andy requested that guest users not be allowed to create proposals. This has been enforced in Explore for some time, but not by the API. I believe the reasoning is that if a user is going to create a proposal, they must be getting serious. And, it is too easy for guest users to loose everything if they clear cookies, have computer issues, etc.
 
Because a PI must be non-guest to create a proposal, and any users linked to a program must be non-guest, the `requirePiAccess` probably isn't strictly necessary for `setProposalStatus` and `updateProposal`, but it seemed to be consistent. It can be removed if there are objections.