### PR TITLE
Add missing program edit subscription events

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0861__more_program_edit_events.sql
+++ b/modules/service/src/main/resources/db/migration/V0861__more_program_edit_events.sql
@@ -1,0 +1,75 @@
+-- Notify of changes to the proposal in the program edit subscription channel
+CREATE OR REPLACE FUNCTION ch_proposal_edit()
+  RETURNS trigger AS $$
+DECLARE
+  proposal record;
+BEGIN
+  proposal := COALESCE(NEW, OLD);
+  -- Since this is a programEdit subscription, it is always an UPDATE to the program
+  PERFORM pg_notify('ch_program_edit', proposal.c_program_id || ',' || 'UPDATE');
+  RETURN proposal;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER ch_program_edit_proposal_trigger
+  AFTER INSERT OR UPDATE OR DELETE ON t_proposal
+  DEFERRABLE
+  FOR EACH ROW
+  EXECUTE PROCEDURE ch_proposal_edit();
+
+-- Notify of changes to the partner splits in the program edit subscription channel
+CREATE OR REPLACE FUNCTION ch_partner_splits_edit()
+  RETURNS trigger AS $$
+DECLARE
+  splits record;
+BEGIN
+  splits := COALESCE(NEW, OLD);
+  -- Since this is a programEdit subscription, it is always an UPDATE to the program
+  PERFORM pg_notify('ch_program_edit', splits.c_program_id || ',' || 'UPDATE');
+  RETURN splits;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER ch_program_edit_partner_split_trigger
+  AFTER INSERT OR UPDATE OR DELETE ON t_partner_split
+  DEFERRABLE
+  FOR EACH ROW
+  EXECUTE PROCEDURE ch_partner_splits_edit();
+
+-- Notify of changes to the program users in the program edit subscription channel
+CREATE OR REPLACE FUNCTION ch_program_user_edit()
+  RETURNS trigger AS $$
+DECLARE
+  proguser record;
+BEGIN
+  proguser := COALESCE(NEW, OLD);
+  -- Since this is a programEdit subscription, it is always an UPDATE to the program
+  PERFORM pg_notify('ch_program_edit', proguser.c_program_id || ',' || 'UPDATE');
+  RETURN proguser;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER ch_program_edit_program_user_trigger
+  AFTER INSERT OR UPDATE OR DELETE ON t_program_user
+  DEFERRABLE
+  FOR EACH ROW
+  EXECUTE PROCEDURE ch_program_user_edit();
+
+-- Notify of changes to the user invitations in the program edit subscription channel
+CREATE OR REPLACE FUNCTION ch_invitation_edit()
+  RETURNS trigger AS $$
+DECLARE
+  invitation record;
+BEGIN
+  invitation := COALESCE(NEW, OLD);
+  -- Since this is a programEdit subscription, it is always an UPDATE to the program
+  PERFORM pg_notify('ch_program_edit', invitation.c_program_id || ',' || 'UPDATE');
+  RETURN invitation;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE CONSTRAINT TRIGGER ch_program_edit_invitation_trigger
+  AFTER INSERT OR UPDATE OR DELETE ON t_invitation
+  DEFERRABLE
+  FOR EACH ROW
+  EXECUTE PROCEDURE ch_invitation_edit();

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -191,7 +191,7 @@ trait DatabaseOperations { this: OdbSuite =>
 
   // For proposal tests where it doesn't matter what the proposal is, just that
   // there is one.
-  def addProposal(user: User, pid: Program.Id): IO[Unit] =
+  def addProposal(user: User, pid: Program.Id, title: String = "my proposal"): IO[Unit] =
     expect(
       user = user,
       query = s"""
@@ -200,6 +200,7 @@ trait DatabaseOperations { this: OdbSuite =>
             input: {
               programId: "$pid"
               SET: {
+                title: "$title"
                 proposalClass: {
                   queue: {
                     minPercentTime: 50
@@ -207,12 +208,6 @@ trait DatabaseOperations { this: OdbSuite =>
                 }
                 category: COSMOLOGY
                 toOActivation: NONE
-                partnerSplits: [
-                  {
-                    partner: US
-                    percent: 100
-                  }
-                ]
               }
             }
           ) {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/programEdit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/programEdit.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import cats.syntax.all.*
 import io.circe.literal.*
 import lucuma.core.model.User
+import lucuma.odb.data.EmailAddress
 
 import scala.concurrent.duration.*
 
@@ -212,6 +213,192 @@ class programEdit extends OdbSuite with SubscriptionUtils {
           createProgramAs(pi).replicateA(2)
         ),
       expected = List.fill(2)(json"""{"programEdit":{"editType":"CREATED","id":0}}""")
+    )
+  }
+
+  test("edit event should show up for proposal creation and update") {
+    import Group2.pi
+    subscriptionExpect(
+      user = pi,
+      query =
+        """
+          subscription {
+            programEdit {
+              editType
+              value {
+                name
+                proposal {
+                  title
+                }
+              }
+            }
+          }
+        """,
+      mutations =
+        Right(
+          createProgram(pi, "foo").flatMap { pid =>
+            IO.sleep(1.second) >> // give time to see the creation before we do an update
+            addProposal(pi, pid, "initial") >>
+            IO.sleep(1.second) >> // give time to see the creation before we do an update
+            query(
+              pi,
+              s"""
+              mutation {
+                updateProposal(input: {
+                  programId: "$pid"
+                  SET: { title: "updated" }
+                }) {
+                  proposal {
+                    title
+                  }
+                }
+              }
+              """
+            )
+          }
+        ),
+      expected =
+        List(
+          json"""{ "programEdit": { "editType" : "CREATED", "value": { "name": "foo", "proposal": null } } }""",
+          json"""{ "programEdit": { "editType" : "UPDATED", "value": { "name": "foo", "proposal": { "title": "initial" } } } }""",
+          json"""{ "programEdit": { "editType" : "UPDATED", "value": { "name": "foo", "proposal": { "title": "updated" } } } }"""
+        )
+    )
+  }
+
+  test("edit event should show up for updating the partner splits") {
+    import Group2.pi
+    subscriptionExpect(
+      user = pi,
+      query =
+        """
+          subscription {
+            programEdit {
+              editType
+              value {
+                name
+                proposal {
+                  partnerSplits {
+                    partner
+                    percent
+                  }
+                }
+              }
+            }
+          }
+        """,
+      mutations =
+        Right(
+          createProgram(pi, "foo").flatMap { pid =>
+            IO.sleep(1.second) >> // give time to see the creation before we do an update
+            addProposal(pi, pid, "initial") >>
+            IO.sleep(1.second) >> // give time to see the creation before we do an update
+            query(
+              pi,
+              s"""
+              mutation {
+                updateProposal(input: {
+                  programId: "$pid"
+                  SET: {
+                    partnerSplits: [
+                      {
+                        partner: US
+                        percent: 60
+                      },
+                      {
+                        partner: AR
+                        percent: 40
+                      }
+                    ]
+                  }
+                }) {
+                  proposal {
+                    title
+                  }
+                }
+              }
+              """
+            )
+          }
+        ),
+      expected =
+        List(
+          json"""{ "programEdit": { "editType" : "CREATED", "value": { "name": "foo", "proposal": null } } }""",
+          json"""{ "programEdit": { "editType" : "UPDATED", "value": { "name": "foo", "proposal": { "partnerSplits": [] } } } }""",
+          json"""{ "programEdit": { "editType" : "UPDATED", "value": { "name": "foo", "proposal": { "partnerSplits": [ { "partner" : "US", "percent" : 60 }, { "partner" : "AR", "percent" : 40 }] } } } }"""
+        )
+    )
+  }
+
+  test("edit event should show up for linking a user") {
+    import Group2.pi
+    import Group1.pi as pi2
+    subscriptionExpect(
+      user = pi,
+      query =
+        """
+          subscription {
+            programEdit {
+              editType
+              value {
+                name
+                users {
+                  role
+                }
+              }
+            }
+          }
+        """,
+      mutations =
+        Right(
+          createProgram(pi, "foo").flatMap { pid =>
+            IO.sleep(1.second) >> // give time to see the creation before we do an update
+            linkCoiAs(pi, pi2.id, pid)
+          }
+        ),
+      expected =
+        List(
+          json"""{ "programEdit": { "editType" : "CREATED", "value": { "name": "foo", "users": [] } } }""",
+          json"""{ "programEdit": { "editType" : "UPDATED", "value": { "name": "foo", "users": [ { "role": "COI" } ] } } }"""
+        )
+    )
+  }
+
+  test("edit event should show up for creating and modifying invitations") {
+    import Group2.pi
+    subscriptionExpect(
+      user = pi,
+      query =
+        """
+          subscription {
+            programEdit {
+              editType
+              value {
+                name
+                userInvitations {
+                  status
+                  recipientEmail
+                }
+              }
+            }
+          }
+        """,
+      mutations =
+        Right(
+          for {
+            pid <- createProgram(pi, "foo")
+            _   <- IO.sleep(1.second)
+            inv <- createUserInvitationAs(pi, pid, recipientEmail = EmailAddress.fromString.getOption("here@there.com").get)
+            _   <- IO.sleep(1.second)
+            _   <- revokeUserInvitationAs(pi, inv.id)
+          } yield ()
+        ),
+      expected =
+        List(
+          json"""{ "programEdit": { "editType" : "CREATED", "value": { "name": "foo", "userInvitations": [] } } }""",
+          json"""{ "programEdit": { "editType" : "UPDATED", "value": { "name": "foo", "userInvitations": [ { "status": "PENDING", "recipientEmail": "here@there.com" } ] } } }""",
+          json"""{ "programEdit": { "editType" : "UPDATED", "value": { "name": "foo", "userInvitations": [ { "status": "REVOKED", "recipientEmail": "here@there.com" } ] } } }"""
+        )
     )
   }
 


### PR DESCRIPTION
This adds `programEdit` events for the t_proposal, t_partner_split, t_program_user and t_invitation tables as described in #1102 