### PR TITLE
Filter out GAIA bands on ITC calls

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -233,8 +233,8 @@ object GeneratorParamsService {
         mode:       InstrumentMode,
         wavelength: Wavelength
       ): ValidatedNel[Error, (Target.Id, (ImagingIntegrationTimeInput, SpectroscopyIntegrationTimeInput))] = {
-        val targetBand = params.sourceProfile.flatMap(_.nearestBand(wavelength)).map(_._1)
-
+        val sourceProf = params.sourceProfile.map(_.gaiaFree)
+        val targetBand = sourceProf.flatMap(_.nearestBand(wavelength)).map(_._1)
         (params.signalToNoise.toValidNel(Error.missing("signal to noise")),
          params.signalToNoiseAt.toValidNel(Error.missing("signal to noise at wavelength")),
          params.targetId.toValidNel(Error.missing("target"))
@@ -242,7 +242,7 @@ object GeneratorParamsService {
           // these are dependent on having a target in the first place
           (targetBand.toValidNel(Error.targetMissing(tid, "brightness measure")),
            params.radialVelocity.toValidNel(Error.targetMissing(tid, "radial velocity")),
-           params.sourceProfile.toValidNel(Error.targetMissing(tid, "source profile"))
+           sourceProf.toValidNel(Error.targetMissing(tid, "source profile"))
           ).mapN { case (b, rv, sp) =>
             tid ->
             (

--- a/modules/service/src/main/scala/lucuma/odb/service/extensions.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/extensions.scala
@@ -9,6 +9,8 @@ import cats.effect.MonadCancelThrow
 import cats.syntax.all.*
 import grackle.Result
 import grackle.ResultT
+import lucuma.core.enums.Band
+import lucuma.core.model.SourceProfile
 import skunk.*
 import skunk.data.Completion
 
@@ -23,3 +25,18 @@ class FromResultPartiallyApplied[F[_]]:
   def apply[A](result: Result[A])(using F: Applicative[F]): ResultT[F, A] =
     ResultT(F.pure(result))
 
+extension (self: SourceProfile)
+  def gaiaBands: Set[Band] =
+    Set(Band.Gaia, Band.GaiaBP, Band.GaiaRP)
+
+  // Remove GAIA bands until the ITC supports them.
+  def gaiaFree: SourceProfile =
+    SourceProfile
+      .integratedBrightnesses
+      .modifyOption(_.removedAll(gaiaBands))(self)
+      .orElse(
+        SourceProfile
+          .surfaceBrightnesses
+          .modifyOption(_.removedAll(gaiaBands))(self)
+      )
+      .getOrElse(self)

--- a/modules/service/src/main/scala/lucuma/odb/service/extensions.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/extensions.scala
@@ -25,10 +25,10 @@ class FromResultPartiallyApplied[F[_]]:
   def apply[A](result: Result[A])(using F: Applicative[F]): ResultT[F, A] =
     ResultT(F.pure(result))
 
-extension (self: SourceProfile)
-  def gaiaBands: Set[Band] =
-    Set(Band.Gaia, Band.GaiaBP, Band.GaiaRP)
+private val gaiaBands: Set[Band] =
+  Set(Band.Gaia, Band.GaiaBP, Band.GaiaRP)
 
+extension (self: SourceProfile)
   // Remove GAIA bands until the ITC supports them.
   def gaiaFree: SourceProfile =
     SourceProfile

--- a/modules/service/src/test/scala/lucuma/odb/service/GaiaFreeSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/GaiaFreeSuite.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service
+
+import lucuma.core.enums.Band
+import lucuma.core.model.SourceProfile
+import lucuma.core.model.arb.*
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop.*
+
+class GaiaFreeSuite extends ScalaCheckSuite {
+
+  import ArbSourceProfile.given
+
+  // For now, fail if the band or source profile contains a Gaia band
+  private def containsGaia(
+    sourceProfile: SourceProfile
+  ): Boolean = {
+    val IsGaia = Set[Band](Band.Gaia, Band.GaiaBP, Band.GaiaRP)
+    return
+      SourceProfile
+        .integratedBrightnesses
+        .exist(m => (m.keySet & IsGaia).nonEmpty)(sourceProfile) ||
+      SourceProfile
+        .surfaceBrightnesses
+        .exist(m => (m.keySet & IsGaia).nonEmpty)(sourceProfile)
+  }
+
+  test("gaia free source profile") {
+    forAll { (sp: SourceProfile) =>
+      assert(!containsGaia(sp.gaiaFree))
+    }
+  }
+
+}


### PR DESCRIPTION
This is a requested hack to remove GAIA bands from source profiles until they are supported in the ITC.