### PR TITLE
Test ITC failure during sequence generation

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -166,11 +166,14 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
           Zipper.one(FakeItcResult)
         ).pure[IO]
 
-      override def spectroscopy(input: SpectroscopyIntegrationTimeInput, useCache: Boolean): IO[IntegrationTimeResult] =
-        IntegrationTimeResult(
+      override def spectroscopy(input: SpectroscopyIntegrationTimeInput, useCache: Boolean): IO[IntegrationTimeResult] = {
+        IO.whenA(input.wavelength.some === lucuma.core.math.Wavelength.fromIntNanometers(666)) {
+          IO.raiseError(new RuntimeException("Artifical exception for test cases."))
+        } *> IntegrationTimeResult(
           FakeItcVersions,
           Zipper.one(FakeItcResult)
         ).pure[IO]
+      }
 
       def optimizedSpectroscopyGraph(
         input: lucuma.itc.client.OptimizedSpectroscopyGraphInput,


### PR DESCRIPTION
Adds a somewhat suspect test case.  The goal is confirm that errors generated by calling the ITC get forwarded on to the client.