### PR TITLE
DO NOT MERGE!! Error swallowed in websocket connection

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
@@ -154,10 +154,11 @@ trait ProgramMapping[F[_]]
     }
 
   private val timeChargeHandler: EffectHandler[F] =
-    keyValueEffectHandler[Program.Id, CategorizedTime]("id") { pid =>
-      services.useTransactionally {
-        timeAccountingService.selectProgram(pid)
-      }
+    keyValueEffectHandler[Program.Id, CategorizedTime]("id") { _ =>
+      throw Exception("Catch me if you can!!!")
+      // services.useTransactionally {
+      //   timeAccountingService.selectProgram(pid)
+      // }
     }
 
 }


### PR DESCRIPTION
This adds an intentional exception to the timeCharge effect handler for Programs. 

If you query the timeCharge for a program via the playground, the exception is printed to the ODB log. 

However, if you run explore and try to load any program, the exception is not printed to the log and the connection is repeatedly dropped.