### PR TITLE
Surround `existsUserAccess` with () if has multiple clauses

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/ProgramService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProgramService.scala
@@ -401,7 +401,7 @@ object ProgramService {
           c_program_id = $program_id
         AND
           c_user_id = $user_id
-      """.apply(pid, uid) |+| existsUserAccess(user, pid).foldMap(void"AND (" |+| _ |+| void")")
+      """.apply(pid, uid) |+| existsUserAccess(user, pid).foldMap(void"AND " |+| _)
 
     val UnlinkUnconditionally: Command[(Program.Id, User.Id)] =
       sql"""
@@ -525,7 +525,7 @@ object ProgramService {
     ): Option[AppliedFragment] =
       user.role match {
         case GuestRole             => existsUserAsPi(programId, user.id).some
-        case Pi(_)                 => (existsUserAsPi(programId, user.id) |+| void" OR " |+| existsUserAsCoi(programId, user.id)).some
+        case Pi(_)                 => (void"(" |+| existsUserAsPi(programId, user.id) |+| void" OR " |+| existsUserAsCoi(programId, user.id) |+| void")").some
         case Ngo(_, partner)       => existsAllocationForPartner(programId, Tag(partner.tag)).some
         case ServiceRole(_) |
              StandardRole.Admin(_) |


### PR DESCRIPTION
When the user is a PI, `existsUserAccess` returns a query with an `OR`. When the user is a COI, this led to some problems, such as this query:
<img width="989" alt="image" src="https://github.com/gemini-hlsw/lucuma-odb/assets/6035943/143ff5aa-0ed5-4d61-80fb-7079b2fb00aa">

One query in the code was smart enough to surround the the return value in parens, but others weren't. Rather than requiring all call sites to know enough to use parens, it seemed better to give that responsibility to `existsUserAccess`.