### PR TITLE
CFP Titles

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -363,6 +363,9 @@ type CallForProposals {
   """
   id: CallForProposalsId!
 
+  "The title of this Call for Proposals."
+  title: NonEmptyString!
+
   """
   Describes which type of proposals are being accepted.
   """

--- a/modules/service/src/main/resources/db/migration/V0867__cfp_titles.sql
+++ b/modules/service/src/main/resources/db/migration/V0867__cfp_titles.sql
@@ -4,32 +4,35 @@
 CREATE FUNCTION format_cfp_title(
   cfp_type e_cfp_type,
   semester d_semester,
-  active   tsrange
+  active   tsrange,
+  instruments d_tag[]
 ) RETURNS text AS $$
+DECLARE
+  instrument_list text;
 BEGIN
+  instrument_list := array_to_string(instruments, ', ');
   RETURN CASE
-    WHEN cfp_type = 'demo_science'        THEN concat(semester, ' ', 'Demo Science')
-    WHEN cfp_type = 'directors_time'      THEN concat(semester, ' ', 'Director''s Time')
+    WHEN cfp_type = 'demo_science'        THEN concat(semester, ' Demo Science')
+    WHEN cfp_type = 'directors_time'      THEN concat(semester, ' Director''s Time')
     WHEN cfp_type = 'fast_turnaround'     THEN
       concat(
-        left(semester, length(semester) - 1),
+        left(semester, -1),
         ' ',
         to_char(lower(active) + (upper(active) - lower(active))/2, 'FMMonth'),
-        ' Fast Turnaround'
+        ' ',
+        'Fast Turnaround'
       )
-    WHEN cfp_type = 'large_program'       THEN concat(semester, ' ', 'Large Program')
-    WHEN cfp_type = 'poor_weather'        THEN concat(semester, ' ', 'Poor Weather')
-    WHEN cfp_type = 'regular_semester'    THEN concat(semester, ' ', 'Regular Semester')
-    WHEN cfp_type = 'system_verification' THEN concat(semester, ' ', 'System Verification')
-    ELSE concat(semester, ' ', 'Unknown Call Type: ', cfp_type)
-  END;
+    WHEN cfp_type = 'large_program'       THEN concat(semester, ' Large Program')
+    WHEN cfp_type = 'poor_weather'        THEN concat(semester, ' Poor Weather')
+    WHEN cfp_type = 'regular_semester'    THEN concat(semester, ' Regular Semester')
+    WHEN cfp_type = 'system_verification' THEN
+          concat(semester, nullif(' ' || instrument_list, ' '), ' System Verification')
+    ELSE concat(semester, ' ', cfp_type)
+  END CASE;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-ALTER TABLE t_cfp
-  ADD COLUMN c_title text GENERATED ALWAYS AS (format_cfp_title(c_type, c_semester, c_active)) STORED;
-
--- Recreate the view to pick up the title column.
+-- Recreate the view to add a title column.
 DROP VIEW v_cfp;
 
 CREATE VIEW v_cfp AS
@@ -39,15 +42,18 @@ CREATE VIEW v_cfp AS
     CASE WHEN c.c_ra_end    IS NOT NULL THEN c.c_cfp_id END AS c_ra_end_id,
     CASE WHEN c.c_dec_start IS NOT NULL THEN c.c_cfp_id END AS c_dec_start_id,
     CASE WHEN c.c_dec_end   IS NOT NULL THEN c.c_cfp_id END AS c_dec_end_id,
-    array_remove(array_agg(i.c_instrument ORDER BY i.c_instrument), NULL) AS c_instruments,
+    array_remove(array_agg(ci.c_instrument ORDER BY ci.c_instrument), NULL) AS c_instruments,
     (SELECT COUNT(*)
       FROM t_cfp_partner
      WHERE t_cfp_partner.c_cfp_id = c.c_cfp_id
        AND t_cfp_partner.c_deadline > CURRENT_TIMESTAMP
-    ) > 0 AS c_is_open
+    ) > 0 AS c_is_open,
+    format_cfp_title(c.c_type, c.c_semester, c.c_active, array_remove(array_agg(i.c_long_name ORDER BY i.c_long_name), NULL)) AS c_title
   FROM
     t_cfp c
   LEFT JOIN
-    t_cfp_instrument i ON c.c_cfp_id = i.c_cfp_id
+    t_cfp_instrument ci ON c.c_cfp_id = ci.c_cfp_id
+  LEFT JOIN
+    t_instrument i ON i.c_tag = ci.c_instrument
   GROUP BY
     c.c_cfp_id;

--- a/modules/service/src/main/resources/db/migration/V0867__cfp_titles.sql
+++ b/modules/service/src/main/resources/db/migration/V0867__cfp_titles.sql
@@ -1,0 +1,53 @@
+-- Format the title of the CFP.
+-- * Nothing prevents two or more CFPs from ending up with the same title.
+-- * FT calls use the month of the midpoint of the active period
+CREATE FUNCTION format_cfp_title(
+  cfp_type e_cfp_type,
+  semester d_semester,
+  active   tsrange
+) RETURNS text AS $$
+BEGIN
+  RETURN CASE
+    WHEN cfp_type = 'demo_science'        THEN concat(semester, ' ', 'Demo Science')
+    WHEN cfp_type = 'directors_time'      THEN concat(semester, ' ', 'Director''s Time')
+    WHEN cfp_type = 'fast_turnaround'     THEN
+      concat(
+        left(semester, length(semester) - 1),
+        ' ',
+        to_char(lower(active) + (upper(active) - lower(active))/2, 'FMMonth'),
+        ' Fast Turnaround'
+      )
+    WHEN cfp_type = 'large_program'       THEN concat(semester, ' ', 'Large Program')
+    WHEN cfp_type = 'poor_weather'        THEN concat(semester, ' ', 'Poor Weather')
+    WHEN cfp_type = 'regular_semester'    THEN concat(semester, ' ', 'Regular Semester')
+    WHEN cfp_type = 'system_verification' THEN concat(semester, ' ', 'System Verification')
+    ELSE concat(semester, ' ', 'Unknown Call Type: ', cfp_type)
+  END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+ALTER TABLE t_cfp
+  ADD COLUMN c_title text GENERATED ALWAYS AS (format_cfp_title(c_type, c_semester, c_active)) STORED;
+
+-- Recreate the view to pick up the title column.
+DROP VIEW v_cfp;
+
+CREATE VIEW v_cfp AS
+  SELECT
+    c.*,
+    CASE WHEN c.c_ra_start  IS NOT NULL THEN c.c_cfp_id END AS c_ra_start_id,
+    CASE WHEN c.c_ra_end    IS NOT NULL THEN c.c_cfp_id END AS c_ra_end_id,
+    CASE WHEN c.c_dec_start IS NOT NULL THEN c.c_cfp_id END AS c_dec_start_id,
+    CASE WHEN c.c_dec_end   IS NOT NULL THEN c.c_cfp_id END AS c_dec_end_id,
+    array_remove(array_agg(i.c_instrument ORDER BY i.c_instrument), NULL) AS c_instruments,
+    (SELECT COUNT(*)
+      FROM t_cfp_partner
+     WHERE t_cfp_partner.c_cfp_id = c.c_cfp_id
+       AND t_cfp_partner.c_deadline > CURRENT_TIMESTAMP
+    ) > 0 AS c_is_open
+  FROM
+    t_cfp c
+  LEFT JOIN
+    t_cfp_instrument i ON c.c_cfp_id = i.c_cfp_id
+  GROUP BY
+    c.c_cfp_id;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CallForProposalsMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CallForProposalsMapping.scala
@@ -30,6 +30,7 @@ trait CallForProposalsMapping[F[_]] extends CallForProposalsView[F] {
       tpe = CallForProposalsType,
       fieldMappings = List(
         SqlField("id",       CallForProposalsView.Id, key = true),
+        SqlField("title",    CallForProposalsView.Title),
         SqlField("type",     CallForProposalsView.Type),
         SqlField("semester", CallForProposalsView.Semester),
         SqlObject("raLimitStart"),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/CallForProposalsView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/CallForProposalsView.scala
@@ -14,6 +14,7 @@ import lucuma.odb.util.Codecs.instrument
 import lucuma.odb.util.Codecs.right_ascension
 import lucuma.odb.util.Codecs.semester
 import lucuma.odb.util.Codecs.tag
+import lucuma.odb.util.Codecs.text_nonempty
 import lucuma.odb.util.Codecs.timestamp_interval_tsrange
 import skunk.codec.boolean.bool
 
@@ -21,6 +22,7 @@ trait CallForProposalsView[F[_]] extends BaseMapping[F] {
 
   object CallForProposalsView extends TableDef("v_cfp") {
     val Id       = col("c_cfp_id",     cfp_id)
+    val Title    = col("c_title",      text_nonempty)
     val Type     = col("c_type",       cfp_type)
     val Semester = col("c_semester",   semester)
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/callForProposals.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/callForProposals.scala
@@ -10,6 +10,8 @@ import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.model.CallForProposals
+import lucuma.core.syntax.string.*
+import lucuma.odb.data.CallForProposalsType
 
 class callForProposals extends OdbSuite {
 
@@ -84,6 +86,93 @@ class callForProposals extends OdbSuite {
         """.asRight
       )
     }
+  }
+
+  private def getTitle(
+    cfpType: CallForProposalsType
+  ): IO[String] =
+    query(
+      user = staff,
+      query = s"""
+        mutation {
+          createCallForProposals(
+            input: {
+              SET: {
+                type:        ${cfpType.tag.toScreamingSnakeCase}
+                semester:    "2025A"
+                activeStart: "2025-02-01 14:00:00"
+                activeEnd:   "2025-07-31 14:00:00"
+              }
+            }
+          ) {
+            callForProposals {
+              title
+            }
+          }
+        }
+      """
+    ).flatMap {
+      _.hcursor
+       .downFields("createCallForProposals", "callForProposals", "title")
+       .as[String]
+       .leftMap(f => new RuntimeException(f.message))
+       .liftTo[IO]
+    }
+
+  test("demo science") {
+    assertIO(getTitle(CallForProposalsType.DemoScience), "2025A Demo Science")
+  }
+
+  test("director's time") {
+    assertIO(getTitle(CallForProposalsType.DirectorsTime), "2025A Director's Time")
+  }
+
+  test("large program") {
+    assertIO(getTitle(CallForProposalsType.LargeProgram), "2025A Large Program")
+  }
+
+  test("poor weather") {
+    assertIO(getTitle(CallForProposalsType.PoorWeather), "2025A Poor Weather")
+  }
+
+  test("regular semester") {
+    assertIO(getTitle(CallForProposalsType.RegularSemester), "2025A Regular Semester")
+  }
+
+  test("system verification") {
+    assertIO(getTitle(CallForProposalsType.SystemVerification), "2025A System Verification")
+  }
+
+  test("fast turnaround") {
+    val title = query(
+      user = staff,
+      query = s"""
+        mutation {
+          createCallForProposals(
+            input: {
+              SET: {
+                type:        FAST_TURNAROUND
+                semester:    "2025A"
+                activeStart: "2025-08-01 14:00:00"
+                activeEnd:   "2025-08-31 14:00:00"
+              }
+            }
+          ) {
+            callForProposals {
+              title
+            }
+          }
+        }
+      """
+    ).flatMap {
+      _.hcursor
+       .downFields("createCallForProposals", "callForProposals", "title")
+       .as[String]
+       .leftMap(f => new RuntimeException(f.message))
+       .liftTo[IO]
+    }
+
+    assertIO(title, "2025 August Fast Turnaround")
   }
 
 }


### PR DESCRIPTION
Adds a Call for Proposals title to the CFP table and view.  This is kept in a generated column which is based solely on other fields of the call.

This is an opening bid for how the titles should be formatted.  I'll ask @andrewwstephens for input.  I suspect SV might need the instrument(s) or something.