### PR TITLE
Add atom id to migration

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0866__atom_event2.sql
+++ b/modules/service/src/main/resources/db/migration/V0866__atom_event2.sql
@@ -1,4 +1,10 @@
 
+-- Add the atom id to step and dataset events.
+UPDATE t_execution_event AS e
+   SET c_atom_id = s.c_atom_id
+  FROM t_step_record AS s
+ WHERE e.c_step_id = s.c_step_id AND e.c_atom_id IS NULL;
+
 -- Update the event type constraint
 ALTER TABLE t_execution_event
   ADD CONSTRAINT check_event_type_conditions CHECK (


### PR DESCRIPTION
Amends a migration that introduces a constraint check which fails otherwise.  It will need to be muscled past CI since it changes an existing migration, albeit a failing one.