### PR TITLE
Proposed schema updates

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -3202,6 +3202,32 @@ interface CallProperties {
 }
 
 """
+Proposal properties for Regular Semester (Classical) CallForProposals.
+"""
+type CallPropertiesClassical implements CallProperties {
+
+  "The corresponding CallForProposals definition itself."
+  call: CallForProposals!
+
+  """
+  Minimum percentage of observing time (first semester) required to consider this
+  proposal successful.
+  """
+  minPercentTime: IntPercent!
+
+  """
+  Describes how time for the program will be apportioned across partners.
+  """
+  partnerSplits: [PartnerSplit!]!
+
+  # TODO: AEON / Multi-facility
+  # TODO: JWST Synergy
+  # TODO: US Long Term
+  # TODO: Visitors?
+
+}
+
+"""
 Proposal properties for Demo Science CallForProposals.
 """
 type CallPropertiesDemoScience implements CallProperties {
@@ -3320,35 +3346,9 @@ type CallPropertiesPoorWeather implements CallProperties {
 }
 
 """
-Proposal properties for Regular Semester (Classical) CallForProposals.
-"""
-type CallPropertiesRegularClassical implements CallProperties {
-
-  "The corresponding CallForProposals definition itself."
-  call: CallForProposals!
-
-  """
-  Minimum percentage of observing time (first semester) required to consider this
-  proposal successful.
-  """
-  minPercentTime: IntPercent!
-
-  """
-  Describes how time for the program will be apportioned across partners.
-  """
-  partnerSplits: [PartnerSplit!]!
-
-  # TODO: AEON / Multi-facility
-  # TODO: JWST Synergy
-  # TODO: US Long Term
-  # TODO: Visitors?
-
-}
-
-"""
 Proposal properties for Regular Semester (Queue) CallForProposals.
 """
-type CallPropertiesRegularQueue implements CallProperties {
+type CallPropertiesQueue implements CallProperties {
 
   "The corresponding CallForProposals definition itself."
   call: CallForProposals!
@@ -3411,6 +3411,8 @@ input CallPropertiesInput {
   """
   callId: CallForProposalsId
 
+  classical: CallPropertiesClassicalInput
+
   demoScience: CallPropertiesDemoScienceInput
 
   directorsTime: CallPropertiesDirectorsTimeInput
@@ -3421,11 +3423,30 @@ input CallPropertiesInput {
 
   poorWeather: CallPropertiesPoorWeatherInput
 
-  regularClassical: CallPropertiesRegularClassicalInput
-
-  regularQueue: CallPropertiesRegularQueueInput
+  queue: CallPropertiesQueueInput
 
   systemVerification: CallPropertiesSystemVerificationInput
+
+}
+
+input CallPropertiesClassicalInput {
+
+  """
+  The minPercentTime field is required when creating a new instance, but
+  optional when editing.
+  """
+  minPercentTime: IntPercent
+
+  """
+  The partnerSplits field is required when creating a new instance of proposal,
+  but optional when editing. When specified, must sum to 100%.
+  """
+  partnerSplits: [PartnerSplitInput!]
+
+  # TODO: AEON / Multi-facility
+  # TODO: JWST Synergy
+  # TODO: US Long Term
+  # TODO: Visitors?
 
 }
 
@@ -3518,28 +3539,7 @@ input CallPropertiesLargeProgramInput {
 input CallPropertiesPoorWeatherInput {
 }
 
-input CallPropertiesRegularClassicalInput {
-
-  """
-  The minPercentTime field is required when creating a new instance, but
-  optional when editing.
-  """
-  minPercentTime: IntPercent
-
-  """
-  The partnerSplits field is required when creating a new instance of proposal,
-  but optional when editing. When specified, must sum to 100%.
-  """
-  partnerSplits: [PartnerSplitInput!]
-
-  # TODO: AEON / Multi-facility
-  # TODO: JWST Synergy
-  # TODO: US Long Term
-  # TODO: Visitors?
-
-}
-
-input CallPropertiesRegularQueueInput {
+input CallPropertiesQueueInput {
 
   """
   The minPercentTime field is required when creating a new instance, but

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -575,16 +575,6 @@ type CategorizedTimeRange {
 }
 
 """
-Classical observing at Gemini
-"""
-input ClassicalInput {
-  """
-  The minPercentTime field is required when creating a new instance of classical, but optional when editing
-  """
-  minPercentTime: IntPercent
-}
-
-"""
 Describes an observation clone operation, making any edits in the `SET`
 parameter.  The observation status in the cloned observation defaults to NEW.
 Identify the observation to clone by specifying either its id or reference.  If
@@ -855,26 +845,6 @@ input DeclinationInput {
 }
 
 """
-Demo science
-"""
-input DemoScienceInput {
-  """
-  The minPercentTime field is required when creating a new instance of demoScience, but optional when editing
-  """
-  minPercentTime: IntPercent
-}
-
-"""
-Director's time
-"""
-input DirectorsTimeInput {
-  """
-  The minPercentTime field is required when creating a new instance of directorsTime, but optional when editing
-  """
-  minPercentTime: IntPercent
-}
-
-"""
 Add or delete targets in an asterism
 """
 input EditAsterismsPatchInput {
@@ -1015,16 +985,6 @@ input EmissionLinesSurfaceInput {
   fluxDensityContinuum: FluxDensityContinuumSurfaceInput
 }
 
-"""
-Exchange observing at Keck/Subaru
-"""
-input ExchangeInput {
-  """
-  The minPercentTime field is required when creating a new instance of exchange, but optional when editing
-  """
-  minPercentTime: IntPercent
-}
-
 "Execution event types."
 enum ExecutionEventType {
   "Sequence-level event type."
@@ -1056,16 +1016,6 @@ input ExposureTimeModeInput {
   The fixedExposure field must be either specified or skipped altogether.  It cannot be unset with a null value.
   """
   fixedExposure: FixedExposureModeInput
-}
-
-"""
-Fast turnaround observing at Gemini
-"""
-input FastTurnaroundInput {
-  """
-  The minPercentTime field is required when creating a new instance of fastTurnaround, but optional when editing
-  """
-  minPercentTime: IntPercent
 }
 
 """
@@ -2444,46 +2394,6 @@ input HourAngleRangeInput {
 }
 
 """
-Intensive program observing at Subaru
-"""
-input IntensiveInput {
-  """
-  The minPercentTime field is required when creating a new instance of intensive, but optional when editing
-  """
-  minPercentTime: IntPercent
-
-  """
-  The minPercentTotalTime field is required when creating a new instance of intensive, but optional when editing
-  """
-  minPercentTotalTime: IntPercent
-
-  """
-  The totalTime field is required when creating a new instance of intensive, but optional when editing
-  """
-  totalTime: TimeSpanInput
-}
-
-"""
-Large program observing at Gemini
-"""
-input LargeProgramInput {
-  """
-  The minPercentTime field is required when creating a new instance of largeProgram, but optional when editing
-  """
-  minPercentTime: IntPercent
-
-  """
-  The minPercentTotalTime field is required when creating a new instance of largeProgram, but optional when editing
-  """
-  minPercentTotalTime: IntPercent
-
-  """
-  The totalTime field is required when creating a new instance of largeProgram, but optional when editing
-  """
-  totalTime: TimeSpanInput
-}
-
-"""
 A line flux value with integrated units
 """
 input LineFluxIntegratedInput {
@@ -2763,6 +2673,9 @@ type Mutation {
     input: CloneTargetInput!
   ): CloneTargetResult!
 
+  """
+  Creates a Call for Proposals.  Requires staff access.
+  """
   createCallForProposals(
     input: CreateCallForProposalsInput!
   ): CreateCallForProposalsResult!
@@ -3173,16 +3086,6 @@ input PartnerSplitInput {
 }
 
 """
-Poor weather
-"""
-input PoorWeatherInput {
-  """
-  The minPercentTime field is required when creating a new instance of poorWeather, but optional when editing
-  """
-  minPercentTime: IntPercent
-}
-
-"""
 Create or edit position angle constraint.  If not specified, then the
 position angle required to reach the best guide star option will be used.
 
@@ -3288,73 +3191,406 @@ input ProperMotionInput {
 }
 
 """
-Proposal class. Choose exactly one class type
+Proposal properties that depend on the particular call for proposals associated
+with this proposal.
 """
-input ProposalClassInput {
-  """
-  Classical observing at Gemini
-  """
-  classical: ClassicalInput
+interface CallProperties {
+
+  "The corresponding CallForProposals definition itself."
+  call: CallForProposals!
+
+}
+
+"""
+Proposal properties for Demo Science CallForProposals.
+"""
+type CallPropertiesDemoScience implements CallProperties {
+
+  "The corresponding CallForProposals definition itself."
+  call: CallForProposals!
 
   """
-  Demo science
+  Whether (and how) the observations in this proposal are available for Target
+  of Opportunity triggering.
   """
-  demoScience: DemoScienceInput
+  toOActivation: ToOActivation!
 
   """
-  Director's time
+  Minimum percentage of observing time required to consider this proposal
+  successful.
   """
-  directorsTime: DirectorsTimeInput
+  minPercentTime: IntPercent!
+
+}
+
+"""
+Proposal properties for Director's Time CallForProposals.
+"""
+type CallPropertiesDirectorsTime implements CallProperties {
+
+  "The corresponding CallForProposals definition itself."
+  call: CallForProposals!
 
   """
-  Exchange observing at Keck/Subaru
+  Whether (and how) the observations in this proposal are available for Target
+  of Opportunity triggering.
   """
-  exchange: ExchangeInput
+  toOActivation: ToOActivation!
 
   """
-  Fast turnaround observing at Gemini
+  Minimum percentage of observing time required to consider this proposal
+  successful.
   """
-  fastTurnaround: FastTurnaroundInput
+  minPercentTime: IntPercent!
+
+}
+
+"""
+Proposal properties for Fast Turnaround CallForProposals.
+"""
+type CallPropertiesFastTurnaround implements CallProperties {
+
+  "The corresponding CallForProposals definition itself."
+  call: CallForProposals!
 
   """
-  Poor weather
+  Whether (and how) the observations in this proposal are available for Target
+  of Opportunity triggering.
   """
-  poorWeather: PoorWeatherInput
+  toOActivation: ToOActivation!
 
   """
-  Queue observing at Gemini
+  Minimum percentage of observing time required to consider this proposal
+  successful.
   """
-  queue: QueueInput
+  minPercentTime: IntPercent!
 
   """
-  System verification
+  Partner associated with this FT proposal.
   """
-  systemVerification: SystemVerificationInput
+  piAffiliation: Partner!
+
+  # TODO: Reviewer?
+}
+
+"""
+Proposal properties for Large Program CallForProposals.
+"""
+type CallPropertiesLargeProgram implements CallProperties {
+
+  "The corresponding CallForProposals definition itself."
+  call: CallForProposals!
 
   """
-  Large program observing at Gemini
+  Whether (and how) the observations in this proposal are available for Target
+  of Opportunity triggering.
   """
-  largeProgram: LargeProgramInput
+  toOActivation: ToOActivation!
 
   """
-  Intensive program observing at Subaru
+  Minimum percentage of observing time (first semester) required to consider this
+  proposal successful.
   """
-  intensive: IntensiveInput
+  minPercentTime: IntPercent!
+
+  """
+  Minimum percentage of the total observing time (over all semesters) required
+  to consider this proposal successful.
+  """
+  minPercentTotalTime: IntPercent!
+
+  """
+  Total time requested (over multiple all semesters) for this proposal.
+  """
+  totalTime: TimeSpan!
+
+  # TODO: AEON / Multi-facility
+  # TODO: JWST Synergy
+
+}
+
+"""
+Proposal properties for Regular Semester (Poor Weather) CallForProposals.
+"""
+type CallPropertiesPoorWeather implements CallProperties {
+
+  "The corresponding CallForProposals definition itself."
+  call: CallForProposals!
+
+}
+
+"""
+Proposal properties for Regular Semester (Classical) CallForProposals.
+"""
+type CallPropertiesRegularClassical implements CallProperties {
+
+  "The corresponding CallForProposals definition itself."
+  call: CallForProposals!
+
+  """
+  Minimum percentage of observing time (first semester) required to consider this
+  proposal successful.
+  """
+  minPercentTime: IntPercent!
+
+  """
+  Describes how time for the program will be apportioned across partners.
+  """
+  partnerSplits: [PartnerSplit!]!
+
+  # TODO: AEON / Multi-facility
+  # TODO: JWST Synergy
+  # TODO: US Long Term
+  # TODO: Visitors?
+
+}
+
+"""
+Proposal properties for Regular Semester (Queue) CallForProposals.
+"""
+type CallPropertiesRegularQueue implements CallProperties {
+
+  "The corresponding CallForProposals definition itself."
+  call: CallForProposals!
+
+  """
+  Minimum percentage of observing time (first semester) required to consider this
+  proposal successful.
+  """
+  minPercentTime: IntPercent!
+
+  """
+  Whether (and how) the observations in this proposal are available for Target
+  of Opportunity triggering.
+  """
+  toOActivation: ToOActivation!
+
+  """
+  Describes how time for the program will be apportioned across partners.
+  """
+  partnerSplits: [PartnerSplit!]!
+
+  # TODO: Band 3 ?
+  # TODO: AEON / Multi-facility
+  # TODO: JWST Synergy
+  # TODO: US Long Term
+
+}
+
+"""
+Proposal properties for System Verification CallForProposals.
+"""
+type CallPropertiesSystemVerification implements CallProperties {
+
+  "The corresponding CallForProposals definition itself."
+  call: CallForProposals!
+
+  """
+  Whether (and how) the observations in this proposal are available for Target
+  of Opportunity triggering.
+  """
+  toOActivation: ToOActivation!
+
+  """
+  Minimum percentage of observing time required to consider this proposal
+  successful.
+  """
+  minPercentTime: IntPercent!
+
+}
+
+input CallPropertiesInput {
+
+  """
+  Sets the associated Call for Proposals.  This is required when creating a new
+  instance, but optional when editing.  Upon creation, additional properties
+  must be set, depending on the call type.  For example, for a REGULAR_SEMESTER
+  request for queue time, specify 'regularQueue' and leave 'demoScience',
+  etc. unset.  If the call properties do not match the call type upon
+  submission, the creation or update will terminate in an error.
+  """
+  callId: CallForProposalsId
+
+  demoScience: CallPropertiesDemoScienceInput
+
+  directorsTime: CallPropertiesDirectorsTimeInput
+
+  fastTurnaround: CallPropertiesFastTurnaroundInput
+
+  largeProgram: CallPropertiesLargeProgramInput
+
+  poorWeather: CallPropertiesPoorWeatherInput
+
+  regularClassical: CallPropertiesRegularClassicalInput
+
+  regularQueue: CallPropertiesRegularQueueInput
+
+  systemVerification: CallPropertiesSystemVerificationInput
+
+}
+
+input CallPropertiesDemoScienceInput {
+
+  """
+  The toOActivation field is optional. If not specified when creating a
+  proposal, it defaults to `NONE'.
+  """
+  toOActivation: ToOActivation
+
+  """
+  The minPercentTime field is required when creating a new instance, but
+  optional when editing.
+  """
+  minPercentTime: IntPercent
+
+}
+
+input CallPropertiesDirectorsTimeInput {
+
+  """
+  The toOActivation field is optional. If not specified when creating a
+  proposal, it defaults to `NONE'.
+  """
+  toOActivation: ToOActivation
+
+  """
+  The minPercentTime field is required when creating a new instance, but
+  optional when editing.
+  """
+  minPercentTime: IntPercent
+
+}
+
+input CallPropertiesFastTurnaroundInput {
+
+  """
+  The toOActivation field is optional. If not specified when creating a
+  proposal, it defaults to `NONE'.
+  """
+  toOActivation: ToOActivation
+
+  """
+  The minPercentTime field is required when creating a new instance, but
+  optional when editing.
+  """
+  minPercentTime: IntPercent
+
+  """
+  Partner associated with this FT proposal.
+  """
+  piAffiliation: Partner
+
+  # TODO: Reviewer?
+
+}
+
+input CallPropertiesLargeProgramInput {
+
+  """
+  The toOActivation field is optional. If not specified when creating a
+  proposal, it defaults to `NONE'.
+  """
+  toOActivation: ToOActivation
+
+  """
+  The minPercentTime field is required when creating a new instance, but
+  optional when editing.
+  """
+  minPercentTime: IntPercent
+
+  """
+  The minPercentTotalTime field is required when creating a new instance of
+  largeProgram, but optional when editing.
+  """
+  minPercentTotalTime: IntPercent
+
+  """
+  The totalTime field is required when creating a new instance of largeProgram,
+  but optional when editing.
+  """
+  totalTime: TimeSpanInput
+
+  # TODO: AEON / Multi-facility
+  # TODO: JWST Synergy
+
+}
+
+input CallPropertiesPoorWeatherInput {
+}
+
+input CallPropertiesRegularClassicalInput {
+
+  """
+  The minPercentTime field is required when creating a new instance, but
+  optional when editing.
+  """
+  minPercentTime: IntPercent
+
+  """
+  The partnerSplits field is required when creating a new instance of proposal,
+  but optional when editing. When specified, must sum to 100%.
+  """
+  partnerSplits: [PartnerSplitInput!]
+
+  # TODO: AEON / Multi-facility
+  # TODO: JWST Synergy
+  # TODO: US Long Term
+  # TODO: Visitors?
+
+}
+
+input CallPropertiesRegularQueueInput {
+
+  """
+  The minPercentTime field is required when creating a new instance, but
+  optional when editing.
+  """
+  minPercentTime: IntPercent
+
+  """
+  The toOActivation field is optional. If not specified when creating a
+  proposal, it defaults to `NONE'.
+  """
+  toOActivation: ToOActivation
+
+  """
+  The partnerSplits field is required when creating a new instance of proposal,
+  but optional when editing When specified, must sum to 100%.
+  """
+  partnerSplits: [PartnerSplitInput!]
+
+  # TODO: Band 3 ?
+  # TODO: AEON / Multi-facility
+  # TODO: JWST Synergy
+  # TODO: US Long Term
+
+}
+
+input CallPropertiesSystemVerificationInput {
+
+  """
+  The toOActivation field is optional. If not specified when creating a
+  proposal, it defaults to `NONE'.
+  """
+  toOActivation: ToOActivation
+
+  """
+  The minPercentTime field is required when creating a new instance, but
+  optional when editing.
+  """
+  minPercentTime: IntPercent
+
 }
 
 """
 Program proposal
 """
 input ProposalPropertiesInput {
+
   """
   The title field may be unset by assigning a null value, or ignored by skipping it altogether
   """
   title: NonEmptyString
-
-  """
-  The proposalClass field is required when creating a new instance of proposal, but optional when editing
-  """
-  proposalClass: ProposalClassInput
 
   """
   The category field may be unset by assigning a null value, or ignored by skipping it altogether
@@ -3362,31 +3598,19 @@ input ProposalPropertiesInput {
   category: TacCategory
 
   """
-  The toOActivation field is optional. If not specified when creating a proposal, it defaults to `NONE'.
-  """
-  toOActivation: ToOActivation
-
-  """
   The abstract field may be unset by assigning a null value, or ignored by skipping it altogether
   """
   abstract: NonEmptyString
 
   """
-  The partnerSplits field is required when creating a new instance of proposal, but optional when editing
-  When specified, must sum to 100%
+  Specifies the Call for Proposals for which time is requested, and associated
+  properties that depend on the call type.  This is required on proposal
+  creation, but optional on editing.
   """
-  partnerSplits: [PartnerSplitInput!]
+  callProperties: CallPropertiesInput
+
 }
 
-"""
-Queue observing at Gemini
-"""
-input QueueInput {
-  """
-  The minPercentTime field is required when creating a new instance of queue, but optional when editing
-  """
-  minPercentTime: IntPercent
-}
 
 """
 Radial velocity, choose one of the available units
@@ -5040,16 +5264,6 @@ enum ChargeClass {
 }
 
 """
-Classical observing at Gemini
-"""
-type Classical implements ProposalClass {
-  """
-  Minimum percent of requested observation time that is required
-  """
-  minPercentTime: IntPercent!
-}
-
-"""
 Cloud extinction
 """
 enum CloudExtinction {
@@ -5445,26 +5659,6 @@ type Declination {
 }
 
 """
-Demo science
-"""
-type DemoScience implements ProposalClass {
-  """
-  Minimum percent of requested observation time that is required
-  """
-  minPercentTime: IntPercent!
-}
-
-"""
-Director's time
-"""
-type DirectorsTime implements ProposalClass {
-  """
-  Minimum percent of requested observation time that is required
-  """
-  minPercentTime: IntPercent!
-}
-
-"""
 Target declination coordinate in format '[+/-]DD:MM:SS.sss'
 """
 scalar DmsString
@@ -5548,16 +5742,6 @@ enum EphemerisKeyType {
 Reference observation epoch in format '[JB]YYYY.YYY'
 """
 scalar EpochString
-
-"""
-Exchange observing at Keck/Subaru
-"""
-type Exchange implements ProposalClass {
-  """
-  Minimum percent of requested observation time that is required
-  """
-  minPercentTime: IntPercent!
-}
 
 type Execution {
 
@@ -5735,16 +5919,6 @@ type ExposureTimeMode {
   Fixed exposure time mode data, if applicable
   """
   fixedExposure: FixedExposureMode
-}
-
-"""
-Fast turnaround observing at Gemini
-"""
-type FastTurnaround implements ProposalClass {
-  """
-  Minimum percent of requested observation time that is required
-  """
-  minPercentTime: IntPercent!
 }
 
 """
@@ -7330,26 +7504,6 @@ An 'Int` in the range 0 to 100
 scalar IntPercent
 
 """
-Intensive program observing at Subaru
-"""
-type Intensive implements ProposalClass {
-  """
-  Minimum percent of time requested for this semester that is required
-  """
-  minPercentTime: IntPercent!
-
-  """
-  Minimum percent of total program time that is required
-  """
-  minPercentTotalTime: IntPercent!
-
-  """
-  Estimated total program time
-  """
-  totalTime: TimeSpan!
-}
-
-"""
 Contains the result of calling the ITC for a particular observation.  Since
 the observation may contain multiple targets, there may be multiple results.
 The "result" field contains the selected, representative, result for all
@@ -7372,27 +7526,6 @@ type ItcResult {
   exposureTime:  TimeSpan!
   exposures:     NonNegInt!
   signalToNoise: SignalToNoise!
-}
-
-
-"""
-Large program observing at Gemini
-"""
-type LargeProgram implements ProposalClass {
-  """
-  Minimum percent of time requested for this semester that is required
-  """
-  minPercentTime: IntPercent!
-
-  """
-  Minimum percent of total program time that is required
-  """
-  minPercentTotalTime: IntPercent!
-
-  """
-  Estimated total program time
-  """
-  totalTime: TimeSpan!
 }
 
 type LineFluxIntegrated {
@@ -7895,16 +8028,6 @@ enum PlanetaryNebulaSpectrum {
 }
 
 """
-Poor Weather
-"""
-type PoorWeather implements ProposalClass {
-  """
-  Minimum percent of requested observation time that is required
-  """
-  minPercentTime: IntPercent!
-}
-
-"""
 Constraints (if any) on the observation's position angle.
 """
 type PosAngleConstraint {
@@ -8215,19 +8338,10 @@ Metadata for `enum ProposalAttachmentType`
 type ProposalAttachmentTypeMeta {
   tag:        ProposalAttachmentType!
   shortName:  String!
-  longName:       String!
+  longName:   String!
 }
 
 type Proposal {
-  """
-  Proposal title
-  """
-  title: NonEmptyString
-
-  """
-  Proposal class
-  """
-  proposalClass: ProposalClass!
 
   """
   The proposal reference, assuming the proposal has been submitted and
@@ -8236,14 +8350,14 @@ type Proposal {
   reference: ProposalReference
 
   """
+  Proposal title
+  """
+  title: NonEmptyString
+
+  """
   Proposal TAC category
   """
   category: TacCategory
-
-  """
-  Target of Opportunity activation
-  """
-  toOActivation: ToOActivation!
 
   """
   Abstract
@@ -8251,74 +8365,10 @@ type Proposal {
   abstract: NonEmptyString
 
   """
-  Partner time allocations
+  Properties of this proposal that are dependent upon the Call for Proposals
+  type.
   """
-  partnerSplits: [PartnerSplit!]!
-}
-
-"""
-Proposal Class interface
-"""
-interface ProposalClass {
-  """
-  Minimum percent of requested observation time that is required
-  """
-  minPercentTime: IntPercent!
-}
-
-"""
-Proposal class type
-"""
-enum ProposalClassEnum {
-  """
-  ProposalClassEnum Classical
-  """
-  CLASSICAL
-
-  """
-  ProposalClassEnum DemoScience
-  """
-  DEMO_SCIENCE
-
-  """
-  ProposalClassEnum DirectorsTime
-  """
-  DIRECTORS_TIME
-
-  """
-  ProposalClassEnum Exchange
-  """
-  EXCHANGE
-
-  """
-  ProposalClassEnum FastTurnaround
-  """
-  FAST_TURNAROUND
-
-  """
-  ProposalClassEnum Intensive
-  """
-  INTENSIVE
-
-  """
-  ProposalClassEnum LargeProgram
-  """
-  LARGE_PROGRAM
-
-  """
-  ProposalClassEnum PoorWeather
-  """
-  POOR_WEATHER
-
-  """
-  ProposalClassEnum Queue
-  """
-  QUEUE
-
-  """
-  ProposalClassEnum SystemVerification
-  """
-  SYSTEM_VERIFICATION
+  callProperties: CallProperties!
 }
 
 type ProposalReference {
@@ -8755,16 +8805,6 @@ type Query {
     includeDeleted: Boolean! = false
   ): TargetSelectResult!
 
-}
-
-"""
-Queue observing at Gemini
-"""
-type Queue implements ProposalClass {
-  """
-  Minimum percent of requested observation time that is required
-  """
-  minPercentTime: IntPercent!
 }
 
 type RadialVelocity {
@@ -9900,16 +9940,6 @@ type StepRecordSelectResult {
   "`true` when there were additional matches that were not returned."
   hasMore: Boolean!
 
-}
-
-"""
-System Verification
-"""
-type SystemVerification implements ProposalClass {
-  """
-  Minimum percent of requested observation time that is required
-  """
-  minPercentTime: IntPercent!
 }
 
 """
@@ -11080,37 +11110,8 @@ input WhereEqProgramType {
 }
 
 """
-Filters on equality (or not) of the property value and the supplied criteria.
-All supplied criteria must match, but usually only one is selected.  E.g.
-'EQ = "Foo"' will match when the property value is "FOO".
-
-"""
-input WhereEqProposalClassType {
-  """
-  Matches if the property is exactly the supplied value.
-  """
-  EQ: ProposalClassEnum
-
-  """
-  Matches if the property is not the supplied value.
-  """
-  NEQ: ProposalClassEnum
-
-  """
-  Matches if the property value is any of the supplied options.
-  """
-  IN: [ProposalClassEnum!]
-
-  """
-  Matches if the property value is none of the supplied values.
-  """
-  NIN: [ProposalClassEnum!]
-}
-
-"""
 Filters on equality of the property.  All supplied
 criteria must match, but usually only one is selected.  E.g., 'EQ: "SUBMITTED'
-
 """
 input WhereEqProposalStatus {
   """
@@ -12720,11 +12721,6 @@ input WhereProposal {
   reference: WhereProposalReference
 
 #  """
-#  Matches the proposal class.
-#  """
-#  class: WhereProposalClass
-#
-#  """
 #  Matches the proposal TAC category.
 #  """
 #  category: WhereOptionEqTacCategory
@@ -12743,21 +12739,6 @@ input WhereProposal {
 #  Matches proposal partners.
 #  """
 #  partners: WhereProposalPartners
-}
-
-"""
-Proposal class filter options.
-"""
-input WhereProposalClass {
-  """
-  Proposal class type match.
-  """
-  type: WhereEqProposalClassType
-
-  """
-  Minimum acceptable percentage match.
-  """
-  minPercent: WhereOrderInt
 }
 
 """

--- a/modules/service/src/main/resources/db/migration/V0871__cfp_proposal.sql
+++ b/modules/service/src/main/resources/db/migration/V0871__cfp_proposal.sql
@@ -1,0 +1,28 @@
+DELETE FROM t_proposal
+  WHERE c_class = 'intensive' OR
+        c_class = 'exchange';
+
+ALTER TABLE t_proposal
+  DROP CONSTRAINT t_proposal_check_min_total,
+  DROP CONSTRAINT t_proposal_check_total;
+
+DELETE FROM t_proposal_class
+  WHERE c_tag = 'intensive' OR
+        c_tag = 'exchange';
+
+DROP TRIGGER update_science_subtype_trigger ON t_proposal;
+
+DROP FUNCTION update_science_subtype;
+
+--    "t_proposal_c_abstract_check" CHECK (c_abstract IS NULL OR length(c_abstract) > 0)
+--    "t_proposal_c_title_check" CHECK (c_title IS NULL OR length(c_title) > 0)
+--    "t_proposal_check_min_total" CHECK ((c_min_percent_total IS NOT NULL) = (c_class::text = 'intensive'::text OR c_class::text = 'large_program'::text))
+--    "t_proposal_check_total" CHECK ((c_total_time IS NOT NULL) = (c_class::text = 'intensive'::text OR c_class::text = 'large_program'::text))
+
+--    "t_proposal_c_category_fkey" FOREIGN KEY (c_category) REFERENCES t_tac_category(c_tag)
+--    "t_proposal_c_class_fkey" FOREIGN KEY (c_class) REFERENCES t_proposal_class(c_tag)
+--    "t_proposal_c_program_id_fkey" FOREIGN KEY (c_program_id) REFERENCES t_program(c_program_id) ON DELETE CASCADE
+
+--    ch_program_edit_proposal_trigger AFTER INSERT OR DELETE OR UPDATE ON t_proposal DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE FUNCTION ch_proposal_edit()
+--    reset_proposal_status_trigger AFTER DELETE ON t_proposal FOR EACH ROW EXECUTE FUNCTION reset_proposal_status()
+--    update_science_subtype_trigger BEFORE INSERT OR UPDATE ON t_proposal FOR EACH ROW EXECUTE FUNCTION update_science_subtype()

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CallPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CallPropertiesInput.scala
@@ -1,0 +1,166 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.applicative.*
+import cats.syntax.apply.*
+import cats.syntax.eq.*
+import cats.syntax.foldable.*
+import cats.syntax.parallel.*
+import grackle.syntax.*
+import lucuma.core.enums.ScienceSubtype
+import lucuma.core.enums.ToOActivation
+import lucuma.core.model.CallForProposals
+import lucuma.core.model.IntPercent
+import lucuma.core.util.TimeSpan
+import lucuma.odb.data.Tag
+import lucuma.odb.graphql.binding.*
+
+object CallPropertiesInput {
+
+  private val fieldNames: List[String] =
+    List(
+      "demoScience",
+      "directorsTime",
+      "fastTurnaround",
+      "poorWeather",
+      "systemVerfication"
+    )
+
+  private lazy val formattedFieldNames: String = {
+    val fs = fieldNames.map(n => s"'$n'")
+    val prefix = fs.init.intercalate(", ")
+    s"$prefix or ${fs.last}"
+  }
+
+  private lazy val ZeroPercent    = IntPercent.unsafeFrom(0)
+  private lazy val HundredPercent = IntPercent.unsafeFrom(100)
+
+  private val PartnerSplitsInput: Matcher[Map[Tag, IntPercent]] =
+    PartnerSplitInput.Binding.List.rmap { splits =>
+      val map = splits.map(a => (a.partner -> a.percent)).toMap
+
+      Matcher
+        .validationFailure("Each partner may only appear once.")
+        .unlessA(splits.length === map.size) *>
+      Matcher
+        .validationFailure("Percentages must sum to exactly 100.")
+        .unlessA(splits.foldMap(_.percent.value) === 100) *>
+      map.success
+
+    }
+
+  case class Create(
+    cfpId:           CallForProposals.Id,
+    scienceSubtype:  ScienceSubtype,
+    tooActivation:   ToOActivation,
+    minPercentTime:  IntPercent,
+    minPercentTotal: IntPercent           = ZeroPercent,
+    totalTime:       TimeSpan             = TimeSpan.Zero,
+    partnerSplits:   Map[Tag, IntPercent] = Map.empty
+  )
+
+  object Create {
+
+    private def simpleCallCreateBinding(s: ScienceSubtype): Matcher[CallForProposals.Id => Create] =
+      ObjectFieldsBinding.rmap {
+        case List(
+          ToOActivationBinding("toOActivation", rToo),
+          IntPercentBinding("minPercentTime", rMin)
+        ) => (rToo, rMin).parMapN { (too, min) => Create(_, s, too, min) }
+      }
+
+    private val Classical: Matcher[CallForProposals.Id => Create] =
+      ObjectFieldsBinding.rmap {
+        case List(
+          IntPercentBinding("minPercentTime", rMin),
+          PartnerSplitsInput("partnerSplits", rSplits)
+        ) => (rMin, rSplits).parMapN { (min, split) =>
+          Create(_, ScienceSubtype.Classical, ToOActivation.None, min, partnerSplits = split)
+        }
+      }
+
+    private val DemoScience: Matcher[CallForProposals.Id => Create] =
+      simpleCallCreateBinding(ScienceSubtype.DemoScience)
+
+    private val DirectorsTime: Matcher[CallForProposals.Id => Create] =
+      simpleCallCreateBinding(ScienceSubtype.DirectorsTime)
+
+    private val FastTurnaround: Matcher[CallForProposals.Id => Create] =
+      ObjectFieldsBinding.rmap {
+        case List(
+          ToOActivationBinding("toOActivation", rToo),
+          IntPercentBinding("minPercentTime", rMin),
+          TagBinding("piAffiliation", rPartner)
+        ) => (rToo, rMin, rPartner).parMapN { (too, min, partner) =>
+          Create(_, ScienceSubtype.FastTurnaround, too, min, partnerSplits = Map(partner -> HundredPercent))
+        }
+      }
+
+    private val LargeProgram: Matcher[CallForProposals.Id => Create] =
+      ObjectFieldsBinding.rmap {
+        case List(
+          ToOActivationBinding("toOActivation", rToo),
+          IntPercentBinding("minPercentTime", rMin),
+          IntPercentBinding("minPercentTotalTime", rMinTotal),
+          TimeSpanInput.Binding("totalTime", rTotal)
+        ) => (rToo, rMin, rMinTotal, rTotal).parMapN { (too, min, minTotal, total) =>
+          Create(_, ScienceSubtype.LargeProgram, too, min, minTotal, total)
+        }
+      }
+
+    private val PoorWeather: Matcher[CallForProposals.Id => Create] =
+      ObjectFieldsBinding.rmap {
+        case Nil =>
+          (cid => Create(cid, ScienceSubtype.PoorWeather, ToOActivation.None, ZeroPercent)).success
+      }
+
+    private val Queue: Matcher[CallForProposals.Id => Create] =
+      ObjectFieldsBinding.rmap {
+        case List(
+          ToOActivationBinding("toOActivation", rToo),
+          IntPercentBinding("minPercentTime", rMin),
+          PartnerSplitsInput("partnerSplits", rSplits)
+        ) => (rToo, rMin, rSplits).parMapN { (too, min, split) =>
+          Create(_, ScienceSubtype.Queue, too, min, partnerSplits = split)
+        }
+      }
+
+    private val SystemVerification: Matcher[CallForProposals.Id => Create] =
+      simpleCallCreateBinding(ScienceSubtype.DirectorsTime)
+
+    val binding: Matcher[Create] =
+      ObjectFieldsBinding.rmap {
+        case List(
+          CallForProposalsIdBinding("callId", rCid),
+          Classical.Option("classical", rClassical),
+          DemoScience.Option("demoScience", rDemo),
+          DirectorsTime.Option("directorsTime", rDirector),
+          FastTurnaround.Option("fastTurnaround", rFast),
+          LargeProgram.Option("largeProgram", rLarge),
+          PoorWeather.Option("poorWeather", rPoor),
+          Queue.Option("queue", rQueue),
+          SystemVerification.Option("systemVerification", rSystem)
+        ) => (rCid, rClassical, rDemo, rDirector, rFast, rLarge, rPoor, rQueue, rSystem).parFlatMapN {
+          (cid, classical, demo, director, fast, large, poor, queue, system) =>
+            List(
+              classical,
+              demo,
+              director,
+              fast,
+              large,
+              poor,
+              queue,
+              system
+            ).flatMap(_.map(_.apply(cid)).toList) match {
+              case Nil      => Matcher.validationFailure(s"One of $formattedFieldNames must be provided.")
+              case c :: Nil => c.success
+              case _        => Matcher.validationFailure(s"Only one of $formattedFieldNames must be provided.")
+            }
+        }
+      }
+  }
+
+}


### PR DESCRIPTION
Unimplemented (draft) updates to the GraphQL schema for discussion.  The goals are to:

* Specify a particular Call for Proposals when a proposal is created.  The selected Call for Proposals will have a particular type, and each proposal submitted to that call must include property settings that are tied to that type.

* Group properties associated with each particular call type, removing from the `Proposal` type those that don't apply across all call types.  For example, the partner splits are only relevant to the regular semester call so they are no longer in `Proposal`.  Regular semester classical does not support ToO observing so has no `toOActivation`.

* Remove (now) redundant `ProposalClass` in favor of the `CallForProposals` and its friends.

* Shunt the `Intensive` and `Exchange` stuff to the nebulous future.

Since this is a big change and is difficult to perceive in the diff, I'll try to summarize it here.

## `Proposal` Updates

Here partner splits and ToO are placed in the new `CallProperties`.

```
type Proposal
  reference:      ProposalReference
  title:          NonEmptyString
  category:       TacCategory
  abstract:       NonEmptyString
  callProperties: CallProperties!
```


## `CallProperties` Interface and Implementations

Description of the properties associated with each type.  Most of the ones that we don't currently track are marked with `TODO`.

```
interface CallProperties
  call: CallForProposals!  # The actual call definition.

type CallPropertiesClassical implements CallProperties
  call:          CallForProposals!
  partnerSplits: [PartnerSplit!]!
  # TODO: AEON / Multi-facility
  # TODO: JWST Synergy
  # TODO: US Long Term
  # TODO: Visitors?

type CallPropertiesDemoScience implements CallProperties
  call:           CallForProposals!
  toOActivation:  ToOActivation!
  minPercentTime: IntPercent!

type CallPropertiesDirectorsTime implements CallProperties
  call:           CallForProposals!
  toOActivation:  ToOActivation!
  minPercentTime: IntPercent!

type CallPropertiesFastTurnaround implements CallProperties
  call:           CallForProposals!
  toOActivation:  ToOActivation!
  minPercentTime: IntPercent!
  piAffiliation:  Partner!
  # TODO: Reviewer?

type CallPropertiesLargeProgram implements CallProperties
  call:                CallForProposals!
  toOActivation:       ToOActivation!
  minPercentTime:      IntPercent!
  minPercentTotalTime: IntPercent!
  totalTime:           TimeSpan!
  # TODO: AEON / Multi-facility
  # TODO: JWST Synergy

type CallPropertiesPoorWeather implements CallProperties
  call: CallForProposals!

type CallPropertiesQueue implements CallProperties
  call:          CallForProposals!
  toOActivation: ToOActivation!
  partnerSplits: [PartnerSplit!]!
  # TODO: AEON / Multi-facility
  # TODO: JWST Synergy
  # TODO: US Long Term

type CallPropertiesSystemVerification implements CallProperties
  call:           CallForProposals!
  toOActivation:  ToOActivation!
  minPercentTime: IntPercent!

```

## `ProposalPropertiesInput`

The inputs reflect the corresponding "output" types above.  `ProposalPropertiesInput` gains a `CallPropertiesInput` and loses individual properties tied to the call type.

```
input ProposalPropertiesInput
  title:          NonEmptyString
  category:       TacCategory
  abstract:       NonEmptyString
  callProperties: CallPropertiesInput
```

## Call Properties Inputs

Here we specify the particular Call for Proposals, which is required when creating a proposal and is not nullable.  Additional properties associated with the particular call type must also be supplied. When a create or update mutation is sent, the call type is matched to the supplied properties and an error is produced if they do not correspond.


```
input CallPropertiesInput
  callId:             CallForProposalsId

  demoScience:        CallPropertiesDemoScienceInput
  directorsTime:      CallPropertiesDirectorsTimeInput
  fastTurnaround:     CallPropertiesFastTurnaroundInput
  largeProgram:       CallPropertiesLargeProgramInput
  poorWeather:        CallPropertiesPoorWeatherInput
  classical:          CallPropertiesClassicalInput
  queue:              CallPropertiesQueueInput
  systemVerification: CallPropertiesSystemVerificationInput

input CallPropertiesClassicalInput
  minPercentTime: IntPercent
  partnerSplits: [PartnerSplitInput!]
  # TODO: AEON / Multi-facility
  # TODO: JWST Synergy
  # TODO: US Long Term
  # TODO: Visitors?

input CallPropertiesDemoScienceInput
  toOActivation:  ToOActivation
  minPercentTime: IntPercent

input CallPropertiesDirectorsTimeInput
  toOActivation:  ToOActivation
  minPercentTime: IntPercent

input CallPropertiesFastTurnaroundInput
  toOActivation:  ToOActivation
  minPercentTime: IntPercent
  piAffiliation:  Partner
  # TODO: Reviewer?

input CallPropertiesLargeProgramInput
  toOActivation:       ToOActivation
  minPercentTime:      IntPercent
  minPercentTotalTime: IntPercent
  totalTime:           TimeSpanInput
  # TODO: AEON / Multi-facility
  # TODO: JWST Synergy

input CallPropertiesPoorWeatherInput

input CallPropertiesQueueInput
  toOActivation: ToOActivation
  minPercentTime: IntPercent
  partnerSplits: [PartnerSplitInput!]
  # TODO: AEON / Multi-facility
  # TODO: JWST Synergy
  # TODO: US Long Term

input CallPropertiesSystemVerificationInput
  toOActivation:  ToOActivation
  minPercentTime: IntPercent
```