### PR TITLE
Abandon Atoms / Steps

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -179,6 +179,9 @@ enum AtomExecutionState {
   "An event with an 'END_ATOM' 'AtomStage' was received."
   COMPLETED
 
+  "An ongoing atom was abandoned."
+  ABANDONED
+
 }
 
 """
@@ -4219,6 +4222,10 @@ enum StepExecutionState {
 
   "An event with a 'STOP' 'StepStage' was received."
   STOPPED
+
+  "An ongoing step was abandoned."
+  ABANDONED
+
 }
 
 """

--- a/modules/service/src/main/resources/db/migration/V0875__abandon.sql
+++ b/modules/service/src/main/resources/db/migration/V0875__abandon.sql
@@ -1,0 +1,7 @@
+-- Whenever an event for an atom is received, all existing ongoing atoms for the
+-- same observation may be considered abandoned.
+ALTER TYPE e_atom_execution_state ADD VALUE 'abandoned';
+
+-- Whenever an event for a step is recevied, all existing ongoing steps for the
+-- same observation may be considered abandoned.
+ALTER TYPE e_step_execution_state ADD VALUE 'abandoned';

--- a/modules/service/src/main/resources/db/migration/V0875__abandon.sql
+++ b/modules/service/src/main/resources/db/migration/V0875__abandon.sql
@@ -1,7 +1,87 @@
--- Whenever an event for an atom is received, all existing ongoing atoms for the
--- same observation may be considered abandoned.
-ALTER TYPE e_atom_execution_state ADD VALUE 'abandoned';
+-- Drop the view since we're updating one of the columns.
+DROP VIEW v_step_record;
 
--- Whenever an event for a step is recevied, all existing ongoing steps for the
--- same observation may be considered abandoned.
-ALTER TYPE e_step_execution_state ADD VALUE 'abandoned';
+-- Creates an execution state table.  Terminal states don't advance when new
+-- events arrive.  We need a table to store this information so we'll convert
+-- the enum to a table.
+CREATE TABLE t_step_execution_state(
+  c_tag      d_tag   PRIMARY KEY,
+  c_name     text    NOT NULL,
+  c_terminal boolean NOT NULL
+);
+
+INSERT INTO t_step_execution_state VALUES ('not_started', 'Not Started', false);
+INSERT INTO t_step_execution_state VALUES ('ongoing',     'Ongoing',     false);
+INSERT INTO t_step_execution_state VALUES ('aborted',     'Aborted',     true);
+INSERT INTO t_step_execution_state VALUES ('completed',   'Completed',   true);
+INSERT INTO t_step_execution_state VALUES ('stopped',     'Stopped',     true);
+INSERT INTO t_step_execution_state VALUES ('abandoned',   'Abandoned',   true);
+
+-- Update t_step_record to use a FK reference instead of an enum value.
+ALTER TABLE t_step_record
+  ALTER COLUMN c_execution_state DROP DEFAULT,
+  ALTER COLUMN c_execution_state TYPE d_tag USING c_execution_state::d_tag,
+  ADD CONSTRAINT t_step_record_c_step_execution_state_c_tag_fkey
+    FOREIGN KEY (c_execution_state) REFERENCES t_step_execution_state(c_tag),
+  ALTER COLUMN c_execution_state SET DEFAULT 'not_started'::d_tag;
+
+-- No longer need the enumeration
+DROP TYPE e_step_execution_state;
+
+-- Recreate the view.
+CREATE VIEW v_step_record AS
+SELECT
+  s.c_step_id,
+  s.c_step_index,
+  s.c_atom_id,
+  s.c_instrument,
+  s.c_step_type,
+  s.c_observe_class,
+  s.c_created,
+  s.c_execution_state,
+  s.c_time_estimate,
+  g.c_gcal_continuum,
+  g.c_gcal_ar_arc,
+  g.c_gcal_cuar_arc,
+  g.c_gcal_thar_arc,
+  g.c_gcal_xe_arc,
+  g.c_gcal_filter,
+  g.c_gcal_diffuser,
+  g.c_gcal_shutter,
+  n.c_offset_p,
+  n.c_offset_q,
+  n.c_guide_state,
+  m.c_smart_gcal_type
+FROM
+  t_step_record s
+LEFT JOIN t_step_config_gcal g
+  ON g.c_step_id = s.c_step_id
+LEFT JOIN t_step_config_science n
+  ON n.c_step_id = s.c_step_id
+LEFT JOIN t_step_config_smart_gcal m
+  ON m.c_step_id = s.c_step_id
+ORDER BY
+  s.c_step_id;
+
+
+-- Do the same for the atom execution state.  Fortunately there's no view to
+-- update in this case.
+CREATE TABLE t_atom_execution_state(
+  c_tag      d_tag   PRIMARY KEY,
+  c_name     text    NOT NULL,
+  c_terminal boolean NOT NULL
+);
+
+INSERT INTO t_atom_execution_state VALUES ('not_started', 'Not Started', false);
+INSERT INTO t_atom_execution_state VALUES ('ongoing',     'Ongoing',     false);
+INSERT INTO t_atom_execution_state VALUES ('completed',   'Completed',   true);
+INSERT INTO t_atom_execution_state VALUES ('abandoned',   'Abandoned',   true);
+
+ALTER TABLE t_atom_record
+  ALTER COLUMN c_execution_state DROP DEFAULT,
+  ALTER COLUMN c_execution_state TYPE d_tag USING c_execution_state::d_tag,
+  ADD CONSTRAINT t_atom_record_c_step_execution_state_c_tag_fkey
+    FOREIGN KEY (c_execution_state) REFERENCES t_atom_execution_state(c_tag),
+  ALTER COLUMN c_execution_state SET DEFAULT 'not_started'::d_tag;
+
+DROP TYPE e_atom_execution_state;

--- a/modules/service/src/main/resources/db/migration/V0875__abandoned_atoms.sql
+++ b/modules/service/src/main/resources/db/migration/V0875__abandoned_atoms.sql
@@ -1,0 +1,3 @@
+-- Whenever an atom is started all others for the same observation may be
+-- considered abandoned.
+ALTER TYPE e_atom_execution_state ADD VALUE 'abandoned';

--- a/modules/service/src/main/resources/db/migration/V0875__abandoned_atoms.sql
+++ b/modules/service/src/main/resources/db/migration/V0875__abandoned_atoms.sql
@@ -1,3 +1,0 @@
--- Whenever an atom is started all others for the same observation may be
--- considered abandoned.
-ALTER TYPE e_atom_execution_state ADD VALUE 'abandoned';

--- a/modules/service/src/main/scala/lucuma/odb/data/AtomExecutionState.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/AtomExecutionState.scala
@@ -21,5 +21,5 @@ enum AtomExecutionState(val tag: String) derives Enumerated:
   /** The atom ended with END_ATOM. */
   case Completed   extends AtomExecutionState("completed")
 
-  /** The atom execution was abandoned without having received an END_ATOM. */
+  /** The atom execution was abandoned. */
   case Abandoned  extends AtomExecutionState("abandoned")

--- a/modules/service/src/main/scala/lucuma/odb/data/AtomExecutionState.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/AtomExecutionState.scala
@@ -10,7 +10,7 @@ import lucuma.core.util.Enumerated
  *
  * @param tag database tag
  */
-enum AtomExecutionState(val tag: String) derives Enumerated {
+enum AtomExecutionState(val tag: String) derives Enumerated:
 
   /** No events have been produced for this step. */
   case NotStarted  extends AtomExecutionState("not_started")
@@ -21,4 +21,5 @@ enum AtomExecutionState(val tag: String) derives Enumerated {
   /** The atom ended with END_ATOM. */
   case Completed   extends AtomExecutionState("completed")
 
-}
+  /** The atom execution was abandoned without having received an END_ATOM. */
+  case Abandoned  extends AtomExecutionState("abandoned")

--- a/modules/service/src/main/scala/lucuma/odb/data/StepExecutionState.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/StepExecutionState.scala
@@ -10,7 +10,7 @@ import lucuma.core.util.Enumerated
  *
  * @param tag database tag
  */
-enum StepExecutionState(val tag: String) derives Enumerated {
+enum StepExecutionState(val tag: String) derives Enumerated:
 
   /** No events have been produced for this step. */
   case NotStarted  extends StepExecutionState("not_started")
@@ -27,4 +27,5 @@ enum StepExecutionState(val tag: String) derives Enumerated {
   /** A STOP event was received */
   case Stopped     extends StepExecutionState("stopped")
 
-}
+  /** An ongoing step was abandonded without having received an END_STEP. */
+//  case Abandoned     extends StepExecutionState("stopped")

--- a/modules/service/src/main/scala/lucuma/odb/data/StepExecutionState.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/StepExecutionState.scala
@@ -28,4 +28,4 @@ enum StepExecutionState(val tag: String) derives Enumerated:
   case Stopped     extends StepExecutionState("stopped")
 
   /** An ongoing step was abandonded. */
-  case Abandoned     extends StepExecutionState("stopped")
+  case Abandoned   extends StepExecutionState("abandoned")

--- a/modules/service/src/main/scala/lucuma/odb/data/StepExecutionState.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/StepExecutionState.scala
@@ -27,5 +27,5 @@ enum StepExecutionState(val tag: String) derives Enumerated:
   /** A STOP event was received */
   case Stopped     extends StepExecutionState("stopped")
 
-  /** An ongoing step was abandonded without having received an END_STEP. */
-//  case Abandoned     extends StepExecutionState("stopped")
+  /** An ongoing step was abandonded. */
+  case Abandoned     extends StepExecutionState("stopped")

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
@@ -118,6 +118,7 @@ object ExecutionEventService {
           e <- ResultT(insert)
           (eid, time, oid, vid) = e
           _ <- ResultT.liftF(services.sequenceService.setAtomExecutionState(atomId, atomStage))
+          _ <- ResultT.liftF(services.sequenceService.abandonOngoing(oid, atomId))
           _ <- ResultT.liftF(timeAccountingService.update(vid))
         } yield AtomEvent(eid, time, oid, vid, atomId, atomStage)).value
       }

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
@@ -118,7 +118,7 @@ object ExecutionEventService {
           e <- ResultT(insert)
           (eid, time, oid, vid) = e
           _ <- ResultT.liftF(services.sequenceService.setAtomExecutionState(atomId, atomStage))
-          _ <- ResultT.liftF(services.sequenceService.abandonOngoing(oid, atomId))
+          _ <- ResultT.liftF(services.sequenceService.abandonOngoingAtomsExcept(oid, atomId))
           _ <- ResultT.liftF(timeAccountingService.update(vid))
         } yield AtomEvent(eid, time, oid, vid, atomId, atomStage)).value
       }
@@ -233,6 +233,7 @@ object ExecutionEventService {
           e <- ResultT(insert)
           (eid, time, oid, vid, aid) = e
           _ <- ResultT.liftF(services.sequenceService.setStepExecutionState(stepId, stepStage, time))
+          _ <- ResultT.liftF(services.sequenceService.abandonOngoingStepsExcept(oid, aid, stepId))
           _ <- ResultT.liftF(timeAccountingService.update(vid))
         } yield StepEvent(eid, time, oid, vid, aid, stepId, stepStage)).value
       }

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
@@ -232,6 +232,7 @@ object ExecutionEventService {
         (for {
           e <- ResultT(insert)
           (eid, time, oid, vid, aid) = e
+          _ <- ResultT.liftF(services.sequenceService.setAtomExecutionState(aid, AtomStage.StartAtom))
           _ <- ResultT.liftF(services.sequenceService.setStepExecutionState(stepId, stepStage, time))
           _ <- ResultT.liftF(services.sequenceService.abandonOngoingStepsExcept(oid, aid, stepId))
           _ <- ResultT.liftF(timeAccountingService.update(vid))

--- a/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
@@ -654,11 +654,13 @@ object SequenceService {
 
     val SetStepExecutionState: Command[(StepExecutionState, Option[Timestamp], Step.Id)] =
       sql"""
-        UPDATE t_step_record
+        UPDATE t_step_record r
            SET c_execution_state = $step_execution_state,
                c_completed       = ${core_timestamp.opt}
-         WHERE c_step_id = $step_id
-           AND c_execution_state != 'abandoned'
+          FROM t_step_execution_state e
+         WHERE r.c_execution_state = e.c_tag
+           AND e.c_terminal = FALSE
+           AND r.c_step_id = $step_id
       """.command
 
     val AbandonOngoingStepsWithoutStepId: Command[(Observation.Id, Step.Id)] =
@@ -685,10 +687,12 @@ object SequenceService {
 
     val SetAtomExecutionState: Command[(AtomExecutionState, Atom.Id)] =
       sql"""
-        UPDATE t_atom_record
+        UPDATE t_atom_record r
            SET c_execution_state = $atom_execution_state
-         WHERE c_atom_id = $atom_id
-           AND c_execution_state != 'abandoned'
+          FROM t_atom_execution_state e
+         WHERE r.c_execution_state = e.c_tag
+           AND e.c_terminal = FALSE
+           AND r.c_atom_id = $atom_id
       """.command
 
     val AbandonOngoingAtomsWithoutAtomId: Command[(Observation.Id, Atom.Id)] =

--- a/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
@@ -163,7 +163,8 @@ trait Codecs {
     )
 
   val atom_execution_state: Codec[AtomExecutionState] =
-    enumerated(Type("e_atom_execution_state"))
+    enumerated[AtomExecutionState](Type.varchar) //("e_step_execution_state"))
+    //enumerated(Type("e_atom_execution_state"))
 
   val atom_id: Codec[Atom.Id] =
     uid[Atom.Id]
@@ -446,7 +447,7 @@ trait Codecs {
     )(_.toBigDecimal)
 
   val step_execution_state: Codec[StepExecutionState] =
-    enumerated(Type("e_step_execution_state"))
+    enumerated[StepExecutionState](Type.varchar) //("e_step_execution_state"))
 
   val step_id: Codec[Step.Id] =
     uid[Step.Id]

--- a/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
@@ -163,8 +163,7 @@ trait Codecs {
     )
 
   val atom_execution_state: Codec[AtomExecutionState] =
-    enumerated[AtomExecutionState](Type.varchar) //("e_step_execution_state"))
-    //enumerated(Type("e_atom_execution_state"))
+    enumerated[AtomExecutionState](Type.varchar)
 
   val atom_id: Codec[Atom.Id] =
     uid[Atom.Id]
@@ -447,7 +446,7 @@ trait Codecs {
     )(_.toBigDecimal)
 
   val step_execution_state: Codec[StepExecutionState] =
-    enumerated[StepExecutionState](Type.varchar) //("e_step_execution_state"))
+    enumerated[StepExecutionState](Type.varchar)
 
   val step_id: Codec[Step.Id] =
     uid[Step.Id]

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -1088,7 +1088,7 @@ trait DatabaseOperations { this: OdbSuite =>
       mutation {
         addAtomEvent(input: {
           atomId:    "$aid",
-          atomStage: ${stage.tag.toUpperCase}
+          atomStage: ${stage.tag.toScreamingSnakeCase}
         }) {
           event {
             id

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/ExecutionState.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/ExecutionState.scala
@@ -1,0 +1,87 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mutation
+
+import cats.effect.IO
+import cats.syntax.either.*
+import cats.syntax.traverse.*
+import lucuma.core.model.Observation
+import lucuma.core.model.User
+import lucuma.odb.data.AtomExecutionState
+import lucuma.odb.data.StepExecutionState
+
+trait ExecutionState { this: OdbSuite =>
+
+  def atomExecutionState(user: User, oid: Observation.Id): IO[List[AtomExecutionState]] =
+    query(
+      user = user,
+      query = s"""
+        query {
+          observation(observationId: "$oid") {
+            execution {
+              atomRecords {
+                matches {
+                  executionState
+                }
+              }
+            }
+          }
+        }
+      """
+    ).flatMap { js =>
+      js.hcursor
+        .downFields("observation", "execution", "atomRecords", "matches")
+        .values
+        .toList
+        .flatTraverse(_.toList.traverse { js =>
+          js.hcursor
+            .downField("executionState")
+            .as[AtomExecutionState]
+            .leftMap(f => new RuntimeException(f.message))
+            .liftTo[IO]
+        })
+    }
+
+  def stepExecutionState(user: User, oid: Observation.Id): IO[List[StepExecutionState]] =
+    query(
+      user = user,
+      query = s"""
+        query {
+          observation(observationId: "$oid") {
+            execution {
+              atomRecords {
+                matches {
+                  steps {
+                    matches {
+                      executionState
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      """
+    ).flatMap { js =>
+      js.hcursor
+        .downFields("observation", "execution", "atomRecords", "matches")
+        .values
+        .toList
+        .flatTraverse(_.toList.flatTraverse { js =>
+          js.hcursor
+            .downFields("steps", "matches")
+            .values
+            .toList
+            .flatTraverse(_.toList.traverse { js =>
+              js.hcursor
+                .downField("executionState")
+                .as[StepExecutionState]
+                .leftMap(f => new RuntimeException(f.message))
+                .liftTo[IO]
+            })
+        })
+    }
+
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addAtomEvent.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addAtomEvent.scala
@@ -7,18 +7,19 @@ package mutation
 import cats.effect.IO
 import cats.syntax.either.*
 import cats.syntax.option.*
-import cats.syntax.traverse.*
 import io.circe.Json
 import io.circe.literal.*
 import lucuma.core.enums.AtomStage
+import lucuma.core.enums.StepStage
 import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.core.model.sequence.Atom
 import lucuma.odb.data.AtomExecutionState
 import lucuma.odb.data.ObservingModeType
+import lucuma.odb.data.StepExecutionState
 import lucuma.core.syntax.string.*
 
-class addAtomEvent extends OdbSuite {
+class addAtomEvent extends OdbSuite with ExecutionState {
 
   val service: User = TestUsers.service(nextId)
 
@@ -103,39 +104,28 @@ class addAtomEvent extends OdbSuite {
     )
   }
 
-  test("addAtomEvent - abandon") {
+  test("addAtomEvent - once terminal, state doesn't change") {
     val user = service
     val mode = ObservingModeType.GmosNorthLongSlit
 
-    def executionState(oid: Observation.Id): IO[List[AtomExecutionState]] =
-      query(
-        user = user,
-        query = s"""
-          query {
-            observation(observationId: "$oid") {
-              execution {
-                atomRecords {
-                  matches {
-                    executionState
-                  }
-                }
-              }
-            }
-          }
-        """
-      ).flatMap { js =>
-        js.hcursor
-          .downFields("observation", "execution", "atomRecords", "matches")
-          .values
-          .toList
-          .flatTraverse(_.toList.traverse { js =>
-            js.hcursor
-              .downField("executionState")
-              .as[AtomExecutionState]
-              .leftMap(f => new RuntimeException(f.message))
-              .liftTo[IO]
-          })
-      }
+    import AtomExecutionState.*
+
+    for {
+      pid  <- createProgramAs(user)
+      oid  <- createObservationAs(user, pid, mode.some)
+      vid  <- recordVisitAs(user, mode.instrument, oid)
+      aid0 <- recordAtomAs(user, mode.instrument, vid)
+      aid1 <- recordAtomAs(user, mode.instrument, vid)
+      _    <- addAtomEventAs(user, aid0, AtomStage.StartAtom)
+      _    <- addAtomEventAs(user, aid1, AtomStage.StartAtom)
+      _    <- addAtomEventAs(user, aid0, AtomStage.EndAtom)  // but remains abandoned
+      res  <- atomExecutionState(user, oid)
+    } yield assertEquals(res, List(Abandoned, Abandoned))
+  }
+
+  test("addAtomEvent - abandon atom") {
+    val user = service
+    val mode = ObservingModeType.GmosNorthLongSlit
 
     import AtomExecutionState.*
 
@@ -150,7 +140,30 @@ class addAtomEvent extends OdbSuite {
       _    <- addAtomEventAs(user, aid1, AtomStage.StartAtom) // 0 -> Abandoned, 1 -> Ongoing
       _    <- addAtomEventAs(user, aid1, AtomStage.EndAtom)   // 0 -> Abandoned, 1 -> Completed
       _    <- addAtomEventAs(user, aid2, AtomStage.StartAtom) // 0 -> Abandoned, 1 -> Completed, 2 -> Ongoing
-      res  <- executionState(oid)
+      res  <- atomExecutionState(user, oid)
     } yield assertEquals(res, List(Abandoned, Completed, Ongoing))
   }
+
+  test("addAtomEvent - abandon step") {
+    val user = service
+    val mode = ObservingModeType.GmosNorthLongSlit
+
+    for {
+      pid  <- createProgramAs(user)
+      oid  <- createObservationAs(user, pid, mode.some)
+      vid  <- recordVisitAs(user, mode.instrument, oid)
+      aid0 <- recordAtomAs(user, mode.instrument, vid)
+      sid0 <- recordStepAs(user, mode.instrument, aid0)
+      aid1 <- recordAtomAs(user, mode.instrument, vid)
+      _    <- addAtomEventAs(user, aid0, AtomStage.StartAtom)
+      _    <- addStepEventAs(user, sid0, StepStage.StartStep)
+      _    <- addAtomEventAs(user, aid1, AtomStage.StartAtom)
+      resA <- atomExecutionState(user, oid)
+      resS <- stepExecutionState(user, oid)
+    } yield {
+      assertEquals(resA, List(AtomExecutionState.Abandoned, AtomExecutionState.Ongoing))
+      assertEquals(resS, List(StepExecutionState.Abandoned))
+    }
+  }
+
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addAtomEvent.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addAtomEvent.scala
@@ -14,10 +14,10 @@ import lucuma.core.enums.StepStage
 import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.core.model.sequence.Atom
+import lucuma.core.syntax.string.*
 import lucuma.odb.data.AtomExecutionState
 import lucuma.odb.data.ObservingModeType
 import lucuma.odb.data.StepExecutionState
-import lucuma.core.syntax.string.*
 
 class addAtomEvent extends OdbSuite with ExecutionState {
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addAtomEvent.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addAtomEvent.scala
@@ -7,13 +7,16 @@ package mutation
 import cats.effect.IO
 import cats.syntax.either.*
 import cats.syntax.option.*
+import cats.syntax.traverse.*
 import io.circe.Json
 import io.circe.literal.*
+import lucuma.core.enums.AtomStage
 import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.core.model.sequence.Atom
+import lucuma.odb.data.AtomExecutionState
 import lucuma.odb.data.ObservingModeType
-
+import lucuma.core.syntax.string.*
 
 class addAtomEvent extends OdbSuite {
 
@@ -30,7 +33,7 @@ class addAtomEvent extends OdbSuite {
       oid <- createObservationAs(user, pid, mode.some)
       vid <- recordVisitAs(user, mode.instrument, oid)
       aid <- recordAtomAs(user, mode.instrument, vid)
-      } yield (oid, aid)
+    } yield (oid, aid)
 
   private def addAtomEventTest(
     mode:     ObservingModeType,
@@ -44,32 +47,34 @@ class addAtomEvent extends OdbSuite {
       _   <- expect(user, query(aid), expected(oid, aid).leftMap(s => List(s)))
     } yield ()
 
-
-  test("addAtomEvent") {
-    def query(aid: Atom.Id): String =
-      s"""
-        mutation {
-          addAtomEvent(input: {
-            atomId:    "$aid",
-            atomStage: START_ATOM
-          }) {
-            event {
-              atom {
-                id
-              }
-              atomStage
-              observation {
-                id
-              }
+  private def addAtomEventQuery(
+    aid:   Atom.Id,
+    stage: AtomStage
+  ): String =
+    s"""
+      mutation {
+        addAtomEvent(input: {
+          atomId:    "$aid",
+          atomStage: ${stage.tag.toScreamingSnakeCase}
+        }) {
+          event {
+            atom {
+              id
+            }
+            atomStage
+            observation {
+              id
             }
           }
         }
-      """
+      }
+    """
 
+  test("addAtomEvent") {
     addAtomEventTest(
       ObservingModeType.GmosNorthLongSlit,
       service,
-      aid => query(aid),
+      aid => addAtomEventQuery(aid, AtomStage.StartAtom),
       (oid, aid) => json"""
       {
         "addAtomEvent": {
@@ -89,30 +94,63 @@ class addAtomEvent extends OdbSuite {
 
   }
 
-   test("addAtomEvent - unknown atom") {
-    def query: String =
-      s"""
-        mutation {
-          addAtomEvent(input: {
-            atomId:    "a-cfebc981-db7e-4c35-964d-6b19aa5ed2d7",
-            atomStage: START_ATOM
-          }) {
-            event {
-              atom {
-                id
-              }
-            }
-          }
-        }
-      """
-
+  test("addAtomEvent - unknown atom") {
     addAtomEventTest(
       ObservingModeType.GmosNorthLongSlit,
       service,
-      _ => query,
+      _ => addAtomEventQuery(Atom.Id.parse("a-cfebc981-db7e-4c35-964d-6b19aa5ed2d7").get, AtomStage.StartAtom),
       (_, _) => s"Atom 'a-cfebc981-db7e-4c35-964d-6b19aa5ed2d7' not found".asLeft
     )
-
   }
 
+  test("addAtomEvent - abandon") {
+    val user = service
+    val mode = ObservingModeType.GmosNorthLongSlit
+
+    def executionState(oid: Observation.Id): IO[List[AtomExecutionState]] =
+      query(
+        user = user,
+        query = s"""
+          query {
+            observation(observationId: "$oid") {
+              execution {
+                atomRecords {
+                  matches {
+                    executionState
+                  }
+                }
+              }
+            }
+          }
+        """
+      ).flatMap { js =>
+        js.hcursor
+          .downFields("observation", "execution", "atomRecords", "matches")
+          .values
+          .toList
+          .flatTraverse(_.toList.traverse { js =>
+            js.hcursor
+              .downField("executionState")
+              .as[AtomExecutionState]
+              .leftMap(f => new RuntimeException(f.message))
+              .liftTo[IO]
+          })
+      }
+
+    import AtomExecutionState.*
+
+    for {
+      pid  <- createProgramAs(user)
+      oid  <- createObservationAs(user, pid, mode.some)
+      vid  <- recordVisitAs(user, mode.instrument, oid)
+      aid0 <- recordAtomAs(user, mode.instrument, vid)
+      aid1 <- recordAtomAs(user, mode.instrument, vid)
+      aid2 <- recordAtomAs(user, mode.instrument, vid)
+      _    <- addAtomEventAs(user, aid0, AtomStage.StartAtom) // 0 -> Ongoing
+      _    <- addAtomEventAs(user, aid1, AtomStage.StartAtom) // 0 -> Abandoned, 1 -> Ongoing
+      _    <- addAtomEventAs(user, aid1, AtomStage.EndAtom)   // 0 -> Abandoned, 1 -> Completed
+      _    <- addAtomEventAs(user, aid2, AtomStage.StartAtom) // 0 -> Abandoned, 1 -> Completed, 2 -> Ongoing
+      res  <- executionState(oid)
+    } yield assertEquals(res, List(Abandoned, Completed, Ongoing))
+  }
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addStepEvent.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addStepEvent.scala
@@ -179,7 +179,7 @@ class addStepEvent extends OdbSuite with ExecutionState {
       resA <- atomExecutionState(user, oid)
       resS <- stepExecutionState(user, oid)
     } yield {
-      assertEquals(resA, List(AtomExecutionState.Abandoned, AtomExecutionState.NotStarted))
+      assertEquals(resA, List(AtomExecutionState.Abandoned, AtomExecutionState.Ongoing))
       assertEquals(resS, List(StepExecutionState.Abandoned, StepExecutionState.Ongoing))
     }
   }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addStepEvent.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addStepEvent.scala
@@ -9,13 +9,17 @@ import cats.syntax.either.*
 import cats.syntax.option.*
 import io.circe.Json
 import io.circe.literal.*
+import lucuma.core.enums.AtomStage
+import lucuma.core.enums.StepStage
 import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.core.model.sequence.Step
+import lucuma.odb.data.AtomExecutionState
 import lucuma.odb.data.ObservingModeType
+import lucuma.odb.data.StepExecutionState
 
 
-class addStepEvent extends OdbSuite {
+class addStepEvent extends OdbSuite with ExecutionState {
 
   val service: User = TestUsers.service(nextId)
 
@@ -87,10 +91,9 @@ class addStepEvent extends OdbSuite {
       }
       """.asRight
     )
-
   }
 
-   test("addStepEvent - unknown step") {
+  test("addStepEvent - unknown step") {
     def query: String =
       s"""
         mutation {
@@ -113,7 +116,72 @@ class addStepEvent extends OdbSuite {
       _ => query,
       (_, _) => s"Step 's-cfebc981-db7e-4c35-964d-6b19aa5ed2d7' not found".asLeft
     )
+  }
 
+  test("addStepEvent - once terminal, state doesn't change") {
+    val user = service
+    val mode = ObservingModeType.GmosNorthLongSlit
+
+    import StepExecutionState.*
+
+    for {
+      pid <- createProgramAs(user)
+      oid <- createObservationAs(user, pid, mode.some)
+      vid <- recordVisitAs(user, mode.instrument, oid)
+      aid <- recordAtomAs(user, mode.instrument, vid)
+      sid <- recordStepAs(user, mode.instrument, aid)
+      _   <- addAtomEventAs(user, aid, AtomStage.StartAtom)
+      _   <- addStepEventAs(user, sid, StepStage.StartStep)
+      _   <- addStepEventAs(user, sid, StepStage.Abort)
+      _   <- addStepEventAs(user, sid, StepStage.EndStep) // won't change state
+      res <- stepExecutionState(user, oid)
+    } yield assertEquals(res, List(Aborted))
+  }
+
+  test("addStepEvent - abandon step") {
+    val user = service
+    val mode = ObservingModeType.GmosNorthLongSlit
+
+    import StepExecutionState.*
+
+    for {
+      pid  <- createProgramAs(user)
+      oid  <- createObservationAs(user, pid, mode.some)
+      vid  <- recordVisitAs(user, mode.instrument, oid)
+      aid0 <- recordAtomAs(user, mode.instrument, vid)
+      sid0 <- recordStepAs(user, mode.instrument, aid0)
+      sid1 <- recordStepAs(user, mode.instrument, aid0)
+      sid2 <- recordStepAs(user, mode.instrument, aid0)
+      _    <- addAtomEventAs(user, aid0, AtomStage.StartAtom)
+      _    <- addStepEventAs(user, sid0, StepStage.StartStep)
+      _    <- addStepEventAs(user, sid1, StepStage.StartStep)
+      _    <- addStepEventAs(user, sid1, StepStage.EndStep)
+      _    <- addStepEventAs(user, sid2, StepStage.StartStep)
+      res  <- stepExecutionState(user, oid)
+    } yield assertEquals(res, List(Abandoned, Completed, Ongoing))
+  }
+
+  test("addStepEvent - abandon atom") {
+    val user = service
+    val mode = ObservingModeType.GmosNorthLongSlit
+
+    for {
+      pid  <- createProgramAs(user)
+      oid  <- createObservationAs(user, pid, mode.some)
+      vid  <- recordVisitAs(user, mode.instrument, oid)
+      aid0 <- recordAtomAs(user, mode.instrument, vid)
+      sid0 <- recordStepAs(user, mode.instrument, aid0)
+      aid1 <- recordAtomAs(user, mode.instrument, vid)
+      sid1 <- recordStepAs(user, mode.instrument, aid1)
+      _    <- addAtomEventAs(user, aid0, AtomStage.StartAtom)
+      _    <- addStepEventAs(user, sid0, StepStage.StartStep)
+      _    <- addStepEventAs(user, sid1, StepStage.StartStep)
+      resA <- atomExecutionState(user, oid)
+      resS <- stepExecutionState(user, oid)
+    } yield {
+      assertEquals(resA, List(AtomExecutionState.Abandoned, AtomExecutionState.NotStarted))
+      assertEquals(resS, List(StepExecutionState.Abandoned, StepExecutionState.Ongoing))
+    }
   }
 
 }


### PR DESCRIPTION
This PR is a response to a request from @rpiaggio to know when an atom has been "abandoned" in terms of completed step/atom matching.  In order to count as successfully executed, all the steps in an atom have to complete without interruption from foreign atom events.  If a step from another atom appears in the event stream, the current atom is considered "abandoned".  To make this visible to the API and clients, I added `ABANDONED` step and atom execution states.  I also updated the logic to not update execution states once a terminal state (such as `ABORTED` or `COMPLETED`) been reached.