### PR TITLE
ShortCut 2887: Limit Forever Sequences

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -5,6 +5,8 @@ package lucuma.odb.logic
 
 import cats.data.EitherT
 import cats.effect.Concurrent
+import cats.syntax.applicative.*
+import cats.syntax.apply.*
 import cats.syntax.either.*
 import cats.syntax.flatMap.*
 import cats.syntax.foldable.*
@@ -105,6 +107,8 @@ sealed trait Generator[F[_]] {
 
 object Generator {
 
+  val SequenceAtomLimit = 100_000
+
   type FutureLimit = Int Refined Interval.Closed[0, 100]
 
   object FutureLimit extends RefinedTypeOps[FutureLimit, Int] {
@@ -146,8 +150,10 @@ object Generator {
 
     case object SequenceTooLong extends Error {
       def format: String =
-        s"The generated sequence is too long (more than ${Int.MaxValue} atoms)"
+        s"The generated sequence is too long (more than $SequenceAtomLimit atoms)."
     }
+
+    val sequenceTooLong: Error = SequenceTooLong
 
     def missingSmartGcalDef(key: String): Error =
       MissingSmartGcalDef(key)
@@ -272,7 +278,10 @@ object Generator {
       private def calcDigestFromContext(
         ctx: Context
       )(using NoTransaction[F]): EitherT[F, Error, ExecutionDigest] =
-        ctx.params match {
+        EitherT
+          .fromEither(Error.sequenceTooLong.asLeft[ExecutionDigest])
+          .unlessA(ctx.scienceIntegrationTime.exposures.value <= SequenceAtomLimit) *>
+        (ctx.params match {
           case GeneratorParams.GmosNorthLongSlit(_, config) =>
             for {
               p <- gmosLongSlit(ctx.oid, ctx.acquisitionIntegrationTime, ctx.scienceIntegrationTime, config, gmos.longslit.Generator.GmosNorth)
@@ -286,7 +295,7 @@ object Generator {
               m <- EitherT.liftF(services.transactionally { services.sequenceService.selectGmosSouthCompletionState(ctx.oid) })
               r <- executionDigest(expandAndEstimate(p, exp.gmosSouth, calculator.gmosSouth, m), calculator.gmosSouth.estimateSetup)
             } yield r
-        }
+        })
 
       override def generate(
         pid: Program.Id,
@@ -396,15 +405,19 @@ object Generator {
         ): F[Either[Error, SequenceDigest]] =
           s.fold(SequenceDigest.Zero.asRight[Error]) { (eDigest, eAtom) =>
             eDigest.flatMap { digest =>
-              digest.incrementAtomCount.toRight(SequenceTooLong).flatMap { incDigest =>
-                eAtom.bimap(
-                  missingSmartGcalDef,
-                  _.steps.foldLeft(incDigest) { (d, s) =>
-                    val dʹ = d.add(s.observeClass).add(CategorizedTime.fromStep(s.observeClass, s.value._2))
-                    offset.getOption(s.stepConfig).fold(dʹ)(dʹ.add)
-                  }
-                )
-              }
+              digest
+                .incrementAtomCount
+                .filter(_.atomCount.value <= SequenceAtomLimit)
+                .toRight(SequenceTooLong)
+                .flatMap { incDigest =>
+                  eAtom.bimap(
+                    missingSmartGcalDef,
+                    _.steps.foldLeft(incDigest) { (d, s) =>
+                      val dʹ = d.add(s.observeClass).add(CategorizedTime.fromStep(s.observeClass, s.value._2))
+                      offset.getOption(s.stepConfig).fold(dʹ)(dʹ.add)
+                    }
+                  )
+                }
             }
           }.compile.onlyOrError
 

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -110,7 +110,7 @@ object Generator {
   // The digest calculation needs to go through every step in the sequence.
   // The ITC sometimes returns `Int.MaxValue`, which leads to timeouts.  This is
   // a reasonable upper limit on the number of atoms in a sequence.
-  val SequenceAtomLimit = 100_000
+  val SequenceAtomLimit = 1000
 
   // This is a user-specifiable limit on how many `possibleFuture` steps should
   // be returned by the sequence generation.  It doesn't limit the overall

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -107,8 +107,14 @@ sealed trait Generator[F[_]] {
 
 object Generator {
 
+  // The digest calculation needs to go through every step in the sequence.
+  // The ITC sometimes returns `Int.MaxValue`, which leads to timeouts.  This is
+  // a reasonable upper limit on the number of atoms in a sequence.
   val SequenceAtomLimit = 100_000
 
+  // This is a user-specifiable limit on how many `possibleFuture` steps should
+  // be returned by the sequence generation.  It doesn't limit the overall
+  // length of the sequence the way that the SequenceAtomLimit above does.
   type FutureLimit = Int Refined Interval.Closed[0, 100]
 
   object FutureLimit extends RefinedTypeOps[FutureLimit, Int] {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -163,13 +163,16 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
       SignalToNoise.unsafeFromBigDecimalExact(50.0)
     )
 
+  def fakeItcResult: IntegrationTime =
+    FakeItcResult
+
   private def itcClient: ItcClient[IO] =
     new ItcClient[IO] {
 
       override def imaging(input: ImagingIntegrationTimeInput, useCache: Boolean): IO[IntegrationTimeResult] =
         IntegrationTimeResult(
           FakeItcVersions,
-          Zipper.one(FakeItcResult)
+          Zipper.one(fakeItcResult)
         ).pure[IO]
 
       override def spectroscopy(input: SpectroscopyIntegrationTimeInput, useCache: Boolean): IO[IntegrationTimeResult] = {
@@ -177,7 +180,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
           IO.raiseError(new RuntimeException("Artifical exception for test cases."))
         } *> IntegrationTimeResult(
           FakeItcVersions,
-          Zipper.one(FakeItcResult)
+          Zipper.one(fakeItcResult)
         ).pure[IO]
       }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -163,6 +163,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
       SignalToNoise.unsafeFromBigDecimalExact(50.0)
     )
 
+  // Provides a hook to allow test cases to alter the dummy ITC results.
   def fakeItcResult: IntegrationTime =
     FakeItcResult
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -339,7 +339,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
 
     val All: List[ClientOption] = List(Http, Ws)
 
-    val Default: ClientOption = Http
+    val Default: ClientOption = Ws
   }
 
   override def beforeAll(): Unit = {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/2887.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/2887.scala
@@ -25,7 +25,7 @@ class ShortCut_2887 extends ExecutionTestSupport {
 
   override def fakeItcResult: IntegrationTime =
     IntegrationTime(
-      596523.hourTimeSpan,
+      1.secTimeSpan,
       PosInt.unsafeFrom(atomCount.get.unsafeRunSync()),
       SignalToNoise.unsafeFromBigDecimalExact(50.0)
     )
@@ -55,7 +55,7 @@ class ShortCut_2887 extends ExecutionTestSupport {
                }
              }
            """,
-        expected = List("The generated sequence is too long (more than 100000 atoms).").asLeft
+        expected = List(s"The generated sequence is too long (more than ${SequenceAtomLimit} atoms).").asLeft
       )
     }
   }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/2887.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/2887.scala
@@ -1,0 +1,175 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package issue.shortcut
+
+import cats.effect.IO
+import eu.timepit.refined.types.numeric.PosInt
+import io.circe.Json
+import io.circe.literal.*
+import lucuma.core.math.SignalToNoise
+import lucuma.core.model.Observation
+import lucuma.core.model.Target
+import lucuma.core.syntax.timespan.*
+import lucuma.itc.IntegrationTime
+import lucuma.odb.graphql.query.ExecutionTestSupport
+
+class ShortCut_2887 extends ExecutionTestSupport {
+
+  override def fakeItcResult: IntegrationTime =
+    IntegrationTime(
+      596523.hourTimeSpan,
+      PosInt.unsafeFrom(2147483647),
+      SignalToNoise.unsafeFromBigDecimalExact(50.0)
+    )
+
+  test("forever sequence") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgram
+        t <- createTargetWithProfileAs(user, p)
+        o <- createGmosNorthLongSlitObservationAs(user, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        user  = user,
+        query =
+          s"""
+             query {
+               observation(observationId: "$oid") {
+                 execution {
+                   digest {
+                     setup {
+                       full { seconds }
+                       reacquisition { seconds }
+                     }
+                     acquisition {
+                       observeClass
+                       timeEstimate {
+                         program { seconds }
+                         partner { seconds }
+                         nonCharged { seconds }
+                         total { seconds }
+                       }
+                       offsets {
+                         p { arcseconds }
+                         q { arcseconds }
+                       }
+                       atomCount
+                     }
+                     science {
+                       observeClass
+                       timeEstimate {
+                         program { seconds }
+                         partner { seconds }
+                         nonCharged { seconds }
+                         total { seconds }
+                       }
+                       offsets {
+                         p { arcseconds }
+                         q { arcseconds }
+                       }
+                       atomCount
+                     }
+                   }
+                 }
+               }
+             }
+           """,
+        expected = Right(
+          json"""
+            {
+              "observation": {
+                "execution": {
+                  "digest": {
+                    "setup" : {
+                      "full" : {
+                        "seconds" : 960.000000
+                      },
+                      "reacquisition" : {
+                        "seconds" : 300.000000
+                      }
+                    },
+                    "acquisition" : {
+                      "observeClass" : "ACQUISITION",
+                      "timeEstimate" : {
+                        "program" : {
+                          "seconds" : 175.162500
+                        },
+                        "partner" : {
+                          "seconds" : 0.000000
+                        },
+                        "nonCharged" : {
+                          "seconds" : 0.000000
+                        },
+                        "total" : {
+                          "seconds" : 175.162500
+                        }
+                      },
+                      "offsets" : [
+                        {
+                          "p" : {
+                            "arcseconds" : 0.000000
+                          },
+                          "q" : {
+                            "arcseconds" : 0.000000
+                          }
+                        },
+                        {
+                          "p" : {
+                            "arcseconds" : 10.000000
+                          },
+                          "q" : {
+                            "arcseconds" : 0.000000
+                          }
+                        }
+                      ],
+                      "atomCount": 1
+                    },
+                    "science" : {
+                      "observeClass" : "SCIENCE",
+                      "timeEstimate" : {
+                        "program" : {
+                          "seconds" : 411.600000
+                        },
+                        "partner" : {
+                          "seconds" : 357.600000
+                        },
+                        "nonCharged" : {
+                          "seconds" : 0.000000
+                        },
+                        "total" : {
+                          "seconds" : 769.200000
+                        }
+                      },
+                      "offsets" : [
+                        {
+                          "p" : {
+                            "arcseconds" : 0.000000
+                          },
+                          "q" : {
+                            "arcseconds" : 0.000000
+                          }
+                        },
+                        {
+                          "p" : {
+                            "arcseconds" : 0.000000
+                          },
+                          "q" : {
+                            "arcseconds" : 15.000000
+                          }
+                        }
+                      ],
+                      "atomCount": 6
+                    }
+                  }
+                }
+              }
+            }
+          """
+        )
+      )
+    }
+  }
+}


### PR DESCRIPTION
Puts an arbitrary 1,000 atom limit on sequences (cleared with Andy). I'd started with 100,000 but even with a short 0.5 second exposure time and one step per atom, that is a multi-night observation.