### PR TITLE
rewrite target source profile blobs

### DIFF
--- a/modules/service/src/main/scala/db/migration/BaseIOMigration.scala
+++ b/modules/service/src/main/scala/db/migration/BaseIOMigration.scala
@@ -1,0 +1,8 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package db.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+
+trait BaseIOMigration extends BaseJavaMigration with IOMigration

--- a/modules/service/src/main/scala/db/migration/V0879__SourceProfile.scala
+++ b/modules/service/src/main/scala/db/migration/V0879__SourceProfile.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package db.migration
+
+import org.flywaydb.core.api.migration.Context
+import org.postgresql.core.BaseConnection
+import cats.effect.IO
+import lucuma.core.model.SourceProfile
+import lucuma.core.util.Gid
+import lucuma.core.model.Target
+import lucuma.odb.json.sourceprofile.given
+import lucuma.odb.json.angle.query.given
+import lucuma.odb.json.wavelength.query.given
+import io.circe.syntax.*
+import org.postgresql.util.PGobject
+import org.flywaydb.core.api.migration.BaseJavaMigration
+
+class V0879__SourceProfile extends BaseIOMigration:
+  def ioMigrate(ctx: Context, baseConnection: BaseConnection): IO[Unit] =
+    IO.delay:
+      val rs = baseConnection.execSQLQuery("select c_target_id, c_source_profile from t_target")
+      val ps = baseConnection.prepareStatement(s"update t_target set c_source_profile = ? where c_target_id = ?")
+      while (rs.next)
+        val tid  = Gid[Target.Id].fromString.getOption(rs.getString(1)).getOrElse(sys.error("bogus"))
+        val json = io.circe.parser.decode[SourceProfile](rs.getString(2)).getOrElse(sys.error("bogus")).asJson
+        ps.setObject(1, {
+          val o = new PGobject
+          o.setType("jsonb")
+          o.setValue(json.noSpaces)
+          o
+        })
+        ps.setString(2, Gid[Target.Id].fromString.reverseGet(tid))
+        ps.execute()
+        ()
+      ps.close()
+      rs.close()
+              

--- a/modules/service/src/main/scala/db/migration/V0879__SourceProfile.scala
+++ b/modules/service/src/main/scala/db/migration/V0879__SourceProfile.scala
@@ -3,18 +3,18 @@
 
 package db.migration
 
+import cats.effect.IO
+import io.circe.syntax.*
+import lucuma.core.model.SourceProfile
+import lucuma.core.model.Target
+import lucuma.core.util.Gid
+import lucuma.odb.json.angle.query.given
+import lucuma.odb.json.sourceprofile.given
+import lucuma.odb.json.wavelength.query.given
+import org.flywaydb.core.api.migration.BaseJavaMigration
 import org.flywaydb.core.api.migration.Context
 import org.postgresql.core.BaseConnection
-import cats.effect.IO
-import lucuma.core.model.SourceProfile
-import lucuma.core.util.Gid
-import lucuma.core.model.Target
-import lucuma.odb.json.sourceprofile.given
-import lucuma.odb.json.angle.query.given
-import lucuma.odb.json.wavelength.query.given
-import io.circe.syntax.*
 import org.postgresql.util.PGobject
-import org.flywaydb.core.api.migration.BaseJavaMigration
 
 class V0879__SourceProfile extends BaseIOMigration:
   def ioMigrate(ctx: Context, baseConnection: BaseConnection): IO[Unit] =

--- a/populate-db-from-dev.sh
+++ b/populate-db-from-dev.sh
@@ -1,7 +1,47 @@
 #!/bin/bash
-heroku pg:backups:capture --app lucuma-postgres-odb-dev
-heroku pg:backups:download --app lucuma-postgres-odb-dev --output /tmp/lucuma-postgres-odb-dev.dump
-pg_restore --verbose --clean --no-acl --no-owner -h localhost -U jimmy -d lucuma-odb /tmp/lucuma-postgres-odb-dev.dump
-rm /tmp/lucuma-postgres-odb-dev.dump
+set -e
 
+HEROKU_APP=lucuma-postgres-odb-dev
+SCRIPT_DIR=modules/service/src/main/resources/db/migration/
+PG_HOST=localhost
+PG_USER=jimmy
+PG_DATABASE=lucuma-odb
+export PGPASSWORD=banana
 
+# Clean up on exit
+function clean_up {
+  if [ $? -eq 0 ]; then
+    echo "🍏 Success!"
+  else
+    echo "🍎 Fail."
+  fi
+}
+trap clean_up EXIT
+
+echo "🍏 Starting the database."
+docker-compose up -d > /dev/null 2>&1
+
+echo "🍏 Waiting for postgres."
+RETRIES=100
+until psql -w -h $PG_HOST -U $PG_USER -d $PG_DATABASE -c "select 1" > /dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
+  sleep 1
+done
+
+echo "🍏 Dropping and re-creating the database with an empty schema."
+psql -h $PG_HOST -U $PG_USER -d postgres -c "drop database \"$PG_DATABASE\"" > /dev/null
+psql -h $PG_HOST -U $PG_USER -d postgres -c "create database \"$PG_DATABASE\"" > /dev/null
+
+echo "🍏 Capturing a Heroku backup."
+# heroku pg:backups:capture --app $HEROKU_APP
+
+echo "🍏 Downloading Heroku backup."
+# heroku pg:backups:download --app $HEROKU_APP --output /tmp/$HEROKU_APP.dump
+
+echo "🍏 Translating binary dump to SQL."
+# pg_restore --verbose --clean --if-exists --no-acl --no-owner -f /tmp/$HEROKU_APP.temp /tmp/$HEROKU_APP.dump > /dev/null 2>&1
+
+echo "🍏 Removing pg_catalog.set_config (temporary, hopefully)."
+# grep -v pg_catalog.set_config /tmp/$HEROKU_APP.temp > /tmp/$HEROKU_APP.sql
+
+echo "🍏 Restoring dump to local database."
+psql -h $PG_HOST -U $PG_USER -d $PG_DATABASE < /tmp/$HEROKU_APP.sql > /dev/null 2>&1

--- a/populate-db-from-dev.sh
+++ b/populate-db-from-dev.sh
@@ -32,16 +32,16 @@ psql -h $PG_HOST -U $PG_USER -d postgres -c "drop database \"$PG_DATABASE\"" > /
 psql -h $PG_HOST -U $PG_USER -d postgres -c "create database \"$PG_DATABASE\"" > /dev/null
 
 echo "🍏 Capturing a Heroku backup."
-# heroku pg:backups:capture --app $HEROKU_APP
+heroku pg:backups:capture --app $HEROKU_APP
 
 echo "🍏 Downloading Heroku backup."
-# heroku pg:backups:download --app $HEROKU_APP --output /tmp/$HEROKU_APP.dump
+heroku pg:backups:download --app $HEROKU_APP --output /tmp/$HEROKU_APP.dump
 
 echo "🍏 Translating binary dump to SQL."
-# pg_restore --verbose --clean --if-exists --no-acl --no-owner -f /tmp/$HEROKU_APP.temp /tmp/$HEROKU_APP.dump > /dev/null 2>&1
+pg_restore --verbose --clean --if-exists --no-acl --no-owner -f /tmp/$HEROKU_APP.temp /tmp/$HEROKU_APP.dump > /dev/null 2>&1
 
 echo "🍏 Removing pg_catalog.set_config (temporary, hopefully)."
-# grep -v pg_catalog.set_config /tmp/$HEROKU_APP.temp > /tmp/$HEROKU_APP.sql
+grep -v pg_catalog.set_config /tmp/$HEROKU_APP.temp > /tmp/$HEROKU_APP.sql
 
 echo "🍏 Restoring dump to local database."
 psql -h $PG_HOST -U $PG_USER -d $PG_DATABASE < /tmp/$HEROKU_APP.sql > /dev/null 2>&1


### PR DESCRIPTION
This adds a migration that rewrites the json blobs for source profiles, to add null fields required by Grackle. It also updates the populate-db-from-dev script to be a little bit better.