### PR TITLE
GMOS FPU nulls

### DIFF
--- a/modules/schema/src/main/scala/lucuma/odb/json/gmos.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/gmos.scala
@@ -208,10 +208,12 @@ trait GmosCodec {
     Encoder.instance[GmosFpuMask[A]] {
       case GmosFpuMask.Builtin(v)       =>
         Json.obj(
-          "builtin"    -> v.asJson
+          "builtin"    -> v.asJson,
+          "customMask" -> Json.Null
         )
       case c @ GmosFpuMask.Custom(_, _) =>
         Json.obj(
+          "builtin"    -> Json.Null,
           "customMask" -> c.asJson
         )
     }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/execution.scala
@@ -426,6 +426,7 @@ class execution extends ExecutionTestSupport {
                                filter
                                fpu {
                                  builtin
+                                 customMask { slitWidth }
                                }
                              }
                              stepConfig {
@@ -519,7 +520,8 @@ class execution extends ExecutionTestSupport {
                                 "gratingConfig": null,
                                 "filter": "G_PRIME",
                                 "fpu": {
-                                  "builtin": "LONG_SLIT_0_50"
+                                  "builtin": "LONG_SLIT_0_50",
+                                  "customMask": null
                                 }
                               },
                               "stepConfig": {
@@ -551,7 +553,8 @@ class execution extends ExecutionTestSupport {
                                 "gratingConfig": null,
                                 "filter": "G_PRIME",
                                 "fpu": {
-                                  "builtin": "LONG_SLIT_0_50"
+                                  "builtin": "LONG_SLIT_0_50",
+                                  "customMask": null
                                 }
                               },
                               "stepConfig": {


### PR DESCRIPTION
For latest Grackle we need to explicitly write `null` values for missing optional fields.  We had no test case, and therefore missed, an instance where `null` is required.  The GMOS FPU is either `builtin` or `customMask`.  The  odd man out needs to be explicitly `null`.

