### PR TITLE
Add validations to observations

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7930,6 +7930,11 @@ type Observation {
   itc: Itc!
 
   """
+  A list of observation validation problems
+  """
+  validations: [ObservationValidation!]!
+
+  """
   Enclosing group, if any.
   """
   groupId: GroupId
@@ -7995,6 +8000,46 @@ observation index. For example, G-2024B-1234-Q-0001 where G-2024B-1234-Q is
 the program reference label and the observation index is 1.
 """
 scalar ObservationReferenceLabel
+
+"""
+An observation validation problem
+"""
+type ObservationValidation {
+  """
+  The type of validation problem
+  """
+  code: ObservationValidationCode!
+
+  """
+  Particular errors for this validation type
+  """
+  messages: [String!]!
+}
+
+"""
+Types of observation validations
+"""
+enum ObservationValidationCode {
+  """
+  The observation or targets are missing required information
+  """
+  MISSING_DATA,
+
+  """
+  The data in the observation or targets is inconsistent.
+  """
+  CONFLICTING_DATA,
+
+  """
+  The observation does not meet the requirements of the Call for Proposals
+  """
+  CFP_ERROR
+
+  """
+  The observation is missing or is not accessible
+  """
+  MISSING_OBSERVATION
+}
 
 """
 Each step in a sequence is tagged with an observe class which identifies its

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -8021,24 +8021,14 @@ Types of observation validations
 """
 enum ObservationValidationCode {
   """
-  The observation or targets are missing required information
+  The observation is not configured correctly and cannot be executed
   """
-  MISSING_DATA,
-
-  """
-  The data in the observation or targets is inconsistent.
-  """
-  CONFLICTING_DATA,
+  CONFIGURATION_ERROR,
 
   """
   The observation does not meet the requirements of the Call for Proposals
   """
   CFP_ERROR
-
-  """
-  The observation is missing or is not accessible
-  """
-  MISSING_OBSERVATION
 }
 
 """

--- a/modules/schema/src/main/scala/lucuma/odb/data/ObservationValidation.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/ObservationValidation.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+
+import cats.data.NonEmptyChain
+import io.circe.Codec
+import io.circe.Decoder
+import io.circe.Encoder
+import lucuma.core.util.Enumerated
+
+enum ObservationValidationCode(
+  val tag: String,
+  val name: String,
+  val description: String
+) derives Enumerated:
+  case MissingData extends ObservationValidationCode("missing_data", "Missing Data", "Some required data is missing")
+  case ConflictingData extends ObservationValidationCode("conflicting_data", "Conflicting Data", "Conflicting data")
+  case CallForProposalsError extends ObservationValidationCode("cfp_error", "CfP Error", "Not valid for the selected Call for Proposals")
+  // we should never get this one, unless we change how the validation method is called.
+  case MissingObservation extends ObservationValidationCode("missing_observation", "Missing Observation", "The observation is missing or not accessible")
+
+case class ObservationValidation(
+  code: ObservationValidationCode,
+  messages: NonEmptyChain[String]
+) derives Codec
+
+object ObservationValidation:
+  def fromMsgs(code: ObservationValidationCode, msg: String, moreMsgs: String*): ObservationValidation =
+    ObservationValidation(code, NonEmptyChain.of(msg, moreMsgs*))
+  def missingData(msg: String, moreMsgs: String*): ObservationValidation =
+    fromMsgs(ObservationValidationCode.MissingData, msg, moreMsgs*)
+  def conflictingData(msg: String, moreMsgs: String*): ObservationValidation =
+    fromMsgs(ObservationValidationCode.ConflictingData, msg, moreMsgs*)
+  def callForProposals(msg: String, moreMsgs: String*): ObservationValidation =
+    fromMsgs(ObservationValidationCode.CallForProposalsError, msg, moreMsgs*)
+  def missingObservation(msg: String, moreMsgs: String*): ObservationValidation =
+    fromMsgs(ObservationValidationCode.MissingObservation, msg, moreMsgs*)

--- a/modules/schema/src/main/scala/lucuma/odb/data/ObservationValidation.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/ObservationValidation.scala
@@ -14,11 +14,8 @@ enum ObservationValidationCode(
   val name: String,
   val description: String
 ) derives Enumerated:
-  case MissingData extends ObservationValidationCode("missing_data", "Missing Data", "Some required data is missing")
-  case ConflictingData extends ObservationValidationCode("conflicting_data", "Conflicting Data", "Conflicting data")
-  case CallForProposalsError extends ObservationValidationCode("cfp_error", "CfP Error", "Not valid for the selected Call for Proposals")
-  // we should never get this one, unless we change how the validation method is called.
-  case MissingObservation extends ObservationValidationCode("missing_observation", "Missing Observation", "The observation is missing or not accessible")
+  case ConfigurationError extends ObservationValidationCode("configuration_error", "Configuration Error", "The observation is not configured correctly and cannot be executed")
+  case CallForProposalsError extends ObservationValidationCode("cfp_error", "Call for Proposals Error", "Not valid for the selected Call for Proposals")
 
 case class ObservationValidation(
   code: ObservationValidationCode,
@@ -28,11 +25,7 @@ case class ObservationValidation(
 object ObservationValidation:
   def fromMsgs(code: ObservationValidationCode, msg: String, moreMsgs: String*): ObservationValidation =
     ObservationValidation(code, NonEmptyChain.of(msg, moreMsgs*))
-  def missingData(msg: String, moreMsgs: String*): ObservationValidation =
-    fromMsgs(ObservationValidationCode.MissingData, msg, moreMsgs*)
-  def conflictingData(msg: String, moreMsgs: String*): ObservationValidation =
-    fromMsgs(ObservationValidationCode.ConflictingData, msg, moreMsgs*)
+  def configuration(msg: String, moreMsgs: String*): ObservationValidation =
+    fromMsgs(ObservationValidationCode.ConfigurationError, msg, moreMsgs*)
   def callForProposals(msg: String, moreMsgs: String*): ObservationValidation =
     fromMsgs(ObservationValidationCode.CallForProposalsError, msg, moreMsgs*)
-  def missingObservation(msg: String, moreMsgs: String*): ObservationValidation =
-    fromMsgs(ObservationValidationCode.MissingObservation, msg, moreMsgs*)

--- a/modules/service/src/main/scala/lucuma/odb/data/ObservationValidationMap.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/ObservationValidationMap.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+
+import cats.Order.*
+import cats.data.NonEmptyChain
+import cats.syntax.all.*
+import lucuma.core.util.NewType
+
+import scala.collection.immutable.SortedMap
+
+object ObservationValidationMap extends NewType[SortedMap[ObservationValidationCode, NonEmptyChain[String]]]:
+  def empty: ObservationValidationMap = ObservationValidationMap(SortedMap.empty[ObservationValidationCode, NonEmptyChain[String]])
+
+  def fromList(l: List[ObservationValidation]) =
+    l.foldLeft(empty){ _.add(_)}
+
+  extension (m: ObservationValidationMap.Type)
+    def add(validation: ObservationValidation): ObservationValidationMap = 
+      addMessages(validation.code, validation.messages)
+    def addMessages(code: ObservationValidationCode, msgs: NonEmptyChain[String]): ObservationValidationMap =
+      ObservationValidationMap(
+        m.value.updatedWith(code){
+          case None        => msgs.some
+          case Some(nec) => Some(nec |+| msgs)
+        }
+      )
+
+    def toList: List[ObservationValidation] = m.value.toList.map(ObservationValidation.apply)
+
+type ObservationValidationMap = ObservationValidationMap.Type

--- a/modules/service/src/main/scala/lucuma/odb/service/AsterismService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AsterismService.scala
@@ -89,7 +89,7 @@ trait AsterismService[F[_]] {
   def getAsterism(
     programId: Program.Id,
     observationId: Observation.Id
-  )(using NoTransaction[F]): F[List[(Target.Id, Target)]]
+  ): F[List[(Target.Id, Target)]]
 }
 
 object AsterismService {
@@ -185,7 +185,7 @@ object AsterismService {
       override def getAsterism(
         programId: Program.Id,
         observationId: Observation.Id
-      )(using NoTransaction[F]): F[List[(Target.Id, Target)]] =
+      ): F[List[(Target.Id, Target)]] =
         val af = Statements.getAsterism(user, programId, observationId)
         session.prepareR(af.fragment.query(Decoders.targetDecoder)).use { ps =>
           ps.stream(af.argument, chunkSize = 1024).compile.toList

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -465,7 +465,7 @@ object ObservationService {
       extension (tsi: TimestampInterval)
         def centerUnsafe: Timestamp =
           if (tsi.isEmpty) tsi.start
-          else tsi.start.plusMicrosOption(tsi.boundedTimeSpan.toMicroseconds).get
+          else tsi.start.plusMicrosOption(tsi.boundedTimeSpan.toMicroseconds / 2).get
 
       extension (ge: GeneratorParamsService.Error)
         def toObsValidation: ObservationValidation = ge match

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -30,19 +30,26 @@ import lucuma.core.math.Declination
 import lucuma.core.math.RightAscension
 import lucuma.core.math.SignalToNoise
 import lucuma.core.math.Wavelength
+import lucuma.core.model.CallForProposals
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ElevationRange
 import lucuma.core.model.Group
+import lucuma.core.model.ObjectTracking
 import lucuma.core.model.Observation
 import lucuma.core.model.ObservationReference
 import lucuma.core.model.Program
 import lucuma.core.model.StandardRole.*
+import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.core.util.Timestamp
+import lucuma.core.util.TimestampInterval
 import lucuma.odb.data.Existence
 import lucuma.odb.data.Nullable
 import lucuma.odb.data.Nullable.Absent
 import lucuma.odb.data.Nullable.NonNull
+import lucuma.odb.data.ObservationValidation
+import lucuma.odb.data.ObservationValidationCode
+import lucuma.odb.data.ObservationValidationMap
 import lucuma.odb.data.ObservingModeType
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
@@ -59,6 +66,7 @@ import lucuma.odb.graphql.input.ScienceRequirementsInput
 import lucuma.odb.graphql.input.SpectroscopyScienceRequirementsInput
 import lucuma.odb.graphql.input.TargetEnvironmentInput
 import lucuma.odb.graphql.input.TimingWindowInput
+import lucuma.odb.service.GeneratorParamsService.Error as GenParamsError
 import lucuma.odb.util.Codecs.*
 import lucuma.odb.util.Codecs.group_id
 import lucuma.odb.util.Codecs.int2_nonneg
@@ -100,6 +108,10 @@ sealed trait ObservationService[F[_]] {
     input: CloneObservationInput
   )(using Transaction[F]): F[Result[ObservationService.CloneIds]]
 
+  def observationValidations(
+    pid: Program.Id,
+    oid: Observation.Id
+  )(using Transaction[F]): F[List[ObservationValidation]]
 }
 
 object ObservationService {
@@ -149,6 +161,13 @@ object ObservationService {
       .find { dc => ex.message.contains(dc.constraint) }
       .map(_.message)
       .getOrElse(GenericConstraintViolationMessage(ex.message))
+
+  // observation validation messages
+  val AsterismOutOfRangeMsg = "Asterism out of Call for Proposals limits."
+  val ExplicitBaseOutOfRangeMsg = "Explicit base out of Call for Proposals limits."
+  def InvalidInstrumentMsg(instr: Instrument) = s"Instrument $instr not part of Call for Proposals."
+  def MissingDataMsg(otid: Option[Target.Id], paramName: String) =
+    otid.fold(s"Missing $paramName")(tid => s"Missing $paramName for target $tid")
 
   case class CloneIds(
     originalId: Observation.Id,
@@ -428,6 +447,128 @@ object ObservationService {
           _             <- ResultT(asterismService.setAsterism(pid, NonEmptyList.of(newOid), input.asterism))
         yield CloneIds(origOid, newOid)).value
         
+      // ***********************
+      // All about the validations
+      // ***********************
+      def cfpError(msg: String): ObservationValidation =
+        ObservationValidation.callForProposals(msg)
+
+      extension (ra: RightAscension)
+        def isInInterval(raStart: RightAscension, raEnd: RightAscension): Boolean =
+          if (raStart > raEnd) raStart <= ra || ra <= raEnd
+          else raStart <= ra && ra <= raEnd
+
+      extension (dec: Declination)
+        def isInInterval(decStart: Declination, decEnd: Declination): Boolean =
+          decStart <= dec && dec <= decEnd
+
+      extension (tsi: TimestampInterval)
+        def centerUnsafe: Timestamp =
+          if (tsi.isEmpty) tsi.start
+          else tsi.start.plusMicrosOption(tsi.boundedTimeSpan.toMicroseconds).get
+
+      extension (ge: GeneratorParamsService.Error)
+        def toObsValidation: ObservationValidation = ge match
+          case GenParamsError.MissingObservation(_, _)     => ObservationValidation.missingObservation(ge.format)
+          case GenParamsError.MissingData(otid, paramName) => ObservationValidation.missingData(MissingDataMsg(otid, paramName))
+          case GenParamsError.ConflictingData              => ObservationValidation.conflictingData(ge.format)
+
+      override def observationValidations(
+        pid: Program.Id,
+        oid: Observation.Id
+      )(using Transaction[F]): F[List[ObservationValidation]] = {
+        val generatorValidations: F[ObservationValidationMap] =
+          generatorParamsService.selectOne(pid, oid).map {
+            case Right(_) => ObservationValidationMap.empty
+            case Left(errors) => ObservationValidationMap.fromList(errors.map(_.toObsValidation).toList)
+          }
+ 
+        val optCfpId: F[Option[CallForProposals.Id]] = {
+          val af = Statements.getProgramCfpId(pid)
+          session.prepareR(af.fragment.query(cfp_id.opt))
+            .use(_.option(af.argument).map(_.flatten))
+        }
+
+        def validateAsterismRaDec(
+          raStart: RightAscension,
+          raEnd: RightAscension,
+          decStart: Declination,
+          decEnd: Declination,
+          active: TimestampInterval
+        ): F[Option[ObservationValidation]] = 
+          asterismService.getAsterism(pid,oid)
+            .map { l =>
+              val targets = l.map(_._2)
+              // The lack of a target will get reported in the generator errors
+              (for {
+                asterism <- NonEmptyList.fromList(targets)
+                tracking  = ObjectTracking.fromAsterism(asterism)
+                coordsAt <- tracking.at(active.centerUnsafe.toInstant)
+                coords    = coordsAt.value
+              } yield {
+                if (coords.ra.isInInterval(raStart, raEnd) && coords.dec.isInInterval(decStart, decEnd)) none
+                else cfpError(AsterismOutOfRangeMsg).some
+              }).flatten
+            }
+        
+        def validateRaDec(
+          cid: CallForProposals.Id,
+          explicitBase: Option[(RightAscension, Declination)]
+        ): F[Option[ObservationValidation]] = {
+          val af = Statements.getCfpInformation(cid)
+          session.prepareR(af.fragment.query(right_ascension.opt *: right_ascension.opt *: declination.opt *: declination.opt *: timestamp_interval_tsrange))
+            .use(_.unique(af.argument))
+            .flatMap( (ora1, ora2, odec1, odec2, active) =>
+              // if the proposal doesn't have Ra/Dec limits, there can't be an error
+              (ora1, ora2, odec1, odec2).tupled
+                .fold(none.pure) { (raStart, raEnd, decStart, decEnd) =>
+                  // if the observation has explicit base declared, use that
+                  explicitBase.fold(validateAsterismRaDec(raStart, raEnd, decStart, decEnd, active)){ (ra, dec) =>
+                    if (ra.isInInterval(raStart, raEnd) && dec.isInInterval(decStart, decEnd)) none.pure
+                    else cfpError(ExplicitBaseOutOfRangeMsg).some.pure
+                  }
+              }
+            )
+        }
+
+        def validateInstrument(cid: CallForProposals.Id, optInstr: Option[Instrument]): F[Option[ObservationValidation]] = {
+          // If there is no instrument in the observation, that will get caught with the generatorValidations
+          optInstr.fold(none.pure){ instr =>
+            val af = Statements.getCfpInstruments(cid)
+            session.prepareR(af.fragment.query(instrument))
+              .use(_.stream(af.argument, chunkSize = 1024).compile.toList)
+              .map(l => 
+                if(l.isEmpty || l.contains(instr)) none 
+                else cfpError(InvalidInstrumentMsg(instr)).some
+              )
+          }
+        }
+
+        val obsInfo: F[(Option[Instrument], Option[RightAscension], Option[Declination])] = {
+          val af = Statements.getObservationValidationInfo(oid)
+          session.prepareR(af.fragment.query(instrument.opt *: right_ascension.opt *: declination.opt))
+            .use(_.unique(af.argument))
+        }
+
+        val cfpValidations: F[ObservationValidationMap] = {
+          optCfpId.flatMap(
+            _.fold(ObservationValidationMap.empty.pure){ cid => 
+              for {
+                (oinstr, ora, odec) <- obsInfo
+                valInstr            <- validateInstrument(cid, oinstr)
+                explicitBase     = (ora, odec).tupled
+                valRaDec            <- validateRaDec(cid, explicitBase)
+              } yield ObservationValidationMap.fromList(List(valInstr, valRaDec).flatten)
+             }
+          )
+        }
+
+
+        for {
+          genVals <- generatorValidations
+          cfpVals <- cfpValidations
+        } yield (genVals |+| cfpVals).toList
+      }
     }
 
   object Statements {
@@ -916,6 +1057,42 @@ object ObservationService {
         FROM t_observation
         WHERE c_observation_id IN (
       """.apply(gid, index) |+| which |+| void")"
+
+    def getProgramCfpId(pid: Program.Id): AppliedFragment =
+      sql"""
+        SELECT c_cfp_id
+        FROM t_proposal
+        WHERE c_program_id = $program_id
+      """.apply(pid)
+
+    def getObservationValidationInfo(oid: Observation.Id): AppliedFragment =
+      sql"""
+        SELECT
+          c_instrument,
+          c_explicit_ra,
+          c_explicit_dec
+        FROM t_observation
+        WHERE c_observation_id = $observation_id
+      """.apply(oid)
+
+    def getCfpInformation(cid: CallForProposals.Id): AppliedFragment =
+      sql"""
+        SELECT
+          c_ra_start,
+          c_ra_end,
+          c_dec_start,
+          c_dec_end,
+          c_active
+        FROM t_cfp
+        WHERE c_cfp_id = $cfp_id
+      """.apply(cid)
+
+    def getCfpInstruments(cid: CallForProposals.Id): AppliedFragment =
+      sql"""
+        SELECT c_instrument
+        FROM t_cfp_instrument
+        WHERE c_cfp_id = $cfp_id
+      """.apply(cid)
   }
 
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -85,7 +85,8 @@ trait DatabaseOperations { this: OdbSuite =>
      callType:    CallForProposalsType = CallForProposalsType.RegularSemester,
      semester:    Semester             = Semester.unsafeFromString("2025A"),
      activeStart: Timestamp            = Timestamp.FromString.unsafeGet("2025-02-01 14:00:00"),
-     activeEnd:   Timestamp            = Timestamp.FromString.unsafeGet("2025-07-31 14:00:00")
+     activeEnd:   Timestamp            = Timestamp.FromString.unsafeGet("2025-07-31 14:00:00"),
+     other:       Option[String]       = None
   ): IO[CallForProposals.Id] =
     query(user, s"""
         mutation {
@@ -96,6 +97,7 @@ trait DatabaseOperations { this: OdbSuite =>
                 semester:    "${semester.format}"
                 activeStart: "${activeStart.format}"
                 activeEnd:   "${activeEnd.format}"
+                ${other.getOrElse("")}
               }
             }
           ) {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observationValidations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observationValidations.scala
@@ -1,0 +1,418 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package query
+
+import cats.effect.IO
+import cats.syntax.all.*
+import io.circe.Json
+import io.circe.syntax.*
+import lucuma.core.enums.Instrument
+import lucuma.core.model.CallForProposals
+import lucuma.core.model.Observation
+import lucuma.core.model.Target
+import lucuma.core.model.User
+import lucuma.core.syntax.string.*
+import lucuma.odb.data.CallForProposalsType
+import lucuma.odb.data.ObservationValidation
+import lucuma.odb.service.ObservationService
+
+class observationValidations extends OdbSuite with ObservingModeSetupOperations {
+  val pi    = TestUsers.Standard.pi(1, 30)
+  val staff = TestUsers.Standard.staff(3, 103)
+  
+  override def validUsers: List[User] = List(pi, staff)
+
+  // ra and dec values in degrees
+  val RaStart = 90
+  val RaCenter = 180
+  val RaEnd = 270
+  val RaStartWrap =  RaEnd
+  val RaCenterWrap = 1
+  val RaEndWrap = RaStart
+  val DecStart = 0
+  val DecCenter = 25
+  val DecEnd = 45
+  val Limits = (RaStart, RaEnd, DecStart, DecEnd)
+  val WrappedLimits = (RaStartWrap, RaEndWrap, DecStart, DecEnd)
+
+  def validationQuery(oid: Observation.Id) = 
+    s"""
+      query {
+        observation(observationId: "$oid") {
+          validations {
+            code
+            messages
+          }
+        }
+      }
+    """
+
+  def queryResult(obsVals: ObservationValidation*): Json = {
+    Json.obj(
+      "observation" ->
+        Json.obj("validations" -> obsVals.asJson)
+    )
+  }
+
+  // only use this if you have instruments, limits or both. Otherwise use createCallForProposalsAs(...)
+  def createCfp(
+    instruments: List[Instrument] = List.empty,
+    limits: Option[(Int, Int, Int, Int)] = none
+  ): IO[CallForProposals.Id] =
+    val inStr = 
+      if (instruments.isEmpty) ""
+      else s"instruments: [${instruments.map(_.tag.toScreamingSnakeCase).mkString(",")}]\n"
+    val limitStr = limits.fold("") { (raStart, raEnd, decStart, decEnd) =>
+      s"""
+        raLimitStart: { degrees: $raStart }
+        raLimitEnd: { degrees: $raEnd }
+        decLimitStart: { degrees: $decStart }
+        decLimitEnd: { degrees: $decEnd }
+      """
+    }
+    createCallForProposalsAs(staff, other = (inStr + limitStr).some)
+
+  def setTargetCoords(tid: Target.Id, raHours: Int, decHours: Int): IO[Unit] =
+    query(
+      user = pi,
+      query = s"""
+        mutation {
+          updateTargets(input: {
+            SET: {
+              sidereal: {
+                ra: { degrees: $raHours }
+                dec: { degrees: $decHours }
+              }
+            }
+            WHERE: {
+              id: { EQ: "$tid" }
+            }
+          }) {
+            targets {
+              id
+            }
+          }
+        }
+      """
+    ).void
+
+  def setObservationExplicitBase(oid: Observation.Id, raHours: Int, decHours: Int): IO[Unit] =
+    query(
+      user = pi,
+      query = s"""
+        mutation {
+          updateObservations(input: {
+            SET: {
+              targetEnvironment: {
+                explicitBase: {
+                  ra: { degrees: $raHours }
+                  dec: { degrees: $decHours }
+                }
+              }
+            },
+            WHERE: {
+              id: { EQ: ${oid.asJson} }
+            }
+          }) {
+            observations {
+              id
+            }
+          }
+        }
+      """
+    ).void
+
+  test("no target") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        oid <- createObservationAs(pi, pid)
+      } yield oid
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        validationQuery(oid),
+        expected = queryResult(
+          ObservationValidation.missingData(ObservationService.MissingDataMsg(none, "target"))
+        ).asRight
+      )
+    }
+  }
+
+  test("no observing mode") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        tid <- createTargetAs(pi, pid)
+        oid <- createObservationAs(pi, pid, tid)
+      } yield oid
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        validationQuery(oid),
+        expected = queryResult(
+          ObservationValidation.missingData(ObservationService.MissingDataMsg(none, "observing mode"))
+        ).asRight
+      )
+    }
+  }
+
+  test("missing target info") {
+    val setup: IO[(Target.Id, Observation.Id)] =
+      for {
+        pid <- createProgramAs(pi)
+        tid <- createTargetAs(pi, pid)
+        oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      } yield (tid, oid)
+    setup.flatMap { (tid, oid) =>
+      expect(
+        pi,
+        validationQuery(oid),
+        expected = queryResult(
+          ObservationValidation.missingData(
+            ObservationService.MissingDataMsg(tid.some, "brightness measure"),
+            ObservationService.MissingDataMsg(tid.some, "radial velocity")
+          )
+        ).asRight
+      )
+    }
+  }
+
+  test("no validations") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        tid <- createTargetWithProfileAs(pi, pid)
+        oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      } yield oid
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        validationQuery(oid),
+        expected = queryResult().asRight
+      )
+    }
+  }
+  
+  test("missing target info, invalid instrument") {
+    val setup: IO[(Target.Id, Observation.Id)] =
+      for {
+        pid <- createProgramAs(pi)
+        cid <- createCfp(List(Instrument.GmosSouth))
+        _   <- addProposal(pi, pid, cid.some)
+        tid <- createTargetAs(pi, pid)
+        oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      } yield (tid, oid)
+    setup.flatMap { (tid, oid) =>
+      expect(
+        pi,
+        validationQuery(oid),
+        expected = queryResult(
+          ObservationValidation.missingData(
+            ObservationService.MissingDataMsg(tid.some, "brightness measure"),
+            ObservationService.MissingDataMsg(tid.some, "radial velocity")
+          ),
+          ObservationValidation.callForProposals(
+            ObservationService.InvalidInstrumentMsg(Instrument.GmosNorth)
+          )
+        ).asRight
+      )
+    }
+  }
+
+  test("valid instrument") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        cid <- createCfp(List(Instrument.GmosNorth))
+        _   <- addProposal(pi, pid, cid.some)
+        tid <- createTargetWithProfileAs(pi, pid)
+        oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      } yield oid
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        validationQuery(oid),
+        expected = queryResult().asRight
+      )
+    }
+  }
+
+  test("invalid instrument") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        cid <- createCfp(List(Instrument.GmosSouth))
+        _   <- addProposal(pi, pid, cid.some)
+        tid <- createTargetWithProfileAs(pi, pid)
+        oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      } yield oid
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        validationQuery(oid),
+        expected = queryResult(
+          ObservationValidation.callForProposals(
+            ObservationService.InvalidInstrumentMsg(Instrument.GmosNorth)
+          )
+        ).asRight
+      )
+    }
+  }
+
+  test("explicit base within limits") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        cid <- createCfp(List(Instrument.GmosNorth), limits = Limits.some)
+        _   <- addProposal(pi, pid, cid.some)
+        tid <- createTargetWithProfileAs(pi, pid)
+        oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      } yield oid
+    setup.flatMap { oid =>
+      List((RaStart, DecStart), (RaEnd, DecEnd), (RaStart, DecEnd), (RaCenter, DecCenter)).traverse { (ra, dec) =>
+        setObservationExplicitBase(oid, ra, dec) >>
+          expect(
+            pi,
+            validationQuery(oid),
+            expected = queryResult().asRight
+          )
+      }
+    }
+  }
+
+  test("explicit base within limits, CfP with wrapped RA limits") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        cid <- createCfp(List(Instrument.GmosNorth), limits = WrappedLimits.some)
+        _   <- addProposal(pi, pid, cid.some)
+        tid <- createTargetWithProfileAs(pi, pid)
+        oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      } yield oid
+    setup.flatMap { oid =>
+      List((RaStartWrap, DecStart), (RaEndWrap, DecEnd), (RaStartWrap, DecEnd), (RaCenterWrap, DecCenter)).traverse { (ra, dec) =>
+        setObservationExplicitBase(oid, ra, dec) >>
+          expect(
+            pi,
+            validationQuery(oid),
+            expected = queryResult().asRight
+          )
+      }
+    }
+  }
+
+  test("explicit base outside limits") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        cid <- createCfp(List(Instrument.GmosNorth), limits = Limits.some)
+        _   <- addProposal(pi, pid, cid.some)
+        tid <- createTargetWithProfileAs(pi, pid)
+        oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      } yield oid
+    setup.flatMap { oid =>
+      List((RaStart - 1, DecStart), (RaEnd, DecEnd + 1), (RaCenterWrap, DecCenter)).traverse { (ra, dec) =>
+        setObservationExplicitBase(oid, ra, dec) >>
+          expect(
+            pi,
+            validationQuery(oid),
+            expected = queryResult(
+              ObservationValidation.callForProposals(ObservationService.ExplicitBaseOutOfRangeMsg)
+            ).asRight
+          )
+      }
+    }
+  }
+
+  test("explicit base outside limits, CfP with wrapped RA limits") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        cid <- createCfp(List(Instrument.GmosNorth), limits = WrappedLimits.some)
+        _   <- addProposal(pi, pid, cid.some)
+        tid <- createTargetWithProfileAs(pi, pid)
+        oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      } yield oid
+    setup.flatMap { oid =>
+      List((RaStartWrap, DecStart - 1), (RaEndWrap + 1, DecEnd), (RaStartWrap - 1, DecEnd), (RaCenter, DecCenter)).traverse { (ra, dec) =>
+        setObservationExplicitBase(oid, ra, dec) >>
+          expect(
+            pi,
+            validationQuery(oid),
+            expected = queryResult(
+              ObservationValidation.callForProposals(ObservationService.ExplicitBaseOutOfRangeMsg)
+            ).asRight
+          )
+      }
+    }
+  }
+
+  test("asterism within limits, valid instrument") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        cid <- createCfp(List(Instrument.GmosNorth), limits = Limits.some)
+        _   <- addProposal(pi, pid, cid.some)
+        tid <- createTargetWithProfileAs(pi, pid)
+        _   <- setTargetCoords(tid, RaCenter, DecCenter)
+        oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      } yield oid
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        validationQuery(oid),
+        expected = queryResult().asRight
+      )
+    }
+  }
+
+  test("asterism outside limits, valid instrument") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        cid <- createCfp(List(Instrument.GmosNorth), limits = Limits.some)
+        _   <- addProposal(pi, pid, cid.some)
+        tid <- createTargetWithProfileAs(pi, pid)
+        _   <- setTargetCoords(tid, RaStart - 20, DecCenter)
+        oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      } yield oid
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        validationQuery(oid),
+        expected = queryResult(
+          ObservationValidation.callForProposals(ObservationService.AsterismOutOfRangeMsg)
+        ).asRight
+      )
+    }
+  }
+
+  test("asterism outside limits, invalid instrument") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        cid <- createCfp(List(Instrument.GmosNorth), limits = Limits.some)
+        _   <- addProposal(pi, pid, cid.some)
+        tid <- createTargetWithProfileAs(pi, pid)
+        _   <- setTargetCoords(tid, RaStart - 20, DecCenter)
+        oid <- createGmosSouthLongSlitObservationAs(pi, pid, List(tid))
+      } yield oid
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        validationQuery(oid),
+        expected = queryResult(
+          ObservationValidation.callForProposals(
+            ObservationService.InvalidInstrumentMsg(Instrument.GmosSouth),
+            ObservationService.AsterismOutOfRangeMsg
+          )
+        ).asRight
+      )
+    }
+  }
+
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observationValidations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observationValidations.scala
@@ -136,7 +136,7 @@ class observationValidations extends OdbSuite with ObservingModeSetupOperations 
         pi,
         validationQuery(oid),
         expected = queryResult(
-          ObservationValidation.missingData(ObservationService.MissingDataMsg(none, "target"))
+          ObservationValidation.configuration(ObservationService.MissingDataMsg(none, "target"))
         ).asRight
       )
     }
@@ -154,7 +154,7 @@ class observationValidations extends OdbSuite with ObservingModeSetupOperations 
         pi,
         validationQuery(oid),
         expected = queryResult(
-          ObservationValidation.missingData(ObservationService.MissingDataMsg(none, "observing mode"))
+          ObservationValidation.configuration(ObservationService.MissingDataMsg(none, "observing mode"))
         ).asRight
       )
     }
@@ -172,7 +172,7 @@ class observationValidations extends OdbSuite with ObservingModeSetupOperations 
         pi,
         validationQuery(oid),
         expected = queryResult(
-          ObservationValidation.missingData(
+          ObservationValidation.configuration(
             ObservationService.MissingDataMsg(tid.some, "brightness measure"),
             ObservationService.MissingDataMsg(tid.some, "radial velocity")
           )
@@ -211,7 +211,7 @@ class observationValidations extends OdbSuite with ObservingModeSetupOperations 
         pi,
         validationQuery(oid),
         expected = queryResult(
-          ObservationValidation.missingData(
+          ObservationValidation.configuration(
             ObservationService.MissingDataMsg(tid.some, "brightness measure"),
             ObservationService.MissingDataMsg(tid.some, "radial velocity")
           ),


### PR DESCRIPTION
Validates that we can create a sequence for an observation. And, if a CfP is selected, that it meets the CfP criteria for instruments and ra/dec limits.

In the future this will be expanded such the for accepted proposals, observations are validated against the ordained configuration/targets/etc.