### PR TITLE
Configuration variable to allow CORS over plain http

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/Config.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Config.scala
@@ -37,16 +37,17 @@ import java.util.UUID
 import scala.concurrent.duration.*
 
 case class Config(
-  port:       Port,             // Our port, nothing fancy.
-  itc:        Config.Itc,       // ITC config
-  sso:        Config.Sso,       // SSO config
-  serviceJwt: String,           // Only service users can exchange API keys, so we need a service user JWT.
-  honeycomb:  Config.Honeycomb, // Honeycomb config
-  database:   Config.Database,  // Database config
-  aws:        Config.Aws,       // AWS config
-  email:      Config.Email,     // Mailgun config
-  domain:     List[String],     // Domains, for CORS headers
-  commitHash: CommitHash        // From Heroku Dyno Metadata
+  port:          Port,             // Our port, nothing fancy.
+  itc:           Config.Itc,       // ITC config
+  sso:           Config.Sso,       // SSO config
+  serviceJwt:    String,           // Only service users can exchange API keys, so we need a service user JWT.
+  honeycomb:     Config.Honeycomb, // Honeycomb config
+  database:      Config.Database,  // Database config
+  aws:           Config.Aws,       // AWS config
+  email:         Config.Email,     // Mailgun config
+  corsOverHttps: Boolean,          // Whether to require CORS over HTTPS
+  domain:        List[String],     // Domains, for CORS headers
+  commitHash:    CommitHash        // From Heroku Dyno Metadata
 ) {
 
   // People send us their JWTs. We need to be able to extract them from the request, decode them,
@@ -171,7 +172,7 @@ object Config {
       envOrProp("ODB_MAX_CONNECTIONS").as[Int].default(Default.MaxConnections),
       envOrProp("DATABASE_URL").as[URI] // passed by Heroku
     ).parTupled.as[Database]
-    
+
   }
 
   case class Aws(
@@ -279,6 +280,7 @@ object Config {
     Database.fromCiris,
     Aws.fromCiris,
     Email.fromCirrus,
+    envOrProp("CORS_OVER_HTTPS").as[Boolean].default(true), // By default require https
     envOrProp("ODB_DOMAIN").map(_.split(",").map(_.trim).toList).as[List[String]],
     envOrProp("HEROKU_SLUG_COMMIT").as[CommitHash].default(CommitHash.Zero)
   ).parMapN(Config.apply)

--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -205,6 +205,7 @@ object FMain extends MainParams {
       config.itcClient,
       config.commitHash,
       config.ssoClient,
+      config.corsOverHttps,
       config.domain,
       S3FileService.s3AsyncClientOpsResource(config.aws),
       S3FileService.s3PresignerResource(config.aws),
@@ -219,6 +220,7 @@ object FMain extends MainParams {
     itcClientResource:   Resource[F, ItcClient[F]],
     commitHash:          CommitHash,
     ssoClientResource:   Resource[F, SsoClient[F, User]],
+    corsOverHttps:       Boolean,
     domain:              List[String],
     s3OpsResource:       Resource[F, S3AsyncClientOp[F]],
     s3PresignerResource: Resource[F, S3Presigner],
@@ -230,7 +232,7 @@ object FMain extends MainParams {
       ssoClient         <- ssoClientResource
       httpClient        <- httpClientResource
       userSvc           <- pool.map(UserService.fromSession(_))
-      middleware        <- Resource.eval(ServerMiddleware(domain, ssoClient, userSvc))
+      middleware        <- Resource.eval(ServerMiddleware(corsOverHttps, domain, ssoClient, userSvc))
       enums             <- Resource.eval(pool.use(Enums.load))
       ptc               <- Resource.eval(pool.use(TimeEstimateCalculator.fromSession(_, enums)))
       graphQLRoutes     <- GraphQLRoutes(itcClient, commitHash, ssoClient, pool, SkunkMonitor.noopMonitor[F], GraphQLServiceTTL, userSvc, enums, ptc, httpClient, emailConfig)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -262,6 +262,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
       itcClient.pure[Resource[IO, *]],
       CommitHash.Zero,
       ssoClient.pure[Resource[IO, *]],
+      true,
       List("unused"),
       s3ClientOpsResource,
       s3PresignerResource,


### PR DESCRIPTION
In some cases, local dev, it would be useful to support CORS over plain http
This PR adds support for that defaulting to requiring CORS