### PR TITLE
Fix GH issue 1237

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0881__update_program_type.sql
+++ b/modules/service/src/main/resources/db/migration/V0881__update_program_type.sql
@@ -1,0 +1,74 @@
+-- Update the update_program_type function to handle COM and MON
+CREATE OR REPLACE FUNCTION update_program_type()
+RETURNS TRIGGER AS $$
+BEGIN
+
+    CASE
+      WHEN NEW.c_program_type = 'calibration'   OR
+           NEW.c_program_type = 'commissioning' OR
+           NEW.c_program_type = 'engineering'   OR
+           NEW.c_program_Type = 'monitoring'    THEN
+        BEGIN
+          IF NEW.c_semester IS NULL THEN
+            RAISE EXCEPTION '% programs must define a semester', INITCAP(NEW.c_program_type);
+          ELSEIF NEW.c_instrument IS NULL THEN
+            RAISE EXCEPTION '% programs must define an instrument', INITCAP(NEW.c_program_type);
+          ELSEIF (NEW.c_program_type != OLD.c_program_type)         OR
+                 (NEW.c_semester   IS DISTINCT FROM OLD.c_semester)   OR
+                 (NEW.c_instrument IS DISTINCT FROM OLD.c_instrument) THEN
+            NEW.c_semester_index := next_semester_index(NEW.c_program_type, NEW.c_semester, NEW.c_instrument);
+          END IF;
+          NEW.c_library_desc    := NULL;
+          NEW.c_science_subtype := NULL;
+        END;
+
+      WHEN NEW.c_program_type = 'example' THEN
+        BEGIN
+          IF NEW.c_instrument IS NULL THEN
+            RAISE EXCEPTION 'Example programs must define an instrument';
+          END IF;
+          NEW.c_semester        := NULL;
+          NEW.c_semester_index  := NULL;
+          NEW.c_library_desc    := NULL;
+          NEW.c_science_subtype := NULL;
+        END;
+
+      WHEN NEW.c_program_type = 'library' THEN
+        BEGIN
+          IF NEW.c_instrument IS NULL THEN
+            RAISE EXCEPTION 'Library programs must define an instrument';
+          ELSEIF NEW.c_library_desc IS NULL THEN
+            RAISE EXCEPTION 'Library programs must define a description';
+          END IF;
+          NEW.c_semester        := NULL;
+          NEW.c_semester_index  := NULL;
+          NEW.c_science_subtype := NULL;
+        END;
+
+      WHEN NEW.c_program_type = 'science' THEN
+        BEGIN
+          IF NEW.c_proposal_status <> 'not_submitted' THEN
+            -- Since it is submitted it must have a semester and subtype.
+            -- If there was a type
+            IF NEW.c_semester IS NULL THEN
+              RAISE EXCEPTION 'Submitted science programs must define a semester';
+            ELSEIF NEW.c_science_subtype IS NULL THEN
+              RAISE EXCEPTION 'Submitted science programs must define a science subtype.';
+            ELSEIF (NEW.c_program_type != OLD.c_program_type) OR
+                   (NEW.c_semester IS DISTINCT FROM OLD.c_semester) OR
+                   (OLD.c_proposal_status = 'not_submitted' AND NEW.c_semester_index IS NULL) THEN
+              NEW.c_semester_index := next_semester_index('science', NEW.c_semester, NULL);
+            END IF;
+          ELSEIF (NEW.c_semester IS DISTINCT FROM OLD.c_semester) THEN
+            -- Since it is not submitted and the semester has changed, we lose
+            -- any index we may have had while previously submitted
+            NEW.c_semester_index := NULL;
+          END IF;
+          NEW.c_instrument   := NULL;
+          NEW.c_library_desc := NULL;
+        END;
+    END CASE;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/modules/service/src/main/resources/db/migration/V0884__update_program_type.sql
+++ b/modules/service/src/main/resources/db/migration/V0884__update_program_type.sql
@@ -67,6 +67,18 @@ BEGIN
           NEW.c_instrument   := NULL;
           NEW.c_library_desc := NULL;
         END;
+
+      WHEN NEW.c_program_type = 'system' THEN
+        BEGIN
+          IF NEW.c_library_desc IS NULL THEN
+            RAISE EXCEPTION 'System programs must define a description';
+          END IF;
+          NEW.c_instrument      := NULL;
+          NEW.c_semester        := NULL;
+          NEW.c_semester_index  := NULL;
+          NEW.c_science_subtype := NULL;
+        END;
+
     END CASE;
 
     RETURN NEW;

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/1237.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/1237.scala
@@ -1,0 +1,73 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package issue.github
+
+import cats.effect.IO
+import cats.syntax.either.*
+import lucuma.core.model.CallForProposals
+import lucuma.core.model.Program
+import lucuma.core.model.ProposalReference
+import lucuma.core.model.Semester
+import lucuma.core.model.User
+
+class GitHub_1237 extends OdbSuite {
+
+  val pi         = TestUsers.Standard.pi(1, 101)
+  val staff      = TestUsers.Standard.staff(4, 104)
+  val validUsers = List(pi, staff)
+
+  val sem24B   = Semester.unsafeFromString("2024B")
+  val sem25A   = Semester.unsafeFromString("2025A")
+  val ref24B01 = ProposalReference.fromString.unsafeGet("G-2024B-0001")
+  val ref24B02 = ProposalReference.fromString.unsafeGet("G-2024B-0002")
+
+  private def switchCfp(user: User, pid: Program.Id, cid: CallForProposals.Id): IO[ProposalReference] =
+    query(
+      user,
+      s"""
+        mutation {
+          updateProposal(
+            input: {
+              programId: "$pid"
+              SET: {
+                callId: "$cid"
+              }
+            }
+          ) {
+            proposal { reference { label } }
+          }
+        }
+      """
+    ).flatMap { js =>
+      js.hcursor
+        .downFields("updateProposal", "proposal", "reference", "label")
+        .as[ProposalReference]
+        .leftMap(f => new RuntimeException(f.message))
+        .liftTo[IO]
+    }
+
+  test("switch proposal semester after unsubmit") {
+    for {
+      cid24B <- createCallForProposalsAs(staff, semester = sem24B)
+      cid25A <- createCallForProposalsAs(staff, semester = sem25A)
+
+      pid1 <- createProgramAs(pi)
+      _    <- addQueueProposal(pi, pid1, cid24B)
+      _    <- addPartnerSplits(pi, pid1)
+      ref1 <- submitProposal(pi, pid1)
+
+      pid2 <- createProgramAs(pi)
+      _    <- addQueueProposal(pi, pid2, cid25A)
+      _    <- addPartnerSplits(pi, pid2)
+      _    <- submitProposal(pi, pid2)
+      _    <- unsubmitProposal(pi, pid2)  // keeps the index 0001 of 2025A that was previously assigned
+      ref2 <- switchCfp(pi, pid2, cid24B) // switches the semester to 2024B (keeping already used index 0001)
+
+    } yield {
+      assertEquals(ref1, ref24B01)
+      assertEquals(ref2, ref24B02)
+    }
+  }
+}


### PR DESCRIPTION
Fixes the problem reported in #1237.  It's a rare edge case.

When a proposal is successfully submitted it gains a sequential semester index.  A desired use case is to be able to un-submit the proposal, make an edit, and then resubmit it without changing the index.  For that reason, when un-submitting we don't change the index.

When a CfP update changes the semester _after_ a proposal has been submitted then un-submitted though, the previous index is no longer valid and must be removed.  The proposal will subsequently gain a new index when it is ultimately submitted.