### PR TITLE
Set Science Band in Allocation

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -118,8 +118,9 @@ input AirMassRangeInput {
 Time allocation
 """
 type Allocation {
-  partner: Partner!
-  duration: TimeSpan!
+  partner:     Partner!
+  scienceBand: ScienceBand!
+  duration:    TimeSpan!
 }
 
 """
@@ -3941,9 +3942,10 @@ input ScienceRequirementsInput {
 }
 
 input SetAllocationInput {
-  programId: ProgramId!
-  partner: Partner!
-  duration: TimeSpanInput!
+  programId:   ProgramId!
+  partner:     Partner!
+  scienceBand: ScienceBand!
+  duration:    TimeSpanInput!
 }
 
 type SetAllocationResult {
@@ -9123,6 +9125,19 @@ enum ScienceMode {
   ScienceMode Spectroscopy
   """
   SPECTROSCOPY
+}
+
+"""
+Science observation priorities.
+"""
+enum ScienceBand {
+  BAND1
+
+  BAND2
+
+  BAND3
+
+  BAND4
 }
 
 """

--- a/modules/schema/src/main/scala/lucuma/odb/data/ScienceBand.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/ScienceBand.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+
+// TODO: move to core enums
+
+import lucuma.core.util.Enumerated
+
+enum ScienceBand(val tag: String) derives Enumerated:
+  case Band1 extends ScienceBand("band1")
+  case Band2 extends ScienceBand("band2")
+  case Band3 extends ScienceBand("band3")
+  case Band4 extends ScienceBand("band4")

--- a/modules/service/src/main/resources/db/migration/V0887__band.sql
+++ b/modules/service/src/main/resources/db/migration/V0887__band.sql
@@ -1,0 +1,19 @@
+-- Science band
+CREATE TYPE e_science_band AS ENUM(
+  'band1',
+  'band2',
+  'band3',
+  'band4'
+);
+
+ALTER TABLE t_allocation
+  ADD COLUMN c_science_band e_science_band;
+
+UPDATE t_allocation
+   SET c_science_band = 'band3';
+
+ALTER TABLE t_allocation
+  ALTER COLUMN c_science_band SET NOT NULL,
+  DROP CONSTRAINT "t_allocation_c_program_id_c_partner_key",
+  ADD CONSTRAINT "t_allocation_pid_partner_band"
+    UNIQUE (c_program_id, c_partner, c_science_band);

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -230,6 +230,7 @@ trait BaseMapping[F[_]]
   lazy val RedeemUserInvitationResultType          = schema.ref("RedeemUserInvitationResult")
   lazy val RevokeUserInvitationResultType          = schema.ref("RevokeUserInvitationResult")
   lazy val RightAscensionType                      = schema.ref("RightAscension")
+  lazy val ScienceBandType                         = schema.ref("ScienceBand")
   lazy val ScienceModeType                         = schema.ref("ScienceMode")
   lazy val ScienceProgramReferenceType             = schema.ref("ScienceProgramReference")
   lazy val ScienceRequirementsType                 = schema.ref("ScienceRequirements")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/ScienceBandBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/ScienceBandBinding.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.odb.data.ScienceBand
+
+val ScienceBandBinding: Matcher[ScienceBand] =
+  enumeratedBinding

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/SetAllocationInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/SetAllocationInput.scala
@@ -10,11 +10,13 @@ import grackle.Result
 import lucuma.core.enums.Partner
 import lucuma.core.model.Program
 import lucuma.core.util.TimeSpan
+import lucuma.odb.data.ScienceBand
 import lucuma.odb.graphql.binding.*
 
 case class SetAllocationInput(
   programId: Program.Id,
   partner: Partner,
+  scienceBand: ScienceBand,
   duration: TimeSpan
 )
 
@@ -25,9 +27,10 @@ object SetAllocationInput {
       case List(
         ProgramIdBinding("programId", rProgramId),
         PartnerBinding("partner", rPartner),
+        ScienceBandBinding("scienceBand", rBand),
         TimeSpanInput.Binding("duration", rDuration),
       ) =>
-        (rProgramId, rPartner, rDuration).mapN(apply)
+        (rProgramId, rPartner, rBand, rDuration).mapN(apply)
     }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AllocationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AllocationMapping.scala
@@ -13,8 +13,9 @@ trait AllocationMapping[F[_]] extends AllocationTable[F]  {
 
   lazy val AllocationMapping =
     ObjectMapping(AllocationType)(
-      SqlField("programId", AllocationTable.ProgramId, key = true, hidden = true),
-      SqlField("partner", AllocationTable.Partner, key = true),
+      SqlField("programId",   AllocationTable.ProgramId,   key = true, hidden = true),
+      SqlField("partner",     AllocationTable.Partner,     key = true),
+      SqlField("scienceBand", AllocationTable.ScienceBand, key = true),
       SqlObject("duration"),
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
@@ -48,6 +48,7 @@ import lucuma.odb.data.Extinction
 import lucuma.odb.data.ObservingModeType
 import lucuma.odb.data.PosAngleConstraintMode
 import lucuma.odb.data.ProgramUserRole
+import lucuma.odb.data.ScienceBand
 import lucuma.odb.data.StepExecutionState
 import lucuma.odb.data.Tag
 import lucuma.odb.data.UserType
@@ -148,6 +149,7 @@ trait LeafMappings[F[_]] extends BaseMapping[F] {
       LeafMapping[Tag](ProposalAttachmentTypeType),
       LeafMapping[ProposalReference](ProposalReferenceLabelType),
       LeafMapping[Tag](ProposalStatusType),
+      LeafMapping[ScienceBand](ScienceBandType),
       LeafMapping[ScienceMode](ScienceModeType),
       LeafMapping[ScienceSubtype](ScienceSubtypeType),
       LeafMapping[Tag](SeeingTrendType),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/AllocationTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/AllocationTable.scala
@@ -11,9 +11,10 @@ import lucuma.odb.util.Codecs.*
 trait AllocationTable[F[_]] extends BaseMapping[F] {
 
   object AllocationTable extends TableDef("t_allocation") {
-    val ProgramId = col("c_program_id", program_id)
-    val Partner = col("c_partner", partner)
-    val Duration = col("c_duration", time_span)
+    val ProgramId   = col("c_program_id",   program_id)
+    val Partner     = col("c_partner",      partner)
+    val ScienceBand = col("c_science_band", science_band)
+    val Duration    = col("c_duration",     time_span)
   }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/service/AllocationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AllocationService.scala
@@ -9,6 +9,7 @@ import grackle.Result
 import lucuma.core.enums.Partner
 import lucuma.core.model.Program
 import lucuma.core.util.TimeSpan
+import lucuma.odb.data.ScienceBand
 import lucuma.odb.graphql.input.SetAllocationInput
 import lucuma.odb.util.Codecs.*
 import skunk.*
@@ -27,19 +28,19 @@ object AllocationService {
 
       def setAllocation(input: SetAllocationInput)(using Transaction[F], Services.StaffAccess): F[Result[Unit]] =
         session.prepareR(Statements.SetAllocation.command).use: ps =>
-          ps.execute(input.programId, input.partner, input.duration).as(Result.unit)
+          ps.execute(input.programId, input.partner, input.scienceBand, input.duration).as(Result.unit)
 
     }
 
   object Statements {
 
-    val SetAllocation: Fragment[(Program.Id, Partner, TimeSpan)] =
+    val SetAllocation: Fragment[(Program.Id, Partner, ScienceBand, TimeSpan)] =
         sql"""
-          INSERT INTO t_allocation (c_program_id, c_partner, c_duration)
-          VALUES ($program_id, $partner, $time_span)
-          ON CONFLICT (c_program_id, c_partner) DO UPDATE
+          INSERT INTO t_allocation (c_program_id, c_partner, c_science_band, c_duration)
+          VALUES ($program_id, $partner, $science_band, $time_span)
+          ON CONFLICT (c_program_id, c_partner, c_science_band) DO UPDATE
           SET c_duration = $time_span
-        """.contramap { case (p, t, d) => (p, t, d, d) }
+        """.contramap { case (p, t, s, d) => (p, t, s, d, d) }
 
   }
 

--- a/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
@@ -57,6 +57,7 @@ import lucuma.odb.data.Md5Hash
 import lucuma.odb.data.ObservingModeType
 import lucuma.odb.data.PosAngleConstraintMode
 import lucuma.odb.data.ProgramUserRole
+import lucuma.odb.data.ScienceBand
 import lucuma.odb.data.StepExecutionState
 import lucuma.odb.data.Tag
 import lucuma.odb.data.TimeCharge.DiscountDiscriminator
@@ -409,6 +410,9 @@ trait Codecs {
       a => RightAscension.fromAngleExact.getOption(a).toRight(s"Invalid right ascension: $a"))(
       RightAscension.fromAngleExact.reverseGet
     )
+
+  val science_band: Codec[ScienceBand] =
+    enumerated(Type("e_science_band"))
 
   val science_mode: Codec[ScienceMode] =
     enumerated[ScienceMode](Type.varchar)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -61,6 +61,7 @@ import lucuma.odb.data.EmailId
 import lucuma.odb.data.Existence
 import lucuma.odb.data.ObservingModeType
 import lucuma.odb.data.ProgramUserRole
+import lucuma.odb.data.ScienceBand
 import lucuma.odb.graphql.input.TimeChargeCorrectionInput
 import lucuma.odb.json.angle.query.given
 import lucuma.odb.json.offset.transport.given
@@ -511,6 +512,7 @@ trait DatabaseOperations { this: OdbSuite =>
     user: User,
     pid: Program.Id,
     partner: Partner,
+    scienceBand: ScienceBand,
     duration: TimeSpan,
   ): IO[Unit] =
     expect(
@@ -519,13 +521,15 @@ trait DatabaseOperations { this: OdbSuite =>
         mutation {
           setAllocation(input: {
             programId: ${pid.asJson}
-            partner:   ${partner.tag.toUpperCase}
+            partner:   ${partner.tag.toScreamingSnakeCase}
+            scienceBand: ${scienceBand.tag.toScreamingSnakeCase}
             duration:  {
               hours: "${duration.toHours}"
             }
           }) {
             allocation {
               partner
+              scienceBand
               duration {
                 microseconds
                 milliseconds
@@ -542,6 +546,7 @@ trait DatabaseOperations { this: OdbSuite =>
           "setAllocation" : {
             "allocation" : {
               "partner":  ${partner.asJson},
+              "scienceBand": ${scienceBand.asJson},
               "duration": {
                 "microseconds": ${duration.toMicroseconds},
                 "milliseconds": ${duration.toMilliseconds},

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/linkUser.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/linkUser.scala
@@ -11,6 +11,7 @@ import lucuma.core.model.User
 import lucuma.core.syntax.timespan.*
 import lucuma.core.util.TimeSpan
 import lucuma.odb.data.OdbError
+import lucuma.odb.data.ScienceBand
 
 class linkUser extends OdbSuite {
 
@@ -74,7 +75,7 @@ class linkUser extends OdbSuite {
   test("[coi] ngo user can add coi to program with time allocated by user's partner") {
     createUsers(pi, pi2, ngo, admin) >>
     createProgramAs(pi).flatMap { pid =>
-      setAllocationAs(admin, pid, Partner.CA, 42.hourTimeSpan) >>
+      setAllocationAs(admin, pid, Partner.CA, ScienceBand.Band1, 42.hourTimeSpan) >>
       linkCoiAs(ngo, pi2.id -> pid, Partner.US)
     }
   }
@@ -147,7 +148,7 @@ class linkUser extends OdbSuite {
   test("[observer] ngo user can add observer to program with time allocated by user's partner") {
     createUsers(pi, pi2, ngo, admin) >>
     createProgramAs(pi).flatMap { pid =>
-      setAllocationAs(admin, pid, Partner.CA, 42.hourTimeSpan) >>
+      setAllocationAs(admin, pid, Partner.CA, ScienceBand.Band1, 42.hourTimeSpan) >>
       linkObserverAs(ngo, pi2.id -> pid, Partner.US)
     }
   }
@@ -193,7 +194,7 @@ class linkUser extends OdbSuite {
   test("[staff support] ngo user can't add staff support to program with time allocated by user's partner") {
     createUsers(pi, pi2, ngo, admin) >>
     createProgramAs(pi).flatMap { pid =>
-      setAllocationAs(admin, pid, Partner.CA, 42.hourTimeSpan) >>
+      setAllocationAs(admin, pid, Partner.CA, ScienceBand.Band1, 42.hourTimeSpan) >>
       interceptGraphQL(s"User ${ngo.id} is not authorized to perform this operation.") {
         linkSupportAs(ngo, pi2.id -> pid)
       }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setAllocation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setAllocation.scala
@@ -11,6 +11,7 @@ import lucuma.core.enums.Partner
 import lucuma.core.model.User
 import lucuma.core.syntax.timespan.*
 import lucuma.core.util.TimeSpan
+import lucuma.odb.data.ScienceBand
 
 class setAllocation extends OdbSuite {
 
@@ -27,7 +28,7 @@ class setAllocation extends OdbSuite {
     List(guest, pi, ngo).traverse { user =>
       createProgramAs(user).flatMap { pid =>
         interceptGraphQL(s"User ${user.id} is not authorized to perform this operation.") {
-          setAllocationAs(user, pid, Partner.CA, 42.hourTimeSpan)
+          setAllocationAs(user, pid, Partner.CA, ScienceBand.Band1, 42.hourTimeSpan)
         }
       }
     }
@@ -36,15 +37,15 @@ class setAllocation extends OdbSuite {
   test("admin, staff, service can set (and update) allocation in any program") {
     createProgramAs(pi).flatMap { pid =>
       List((admin, 2L), (staff, 3L), (service, 4L)).traverse { case (user, hours) =>
-        setAllocationAs(user, pid, Partner.US, TimeSpan.fromHours(hours).get)
+        setAllocationAs(user, pid, Partner.US, ScienceBand.Band1, TimeSpan.fromHours(hours).get)
       }
     }
   }
 
   test("should be able to read allocations back") {
     createProgramAs(pi).flatMap { pid =>
-      setAllocationAs(staff, pid, Partner.US, TimeSpan.fromHours(1.23).get) >>
-      setAllocationAs(staff, pid, Partner.CA, TimeSpan.fromHours(4.56).get) >>
+      setAllocationAs(staff, pid, Partner.US, ScienceBand.Band2, TimeSpan.fromHours(1.23).get) >>
+      setAllocationAs(staff, pid, Partner.CA, ScienceBand.Band3, TimeSpan.fromHours(4.56).get) >>
       expect(
         user = pi,
         query = s"""
@@ -52,6 +53,7 @@ class setAllocation extends OdbSuite {
             program(programId: "$pid") {
               allocations {
                 partner
+                scienceBand
                 duration {
                   hours
                 }              
@@ -66,12 +68,14 @@ class setAllocation extends OdbSuite {
                 "allocations" : [
                   {
                     "partner" : "CA",
+                    "scienceBand": "BAND3",
                     "duration" : {
                       "hours" : 4.560000
                     }
                   },
                   {
                     "partner" : "US",
+                    "scienceBand": "BAND2",
                     "duration" : {
                       "hours" : 1.230000
                     }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/unlinkUser.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/unlinkUser.scala
@@ -13,6 +13,7 @@ import lucuma.core.util.Enumerated
 import lucuma.core.util.TimeSpan
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.ProgramUserRole
+import lucuma.odb.data.ScienceBand
 
 class unlinkUser extends OdbSuite {
 
@@ -144,7 +145,7 @@ class unlinkUser extends OdbSuite {
           _   <- createUsers(pi1, pi2, admin, ngo)
           pid <- createProgramAs(pi1)
           _   <- linkAs(admin, pi2.id, pid, link, Option.when(link != ProgramUserRole.Support)(Partner.US))
-          _   <- setAllocationAs(admin, pid, Partner.CA, TimeSpan.Max) // so ngo can see the program
+          _   <- setAllocationAs(admin, pid, Partner.CA, ScienceBand.Band1, TimeSpan.Max) // so ngo can see the program
           _   <- unlinkAs(ngo, pi2.id, pid)
         yield ()
       } {


### PR DESCRIPTION
This is a straightforward update to add the science band to the time allocation.  It does not yet associate bands with observations or do any validation beyond what was already being done.