### PR TITLE
Inclusive Active Period End

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -390,7 +390,7 @@ type CallForProposals {
 
   """
   The active period during which accepted observations for this call may be
-  observed.
+  observed (inclusive start and end dates).
   """
   active: DateInterval!
 
@@ -444,15 +444,15 @@ input CallForProposalsPropertiesInput {
   Active period start date (inclusive) for this call.  Required on create.  The
   active period for this call will start on the night of the provided `Date`
   value. Must be before the `activeEnd` date.  Not nullable.  Limited to dates
-  between 1900 and 2100 (exclusive).
+  between the years 1900 and 2100 (exclusive).
   """
   activeStart: Date
 
   """
-  Active period end date (exclusive) for this call.  Required on create.  The
+  Active period end date (inclusive) for this call.  Required on create.  The
   active period for this call will end on the morning of the provided `Date`
-  value.  Must be after the `activeStart` date.  Not nullable.  Limited to dates
-  between 1900 and 2100 (exclusive).
+  value.  Must be equal to or after the `activeStart` date.  Not nullable.
+  Limited to dates between the years 1900 and 2100 (exclusive).
   """
   activeEnd: Date
 
@@ -911,14 +911,14 @@ Date in ISO-8601 representation in format YYYY-MM-DD (e.g., '2024-07-31').
 scalar Date
 
 """
-Date interval marked by a start 'Date' (inclusive) and an end 'Date' (exclusive).
+Date interval marked by a start 'Date' and an end 'Date'.
 """
 type DateInterval {
 
-  "Start date of the interval (inclusive)."
+  "Start date of the interval."
   start: Date!
 
-  "End date of the interval (exclusive)."
+  "End date of the interval."
   end: Date!
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CallForProposalsPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CallForProposalsPropertiesInput.scala
@@ -69,7 +69,7 @@ object CallForProposalsPropertiesInput {
           val rValidEnd   = validateYear("activeEnd", rActiveEnd)
           val rActive = (rValidStart, rValidEnd).parTupled.flatMap { (start, end) =>
             Result.fromOption(
-              Option.when(start < end)(DateInterval.between(start, end)),
+              Option.when(start <= end)(DateInterval.between(start, end.plusDays(1L))),
               Matcher.validationProblem("activeStart must come before activeEnd")
             )
           }
@@ -143,7 +143,7 @@ object CallForProposalsPropertiesInput {
             case (Some(start), Some(end)) if start > end =>
               Matcher.validationFailure("activeStart must come before activeEnd")
             case (s, e)                                  =>
-              Result(Ior.fromOptions(s, e))
+              Result(Ior.fromOptions(s, e.map(_.plusDays(1L))))
           }
           val rPartnersʹ    = dedup("partners",    rPartners)(_.partner, _.tag.toScreamingSnakeCase)
           val rInstrumentsʹ = dedup("instruments", rInstruments)(identity, _.tag.toScreamingSnakeCase)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/DateIntervalMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/DateIntervalMapping.scala
@@ -6,23 +6,27 @@ package lucuma.odb.graphql.mapping
 import grackle.Path
 import lucuma.odb.graphql.table.CallForProposalsView
 
+import java.time.LocalDate
+
 trait DateIntervalMapping[F[_]] extends CallForProposalsView[F] {
 
   private def dateIntervalMappingAtPath(
     path: Path,
+    idColumn: ColumnRef,
     startColumn: ColumnRef,
     endColumn:   ColumnRef,
-    idColumn: ColumnRef
+    inclusiveEnd: Boolean = false
   ): ObjectMapping =
     ObjectMapping(path)(
       SqlField(s"synthetic_id", idColumn, key = true, hidden = true),
       SqlField("start", startColumn),
-      SqlField("end", endColumn)
+      SqlField("_exclusive_end", endColumn, hidden = true),
+      FieldRef[LocalDate]("_exclusive_end").as("end", date => if (inclusiveEnd) date.minusDays(1L) else date)
     )
 
   lazy val DateIntervalMappings: List[TypeMapping] =
     List(
-      dateIntervalMappingAtPath(CallForProposalsType / "active", CallForProposalsView.ActiveStart, CallForProposalsView.ActiveEnd, CallForProposalsView.Id)
+      dateIntervalMappingAtPath(CallForProposalsType / "active", CallForProposalsView.Id, CallForProposalsView.ActiveStart, CallForProposalsView.ActiveEnd, inclusiveEnd = true)
     )
 
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createCallForProposals.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createCallForProposals.scala
@@ -192,6 +192,75 @@ class createCallForProposals extends OdbSuite {
     )
   }
 
+  test("success - another ra/dec example") {
+
+    // existence defaults to PRESENT
+    expect(
+      user = staff,
+      query = """
+        mutation {
+          createCallForProposals(
+            input: {
+              SET: {
+                type:        REGULAR_SEMESTER
+                semester:    "2024B"
+                activeStart: "2024-08-01"
+                activeEnd:   "2024-10-31"
+              }
+            }
+          ) {
+            callForProposals {
+              coordinateLimits {
+                north {
+                  raStart { hms }
+                  raEnd { hms }
+                  decStart { dms }
+                  decEnd { dms }
+                }
+                south {
+                  raStart { hms }
+                  raEnd { hms }
+                  decStart { dms }
+                  decEnd { dms }
+                }
+              }
+              active {
+                start
+                end
+              }
+            }
+          }
+        }
+      """,
+      expected = json"""
+        {
+          "createCallForProposals": {
+            "callForProposals": {
+              "coordinateLimits": {
+                "north": {
+                  "raStart": { "hms": "16:30:00.000000" },
+                  "raEnd": { "hms": "07:30:00.000000" },
+                  "decStart": { "dms": "-37:00:00.000000" },
+                  "decEnd": { "dms": "+90:00:00.000000" }
+                },
+                "south": {
+                  "raStart": { "hms": "15:30:00.000000" },
+                  "raEnd": { "hms": "06:30:00.000000" },
+                  "decStart": { "dms": "-90:00:00.000000" },
+                  "decEnd": { "dms": "+28:00:00.000000" }
+                }
+              },
+              "active": {
+                "start": "2024-08-01",
+                "end": "2024-10-31"
+              }
+            }
+          }
+        }
+      """.asRight
+    )
+  }
+
   test("failure - end before start") {
     expect(
       user = staff,
@@ -243,7 +312,6 @@ class createCallForProposals extends OdbSuite {
             }
           ) {
              callForProposals {
-               id
                submissionDeadlineDefault
                partners {
                  partner
@@ -258,7 +326,6 @@ class createCallForProposals extends OdbSuite {
         {
           "createCallForProposals": {
             "callForProposals": {
-              "id": "c-101",
               "submissionDeadlineDefault": "2025-07-31 10:00:02",
               "partners": [
                 {
@@ -301,7 +368,6 @@ class createCallForProposals extends OdbSuite {
             }
           ) {
              callForProposals {
-               id
                partners { partner }
              }
           }
@@ -311,7 +377,6 @@ class createCallForProposals extends OdbSuite {
         {
           "createCallForProposals": {
             "callForProposals": {
-              "id": "c-102",
               "partners": []
             }
           }
@@ -346,7 +411,6 @@ class createCallForProposals extends OdbSuite {
             }
           ) {
              callForProposals {
-               id
                partners {
                  partner
                  submissionDeadline

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createCallForProposals.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createCallForProposals.scala
@@ -90,7 +90,7 @@ class createCallForProposals extends OdbSuite {
                 type:        REGULAR_SEMESTER
                 semester:    "2024B"
                 activeStart: "2024-07-31"
-                activeEnd:   "2025-02-01"
+                activeEnd:   "2025-01-31"
               }
             }
           ) {
@@ -150,7 +150,7 @@ class createCallForProposals extends OdbSuite {
               },
               "active": {
                 "start": "2024-07-31",
-                "end": "2025-02-01"
+                "end": "2025-01-31"
               },
               "submissionDeadlineDefault": null,
               "partners": [
@@ -495,7 +495,7 @@ class createCallForProposals extends OdbSuite {
                 type:         REGULAR_SEMESTER
                 semester:    "2024B"
                 activeStart: "2024-07-31"
-                activeEnd:   "2025-02-01"
+                activeEnd:   "2025-01-31"
                 coordinateLimits: {
                   north: {
                     raStart: { hms: "17:00:00" }
@@ -560,7 +560,7 @@ class createCallForProposals extends OdbSuite {
                 type:         REGULAR_SEMESTER
                 semester:    "2024B"
                 activeStart: "2024-07-31"
-                activeEnd:   "2025-02-01"
+                activeEnd:   "2025-01-31"
                 coordinateLimits: {
                   south: {
                     decStart: { dms: "45:00:00" }


### PR DESCRIPTION
It was requested in [Short Cut 2951](https://app.shortcut.com/lucuma/story/2951/calculate-ra-limit-according-to-cfp-active-period#activity-3095) to make the end date of the active period inclusive rather than exclusive. This cuts against the grain of intervals, at least in my mind and certainly relative to the `TimestampInterval`.  Exclusive end is more convenient in most contexts because then the end of one interval is equal to the start of the next abutting interval.  Not to mention that end minus start yields the length of the interval.  I realized I could handle this just by adding a day on input and subtracting a day on output.

The drawback is that what we store and what we model internally would still be an exclusive end.  I'm guessing this discrepancy will bite us or our descendants at some point, but I'm reluctant to make an interval with an inclusive end for dates while leaving timestamps with an exclusive end.  Converting `TimestampInterval` to inclusive end would be challenging since it is used extensively in time accounting.


What do we think?