### PR TITLE
Update FT title

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0890__ft_cfp_title.sql
+++ b/modules/service/src/main/resources/db/migration/V0890__ft_cfp_title.sql
@@ -1,0 +1,33 @@
+
+-- Format the title of the CFP.
+CREATE OR REPLACE FUNCTION format_cfp_title(
+  cfp_type  e_cfp_type,
+  semester  d_semester,
+  startDate date,
+  endDate   date,
+  instruments d_tag[]
+) RETURNS text AS $$
+DECLARE
+  instrument_list text;
+BEGIN
+  instrument_list := array_to_string(instruments, ', ');
+  RETURN CASE
+    WHEN cfp_type = 'demo_science'        THEN concat(semester, ' Demo Science')
+    WHEN cfp_type = 'directors_time'      THEN concat(semester, ' Director''s Time')
+    WHEN cfp_type = 'fast_turnaround'     THEN
+      concat(
+        left(semester, -1),
+        ' ',
+        to_char(date_trunc('month', startDate) - INTERVAL '2 months', 'FMMonth'),
+        ' ',
+        'Fast Turnaround'
+      )
+    WHEN cfp_type = 'large_program'       THEN concat(semester, ' Large Program')
+    WHEN cfp_type = 'poor_weather'        THEN concat(semester, ' Poor Weather')
+    WHEN cfp_type = 'regular_semester'    THEN concat(semester, ' Regular Semester')
+    WHEN cfp_type = 'system_verification' THEN
+          concat(semester, nullif(' ' || instrument_list, ' '), ' System Verification')
+    ELSE concat(semester, ' ', cfp_type)
+  END CASE;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/callForProposals.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/callForProposals.scala
@@ -168,7 +168,7 @@ class callForProposals extends OdbSuite {
        .liftTo[IO]
     }
 
-    assertIO(title, "2025 August Fast Turnaround")
+    assertIO(title, "2025 June Fast Turnaround")
   }
 
   test("system verification - no instruments") {


### PR DESCRIPTION
Changes the computation of Fast Turnaround CfPs to be two months before the start of the active period, as discussed in [Short Cut 3089](https://app.shortcut.com/lucuma/story/3089/fast-turnaround-cfp-name).