### PR TITLE
Select optimal spectrophotometric standard

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0892__calibration_targets_change.sql
+++ b/modules/service/src/main/resources/db/migration/V0892__calibration_targets_change.sql
@@ -1,0 +1,25 @@
+-- Calibration programs' targets are marked with the same calibration type
+CREATE OR REPLACE FUNCTION calibration_targets_on_calibration_programs()
+  RETURNS trigger AS $$
+DECLARE
+    calibration_role e_calibration_role;
+BEGIN
+    -- Fetch the value from the source table
+    SELECT c_calibration_role INTO calibration_role
+    FROM t_program
+    WHERE c_program_id = NEW.c_program_id;
+
+    -- Only set NEW.c_calibration_role if calibration_role is not null
+    IF calibration_role IS NOT NULL THEN
+        NEW.c_calibration_role := calibration_role;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS ch_target_calibration_target ON t_target;
+CREATE TRIGGER ch_target_calibration_target
+  BEFORE INSERT OR UPDATE ON t_target
+  FOR EACH ROW
+  EXECUTE PROCEDURE calibration_targets_on_calibration_programs();

--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -44,10 +44,12 @@ import skunk.AppliedFragment
 import skunk.Query
 import skunk.Transaction
 import skunk.syntax.all.*
+import java.time.LocalDate
 
 trait CalibrationsService[F[_]] {
   def recalculateCalibrations(
-    pid: Program.Id
+    pid: Program.Id,
+    referenceDate: LocalDate
   )(using Transaction[F]): F[Unit]
 }
 
@@ -202,7 +204,7 @@ object CalibrationsService {
         } yield ()
       }
 
-      def recalculateCalibrations(pid: Program.Id)(using Transaction[F]): F[Unit] =
+      def recalculateCalibrations(pid: Program.Id, referenceDate: LocalDate)(using Transaction[F]): F[Unit] =
         for {
           gnls <- session.execute(Statements.selectGmosNorthLongSlitConfigurations(false))(pid)
           gsls <- session.execute(Statements.selectGmosSouthLongSlitConfigurations(false))(pid)

--- a/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
@@ -506,7 +506,7 @@ object ProposalService {
 
     def selectProposalContext(user: User, pid: Program.Id): AppliedFragment =
       sql"""
-        SELECT 
+        SELECT
           prog.c_program_type,
           prog.c_proposal_status,
           prop.c_program_id IS NOT NULL,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/calibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/calibrations.scala
@@ -24,6 +24,7 @@ import lucuma.core.math.Angle
 import java.time.format.DateTimeFormatter
 import java.time.ZoneOffset
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 class calibrations extends OdbSuite {
 
@@ -32,7 +33,7 @@ class calibrations extends OdbSuite {
 
   val validUsers = List(pi, service)
 
-  val when = LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant
+  val when = LocalDateTime.of(2024, 1, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
 
   case class CalibTarget(id: Target.Id) derives Decoder
   case class CalibTE(firstScienceTarget: Option[CalibTarget]) derives Decoder

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/calibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/calibrations.scala
@@ -21,9 +21,9 @@ import lucuma.core.model.ProgramReference.Description
 import io.circe.Json
 import lucuma.core.model.Target
 import lucuma.core.math.Angle
-import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.ZoneOffset
+import java.time.LocalDate
 
 class calibrations extends OdbSuite {
 
@@ -32,7 +32,7 @@ class calibrations extends OdbSuite {
 
   val validUsers = List(pi, service)
 
-  val referenceDate = LocalDate.of(2024, 1, 1)
+  val when = LocalDate.of(2024, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant
 
   case class CalibTarget(id: Target.Id) derives Decoder
   case class CalibTE(firstScienceTarget: Option[CalibTarget]) derives Decoder
@@ -152,7 +152,7 @@ class calibrations extends OdbSuite {
       oid <- createObservationAs(pi, pid, None)
       _   <- withServices(service) { services =>
                services.session.transaction.use { xa =>
-                 services.calibrationsService.recalculateCalibrations(pid, referenceDate)(using xa)
+                 services.calibrationsService.recalculateCalibrations(pid, when)(using xa)
                }
              }
       gr1  <- groupElementsAs(pi, pid, None)
@@ -171,7 +171,7 @@ class calibrations extends OdbSuite {
       gr  <- groupElementsAs(pi, pid, None)
       _   <- withServices(service) { services =>
                services.session.transaction.use { xa =>
-                 services.calibrationsService.recalculateCalibrations(pid, referenceDate)(using xa)
+                 services.calibrationsService.recalculateCalibrations(pid, when)(using xa)
                }
              }
       gr1  <- groupElementsAs(pi, pid, None)
@@ -196,7 +196,7 @@ class calibrations extends OdbSuite {
       oid2 <- createObservationAs(pi, pid, ObservingModeType.GmosSouthLongSlit.some)
       _    <- withServices(service) { services =>
                 services.session.transaction.use { xa =>
-                  services.calibrationsService.recalculateCalibrations(pid, referenceDate)(using xa)
+                  services.calibrationsService.recalculateCalibrations(pid, when)(using xa)
                 }
               }
       gr1  <- groupElementsAs(pi, pid, None)
@@ -225,8 +225,8 @@ class calibrations extends OdbSuite {
       oid2 <- createObservationAs(pi, pid, ObservingModeType.GmosSouthLongSlit.some)
       _    <- withServices(service) { services =>
                 services.session.transaction.use { xa =>
-                  services.calibrationsService.recalculateCalibrations(pid, referenceDate)(using xa) *>
-                    services.calibrationsService.recalculateCalibrations(pid, referenceDate)(using xa)
+                  services.calibrationsService.recalculateCalibrations(pid, when)(using xa) *>
+                    services.calibrationsService.recalculateCalibrations(pid, when)(using xa)
                 }
               }
       gr1  <- groupElementsAs(pi, pid, None)
@@ -341,7 +341,7 @@ class calibrations extends OdbSuite {
               }
       _    <- withServices(service) { services =>
                 services.session.transaction.use { xa =>
-                  services.calibrationsService.recalculateCalibrations(pid, referenceDate)(using xa)
+                  services.calibrationsService.recalculateCalibrations(pid, when)(using xa)
                 }
               }
       ob   <- queryCalibrationObservations(pid)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/calibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/calibrations.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Decoder
+import io.circe.syntax.*
 import io.circe.refined.*
 import lucuma.core.model.Group
 import lucuma.core.model.Observation
@@ -16,6 +17,17 @@ import lucuma.core.model.User
 import lucuma.odb.data.CalibrationRole
 import lucuma.odb.data.ObservingModeType
 import lucuma.odb.service.CalibrationsService
+import lucuma.odb.graphql.input.ProgramPropertiesInput
+import lucuma.core.model.ProgramReference.Description
+import lucuma.odb.graphql.mutation.createTarget
+import lucuma.core.model.SourceProfile
+import io.circe.Json
+import lucuma.core.model.Target
+import lucuma.core.math.RightAscension
+import lucuma.core.math.Angle
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.ZoneOffset
 
 class calibrations extends OdbSuite {
 
@@ -24,7 +36,9 @@ class calibrations extends OdbSuite {
 
   val validUsers = List(pi, service)
 
-  case class CalibObs(id: Observation.Id, groupId: Option[Group.Id], calibrationRole: Option[CalibrationRole]) derives Decoder
+  case class CalibTarget(id: Target.Id) derives Decoder
+  case class CalibTE(firstScienceTarget: Option[CalibTarget]) derives Decoder
+  case class CalibObs(id: Observation.Id, groupId: Option[Group.Id], calibrationRole: Option[CalibrationRole], targetEnvironment: Option[CalibTE]) derives Decoder
 
   private def queryGroup(gid: Group.Id): IO[(Group.Id, Boolean, NonEmptyString)] =
     query(
@@ -43,7 +57,35 @@ class calibrations extends OdbSuite {
   private def queryCalibrationObservations(pid: Program.Id): IO[List[CalibObs]] =
     query(
       service,
-      s"""query { observations(WHERE: {program: {id: {EQ: "$pid"}}}) { matches {id groupId calibrationRole} } }"""
+      s"""query {
+            observations(
+              WHERE: {
+                program: {
+                  id: {
+                    EQ: "$pid"
+                  }
+                }
+              }) {
+                matches {
+                  id
+                  groupId
+                  calibrationRole
+                  targetEnvironment {
+                    firstScienceTarget {
+                      id
+                      sidereal {
+                        ra {
+                          degrees
+                        }
+                        dec {
+                          degrees
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }"""
     ).flatMap { c =>
       (for {
         id    <- c.hcursor.downField("observations").downField("matches").as[List[CalibObs]]
@@ -51,6 +93,61 @@ class calibrations extends OdbSuite {
         .leftMap(f => new RuntimeException(f.message))
         .liftTo[IO]
      }
+
+  private def updateTargetProperties(tid: Target.Id, ra: Long, dec: Long, rv:  Double): IO[Json] =
+    query(
+      service,
+      s"""
+          mutation {
+            updateTargets(input: {
+              SET: {
+                sidereal: {
+                  ra: { degrees: ${Angle.fromMicroarcseconds(ra).toDoubleDegrees} }
+                  dec: { degrees: ${Angle.fromMicroarcseconds(dec).toDoubleDegrees} }
+                  radialVelocity: { metersPerSecond: $rv }
+                  epoch: "J2000.000"
+                }
+              }
+              WHERE: {
+                id: { EQ: "$tid"}
+              }
+            }) {
+              targets {
+                id
+              }
+            }
+          }
+      """
+    )
+
+  def formatLD(ld: LocalDate): String = {
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX")
+    ld.atStartOfDay().atOffset(ZoneOffset.UTC).format(formatter)
+  }
+
+  private def updateVizTime(oid: Observation.Id, vt: LocalDate): IO[Json] =
+    IO.println(vt) *>
+    query(
+      service,
+      s"""
+        mutation {
+          updateObservations(input: {
+            WHERE: {
+              id: {
+                EQ: "$oid"
+              }
+            },
+            SET: {
+              visualizationTime: "${formatLD(vt)}"
+            }
+          }) {
+            observations {
+              id
+            }
+          }
+        }
+      """
+    )
 
   test("no calibrations group if not needed") {
     for {
@@ -111,12 +208,12 @@ class calibrations extends OdbSuite {
       val oids = gr1.collect { case Right(oid) => oid }
       val cgid = gr1.collect { case Left(gid) => gid }.headOption
       val cCount = ob.count {
-        case CalibObs(_, _, Some(_)) => true
-        case _                       => false
+        case CalibObs(_, _, Some(_), _) => true
+        case _                          => false
       }
       // calibs belong to the calib group
       val obsGids = ob.collect {
-        case CalibObs(_, Some(gid), _) => gid
+        case CalibObs(_, Some(gid), _, _) => gid
       }
       assert(obsGids.forall(g => cgid.exists(_ == g)))
       assertEquals(cCount, 2)
@@ -125,27 +222,135 @@ class calibrations extends OdbSuite {
   }
 
   test("add calibrations is idempotent") {
-        for {
-          pid  <- createProgramAs(pi)
-          oid1 <- createObservationAs(pi, pid, ObservingModeType.GmosNorthLongSlit.some)
-          oid2 <- createObservationAs(pi, pid, ObservingModeType.GmosSouthLongSlit.some)
-          _    <- withServices(service) { services =>
-                    services.session.transaction.use { xa =>
-                      services.calibrationsService.recalculateCalibrations(pid)(using xa) *>
-                        services.calibrationsService.recalculateCalibrations(pid)(using xa)
-                    }
-                  }
-          gr1  <- groupElementsAs(pi, pid, None)
-          ob   <- queryCalibrationObservations(pid)
-        } yield {
-          val oids = gr1.collect { case Right(oid) => oid }
-          val cCount = ob.count {
-            case CalibObs(_, _, Some(_)) => true
-            case _                       => false
-          }
-          assertEquals(cCount, 2)
-          assertEquals(oids.size, 2)
-        }
+    for {
+      pid  <- createProgramAs(pi)
+      oid1 <- createObservationAs(pi, pid, ObservingModeType.GmosNorthLongSlit.some)
+      oid2 <- createObservationAs(pi, pid, ObservingModeType.GmosSouthLongSlit.some)
+      _    <- withServices(service) { services =>
+                services.session.transaction.use { xa =>
+                  services.calibrationsService.recalculateCalibrations(pid)(using xa) *>
+                    services.calibrationsService.recalculateCalibrations(pid)(using xa)
+                }
+              }
+      gr1  <- groupElementsAs(pi, pid, None)
+      ob   <- queryCalibrationObservations(pid)
+    } yield {
+      val oids = gr1.collect { case Right(oid) => oid }
+      val cCount = ob.count {
+        case CalibObs(_, _, Some(_), _) => true
+        case _                          => false
+      }
+      assertEquals(cCount, 2)
+      assertEquals(oids.size, 2)
+    }
   }
 
+  val spectroPhotometricTargets: List[(String, Long, Long, Double, String)] =
+    List(
+      ("BD+28  4211",
+        1180065332865L,
+        103910367627L,
+        0.000,
+        """{
+          "sourceProfile": {
+            "point": {
+                "emissionLines": null,
+                "bandNormalized": {
+                    "sed": null,
+                    "brightnesses": [
+                        {
+                            "band": "U",
+                            "error": null,
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "8.922"
+                        },
+                        {
+                            "band": "B",
+                            "error": "0.03",
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "10.25"
+                        },
+                        {
+                            "band": "V",
+                            "error": "0.05",
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "10.58"
+                        },
+                        {
+                            "band": "R",
+                            "error": null,
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "10.656"
+                        },
+                        {
+                            "band": "I",
+                            "error": null,
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "10.831"
+                        },
+                        {
+                            "band": "J",
+                            "error": "0.026",
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "11.275"
+                        },
+                        {
+                            "band": "H",
+                            "error": "0.036",
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "11.438"
+                        },
+                        {
+                            "band": "K",
+                            "error": "0.028",
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "11.556"
+                        },
+                        {
+                            "band": "GAIA",
+                            "error": "0.002851",
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "10.45304"
+                        }
+                    ]
+                }
+            },
+            "uniform": null,
+            "gaussian": null
+          }
+      }""")
+    )
+
+  test("select calibration target") {
+    for {
+      tpid <- withServices(service) { s =>
+                s.session.transaction.use { xa =>
+                  s.programService
+                    .insertCalibrationProgram(
+                      ProgramPropertiesInput.Create(None).some,
+                      CalibrationRole.SpectroPhotometric,
+                      Description.unsafeFrom("SPECTROTEST"))(using xa)
+                }
+              }
+      // Add some spectrophotometric targets
+      _    <- spectroPhotometricTargets.traverse {  case (n, ra, dec, rv, s) =>
+                 createTargetAs(service, tpid, n).flatTap(tid =>
+                   updateTargetProperties(tid, ra, dec, rv)
+                 )
+              }
+      pid  <- createProgramAs(pi)
+      oid1 <- createObservationAs(pi, pid, ObservingModeType.GmosNorthLongSlit.some).flatTap { oid =>
+                updateVizTime(oid, LocalDate.of(2024, 1, 1))
+              }
+      _    <- withServices(service) { services =>
+                services.session.transaction.use { xa =>
+                  services.calibrationsService.recalculateCalibrations(pid)(using xa)
+                }
+              }
+      ob   <- queryCalibrationObservations(pid)
+    } yield {
+      println(ob)
+      true
+    }
+  }
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
@@ -247,7 +247,7 @@ class cloneTarget extends OdbSuite {
                   {
                     "target": {
                       "id": $tid2,
-                      "calibrationRole": null
+                      "calibrationRole": "TELLURIC"
                     }
                   }
                 """)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/targets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/targets.scala
@@ -315,7 +315,7 @@ class targets extends OdbSuite {
               Right(Json.obj(
                 "targets" -> Json.obj(
                   "matches" -> Json.fromValues {
-                      // Only Photometric targets
+                      // Only Tellric targets
                       tids.map { id =>
                         Json.obj(
                           "id" -> id.asJson,


### PR DESCRIPTION
This is the next step to get the calibrations working
In this PR we select the best  target for the calibration. It does as follow:

* A calibration calculation is triggered, get the current time
* query the calibration targets
* Select the target based on minimum distance to zenith at each site
* Create calibration observations based on the config and the selected target

Note that every time we decide to re calculate a new target is cloned thus we may endup having multiple target copies.
I may add later on a cleaning step to remove thoe