### PR TITLE
Science Band Validations

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -527,7 +527,7 @@ trait MutationMapping[F[_]] extends Predicates[F] {
     MutationField("setAllocations", SetAllocationsInput.Binding): (input, child) =>
       services.useTransactionally:
         requireStaffAccess:
-          allocationService.setAllocations(input).as(
+          allocationService.setAllocations(input).map(_ *>
             allocationResultSubquery(input.programId, child)
           )
 

--- a/modules/service/src/main/scala/lucuma/odb/service/AllocationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AllocationService.scala
@@ -6,9 +6,13 @@ package lucuma.odb.service
 import cats.data.NonEmptyList
 import cats.effect.MonadCancelThrow
 import cats.syntax.all.*
+import grackle.Result
 import lucuma.core.enums.Partner
 import lucuma.core.model.Program
+import lucuma.core.syntax.string.*
 import lucuma.core.util.TimeSpan
+import lucuma.odb.data.OdbError
+import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.data.ScienceBand
 import lucuma.odb.graphql.input.AllocationInput
 import lucuma.odb.graphql.input.SetAllocationsInput
@@ -20,12 +24,25 @@ import Services.Syntax.*
 
 trait AllocationService[F[_]] {
   def setAllocations(input: SetAllocationsInput)(using Transaction[F], Services.StaffAccess): F[Unit]
+
+  /** Validats that the given `band` may be assigned to these `pids`. */
+  def validateBand(band: ScienceBand, pids: List[Program.Id]): F[Result[Unit]]
 }
 
 object AllocationService {
 
   def instantiate[F[_]: MonadCancelThrow](using Services[F]): AllocationService[F] =
     new AllocationService[F] {
+
+      def validateBand(band: ScienceBand, pids: List[Program.Id]): F[Result[Unit]] =
+        NonEmptyList.fromList(pids).fold(Result.unit.pure[F]) { nelPids =>
+          session.execute(Statements.validPidsForBand(nelPids))((band, nelPids)).map { validPids =>
+            (pids.toSet &~ validPids.toSet).toList match {
+              case Nil => Result.unit  // there are no `pids` not in `validPids`
+              case ps  => OdbError.InvalidArgument(s"One or more programs have not been allocated time in ${band.tag.toScreamingSnakeCase}: ${pids.mkString("[", ", ", "]")}".some).asFailure
+            }
+          }
+        }
 
       def deleteAllocations(pid: Program.Id)(using Transaction[F]): F[Unit] =
         session.execute(Statements.DeleteAllocations)(pid).void
@@ -36,12 +53,25 @@ object AllocationService {
           session.execute(Statements.setAllocations(lst))((input.programId, lst))
         }                                  *>
         observationService
-          .setScienceBand(input.programId, input.bands.head)
+          .setScienceBandInAllObservationsNoValidation(input.programId, input.bands.head)
           .whenA(input.bands.sizeIs == 1)
 
     }
 
   object Statements {
+
+    /**
+     * Obtains the subset of `pids` to which a given science band may be legally
+     * assigned.
+     */
+    def validPidsForBand(pids: NonEmptyList[Program.Id]): Query[(ScienceBand, pids.type), Program.Id] =
+      sql"""
+        SELECT c_program_id
+        FROM t_allocation
+        WHERE c_science_band = $science_band
+          AND c_duration > INTERVAL '0'
+          AND c_program_id IN (${program_id.values.list(pids.size)})
+      """.query(program_id).contramap { (band, nel) => (band, nel.toList) }
 
     def setAllocations(allocations: NonEmptyList[AllocationInput]): Command[(Program.Id, allocations.type)] =
       sql"""

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation.scala
@@ -447,7 +447,7 @@ class createObservation extends OdbSuite {
               }
             }
           """,
-          List(s"One or more programs have not been allocated time in BAND1: [$pid]").asLeft
+          List(s"One or more programs have not been allocated time in BAND1: $pid").asLeft
         )
       }
   }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
@@ -1859,7 +1859,7 @@ class updateObservations extends OdbSuite
             }
           }
         """,
-        List(s"One or more programs have not been allocated time in BAND1: [$pid]").asLeft
+        List(s"One or more programs have not been allocated time in BAND1: $pid").asLeft
       )
     } yield ()
   }


### PR DESCRIPTION
Performs a few validations related to setting observation science bands:

* Disallows creating an observation with a science band for which time has not been allocated
* Disallows updating an observation and setting a science band for which time has not been allocated
* Permits updating allocations, even if it would leave observations with an invalid science band, but generates a warning

I'll add a validation check for observations assigned a science band without a time allocation in the next (?) PR.

