### PR TITLE
Create new observations with a band when appropriate

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
@@ -20,6 +20,8 @@ import lucuma.odb.data.Existence
 import lucuma.odb.data.Nullable
 import lucuma.odb.data.ScienceBand
 import lucuma.odb.graphql.binding.*
+import monocle.Focus
+import monocle.Lens
 
 object ObservationPropertiesInput {
 
@@ -55,6 +57,9 @@ object ObservationPropertiesInput {
   ) extends AsterismInput
 
   object Create {
+
+    val scienceBand: Lens[Create, Option[ScienceBand]] =
+      Focus[Create](_.scienceBand)
 
     val Default: Create =
       Create(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation.scala
@@ -452,6 +452,70 @@ class createObservation extends OdbSuite {
       }
   }
 
+  test("[general] create observation with a single science band allocation") {
+    createProgramAs(pi)
+      .flatTap(pid => setAllocationsAs(staff, pid, List(AllocationInput(Partner.US, ScienceBand.Band2, 1.hourTimeSpan))))
+      .flatMap { pid =>
+        expect(pi,
+          s"""
+            mutation {
+              createObservation(input: {
+                programId: ${pid.asJson}
+                SET: { }
+              }) {
+                observation {
+                  scienceBand
+                }
+              }
+            }
+          """,
+          json"""
+            {
+              "createObservation": {
+                "observation": {
+                  "scienceBand": "BAND2"
+                }
+              }
+            }
+          """.asRight
+        )
+      }
+  }
+
+  test("[general] create observation with a multiple science band allocation") {
+    val allocations = List(
+      AllocationInput(Partner.US, ScienceBand.Band1, 1.hourTimeSpan),
+      AllocationInput(Partner.US, ScienceBand.Band2, 1.hourTimeSpan)
+    )
+    createProgramAs(pi)
+      .flatTap(pid => setAllocationsAs(staff, pid, allocations))
+      .flatMap { pid =>
+        expect(pi,
+          s"""
+            mutation {
+              createObservation(input: {
+                programId: ${pid.asJson}
+                SET: { }
+              }) {
+                observation {
+                  scienceBand
+                }
+              }
+            }
+          """,
+          json"""
+            {
+              "createObservation": {
+                "observation": {
+                  "scienceBand": null
+                }
+              }
+            }
+          """.asRight
+        )
+      }
+  }
+
   test("[general] created observation should have specified visualization time") {
     createProgramAs(pi).flatMap { pid =>
       query(pi,


### PR DESCRIPTION
When a new observation is created, if the program has time allocated in a single band, the desired behavior is that the observation be automatically assigned that band.  If time is allocated in multiple bands, new observations are not automatically assigned any band.