### PR TITLE
Ready Observations Must Have a Science Band

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0895__obs_status_constraint.sql
+++ b/modules/service/src/main/resources/db/migration/V0895__obs_status_constraint.sql
@@ -1,0 +1,11 @@
+-- Arbitrarily lower the observation status for all observations which do not
+-- have a science band.
+UPDATE t_observation
+   SET c_status = 'for_review'::e_obs_status
+ WHERE c_status >= 'ready'::e_obs_status AND c_science_band IS NULL;
+
+-- An observation must be assigned a band if its status is ready or greater.
+ALTER TABLE t_observation
+  ADD CONSTRAINT obs_status_science_band CHECK (
+    c_status < 'ready'::e_obs_status OR c_science_band IS NOT NULL
+  );

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -251,6 +251,9 @@ object ObservationService {
                   }
                 }
               }
+          }.recoverWith {
+             case SqlState.CheckViolation(ex) =>
+               OdbError.InvalidArgument(Some(constraintViolationMessage(ex))).asFailureF
           }
         }
 
@@ -414,7 +417,7 @@ object ObservationService {
             _ <- moveObservations(SET.group, SET.groupIndex, which)
             r <- updates.value.recoverWith {
                    case SqlState.CheckViolation(ex) =>
-                    OdbError.InvalidArgument(Some(constraintViolationMessage(ex))).asFailureF
+                     OdbError.InvalidArgument(Some(constraintViolationMessage(ex))).asFailureF
                  }
             _ <- transaction.rollback.unlessA(r.hasValue) // rollback if something failed
           } yield r

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -153,6 +153,12 @@ object ObservationService {
       "hourAngle constraint requires both minHours and maxHours."
     )
 
+  val MissingScienceBandConstraint: DatabaseConstraint =
+    DatabaseConstraint(
+      "obs_status_science_band",
+      "a science band must be assigned to ready, executing or executed observations"
+    )
+
   val BothExplicitCoordinatesConstraint: DatabaseConstraint =
     DatabaseConstraint(
       "explicit_base_neither_or_both",
@@ -166,6 +172,7 @@ object ObservationService {
     List(
       MissingAirMassConstraint,
       MissingHourAngleConstraint,
+      MissingScienceBandConstraint,
       BothExplicitCoordinatesConstraint
     )
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
@@ -12,11 +12,14 @@ import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.ObsActiveStatus
 import lucuma.core.enums.ObsStatus
+import lucuma.core.enums.Partner
 import lucuma.core.model.Observation
 import lucuma.core.model.ObservationReference
 import lucuma.core.model.Target
+import lucuma.core.syntax.timespan.*
 import lucuma.odb.data.Existence
 import lucuma.odb.data.ObservingModeType
+import lucuma.odb.data.ScienceBand
 
 class cloneObservation extends OdbSuite {
   val pi, pi2 = TestUsers.Standard.pi(nextId, nextId)
@@ -234,6 +237,7 @@ class cloneObservation extends OdbSuite {
           mutation {
             updateObservations(input: {
               SET: {
+                scienceBand: ${ScienceBand.Band1.tag.toUpperCase}
                 existence: ${Existence.Deleted.tag.toUpperCase}
                 status: ${ObsStatus.Observed.tag.toUpperCase}
                 activeStatus: ${ObsActiveStatus.Inactive.tag.toUpperCase}
@@ -244,6 +248,7 @@ class cloneObservation extends OdbSuite {
             }) {
               observations {
                 id
+                scienceBand
                 existence
                 status
                 activeStatus
@@ -258,6 +263,7 @@ class cloneObservation extends OdbSuite {
                 "observations" : [
                   {
                     "id" : $oid,
+                    "scienceBand": "BAND1",
                     "existence" : "DELETED",
                     "status" : "OBSERVED",
                     "activeStatus" : "INACTIVE"
@@ -272,6 +278,7 @@ class cloneObservation extends OdbSuite {
     val setup =
       for
         pid <- createProgramAs(pi)
+        _   <- setOneAllocationAs(staff, pid, Partner.US, ScienceBand.Band1, 1.hourTimeSpan)
         oid <- createObservationAs(pi, pid)
         _   <- updateFields(oid)
       yield oid
@@ -285,6 +292,7 @@ class cloneObservation extends OdbSuite {
               observationId: "$oid"
             }) {
               newObservation {
+                scienceBand
                 existence
                 status
                 activeStatus
@@ -297,6 +305,7 @@ class cloneObservation extends OdbSuite {
             {
               "cloneObservation" : {
                 "newObservation" : {
+                  "scienceBand": "BAND1",
                   "existence" : "PRESENT",
                   "status" : "NEW",
                   "activeStatus" : "ACTIVE"

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
@@ -1864,6 +1864,61 @@ class updateObservations extends OdbSuite
     } yield ()
   }
 
+  test("constraint set: ready but no science band") {
+    oneUpdateTest(
+      user   = pi,
+      update = """
+        status: READY
+      """,
+      query = """
+        observations {
+          status
+        }
+      """,
+      expected = ObservationService.MissingScienceBandConstraint.message.asLeft
+    )
+  }
+
+  test("constraint set: science band / ready set together") {
+    for
+      pid <- createProgramAs(pi)
+      _   <- setOneAllocationAs(staff, pid, Partner.US, ScienceBand.Band1, 1.hourTimeSpan)
+      oid <- createObservationAs(pi, pid)
+      _   <- expect(
+        user   = pi,
+        query = s"""
+          mutation {
+            updateObservations(input: {
+              SET: {
+                status: READY
+                scienceBand: BAND1
+              },
+              WHERE: {
+                id: { EQ: "$oid" }
+              }
+            }) {
+              observations {
+                status
+                scienceBand
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "updateObservations": {
+              "observations": [
+                {
+                  "status": "READY",
+                  "scienceBand": "BAND1"
+                }
+              ]
+            }
+          }
+        """.asRight
+      )
+    yield ()
+  }
 }
 
 trait UpdateConstraintSetOps { this: OdbSuite =>


### PR DESCRIPTION
Adds a constraint on `t_observation` that a ready (or beyond) observation must have been assigned a science band.