### PR TITLE
Initial group contents

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7306,6 +7306,12 @@ type GroupElement {
   existence: Existence!
 }
 
+"A group element identifier. Exactly one of groupId and observationId must be provided."
+input GroupElementInput {
+  groupId: GroupId
+  observationId: ObservationId
+}
+
 input GroupPropertiesInput {
 
   "Group name (optional)."
@@ -7347,6 +7353,9 @@ input CreateGroupInput {
   proposalReference: ProposalReferenceLabel
   programReference: ProgramReferenceLabel
   SET: GroupPropertiesInput
+  
+  "Group elements specified here, if any, will be moved into the created group in the specified order."
+  initialContents: [GroupElementInput]
 }
 
 "The result of creating a new group."

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CreateGroupInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CreateGroupInput.scala
@@ -5,12 +5,12 @@ package lucuma.odb.graphql
 package input
 
 import cats.syntax.all.*
+import lucuma.core.model.Group
+import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.ProgramReference
 import lucuma.core.model.ProposalReference
 import lucuma.odb.graphql.binding.*
-import lucuma.core.model.Group
-import lucuma.core.model.Observation
 
 case class CreateGroupInput(
   programId:         Option[Program.Id],

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CreateGroupInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CreateGroupInput.scala
@@ -9,12 +9,15 @@ import lucuma.core.model.Program
 import lucuma.core.model.ProgramReference
 import lucuma.core.model.ProposalReference
 import lucuma.odb.graphql.binding.*
+import lucuma.core.model.Group
+import lucuma.core.model.Observation
 
 case class CreateGroupInput(
   programId:         Option[Program.Id],
   proposalReference: Option[ProposalReference],
   programReference:  Option[ProgramReference],
-  SET:               GroupPropertiesInput.Create
+  SET:               GroupPropertiesInput.Create,
+  initialContents:   List[Either[Group.Id, Observation.Id]],
 )
 
 object CreateGroupInput {
@@ -24,9 +27,10 @@ object CreateGroupInput {
         ProgramIdBinding.Option("programId", rPid),
         ProposalReferenceBinding.Option("proposalReference", rProp),
         ProgramReferenceBinding.Option("programReference", rProg),
-        GroupPropertiesInput.CreateBinding.Option("SET", rInput)
-      ) => (rPid, rProp, rProg, rInput).mapN { (pid, prop, prog, oset) =>
-        CreateGroupInput(pid, prop, prog, oset.getOrElse(GroupPropertiesInput.Empty))
+        GroupPropertiesInput.CreateBinding.Option("SET", rInput),
+        GroupElementInput.Binding.List.Option("initialContents", rInitialContents),
+      ) => (rPid, rProp, rProg, rInput, rInitialContents).mapN { (pid, prop, prog, oset, initialContents) =>
+        CreateGroupInput(pid, prop, prog, oset.getOrElse(GroupPropertiesInput.Empty), initialContents.foldMap(_.map(_.value)))
       }
     }
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GroupElementInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GroupElementInput.scala
@@ -4,12 +4,12 @@
 package lucuma.odb.graphql.input
 
 import cats.syntax.all.*
+import grackle.Result
 import lucuma.core.model.Group
 import lucuma.core.model.Observation
+import lucuma.odb.graphql.binding.GroupIdBinding
 import lucuma.odb.graphql.binding.ObjectFieldsBinding
 import lucuma.odb.graphql.binding.ObservationIdBinding
-import lucuma.odb.graphql.binding.GroupIdBinding
-import grackle.Result
 
 final case class GroupElementInput(value: Either[Group.Id, Observation.Id])
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GroupElementInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GroupElementInput.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.input
+
+import cats.syntax.all.*
+import lucuma.core.model.Group
+import lucuma.core.model.Observation
+import lucuma.odb.graphql.binding.ObjectFieldsBinding
+import lucuma.odb.graphql.binding.ObservationIdBinding
+import lucuma.odb.graphql.binding.GroupIdBinding
+import grackle.Result
+
+final case class GroupElementInput(value: Either[Group.Id, Observation.Id])
+
+object GroupElementInput:
+  val Binding = ObjectFieldsBinding.rmap:
+    case List(
+      GroupIdBinding.Option("groupId", rGroupId),
+      ObservationIdBinding.Option("observationId", rObservationId),
+    ) =>
+      (rGroupId, rObservationId).parTupled.flatMap:
+        case (Some(g), None) => Result.Success(GroupElementInput(Left(g)))
+        case (None, Some(p)) => Result.Success(GroupElementInput(Right(p)))
+        case _ => Result.failure("Exactly one of groupId and observationId must be specified.")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
@@ -143,6 +143,26 @@ object ObservationPropertiesInput {
 
   object Edit {
 
+    val Empty: Edit =
+      Edit(
+        subtitle =           Nullable.Absent,
+        status =             None,
+        activeStatus =       None,
+        scienceBand =        Nullable.Absent,
+        visualizationTime =  Nullable.Absent,
+        posAngleConstraint = None,
+        targetEnvironment =  None,
+        constraintSet =      None,
+        timingWindows =      Nullable.Absent,
+        obsAttachments =     Nullable.Absent,
+        scienceRequirements =None,
+        observingMode =      Nullable.Absent,
+        existence =          None,
+        group =              Nullable.Absent,
+        groupIndex =         None,
+        observerNotes =      Nullable.Absent,
+      )
+
     val Binding: Matcher[Edit] =
       ObjectFieldsBinding.rmap {
         case List(

--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -129,7 +129,8 @@ object CalibrationsService {
                           parentGroupId = none,
                           parentGroupIndex = none,
                           existence = Existence.Present
-                        )
+                        ),
+                        Nil
                       ),
                     system = true
                   ).map(_.toOption)

--- a/modules/service/src/main/scala/lucuma/odb/service/GroupService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GroupService.scala
@@ -10,20 +10,20 @@ import eu.timepit.refined.types.numeric.NonNegShort
 import grackle.Result
 import lucuma.core.model.Access
 import lucuma.core.model.Group
+import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.odb.data.Existence
 import lucuma.odb.data.GroupTree
 import lucuma.odb.data.Nullable
 import lucuma.odb.graphql.input.CreateGroupInput
 import lucuma.odb.graphql.input.GroupPropertiesInput
+import lucuma.odb.graphql.input.ObservationPropertiesInput
 import lucuma.odb.util.Codecs.*
 import skunk.*
 import skunk.codec.all.*
 import skunk.implicits.*
 
 import Services.Syntax.*
-import lucuma.core.model.Observation
-import lucuma.odb.graphql.input.ObservationPropertiesInput
 
 trait GroupService[F[_]] {
   def createGroup(input: CreateGroupInput, system: Boolean = false)(using Transaction[F]): F[Result[Group.Id]]

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createGroup.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createGroup.scala
@@ -151,6 +151,17 @@ class createGroup extends OdbSuite {
     } yield assertEquals(ids, List(Left(g1), Left(g3), Left(g2)))
   }
 
+  test("create a group with initial contents") {
+    for {
+      pid <- createProgramAs(pi)
+      o1  <- createObservationAs(pi, pid)
+      g1  <- createGroupAs(pi, pid)
+      o2  <- createObservationAs(pi, pid)
+      g2  <- createGroupAs(pi, pid, initialContents = Some(List(Right(o1), Left(g1), Right(o2))))
+      ids  <- groupElementsAs(pi, pid, Some(g2))
+    } yield assertEquals(ids, List(Right(o1), Left(g1), Right(o2)))
+  }
+
   test("create group with a proposal reference") {
     val createWithReference: IO[Unit] =
       expect(


### PR DESCRIPTION
This adds a parameter to `CreateGroupInput` allowing the user to specify the initial contents of the group. Elements specified will be moved into the new group in the order specified.