### PR TITLE
ShortCut 3017: Phase 0 instrument configuration option update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: sbt -v -J-Xmx6g +update
 
       - name: Docker compose up
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Check that workflows are up to date
         run: sbt -v -J-Xmx6g githubWorkflowCheck
@@ -93,7 +93,7 @@ jobs:
         uses: codecov/codecov-action@v4
 
       - name: Docker compose down
-        run: docker-compose down
+        run: docker compose down
 
   publish:
     name: Publish Artifacts

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,6 +24,14 @@ pull_request_rules:
       add:
       - calibrations
       remove: []
+- name: Label phase0 PRs
+  conditions:
+  - files~=^modules/phase0/
+  actions:
+    label:
+      add:
+      - phase0
+      remove: []
 - name: Label schema PRs
   conditions:
   - files~=^modules/schema/

--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,7 @@ lazy val smartgcal = project
 
 lazy val service = project
   .in(file("modules/service"))
-  .dependsOn(sequence, smartgcal)
+  .dependsOn(phase0, sequence, smartgcal)
   .enablePlugins(NoPublishPlugin, JavaAppPackaging)
   .settings(
     name := "lucuma-odb-service",
@@ -159,5 +159,22 @@ lazy val calibrations = project
     name := "calibrations-service",
     projectDependencyArtifacts := (Compile / dependencyClasspathAsJars).value,
     reStart / envVars += "PORT" -> "8082"
+  )
+
+lazy val phase0 = project
+  .in(file("modules/phase0"))
+  .enablePlugins(NoPublishPlugin)
+  .settings(
+    name := "lucuma-odb-phase0",
+    libraryDependencies ++= Seq(
+      "org.typelevel"  %% "cats-parse"                      % catsParseVersion,
+      "co.fs2"         %% "fs2-core"                        % fs2Version,
+      "co.fs2"         %% "fs2-io"                          % fs2Version,
+      "edu.gemini"     %% "lucuma-core"                     % lucumaCoreVersion,
+      "edu.gemini"     %% "lucuma-core-testkit"             % lucumaCoreVersion          % Test,
+      "org.scalameta"  %% "munit"                           % munitVersion               % Test,
+      "org.scalameta"  %% "munit-scalacheck"                % munitVersion               % Test,
+      "org.typelevel"  %% "discipline-munit"                % munitDisciplineVersion     % Test,
+    )
   )
 

--- a/modules/phase0/src/main/resources/phase0/Phase0_Instrument_Matrix - Spectroscopy.tsv
+++ b/modules/phase0/src/main/resources/phase0/Phase0_Instrument_Matrix - Spectroscopy.tsv
@@ -1,0 +1,613 @@
+Instrument	Config	Focal Plane	fpu	slit width	slit length	disperser	filter	wave min	wave max	wave optimal	wave coverage	resolution	AO	capabilities	site
+GMOS-N	B1200 0.25"	singleslit,multislit	0.25"	0.250	330	B1200	none	0.36	0.72	0.463	0.164	7488	no		n
+GMOS-N	B1200 0.50"	singleslit,multislit	0.50"	0.500	330	B1200	none	0.36	0.72	0.463	0.164	3744	no		n
+GMOS-N	B1200 0.75"	singleslit,multislit	0.75"	0.750	330	B1200	none	0.36	0.72	0.463	0.164	2496	no		n
+GMOS-N	B1200 1.0"	singleslit,multislit	1.0"	1.000	330	B1200	none	0.36	0.72	0.463	0.164	1872	no		n
+GMOS-N	B1200 1.5"	singleslit,multislit	1.5"	1.500	330	B1200	none	0.36	0.72	0.463	0.164	1248	no		n
+GMOS-N	B1200 2.0"	singleslit,multislit	2.0"	2.000	330	B1200	none	0.36	0.72	0.463	0.164	936	no		n
+GMOS-N	B1200 5.0"	singleslit,multislit	5.0"	5.000	330	B1200	none	0.36	0.72	0.463	0.164	374	no		n
+GMOS-N	B1200 0.25" GG455	singleslit,multislit	0.25"	0.250	330	B1200	GG455	0.46	0.92	0.463	0.164	7488	no		n
+GMOS-N	B1200 0.50" GG455	singleslit,multislit	0.50"	0.500	330	B1200	GG455	0.46	0.92	0.463	0.164	3744	no		n
+GMOS-N	B1200 0.75"  GG455	singleslit,multislit	0.75"	0.750	330	B1200	GG455	0.46	0.92	0.463	0.164	2496	no		n
+GMOS-N	B1200 1.0"  GG455	singleslit,multislit	1.0"	1.000	330	B1200	GG455	0.46	0.92	0.463	0.164	1872	no		n
+GMOS-N	B1200 1.5"  GG455	singleslit,multislit	1.5"	1.500	330	B1200	GG455	0.46	0.92	0.463	0.164	1248	no		n
+GMOS-N	B1200 2.0"  GG455	singleslit,multislit	2.0"	2.000	330	B1200	GG455	0.46	0.92	0.463	0.164	936	no		n
+GMOS-N	B1200 5.0"  GG455	singleslit,multislit	5.0"	5.000	330	B1200	GG455	0.46	0.92	0.463	0.164	374	no		n
+GMOS-N	B1200 0.25" OG515	singleslit,multislit	0.25"	0.250	330	B1200	OG515	0.52	1.03	0.463	0.164	7488	no		n
+GMOS-N	B1200 0.50" OG515	singleslit,multislit	0.50"	0.500	330	B1200	OG515	0.52	1.03	0.463	0.164	3744	no		n
+GMOS-N	B1200 0.75" OG515	singleslit,multislit	0.75"	0.750	330	B1200	OG515	0.52	1.03	0.463	0.164	2496	no		n
+GMOS-N	B1200 1.0" OG515	singleslit,multislit	1.0"	1.000	330	B1200	OG515	0.52	1.03	0.463	0.164	1872	no		n
+GMOS-N	B1200 1.5" OG515	singleslit,multislit	1.5"	1.500	330	B1200	OG515	0.52	1.03	0.463	0.164	1248	no		n
+GMOS-N	B1200 2.0" OG515	singleslit,multislit	2.0"	2.000	330	B1200	OG515	0.52	1.03	0.463	0.164	936	no		n
+GMOS-N	B1200 5.0" OG515	singleslit,multislit	5.0"	5.000	330	B1200	OG515	0.52	1.03	0.463	0.164	374	no		n
+GMOS-N	B1200 0.25" RG610	singleslit,multislit	0.25"	0.250	330	B1200	RG610	0.61	1.03	0.463	0.164	7488	no		n
+GMOS-N	B1200 0.50" RG610	singleslit,multislit	0.50"	0.500	330	B1200	RG610	0.61	1.03	0.463	0.164	3744	no		n
+GMOS-N	B1200 0.75" RG610	singleslit,multislit	0.75"	0.750	330	B1200	RG610	0.61	1.03	0.463	0.164	2496	no		n
+GMOS-N	B1200 1.0" RG610	singleslit,multislit	1.0"	1.000	330	B1200	RG610	0.61	1.03	0.463	0.164	1872	no		n
+GMOS-N	B1200 1.5" RG610	singleslit,multislit	1.5"	1.500	330	B1200	RG610	0.61	1.03	0.463	0.164	1248	no		n
+GMOS-N	B1200 2.0" RG610	singleslit,multislit	2.0"	2.000	330	B1200	RG610	0.61	1.03	0.463	0.164	936	no		n
+GMOS-N	B1200 5.0" RG610	singleslit,multislit	5.0"	5.000	330	B1200	RG610	0.61	1.03	0.463	0.164	374	no		n
+GMOS-N	R831 0.25"	singleslit,multislit	0.25"	0.250	330	R831	none	0.36	0.72	0.757	0.235	8792	no		n
+GMOS-N	R831 0.50"	singleslit,multislit	0.50"	0.500	330	R831	none	0.36	0.72	0.757	0.235	4396	no		n
+GMOS-N	R831 0.75"	singleslit,multislit	0.75"	0.750	330	R831	none	0.36	0.72	0.757	0.235	2931	no		n
+GMOS-N	R831 1.0"	singleslit,multislit	1.0"	1.000	330	R831	none	0.36	0.72	0.757	0.235	2198	no		n
+GMOS-N	R831 1.5"	singleslit,multislit	1.5"	1.500	330	R831	none	0.36	0.72	0.757	0.235	1465	no		n
+GMOS-N	R831 2.0"	singleslit,multislit	2.0"	2.000	330	R831	none	0.36	0.72	0.757	0.235	1099	no		n
+GMOS-N	R831 5.0"	singleslit,multislit	5.0"	5.000	330	R831	none	0.36	0.72	0.757	0.235	440	no		n
+GMOS-N	R831 0.25" GG455	singleslit,multislit	0.25"	0.250	330	R831	GG455	0.46	0.92	0.757	0.235	8792	no		n
+GMOS-N	R831 0.50"  GG455	singleslit,multislit	0.50"	0.500	330	R831	GG455	0.46	0.92	0.757	0.235	4396	no		n
+GMOS-N	R831 0.75"  GG455	singleslit,multislit	0.75"	0.750	330	R831	GG455	0.46	0.92	0.757	0.235	2931	no		n
+GMOS-N	R831 1.0" GG455	singleslit,multislit	1.0"	1.000	330	R831	GG455	0.46	0.92	0.757	0.235	2198	no		n
+GMOS-N	R831 1.5" GG455	singleslit,multislit	1.5"	1.500	330	R831	GG455	0.46	0.92	0.757	0.235	1465	no		n
+GMOS-N	R831 2.0" GG455	singleslit,multislit	2.0"	2.000	330	R831	GG455	0.46	0.92	0.757	0.235	1099	no		n
+GMOS-N	R831 5.0" GG455	singleslit,multislit	5.0"	5.000	330	R831	GG455	0.46	0.92	0.757	0.235	440	no		n
+GMOS-N	R831 0.25" OG515	singleslit,multislit	0.25"	0.250	330	R831	OG515	0.52	1.03	0.757	0.235	8792	no		n
+GMOS-N	R831 0.50" OG515	singleslit,multislit	0.50"	0.500	330	R831	OG515	0.52	1.03	0.757	0.235	4396	no		n
+GMOS-N	R831 0.75" OG515	singleslit,multislit	0.75"	0.750	330	R831	OG515	0.52	1.03	0.757	0.235	2931	no		n
+GMOS-N	R831 1.0" OG515	singleslit,multislit	1.0"	1.000	330	R831	OG515	0.52	1.03	0.757	0.235	2198	no		n
+GMOS-N	R831 1.5" OG515	singleslit,multislit	1.5"	1.500	330	R831	OG515	0.52	1.03	0.757	0.235	1465	no		n
+GMOS-N	R831 2.0" OG515	singleslit,multislit	2.0"	2.000	330	R831	OG515	0.52	1.03	0.757	0.235	1099	no		n
+GMOS-N	R831 5.0" OG515	singleslit,multislit	5.0"	5.000	330	R831	OG515	0.52	1.03	0.757	0.235	440	no		n
+GMOS-N	R831 0.25" RG610	singleslit,multislit	0.25"	0.250	330	R831	RG610	0.61	1.03	0.757	0.235	8792	no		n
+GMOS-N	R831 0.50" RG610	singleslit,multislit	0.50"	0.500	330	R831	RG610	0.61	1.03	0.757	0.235	4396	no		n
+GMOS-N	R831 0.75" RG610	singleslit,multislit	0.75"	0.750	330	R831	RG610	0.61	1.03	0.757	0.235	2931	no		n
+GMOS-N	R831 1.0" RG610	singleslit,multislit	1.0"	1.000	330	R831	RG610	0.61	1.03	0.757	0.235	2198	no		n
+GMOS-N	R831 1.5" RG610	singleslit,multislit	1.5"	1.500	330	R831	RG610	0.61	1.03	0.757	0.235	1465	no		n
+GMOS-N	R831 2.0" RG610	singleslit,multislit	2.0"	2.000	330	R831	RG610	0.61	1.03	0.757	0.235	1099	no		n
+GMOS-N	R831 5.0" RG610	singleslit,multislit	5.0"	5.000	330	R831	RG610	0.61	1.03	0.757	0.235	440	no		n
+GMOS-N	R831 0.25" CaT	singleslit,multislit	0.25"	0.250	330	R831	CaT	0.78	0.933	0.86	0.153	8792	no		n
+GMOS-N	R831 0.50" CaT	singleslit,multislit	0.50"	0.500	330	R831	CaT	0.78	0.933	0.86	0.153	4396	no		n
+GMOS-N	R831 0.75" CaT	singleslit,multislit	0.75"	0.750	330	R831	CaT	0.78	0.933	0.86	0.153	2931	no		n
+GMOS-N	R831 1.0" CaT	singleslit,multislit	1.0"	1.000	330	R831	CaT	0.78	0.933	0.86	0.153	2198	no		n
+GMOS-N	R831 1.5" CaT	singleslit,multislit	1.5"	1.500	330	R831	CaT	0.78	0.933	0.86	0.153	1465	no		n
+GMOS-N	R831 2.0" CaT	singleslit,multislit	2.0"	2.000	330	R831	CaT	0.78	0.933	0.86	0.153	1099	no		n
+GMOS-N	R831 5.0" CaT	singleslit,multislit	5.0"	5.000	330	R831	CaT	0.78	0.933	0.86	0.153	440	no		n
+GMOS-N	B480 0.25"	singleslit,multislit	0.25"	0.250	330	B480	none	0.36	0.72	0.422	0.39	3040	no		n
+GMOS-N	B480 0.50"	singleslit,multislit	0.50"	0.500	330	B480	none	0.36	0.72	0.422	0.39	1520	no		n
+GMOS-N	B480 0.75"	singleslit,multislit	0.75"	0.750	330	B480	none	0.36	0.72	0.422	0.39	1013	no		n
+GMOS-N	B480 1.0"	singleslit,multislit	1.0"	1.000	330	B480	none	0.36	0.72	0.422	0.39	760	no		n
+GMOS-N	B480 1.5"	singleslit,multislit	1.5"	1.500	330	B480	none	0.36	0.72	0.422	0.39	507	no		n
+GMOS-N	B480 2.0"	singleslit,multislit	2.0"	2.000	330	B480	none	0.36	0.72	0.422	0.39	380	no		n
+GMOS-N	B480 5.0"	singleslit,multislit	5.0"	5.000	330	B480	none	0.36	0.72	0.422	0.39	152	no		n
+GMOS-N	B480 0.25" GG455	singleslit,multislit	0.25"	0.250	330	B480	GG455	0.46	0.92	0.422	0.39	3040	no		n
+GMOS-N	B480 0.50" GG455	singleslit,multislit	0.50"	0.500	330	B480	GG455	0.46	0.92	0.422	0.39	1520	no		n
+GMOS-N	B480 0.75" GG455	singleslit,multislit	0.75"	0.750	330	B480	GG455	0.46	0.92	0.422	0.39	1013	no		n
+GMOS-N	B480 1.0" GG455	singleslit,multislit	1.0"	1.000	330	B480	GG455	0.46	0.92	0.422	0.39	760	no		n
+GMOS-N	B480 1.5" GG455	singleslit,multislit	1.5"	1.500	330	B480	GG455	0.46	0.92	0.422	0.39	507	no		n
+GMOS-N	B480 2.0" GG455	singleslit,multislit	2.0"	2.000	330	B480	GG455	0.46	0.92	0.422	0.39	380	no		n
+GMOS-N	B480 5.0" GG455	singleslit,multislit	5.0"	5.000	330	B480	GG455	0.46	0.92	0.422	0.39	152	no		n
+GMOS-N	B480 0.25" OG515	singleslit,multislit	0.25"	0.250	330	B480	OG515	0.52	1.03	0.422	0.39	3040	no		n
+GMOS-N	B480 0.50" OG515	singleslit,multislit	0.50"	0.500	330	B480	OG515	0.52	1.03	0.422	0.39	1520	no		n
+GMOS-N	B480 0.75" OG515	singleslit,multislit	0.75"	0.750	330	B480	OG515	0.52	1.03	0.422	0.39	1013	no		n
+GMOS-N	B480 1.0" OG515	singleslit,multislit	1.0"	1.000	330	B480	OG515	0.52	1.03	0.422	0.39	760	no		n
+GMOS-N	B480 1.5" OG515	singleslit,multislit	1.5"	1.500	330	B480	OG515	0.52	1.03	0.422	0.39	507	no		n
+GMOS-N	B480 2.0" OG515	singleslit,multislit	2.0"	2.000	330	B480	OG515	0.52	1.03	0.422	0.39	380	no		n
+GMOS-N	B480 5.0" OG515	singleslit,multislit	5.0"	5.000	330	B480	OG515	0.52	1.03	0.422	0.39	152	no		n
+GMOS-N	B480 0.25" RG610	singleslit,multislit	0.25"	0.250	330	B480	RG610	0.61	1.03	0.422	0.39	3040	no		n
+GMOS-N	B480 0.50" RG610	singleslit,multislit	0.50"	0.500	330	B480	RG610	0.61	1.03	0.422	0.39	1520	no		n
+GMOS-N	B480 0.75" RG610	singleslit,multislit	0.75"	0.750	330	B480	RG610	0.61	1.03	0.422	0.39	1013	no		n
+GMOS-N	B480 1.0" RG610	singleslit,multislit	1.0"	1.000	330	B480	RG610	0.61	1.03	0.422	0.39	760	no		n
+GMOS-N	B480 1.5" RG610	singleslit,multislit	1.5"	1.500	330	B480	RG610	0.61	1.03	0.422	0.39	507	no		n
+GMOS-N	B480 2.0" RG610	singleslit,multislit	2.0"	2.000	330	B480	RG610	0.61	1.03	0.422	0.39	380	no		n
+GMOS-N	B480 5.0" RG610	singleslit,multislit	5.0"	5.000	330	B480	RG610	0.61	1.03	0.422	0.39	152	no		n
+GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	none	0.36	0.72	0.764	0.472	3836	no		n
+GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	none	0.36	0.72	0.764	0.472	1918	no		n
+GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	none	0.36	0.72	0.764	0.472	1279	no		n
+GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	none	0.36	0.72	0.764	0.472	959	no		n
+GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	none	0.36	0.72	0.764	0.472	639	no		n
+GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	none	0.36	0.72	0.764	0.472	480	no		n
+GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	none	0.36	0.72	0.764	0.472	192	no		n
+GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	GG455	0.46	0.92	0.764	0.472	3836	no		n
+GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	GG455	0.46	0.92	0.764	0.472	1918	no		n
+GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	GG455	0.46	0.92	0.764	0.472	1279	no		n
+GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	GG455	0.46	0.92	0.764	0.472	959	no		n
+GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	GG455	0.46	0.92	0.764	0.472	639	no		n
+GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	GG455	0.46	0.92	0.764	0.472	480	no		n
+GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	GG455	0.46	0.92	0.764	0.472	192	no		n
+GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	OG515	0.52	1.03	0.764	0.472	3836	no		n
+GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	OG515	0.52	1.03	0.764	0.472	1918	no		n
+GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	OG515	0.52	1.03	0.764	0.472	1279	no		n
+GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	OG515	0.52	1.03	0.764	0.472	959	no		n
+GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	OG515	0.52	1.03	0.764	0.472	639	no		n
+GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	OG515	0.52	1.03	0.764	0.472	480	no		n
+GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	OG515	0.52	1.03	0.764	0.472	192	no		n
+GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	RG610	0.61	1.03	0.764	0.472	3836	no		n
+GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	RG610	0.61	1.03	0.764	0.472	1918	no		n
+GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	RG610	0.61	1.03	0.764	0.472	1279	no		n
+GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	RG610	0.61	1.03	0.764	0.472	959	no		n
+GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	RG610	0.61	1.03	0.764	0.472	639	no		n
+GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	RG610	0.61	1.03	0.764	0.472	480	no		n
+GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	RG610	0.61	1.03	0.764	0.472	192	no		n
+GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	CaT	0.78	0.933	0.86	0.153	3836	no		n
+GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	CaT	0.78	0.933	0.86	0.153	1918	no		n
+GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	CaT	0.78	0.933	0.86	0.153	1279	no		n
+GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	CaT	0.78	0.933	0.86	0.153	959	no		n
+GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	CaT	0.78	0.933	0.86	0.153	639	no		n
+GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	CaT	0.78	0.933	0.86	0.153	480	no		n
+GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	CaT	0.78	0.933	0.86	0.153	192	no		n
+GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	none	0.36	0.72	0.717	1.219	1262	no		n
+GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	none	0.36	0.72	0.717	1.219	631	no		n
+GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	none	0.36	0.72	0.717	1.219	421	no		n
+GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	none	0.36	0.72	0.717	1.219	316	no		n
+GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	none	0.36	0.72	0.717	1.219	210	no		n
+GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	none	0.36	0.72	0.717	1.219	158	no		n
+GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	none	0.36	0.72	0.717	1.219	63	no		n
+GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	GG455	0.46	0.92	0.717	1.219	1262	no		n
+GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	GG455	0.46	0.92	0.717	1.219	631	no		n
+GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	GG455	0.46	0.92	0.717	1.219	421	no		n
+GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	GG455	0.46	0.92	0.717	1.219	316	no		n
+GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	GG455	0.46	0.92	0.717	1.219	210	no		n
+GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	GG455	0.46	0.92	0.717	1.219	158	no		n
+GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	GG455	0.46	0.92	0.717	1.219	63	no		n
+GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	OG515	0.52	1.03	0.717	1.219	1262	no		n
+GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	OG515	0.52	1.03	0.717	1.219	631	no		n
+GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	OG515	0.52	1.03	0.717	1.219	421	no		n
+GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	OG515	0.52	1.03	0.717	1.219	316	no		n
+GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	OG515	0.52	1.03	0.717	1.219	210	no		n
+GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	OG515	0.52	1.03	0.717	1.219	158	no		n
+GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	OG515	0.52	1.03	0.717	1.219	63	no		n
+GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	RG610	0.61	1.03	0.717	1.219	1262	no		n
+GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	RG610	0.61	1.03	0.717	1.219	631	no		n
+GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	RG610	0.61	1.03	0.717	1.219	421	no		n
+GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	RG610	0.61	1.03	0.717	1.219	316	no		n
+GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	RG610	0.61	1.03	0.717	1.219	210	no		n
+GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	RG610	0.61	1.03	0.717	1.219	158	no		n
+GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	RG610	0.61	1.03	0.717	1.219	63	no		n
+GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	CaT	0.78	0.933	0.86	1.219	1262	no		n
+GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	CaT	0.78	0.933	0.86	1.219	631	no		n
+GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	CaT	0.78	0.933	0.86	1.219	421	no		n
+GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	CaT	0.78	0.933	0.86	1.219	316	no		n
+GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	CaT	0.78	0.933	0.86	1.219	210	no		n
+GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	CaT	0.78	0.933	0.86	1.219	158	no		n
+GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	CaT	0.78	0.933	0.86	1.219	63	no		n
+GMOS-N	B480 IFU2	ifu	IFU-2	5	7	B480	g	0.398	0.552	0.461	0.154	2500	no		n
+GMOS-S	B1200 0.25"	singleslit,multislit	0.25"	0.250	330	B1200	none	0.36	0.72	0.463	0.159	7488	no		s
+GMOS-S	B1200 0.50"	singleslit,multislit	0.50"	0.500	330	B1200	none	0.36	0.72	0.463	0.159	3744	no		s
+GMOS-S	B1200 0.75"	singleslit,multislit	0.75"	0.750	330	B1200	none	0.36	0.72	0.463	0.159	2496	no		s
+GMOS-S	B1200 1.0"	singleslit,multislit	1.0"	1.000	330	B1200	none	0.36	0.72	0.463	0.159	1872	no		s
+GMOS-S	B1200 1.5"	singleslit,multislit	1.5"	1.500	330	B1200	none	0.36	0.72	0.463	0.159	1248	no		s
+GMOS-S	B1200 2.0"	singleslit,multislit	2.0"	2.000	330	B1200	none	0.36	0.72	0.463	0.159	936	no		s
+GMOS-S	B1200 5.0"	singleslit,multislit	5.0"	5.000	330	B1200	none	0.36	0.72	0.463	0.159	374	no		s
+GMOS-S	B1200 0.25" GG455	singleslit,multislit	0.25"	0.250	330	B1200	GG455	0.46	0.92	0.463	0.159	7488	no		s
+GMOS-S	B1200 0.50" GG455	singleslit,multislit	0.50"	0.500	330	B1200	GG455	0.46	0.92	0.463	0.159	3744	no		s
+GMOS-S	B1200 0.75" GG455	singleslit,multislit	0.75"	0.750	330	B1200	GG455	0.46	0.92	0.463	0.159	2496	no		s
+GMOS-S	B1200 1.0" GG455	singleslit,multislit	1.0"	1.000	330	B1200	GG455	0.46	0.92	0.463	0.159	1872	no		s
+GMOS-S	B1200 1.5" GG455	singleslit,multislit	1.5"	1.500	330	B1200	GG455	0.46	0.92	0.463	0.159	1248	no		s
+GMOS-S	B1200 2.0" GG455	singleslit,multislit	2.0"	2.000	330	B1200	GG455	0.46	0.92	0.463	0.159	936	no		s
+GMOS-S	B1200 5.0" GG455	singleslit,multislit	5.0"	5.000	330	B1200	GG455	0.46	0.92	0.463	0.159	374	no		s
+GMOS-S	B1200 0.25" OG515	singleslit,multislit	0.25"	0.250	330	B1200	OG515	0.52	1.03	0.463	0.159	7488	no		s
+GMOS-S	B1200 0.50" OG515	singleslit,multislit	0.50"	0.500	330	B1200	OG515	0.52	1.03	0.463	0.159	3744	no		s
+GMOS-S	B1200 0.75" OG515	singleslit,multislit	0.75"	0.750	330	B1200	OG515	0.52	1.03	0.463	0.159	2496	no		s
+GMOS-S	B1200 1.0" OG515	singleslit,multislit	1.0"	1.000	330	B1200	OG515	0.52	1.03	0.463	0.159	1872	no		s
+GMOS-S	B1200 1.5" OG515	singleslit,multislit	1.5"	1.500	330	B1200	OG515	0.52	1.03	0.463	0.159	1248	no		s
+GMOS-S	B1200 2.0" OG515	singleslit,multislit	2.0"	2.000	330	B1200	OG515	0.52	1.03	0.463	0.159	936	no		s
+GMOS-S	B1200 5.0" OG515	singleslit,multislit	5.0"	5.000	330	B1200	OG515	0.52	1.03	0.463	0.159	374	no		s
+GMOS-S	B1200 0.25" RG610	singleslit,multislit	0.25"	0.250	330	B1200	RG610	0.61	1.03	0.463	0.159	7488	no		s
+GMOS-S	B1200 0.50" RG610	singleslit,multislit	0.50"	0.500	330	B1200	RG610	0.61	1.03	0.463	0.159	3744	no		s
+GMOS-S	B1200 0.75" RG610	singleslit,multislit	0.75"	0.750	330	B1200	RG610	0.61	1.03	0.463	0.159	2496	no		s
+GMOS-S	B1200 1.0" RG610	singleslit,multislit	1.0"	1.000	330	B1200	RG610	0.61	1.03	0.463	0.159	1872	no		s
+GMOS-S	B1200 1.5" RG610	singleslit,multislit	1.5"	1.500	330	B1200	RG610	0.61	1.03	0.463	0.159	1248	no		s
+GMOS-S	B1200 2.0" RG610	singleslit,multislit	2.0"	2.000	330	B1200	RG610	0.61	1.03	0.463	0.159	936	no		s
+GMOS-S	B1200 5.0" RG610	singleslit,multislit	5.0"	5.000	330	B1200	RG610	0.61	1.03	0.463	0.159	374	no		s
+GMOS-S	B600 0.25"	singleslit,multislit	0.25"	0.250	330	B600	none	0.36	0.72	0.461	0.307	3376	no		s
+GMOS-S	B600 0.50"	singleslit,multislit	0.50"	0.500	330	B600	none	0.36	0.72	0.461	0.307	1688	no		s
+GMOS-S	B600 0.75"	singleslit,multislit	0.75"	0.750	330	B600	none	0.36	0.72	0.461	0.307	1125	no		s
+GMOS-S	B600 1.0"	singleslit,multislit	1.0"	1.000	330	B600	none	0.36	0.72	0.461	0.307	844	no		s
+GMOS-S	B600 1.5"	singleslit,multislit	1.5"	1.500	330	B600	none	0.36	0.72	0.461	0.307	563	no		s
+GMOS-S	B600 2.0"	singleslit,multislit	2.0"	2.000	330	B600	none	0.36	0.72	0.461	0.307	422	no		s
+GMOS-S	B600 5.0"	singleslit,multislit	5.0"	5.000	330	B600	none	0.36	0.72	0.461	0.307	169	no		s
+GMOS-S	B600 0.25"  GG455	singleslit,multislit	0.25"	0.250	330	B600	GG455	0.46	0.92	0.461	0.307	3376	no		s
+GMOS-S	B600 0.50"  GG455	singleslit,multislit	0.50"	0.500	330	B600	GG455	0.46	0.92	0.461	0.307	1688	no		s
+GMOS-S	B600 0.75"  GG455	singleslit,multislit	0.75"	0.750	330	B600	GG455	0.46	0.92	0.461	0.307	1125	no		s
+GMOS-S	B600 1.0"  GG455	singleslit,multislit	1.0"	1.000	330	B600	GG455	0.46	0.92	0.461	0.307	844	no		s
+GMOS-S	B600 1.5"  GG455	singleslit,multislit	1.5"	1.500	330	B600	GG455	0.46	0.92	0.461	0.307	563	no		s
+GMOS-S	B600 2.0"  GG455	singleslit,multislit	2.0"	2.000	330	B600	GG455	0.46	0.92	0.461	0.307	422	no		s
+GMOS-S	B600 5.0"  GG455	singleslit,multislit	5.0"	5.000	330	B600	GG455	0.46	0.92	0.461	0.307	169	no		s
+GMOS-S	B600 0.25" OG515	singleslit,multislit	0.25"	0.250	330	B600	OG515	0.52	1.03	0.461	0.307	3376	no		s
+GMOS-S	B600 0.50" OG515	singleslit,multislit	0.50"	0.500	330	B600	OG515	0.52	1.03	0.461	0.307	1688	no		s
+GMOS-S	B600 0.75" OG515	singleslit,multislit	0.75"	0.750	330	B600	OG515	0.52	1.03	0.461	0.307	1125	no		s
+GMOS-S	B600 1.0" OG515	singleslit,multislit	1.0"	1.000	330	B600	OG515	0.52	1.03	0.461	0.307	844	no		s
+GMOS-S	B600 1.5" OG515	singleslit,multislit	1.5"	1.500	330	B600	OG515	0.52	1.03	0.461	0.307	563	no		s
+GMOS-S	B600 2.0" OG515	singleslit,multislit	2.0"	2.000	330	B600	OG515	0.52	1.03	0.461	0.307	422	no		s
+GMOS-S	B600 5.0" OG515	singleslit,multislit	5.0"	5.000	330	B600	OG515	0.52	1.03	0.461	0.307	169	no		s
+GMOS-S	B600 0.25" RG610	singleslit,multislit	0.25"	0.250	330	B600	RG610	0.61	1.03	0.461	0.307	3376	no		s
+GMOS-S	B600 0.50" RG610	singleslit,multislit	0.50"	0.500	330	B600	RG610	0.61	1.03	0.461	0.307	1688	no		s
+GMOS-S	B600 0.75" RG610	singleslit,multislit	0.75"	0.750	330	B600	RG610	0.61	1.03	0.461	0.307	1125	no		s
+GMOS-S	B600 1.0" RG610	singleslit,multislit	1.0"	1.000	330	B600	RG610	0.61	1.03	0.461	0.307	844	no		s
+GMOS-S	B600 1.5" RG610	singleslit,multislit	1.5"	1.500	330	B600	RG610	0.61	1.03	0.461	0.307	563	no		s
+GMOS-S	B600 2.0" RG610	singleslit,multislit	2.0"	2.000	330	B600	RG610	0.61	1.03	0.461	0.307	422	no		s
+GMOS-S	B600 5.0" RG610	singleslit,multislit	5.0"	5.000	330	B600	RG610	0.61	1.03	0.461	0.307	169	no		s
+GMOS-S	R831 0.25"	singleslit,multislit	0.25"	0.250	330	R831	none	0.36	0.72	0.757	0.23	8792	no		s
+GMOS-S	R831 0.50"	singleslit,multislit	0.50"	0.500	330	R831	none	0.36	0.72	0.757	0.23	4396	no		s
+GMOS-S	R831 0.75"	singleslit,multislit	0.75"	0.750	330	R831	none	0.36	0.72	0.757	0.23	2931	no		s
+GMOS-S	R831 1.0"	singleslit,multislit	1.0"	1.000	330	R831	none	0.36	0.72	0.757	0.23	2198	no		s
+GMOS-S	R831 1.5"	singleslit,multislit	1.5"	1.500	330	R831	none	0.36	0.72	0.757	0.23	1465	no		s
+GMOS-S	R831 2.0"	singleslit,multislit	2.0"	2.000	330	R831	none	0.36	0.72	0.757	0.23	1099	no		s
+GMOS-S	R831 5.0"	singleslit,multislit	5.0"	5.000	330	R831	none	0.36	0.72	0.757	0.23	440	no		s
+GMOS-S	R831 0.25"  GG455	singleslit,multislit	0.25"	0.250	330	R831	GG455	0.46	0.92	0.757	0.23	8792	no		s
+GMOS-S	R831 0.50"  GG455	singleslit,multislit	0.50"	0.500	330	R831	GG455	0.46	0.92	0.757	0.23	4396	no		s
+GMOS-S	R831 0.75"  GG455	singleslit,multislit	0.75"	0.750	330	R831	GG455	0.46	0.92	0.757	0.23	2931	no		s
+GMOS-S	R831 1.0"  GG455	singleslit,multislit	1.0"	1.000	330	R831	GG455	0.46	0.92	0.757	0.23	2198	no		s
+GMOS-S	R831 1.5"  GG455	singleslit,multislit	1.5"	1.500	330	R831	GG455	0.46	0.92	0.757	0.23	1465	no		s
+GMOS-S	R831 2.0"  GG455	singleslit,multislit	2.0"	2.000	330	R831	GG455	0.46	0.92	0.757	0.23	1099	no		s
+GMOS-S	R831 5.0"  GG455	singleslit,multislit	5.0"	5.000	330	R831	GG455	0.46	0.92	0.757	0.23	440	no		s
+GMOS-S	R831 0.25" OG515	singleslit,multislit	0.25"	0.250	330	R831	OG515	0.52	1.03	0.757	0.23	8792	no		s
+GMOS-S	R831 0.50" OG515	singleslit,multislit	0.50"	0.500	330	R831	OG515	0.52	1.03	0.757	0.23	4396	no		s
+GMOS-S	R831 0.75" OG515	singleslit,multislit	0.75"	0.750	330	R831	OG515	0.52	1.03	0.757	0.23	2931	no		s
+GMOS-S	R831 1.0" OG515	singleslit,multislit	1.0"	1.000	330	R831	OG515	0.52	1.03	0.757	0.23	2198	no		s
+GMOS-S	R831 1.5" OG515	singleslit,multislit	1.5"	1.500	330	R831	OG515	0.52	1.03	0.757	0.23	1465	no		s
+GMOS-S	R831 2.0" OG515	singleslit,multislit	2.0"	2.000	330	R831	OG515	0.52	1.03	0.757	0.23	1099	no		s
+GMOS-S	R831 5.0" OG515	singleslit,multislit	5.0"	5.000	330	R831	OG515	0.52	1.03	0.757	0.23	440	no		s
+GMOS-S	R831 0.25" RG610	singleslit,multislit	0.25"	0.250	330	R831	RG610	0.61	1.03	0.757	0.23	8792	no		s
+GMOS-S	R831 0.50" RG610	singleslit,multislit	0.50"	0.500	330	R831	RG610	0.61	1.03	0.757	0.23	4396	no		s
+GMOS-S	R831 0.75" RG610	singleslit,multislit	0.75"	0.750	330	R831	RG610	0.61	1.03	0.757	0.23	2931	no		s
+GMOS-S	R831 1.0" RG610	singleslit,multislit	1.0"	1.000	330	R831	RG610	0.61	1.03	0.757	0.23	2198	no		s
+GMOS-S	R831 1.5" RG610	singleslit,multislit	1.5"	1.500	330	R831	RG610	0.61	1.03	0.757	0.23	1465	no		s
+GMOS-S	R831 2.0" RG610	singleslit,multislit	2.0"	2.000	330	R831	RG610	0.61	1.03	0.757	0.23	1099	no		s
+GMOS-S	R831 5.0" RG610	singleslit,multislit	5.0"	5.000	330	R831	RG610	0.61	1.03	0.757	0.23	440	no		s
+GMOS-S	R831 0.25" RG780	singleslit,multislit	0.25"	0.250	330	R831	RG780	0.78	1.03	0.757	0.23	8792	no		s
+GMOS-S	R831 0.50" RG780	singleslit,multislit	0.50"	0.500	330	R831	RG780	0.78	1.03	0.757	0.23	4396	no		s
+GMOS-S	R831 0.75" RG780	singleslit,multislit	0.75"	0.750	330	R831	RG780	0.78	1.03	0.757	0.23	2931	no		s
+GMOS-S	R831 1.0" RG780	singleslit,multislit	1.0"	1.000	330	R831	RG780	0.78	1.03	0.757	0.23	2198	no		s
+GMOS-S	R831 1.5" RG780	singleslit,multislit	1.5"	1.500	330	R831	RG780	0.78	1.03	0.757	0.23	1465	no		s
+GMOS-S	R831 2.0" RG780	singleslit,multislit	2.0"	2.000	330	R831	RG780	0.78	1.03	0.757	0.23	1099	no		s
+GMOS-S	R831 5.0" RG780	singleslit,multislit	5.0"	5.000	330	R831	RG780	0.78	1.03	0.757	0.23	440	no		s
+GMOS-S	R831 0.25" CaT	singleslit,multislit	0.25"	0.250	330	R831	CaT	0.78	0.933	0.86	0.153	8792	no		s
+GMOS-S	R831 0.50" CaT	singleslit,multislit	0.50"	0.500	330	R831	CaT	0.78	0.933	0.86	0.153	4396	no		s
+GMOS-S	R831 0.75" CaT	singleslit,multislit	0.75"	0.750	330	R831	CaT	0.78	0.933	0.86	0.153	2931	no		s
+GMOS-S	R831 1.0" CaT	singleslit,multislit	1.0"	1.000	330	R831	CaT	0.78	0.933	0.86	0.153	2198	no		s
+GMOS-S	R831 1.5" CaT	singleslit,multislit	1.5"	1.500	330	R831	CaT	0.78	0.933	0.86	0.153	1465	no		s
+GMOS-S	R831 2.0" CaT	singleslit,multislit	2.0"	2.000	330	R831	CaT	0.78	0.933	0.86	0.153	1099	no		s
+GMOS-S	R831 5.0" CaT	singleslit,multislit	5.0"	5.000	330	R831	CaT	0.78	0.933	0.86	0.153	440	no		s
+GMOS-S	B480 0.25"	singleslit,multislit	0.25"	0.250	330	B480	none	0.36	0.72	0.422	0.39	3040	no		s
+GMOS-S	B480 0.50"	singleslit,multislit	0.50"	0.500	330	B480	none	0.36	0.72	0.422	0.39	1520	no		s
+GMOS-S	B480 0.75"	singleslit,multislit	0.75"	0.750	330	B480	none	0.36	0.72	0.422	0.39	1013	no		s
+GMOS-S	B480 1.0"	singleslit,multislit	1.0"	1.000	330	B480	none	0.36	0.72	0.422	0.39	760	no		s
+GMOS-S	B480 1.5"	singleslit,multislit	1.5"	1.500	330	B480	none	0.36	0.72	0.422	0.39	507	no		s
+GMOS-S	B480 2.0"	singleslit,multislit	2.0"	2.000	330	B480	none	0.36	0.72	0.422	0.39	380	no		s
+GMOS-S	B480 5.0"	singleslit,multislit	5.0"	5.000	330	B480	none	0.36	0.72	0.422	0.39	152	no		s
+GMOS-S	B480 0.25"  GG455	singleslit,multislit	0.25"	0.250	330	B480	GG455	0.46	0.92	0.422	0.39	3040	no		s
+GMOS-S	B480 0.50"  GG455	singleslit,multislit	0.50"	0.500	330	B480	GG455	0.46	0.92	0.422	0.39	1520	no		s
+GMOS-S	B480 0.75"  GG455	singleslit,multislit	0.75"	0.750	330	B480	GG455	0.46	0.92	0.422	0.39	1013	no		s
+GMOS-S	B480 1.0"  GG455	singleslit,multislit	1.0"	1.000	330	B480	GG455	0.46	0.92	0.422	0.39	760	no		s
+GMOS-S	B480 1.5"  GG455	singleslit,multislit	1.5"	1.500	330	B480	GG455	0.46	0.92	0.422	0.39	507	no		s
+GMOS-S	B480 2.0"  GG455	singleslit,multislit	2.0"	2.000	330	B480	GG455	0.46	0.92	0.422	0.39	380	no		s
+GMOS-S	B480 5.0"  GG455	singleslit,multislit	5.0"	5.000	330	B480	GG455	0.46	0.92	0.422	0.39	152	no		s
+GMOS-S	B480 0.25" OG515	singleslit,multislit	0.25"	0.250	330	B480	OG515	0.52	1.03	0.422	0.39	3040	no		s
+GMOS-S	B480 0.50" OG515	singleslit,multislit	0.50"	0.500	330	B480	OG515	0.52	1.03	0.422	0.39	1520	no		s
+GMOS-S	B480 0.75" OG515	singleslit,multislit	0.75"	0.750	330	B480	OG515	0.52	1.03	0.422	0.39	1013	no		s
+GMOS-S	B480 1.0" OG515	singleslit,multislit	1.0"	1.000	330	B480	OG515	0.52	1.03	0.422	0.39	760	no		s
+GMOS-S	B480 1.5" OG515	singleslit,multislit	1.5"	1.500	330	B480	OG515	0.52	1.03	0.422	0.39	507	no		s
+GMOS-S	B480 2.0" OG515	singleslit,multislit	2.0"	2.000	330	B480	OG515	0.52	1.03	0.422	0.39	380	no		s
+GMOS-S	B480 5.0" OG515	singleslit,multislit	5.0"	5.000	330	B480	OG515	0.52	1.03	0.422	0.39	152	no		s
+GMOS-S	B480 0.25" RG610	singleslit,multislit	0.25"	0.250	330	B480	RG610	0.61	1.03	0.422	0.39	3040	no		s
+GMOS-S	B480 0.50" RG610	singleslit,multislit	0.50"	0.500	330	B480	RG610	0.61	1.03	0.422	0.39	1520	no		s
+GMOS-S	B480 0.75" RG610	singleslit,multislit	0.75"	0.750	330	B480	RG610	0.61	1.03	0.422	0.39	1013	no		s
+GMOS-S	B480 1.0" RG610	singleslit,multislit	1.0"	1.000	330	B480	RG610	0.61	1.03	0.422	0.39	760	no		s
+GMOS-S	B480 1.5" RG610	singleslit,multislit	1.5"	1.500	330	B480	RG610	0.61	1.03	0.422	0.39	507	no		s
+GMOS-S	B480 2.0" RG610	singleslit,multislit	2.0"	2.000	330	B480	RG610	0.61	1.03	0.422	0.39	380	no		s
+GMOS-S	B480 5.0" RG610	singleslit,multislit	5.0"	5.000	330	B480	RG610	0.61	1.03	0.422	0.39	152	no		s
+GMOS-S	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	none	0.36	0.72	0.764	0.462	3836	no		s
+GMOS-S	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	none	0.36	0.72	0.764	0.462	1918	no		s
+GMOS-S	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	none	0.36	0.72	0.764	0.462	1279	no		s
+GMOS-S	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	none	0.36	0.72	0.764	0.462	959	no		s
+GMOS-S	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	none	0.36	0.72	0.764	0.462	639	no		s
+GMOS-S	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	none	0.36	0.72	0.764	0.462	480	no		s
+GMOS-S	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	none	0.36	0.72	0.764	0.462	192	no		s
+GMOS-S	R400 0.25"  GG455	singleslit,multislit	0.25"	0.250	330	R400	GG455	0.46	0.92	0.764	0.462	3836	no		s
+GMOS-S	R400 0.50"  GG455	singleslit,multislit	0.50"	0.500	330	R400	GG455	0.46	0.92	0.764	0.462	1918	no		s
+GMOS-S	R400 0.75"  GG455	singleslit,multislit	0.75"	0.750	330	R400	GG455	0.46	0.92	0.764	0.462	1279	no		s
+GMOS-S	R400 1.0"  GG455	singleslit,multislit	1.0"	1.000	330	R400	GG455	0.46	0.92	0.764	0.462	959	no		s
+GMOS-S	R400 1.5"  GG455	singleslit,multislit	1.5"	1.500	330	R400	GG455	0.46	0.92	0.764	0.462	639	no		s
+GMOS-S	R400 2.0"  GG455	singleslit,multislit	2.0"	2.000	330	R400	GG455	0.46	0.92	0.764	0.462	480	no		s
+GMOS-S	R400 5.0"  GG455	singleslit,multislit	5.0"	5.000	330	R400	GG455	0.46	0.92	0.764	0.462	192	no		s
+GMOS-S	R400 0.25" OG515	singleslit,multislit	0.25"	0.250	330	R400	OG515	0.52	1.03	0.764	0.462	3836	no		s
+GMOS-S	R400 0.50" OG515	singleslit,multislit	0.50"	0.500	330	R400	OG515	0.52	1.03	0.764	0.462	1918	no		s
+GMOS-S	R400 0.75" OG515	singleslit,multislit	0.75"	0.750	330	R400	OG515	0.52	1.03	0.764	0.462	1279	no		s
+GMOS-S	R400 1.0" OG515	singleslit,multislit	1.0"	1.000	330	R400	OG515	0.52	1.03	0.764	0.462	959	no		s
+GMOS-S	R400 1.5" OG515	singleslit,multislit	1.5"	1.500	330	R400	OG515	0.52	1.03	0.764	0.462	639	no		s
+GMOS-S	R400 2.0" OG515	singleslit,multislit	2.0"	2.000	330	R400	OG515	0.52	1.03	0.764	0.462	480	no		s
+GMOS-S	R400 5.0" OG515	singleslit,multislit	5.0"	5.000	330	R400	OG515	0.52	1.03	0.764	0.462	192	no		s
+GMOS-S	R400 0.25" RG610	singleslit,multislit	0.25"	0.250	330	R400	RG610	0.61	1.03	0.764	0.462	3836	no		s
+GMOS-S	R400 0.50" RG610	singleslit,multislit	0.50"	0.500	330	R400	RG610	0.61	1.03	0.764	0.462	1918	no		s
+GMOS-S	R400 0.75" RG610	singleslit,multislit	0.75"	0.750	330	R400	RG610	0.61	1.03	0.764	0.462	1279	no		s
+GMOS-S	R400 1.0" RG610	singleslit,multislit	1.0"	1.000	330	R400	RG610	0.61	1.03	0.764	0.462	959	no		s
+GMOS-S	R400 1.5" RG610	singleslit,multislit	1.5"	1.500	330	R400	RG610	0.61	1.03	0.764	0.462	639	no		s
+GMOS-S	R400 2.0" RG610	singleslit,multislit	2.0"	2.000	330	R400	RG610	0.61	1.03	0.764	0.462	480	no		s
+GMOS-S	R400 5.0" RG610	singleslit,multislit	5.0"	5.000	330	R400	RG610	0.61	1.03	0.764	0.462	192	no		s
+GMOS-S	R400 0.25" RG780	singleslit,multislit	0.25"	0.250	330	R400	RG780	0.78	1.03	0.764	0.462	3836	no		s
+GMOS-S	R400 0.50" RG780	singleslit,multislit	0.50"	0.500	330	R400	RG780	0.78	1.03	0.764	0.462	1918	no		s
+GMOS-S	R400 0.75" RG780	singleslit,multislit	0.75"	0.750	330	R400	RG780	0.78	1.03	0.764	0.462	1279	no		s
+GMOS-S	R400 1.0" RG780	singleslit,multislit	1.0"	1.000	330	R400	RG780	0.78	1.03	0.764	0.462	959	no		s
+GMOS-S	R400 1.5" RG780	singleslit,multislit	1.5"	1.500	330	R400	RG780	0.78	1.03	0.764	0.462	639	no		s
+GMOS-S	R400 2.0" RG780	singleslit,multislit	2.0"	2.000	330	R400	RG780	0.78	1.03	0.764	0.462	480	no		s
+GMOS-S	R400 5.0" RG780	singleslit,multislit	5.0"	5.000	330	R400	RG780	0.78	1.03	0.764	0.462	192	no		s
+GMOS-S	R400 0.25" CaT	singleslit,multislit	0.25"	0.250	330	R400	CaT	0.78	0.933	0.86	0.153	3836	no		s
+GMOS-S	R400 0.50" CaT	singleslit,multislit	0.50"	0.500	330	R400	CaT	0.78	0.933	0.86	0.153	1918	no		s
+GMOS-S	R400 0.75" CaT	singleslit,multislit	0.75"	0.750	330	R400	CaT	0.78	0.933	0.86	0.153	1279	no		s
+GMOS-S	R400 1.0" CaT	singleslit,multislit	1.0"	1.000	330	R400	CaT	0.78	0.933	0.86	0.153	959	no		s
+GMOS-S	R400 1.5" CaT	singleslit,multislit	1.5"	1.500	330	R400	CaT	0.78	0.933	0.86	0.153	639	no		s
+GMOS-S	R400 2.0" CaT	singleslit,multislit	2.0"	2.000	330	R400	CaT	0.78	0.933	0.86	0.153	480	no		s
+GMOS-S	R400 5.0" CaT	singleslit,multislit	5.0"	5.000	330	R400	CaT	0.78	0.933	0.86	0.153	192	no		s
+GMOS-S	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	none	0.36	0.72	0.717	1.19	1262	no		s
+GMOS-S	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	none	0.36	0.72	0.717	1.19	631	no		s
+GMOS-S	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	none	0.36	0.72	0.717	1.19	421	no		s
+GMOS-S	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	none	0.36	0.72	0.717	1.19	316	no		s
+GMOS-S	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	none	0.36	0.72	0.717	1.19	210	no		s
+GMOS-S	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	none	0.36	0.72	0.717	1.19	158	no		s
+GMOS-S	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	none	0.36	0.72	0.717	1.19	63	no		s
+GMOS-S	R150 0.25"  GG455	singleslit,multislit	0.25"	0.250	330	R150	GG455	0.46	0.92	0.717	1.19	1262	no		s
+GMOS-S	R150 0.50"  GG455	singleslit,multislit	0.50"	0.500	330	R150	GG455	0.46	0.92	0.717	1.19	631	no		s
+GMOS-S	R150 0.75"  GG455	singleslit,multislit	0.75"	0.750	330	R150	GG455	0.46	0.92	0.717	1.19	421	no		s
+GMOS-S	R150 1.0"  GG455	singleslit,multislit	1.0"	1.000	330	R150	GG455	0.46	0.92	0.717	1.19	316	no		s
+GMOS-S	R150 1.5"  GG455	singleslit,multislit	1.5"	1.500	330	R150	GG455	0.46	0.92	0.717	1.19	210	no		s
+GMOS-S	R150 2.0"  GG455	singleslit,multislit	2.0"	2.000	330	R150	GG455	0.46	0.92	0.717	1.19	158	no		s
+GMOS-S	R150 5.0"  GG455	singleslit,multislit	5.0"	5.000	330	R150	GG455	0.46	0.92	0.717	1.19	63	no		s
+GMOS-S	R150 0.25" OG515	singleslit,multislit	0.25"	0.250	330	R150	OG515	0.52	1.03	0.717	1.19	1262	no		s
+GMOS-S	R150 0.50" OG515	singleslit,multislit	0.50"	0.500	330	R150	OG515	0.52	1.03	0.717	1.19	631	no		s
+GMOS-S	R150 0.75" OG515	singleslit,multislit	0.75"	0.750	330	R150	OG515	0.52	1.03	0.717	1.19	421	no		s
+GMOS-S	R150 1.0" OG515	singleslit,multislit	1.0"	1.000	330	R150	OG515	0.52	1.03	0.717	1.19	316	no		s
+GMOS-S	R150 1.5" OG515	singleslit,multislit	1.5"	1.500	330	R150	OG515	0.52	1.03	0.717	1.19	210	no		s
+GMOS-S	R150 2.0" OG515	singleslit,multislit	2.0"	2.000	330	R150	OG515	0.52	1.03	0.717	1.19	158	no		s
+GMOS-S	R150 5.0" OG515	singleslit,multislit	5.0"	5.000	330	R150	OG515	0.52	1.03	0.717	1.19	63	no		s
+GMOS-S	R150 0.25" RG610	singleslit,multislit	0.25"	0.250	330	R150	RG610	0.61	1.03	0.717	1.19	1262	no		s
+GMOS-S	R150 0.50" RG610	singleslit,multislit	0.50"	0.500	330	R150	RG610	0.61	1.03	0.717	1.19	631	no		s
+GMOS-S	R150 0.75" RG610	singleslit,multislit	0.75"	0.750	330	R150	RG610	0.61	1.03	0.717	1.19	421	no		s
+GMOS-S	R150 1.0" RG610	singleslit,multislit	1.0"	1.000	330	R150	RG610	0.61	1.03	0.717	1.19	316	no		s
+GMOS-S	R150 1.5" RG610	singleslit,multislit	1.5"	1.500	330	R150	RG610	0.61	1.03	0.717	1.19	210	no		s
+GMOS-S	R150 2.0" RG610	singleslit,multislit	2.0"	2.000	330	R150	RG610	0.61	1.03	0.717	1.19	158	no		s
+GMOS-S	R150 5.0" RG610	singleslit,multislit	5.0"	5.000	330	R150	RG610	0.61	1.03	0.717	1.19	63	no		s
+GMOS-S	R150 0.25" RG780	singleslit,multislit	0.25"	0.250	330	R150	RG780	0.78	1.03	0.717	1.19	1262	no		s
+GMOS-S	R150 0.50" RG780	singleslit,multislit	0.50"	0.500	330	R150	RG780	0.78	1.03	0.717	1.19	631	no		s
+GMOS-S	R150 0.75" RG780	singleslit,multislit	0.75"	0.750	330	R150	RG780	0.78	1.03	0.717	1.19	421	no		s
+GMOS-S	R150 1.0" RG780	singleslit,multislit	1.0"	1.000	330	R150	RG780	0.78	1.03	0.717	1.19	316	no		s
+GMOS-S	R150 1.5" RG780	singleslit,multislit	1.5"	1.500	330	R150	RG780	0.78	1.03	0.717	1.19	210	no		s
+GMOS-S	R150 2.0" RG780	singleslit,multislit	2.0"	2.000	330	R150	RG780	0.78	1.03	0.717	1.19	158	no		s
+GMOS-S	R150 5.0" RG780	singleslit,multislit	5.0"	5.000	330	R150	RG780	0.78	1.03	0.717	1.19	63	no		s
+GMOS-S	R150 0.25" CaT	singleslit,multislit	0.25"	0.250	330	R150	CaT	0.78	0.933	0.86	0.153	1262	no		s
+GMOS-S	R150 0.50" CaT	singleslit,multislit	0.50"	0.500	330	R150	CaT	0.78	0.933	0.86	0.153	631	no		s
+GMOS-S	R150 0.75" CaT	singleslit,multislit	0.75"	0.750	330	R150	CaT	0.78	0.933	0.86	0.153	421	no		s
+GMOS-S	R150 1.0" CaT	singleslit,multislit	1.0"	1.000	330	R150	CaT	0.78	0.933	0.86	0.153	316	no		s
+GMOS-S	R150 1.5" CaT	singleslit,multislit	1.5"	1.500	330	R150	CaT	0.78	0.933	0.86	0.153	210	no		s
+GMOS-S	R150 2.0" CaT	singleslit,multislit	2.0"	2.000	330	R150	CaT	0.78	0.933	0.86	0.153	158	no		s
+GMOS-S	R150 5.0" CaT	singleslit,multislit	5.0"	5.000	330	R150	CaT	0.78	0.933	0.86	0.153	63	no		s
+GMOS-S	B600 IFU2	ifu	IFU-2	5	7	B600	g	0.398	0.552	0.461	0.154	2723	no		s
+GMOS-S	B600 IFU1 NS	ifu	IFU-NS-2	3	5	B600	none	0.36	1.03	0.461	0.307	2723	no	Nod&Shuffle	s
+GMOS-S	B600 IFU2 NS	ifu	IFU-NS-B	5	7	B600	g	0.398	0.552	0.461	0.154	2723	no	Nod&Shuffle	s
+GMOS-S	R150 NS1.0 GG455	singleslit,multislit	NS1.0"	1.000	330	R150	GG455	0.46	1.03	0.717	0.57	316	no	Nod&Shuffle	s
+GMOS-S	R150 NS1.0 OG515	singleslit,multislit	NS1.0"	1.000	330	R150	OG515	0.52	1.03	0.717	0.51	316	no	Nod&Shuffle	s
+GMOS-S	R831 NS1.0 CaT	singleslit,multislit	NS1.0"	1.000	330	R831	CaT	0.78	0.933	0.757	0.23	2198	no	Nod&Shuffle	s
+FLAMINGOS2	R3K + J + 0.36"	singleslit,multislit	2pixel	0.360	263	R3000	J	1.175	1.333	1.254	0.158	2800	no		s
+FLAMINGOS2	R3K + H + 0.36"	singleslit,multislit	2pixel	0.360	263	R3000	H	1.486	1.775	1.6305	0.289	2800	no		s
+FLAMINGOS2	R3K + Ks + 0.36"	singleslit,multislit	2pixel	0.360	263	R3000	K-short	1.991	2.32	2.1555	0.329	2900	no		s
+FLAMINGOS2	R3K + Kb + 0.36"	singleslit,multislit	2pixel	0.360	263	R3000	K-blue	1.934	2.177	2.0555	0.243	2900	no		s
+FLAMINGOS2	R3K + Kr + 0.36"	singleslit,multislit	2pixel	0.360	263	R3000	K-red	2.181	2.446	2.3135	0.265	2900	no		s
+FLAMINGOS2	JH 0.36"	singleslit,multislit	2pixel	0.360	263	R1200JH	JH	0.97	1.805	1.3875	0.835	900	no		s
+FLAMINGOS2	HK 0.36"	singleslit,multislit	2pixel	0.360	263	R1200HK	HK	1.261	2.551	1.906	1.29	900	no		s
+FLAMINGOS2	R3K + J + 0.36"	singleslit,multislit	3pixel	0.540	263	R3000	J	1.175	1.333	1.254	0.158	1867	no		s
+FLAMINGOS2	R3K + H + 0.36"	singleslit,multislit	3pixel	0.540	263	R3000	H	1.486	1.775	1.6305	0.289	1867	no		s
+FLAMINGOS2	R3K + Ks + 0.36"	singleslit,multislit	3pixel	0.540	263	R3000	K-short	1.991	2.32	2.1555	0.329	1933	no		s
+FLAMINGOS2	R3K + Kb + 0.36"	singleslit,multislit	3pixel	0.540	263	R3000	K-blue	1.934	2.177	2.0555	0.243	1933	no		s
+FLAMINGOS2	R3K + Kr + 0.36"	singleslit,multislit	3pixel	0.540	263	R3000	K-red	2.181	2.446	2.3135	0.265	1933	no		s
+FLAMINGOS2	JH 0.36"	singleslit,multislit	3pixel	0.540	263	R1200JH	JH	0.97	1.805	1.3875	0.835	600	no		s
+FLAMINGOS2	HK 0.36"	singleslit,multislit	3pixel	0.540	263	R1200HK	HK	1.261	2.551	1.906	1.29	600	no		s
+FLAMINGOS2	R3K + J + 0.36"	singleslit,multislit	4pixel	0.720	263	R3000	J	1.175	1.333	1.254	0.158	1400	no		s
+FLAMINGOS2	R3K + H + 0.36"	singleslit,multislit	4pixel	0.720	263	R3000	H	1.486	1.775	1.6305	0.289	1400	no		s
+FLAMINGOS2	R3K + Ks + 0.36"	singleslit,multislit	4pixel	0.720	263	R3000	K-short	1.991	2.32	2.1555	0.329	1450	no		s
+FLAMINGOS2	R3K + Kb + 0.36"	singleslit,multislit	4pixel	0.720	263	R3000	K-blue	1.934	2.177	2.0555	0.243	1450	no		s
+FLAMINGOS2	R3K + Kr + 0.36"	singleslit,multislit	4pixel	0.720	263	R3000	K-red	2.181	2.446	2.3135	0.265	1450	no		s
+FLAMINGOS2	JH 0.36"	singleslit,multislit	4pixel	0.720	263	R1200JH	JH	0.97	1.805	1.3875	0.835	450	no		s
+FLAMINGOS2	HK 0.36"	singleslit,multislit	4pixel	0.720	263	R1200HK	HK	1.261	2.551	1.906	1.29	450	no		s
+FLAMINGOS2	R3K + J + 0.36"	singleslit,multislit	6pixel	1.080	263	R3000	J	1.175	1.333	1.254	0.158	933	no		s
+FLAMINGOS2	R3K + H + 0.36"	singleslit,multislit	6pixel	1.080	263	R3000	H	1.486	1.775	1.6305	0.289	933	no		s
+FLAMINGOS2	R3K + Ks + 0.36"	singleslit,multislit	6pixel	1.080	263	R3000	K-short	1.991	2.32	2.1555	0.329	967	no		s
+FLAMINGOS2	R3K + Kb + 0.36"	singleslit,multislit	6pixel	1.080	263	R3000	K-blue	1.934	2.177	2.0555	0.243	967	no		s
+FLAMINGOS2	R3K + Kr + 0.36"	singleslit,multislit	6pixel	1.080	263	R3000	K-red	2.181	2.446	2.3135	0.265	967	no		s
+FLAMINGOS2	JH 0.36"	singleslit,multislit	6pixel	1.080	263	R1200JH	JH	0.97	1.805	1.3875	0.835	300	no		s
+FLAMINGOS2	HK 0.36"	singleslit,multislit	6pixel	1.080	263	R1200HK	HK	1.261	2.551	1.906	1.29	300	no		s
+FLAMINGOS2	R3K + J + 0.36"	singleslit,multislit	8pixel	1.440	263	R3000	J	1.175	1.333	1.254	0.158	700	no		s
+FLAMINGOS2	R3K + H + 0.36"	singleslit,multislit	8pixel	1.440	263	R3000	H	1.486	1.775	1.6305	0.289	700	no		s
+FLAMINGOS2	R3K + Ks + 0.36"	singleslit,multislit	8pixel	1.440	263	R3000	K-short	1.991	2.32	2.1555	0.329	725	no		s
+FLAMINGOS2	R3K + Kb + 0.36"	singleslit,multislit	8pixel	1.440	263	R3000	K-blue	1.934	2.177	2.0555	0.243	725	no		s
+FLAMINGOS2	R3K + Kr + 0.36"	singleslit,multislit	8pixel	1.440	263	R3000	K-red	2.181	2.446	2.3135	0.265	725	no		s
+FLAMINGOS2	JH 0.36"	singleslit,multislit	8pixel	1.440	263	R1200JH	JH	0.97	1.805	1.3875	0.835	225	no		s
+FLAMINGOS2	HK 0.36"	singleslit,multislit	8pixel	1.440	263	R1200HK	HK	1.261	2.551	1.906	1.29	225	no		s
+GPI-2	Y	ifu	Coronagraph	0.156	2.8	Prism	Y	0.95	1.14	1.045	0.19	35	yes	coronagraph	s
+GPI-2	J	ifu	Coronagraph	0.184	2.8	Prism	J	1.12	1.35	1.235	0.23	36	yes	coronagraph	s
+GPI-2	H	ifu	Coronagraph	0.246	2.8	Prism	H	1.5	1.8	1.65	0.30	46	yes	coronagraph	s
+GPI-2	K1	ifu	Coronagraph	0.306	2.8	Prism	K1	1.9	2.19	2.045	0.29	66	yes	coronagraph	s
+GPI-2	K2	ifu	Coronagraph	0.306	2.8	Prism	K2	2.13	2.4	2.265	0.27	79	yes	coronagraph	s
+SCORPIO	foo	singleslit	?	0.300	180	?	dichroic	0.37	2.35	1.36	1.98	4000	no		s
+GNIRS	SC	singleslit	0.3	0.300	99	32	X	1.03	1.17	1.1	0.331	1700	no		n
+GNIRS	SC	singleslit	0.3	0.300	99	32	J	1.17	1.37	1.27	0.397	1600	no		n
+GNIRS	SC	singleslit	0.3	0.300	99	32	H	1.49	1.8	1.645	0.496	1700	no		n
+GNIRS	SC	singleslit	0.3	0.300	99	32	K	1.91	2.49	2.2	0.661	1700	no		n
+GNIRS	SC	singleslit	0.3	0.300	99	32	L	2.8	4.2	3.5	0.992	1800	no		n
+GNIRS	SC	singleslit	0.45	0.450	99	32	X	1.03	1.17	1.1	0.331	1133	no		n
+GNIRS	SC	singleslit	0.45	0.450	99	32	J	1.17	1.37	1.27	0.397	1067	no		n
+GNIRS	SC	singleslit	0.45	0.450	99	32	H	1.49	1.8	1.645	0.496	1133	no		n
+GNIRS	SC	singleslit	0.45	0.450	99	32	K	1.91	2.49	2.2	0.661	1133	no		n
+GNIRS	SC	singleslit	0.45	0.450	99	32	L	2.8	4.2	3.5	0.992	1200	no		n
+GNIRS	SC	singleslit	0.675	0.675	99	32	X	1.03	1.17	1.1	0.331	756	no		n
+GNIRS	SC	singleslit	0.675	0.675	99	32	J	1.17	1.37	1.27	0.397	711	no		n
+GNIRS	SC	singleslit	0.675	0.675	99	32	H	1.49	1.8	1.645	0.496	756	no		n
+GNIRS	SC	singleslit	0.675	0.675	99	32	K	1.91	2.49	2.2	0.661	756	no		n
+GNIRS	SC	singleslit	0.675	0.675	99	32	L	2.8	4.2	3.5	0.992	800	no		n
+GNIRS	SC	singleslit	1.0	1.000	99	32	X	1.03	1.17	1.1	0.331	510	no		n
+GNIRS	SC	singleslit	1.0	1.000	99	32	J	1.17	1.37	1.27	0.397	480	no		n
+GNIRS	SC	singleslit	1.0	1.000	99	32	H	1.49	1.8	1.645	0.496	510	no		n
+GNIRS	SC	singleslit	1.0	1.000	99	32	K	1.91	2.49	2.2	0.661	510	no		n
+GNIRS	SC	singleslit	1.0	1.000	99	32	L	2.8	4.2	3.5	0.992	540	no		n
+GNIRS	SC	singleslit	0.3	0.300	99	111	X	1.03	1.17	1.1	0.094	6600	no		n
+GNIRS	SC	singleslit	0.3	0.300	99	111	J	1.17	1.37	1.27	0.113	7200	no		n
+GNIRS	SC	singleslit	0.3	0.300	99	111	H	1.49	1.8	1.645	0.142	5900	no		n
+GNIRS	SC	singleslit	0.3	0.300	99	111	K	1.91	2.49	2.2	0.189	5900	no		n
+GNIRS	SC	singleslit	0.3	0.300	99	111	L	2.8	4.2	3.5	0.28	6400	no		n
+GNIRS	SC	singleslit	0.3	0.300	99	111	M	4.4	6	4.8	0.575	4300	no		n
+GNIRS	SC	singleslit	0.45	0.450	99	111	X	1.03	1.17	1.1	0.094	4400	no		n
+GNIRS	SC	singleslit	0.45	0.450	99	111	J	1.17	1.37	1.27	0.113	4800	no		n
+GNIRS	SC	singleslit	0.45	0.450	99	111	H	1.49	1.8	1.645	0.142	3933	no		n
+GNIRS	SC	singleslit	0.45	0.450	99	111	K	1.91	2.49	2.2	0.189	3933	no		n
+GNIRS	SC	singleslit	0.45	0.450	99	111	L	2.8	4.2	3.5	0.28	4267	no		n
+GNIRS	SC	singleslit	0.45	0.450	99	111	M	4.4	6	4.8	0.575	2867	no		n
+GNIRS	SC	singleslit	0.675	0.675	99	111	X	1.03	1.17	1.1	0.094	2933	no		n
+GNIRS	SC	singleslit	0.675	0.675	99	111	J	1.17	1.37	1.27	0.113	3200	no		n
+GNIRS	SC	singleslit	0.675	0.675	99	111	H	1.49	1.8	1.645	0.142	2622	no		n
+GNIRS	SC	singleslit	0.675	0.675	99	111	K	1.91	2.49	2.2	0.189	2622	no		n
+GNIRS	SC	singleslit	0.675	0.675	99	111	L	2.8	4.2	3.5	0.28	2844	no		n
+GNIRS	SC	singleslit	0.675	0.675	99	111	M	4.4	6	4.8	0.575	1911	no		n
+GNIRS	SC	singleslit	1.00	1.000	99	111	X	1.03	1.17	1.1	0.094	1980	no		n
+GNIRS	SC	singleslit	1.00	1.000	99	111	J	1.17	1.37	1.27	0.113	2160	no		n
+GNIRS	SC	singleslit	1.00	1.000	99	111	H	1.49	1.8	1.645	0.142	1770	no		n
+GNIRS	SC	singleslit	1.00	1.000	99	111	K	1.91	2.49	2.2	0.189	1770	no		n
+GNIRS	SC	singleslit	1.00	1.000	99	111	L	2.8	4.2	3.5	0.28	1920	no		n
+GNIRS	SC	singleslit	1.00	1.000	99	111	M	4.4	6	4.8	0.575	1290	no		n
+GNIRS	LC	singleslit	0.10	0.100	49	10	X	1.03	1.17	1.1	0.332	2100	yes		n
+GNIRS	LC	singleslit	0.10	0.100	49	10	J	1.17	1.37	1.27	0.398	1600	yes		n
+GNIRS	LC	singleslit	0.10	0.100	49	10	H	1.49	1.8	1.645	0.497	1700	yes		n
+GNIRS	LC	singleslit	0.10	0.100	49	10	K	1.91	2.49	2.2	0.663	1700	yes		n
+GNIRS	LC	singleslit	0.10	0.100	49	10	L	2.8	4.2	3.5	0.995	1800	no		n
+GNIRS	LC	singleslit	0.15	0.150	49	10	X	1.03	1.17	1.1	0.332	1400	yes		n
+GNIRS	LC	singleslit	0.15	0.150	49	10	J	1.17	1.37	1.27	0.398	1067	yes		n
+GNIRS	LC	singleslit	0.15	0.150	49	10	H	1.49	1.8	1.645	0.497	1133	yes		n
+GNIRS	LC	singleslit	0.15	0.150	49	10	K	1.91	2.49	2.2	0.663	1133	yes		n
+GNIRS	LC	singleslit	0.15	0.150	49	10	L	2.8	4.2	3.5	0.995	1200	no		n
+GNIRS	LC	singleslit	0.20	0.200	49	10	X	1.03	1.17	1.1	0.332	1050	yes		n
+GNIRS	LC	singleslit	0.20	0.200	49	10	J	1.17	1.37	1.27	0.398	800	yes		n
+GNIRS	LC	singleslit	0.20	0.200	49	10	H	1.49	1.8	1.645	0.497	850	yes		n
+GNIRS	LC	singleslit	0.20	0.200	49	10	K	1.91	2.49	2.2	0.663	850	yes		n
+GNIRS	LC	singleslit	0.20	0.200	49	10	L	2.8	4.2	3.5	0.995	900	no		n
+GNIRS	LC	singleslit	0.30	0.300	49	10	X	1.03	1.17	1.1	0.332	700	yes		n
+GNIRS	LC	singleslit	0.30	0.300	49	10	J	1.17	1.37	1.27	0.398	533	yes		n
+GNIRS	LC	singleslit	0.30	0.300	49	10	H	1.49	1.8	1.645	0.497	567	yes		n
+GNIRS	LC	singleslit	0.30	0.300	49	10	K	1.91	2.49	2.2	0.663	567	yes		n
+GNIRS	LC	singleslit	0.30	0.300	49	10	L	2.8	4.2	3.5	0.995	600	no		n
+GNIRS	LC	singleslit	0.45	0.450	49	10	X	1.03	1.17	1.1	0.332	467	yes		n
+GNIRS	LC	singleslit	0.45	0.450	49	10	J	1.17	1.37	1.27	0.398	356	yes		n
+GNIRS	LC	singleslit	0.45	0.450	49	10	H	1.49	1.8	1.645	0.497	378	yes		n
+GNIRS	LC	singleslit	0.45	0.450	49	10	K	1.91	2.49	2.2	0.663	378	yes		n
+GNIRS	LC	singleslit	0.45	0.450	49	10	L	2.8	4.2	3.5	0.995	400	no		n
+GNIRS	LC	singleslit	0.675	0.675	49	10	X	1.03	1.17	1.1	0.332	311	yes		n
+GNIRS	LC	singleslit	0.675	0.675	49	10	J	1.17	1.37	1.27	0.398	237	yes		n
+GNIRS	LC	singleslit	0.675	0.675	49	10	H	1.49	1.8	1.645	0.497	252	yes		n
+GNIRS	LC	singleslit	0.675	0.675	49	10	K	1.91	2.49	2.2	0.663	252	yes		n
+GNIRS	LC	singleslit	0.675	0.675	49	10	L	2.8	4.2	3.5	0.995	267	no		n
+GNIRS	LC	singleslit	1.00	1.000	49	10	X	1.03	1.17	1.1	0.332	210	yes		n
+GNIRS	LC	singleslit	1.00	1.000	49	10	J	1.17	1.37	1.27	0.398	160	yes		n
+GNIRS	LC	singleslit	1.00	1.000	49	10	H	1.49	1.8	1.645	0.497	170	yes		n
+GNIRS	LC	singleslit	1.00	1.000	49	10	K	1.91	2.49	2.2	0.663	170	yes		n
+GNIRS	LC	singleslit	1.00	1.000	49	10	L	2.8	4.2	3.5	0.995	180	no		n
+GNIRS	LC	singleslit	0.1	0.100	49	32	X	1.03	1.17	1.1	0.11	5100	yes		n
+GNIRS	LC	singleslit	0.1	0.100	49	32	J	1.17	1.37	1.27	0.132	4800	yes		n
+GNIRS	LC	singleslit	0.1	0.100	49	32	H	1.49	1.8	1.645	0.166	5100	yes		n
+GNIRS	LC	singleslit	0.1	0.100	49	32	K	1.91	2.49	2.2	0.221	5100	yes		n
+GNIRS	LC	singleslit	0.1	0.100	49	32	L	2.8	4.2	3.5	0.332	5400	no		n
+GNIRS	LC	singleslit	0.1	0.100	49	32	M	4.4	6	4.8	0.66	3700	no		n
+GNIRS	LC	singleslit	0.15	0.150	49	32	X	1.03	1.17	1.1	0.11	3400	yes		n
+GNIRS	LC	singleslit	0.15	0.150	49	32	J	1.17	1.37	1.27	0.132	3200	yes		n
+GNIRS	LC	singleslit	0.15	0.150	49	32	H	1.49	1.8	1.645	0.166	3400	yes		n
+GNIRS	LC	singleslit	0.15	0.150	49	32	K	1.91	2.49	2.2	0.221	3400	yes		n
+GNIRS	LC	singleslit	0.15	0.150	49	32	L	2.8	4.2	3.5	0.332	3600	no		n
+GNIRS	LC	singleslit	0.15	0.150	49	32	M	4.4	6	4.8	0.66	2467	no		n
+GNIRS	LC	singleslit	0.2	0.200	49	32	X	1.03	1.17	1.1	0.11	2550	yes		n
+GNIRS	LC	singleslit	0.2	0.200	49	32	J	1.17	1.37	1.27	0.132	2400	yes		n
+GNIRS	LC	singleslit	0.2	0.200	49	32	H	1.49	1.8	1.645	0.166	2550	yes		n
+GNIRS	LC	singleslit	0.2	0.200	49	32	K	1.91	2.49	2.2	0.221	2550	yes		n
+GNIRS	LC	singleslit	0.2	0.200	49	32	L	2.8	4.2	3.5	0.332	2700	no		n
+GNIRS	LC	singleslit	0.2	0.200	49	32	M	4.4	6	4.8	0.66	1850	no		n
+GNIRS	LC	singleslit	0.3	0.300	49	32	X	1.03	1.17	1.1	0.11	1700	yes		n
+GNIRS	LC	singleslit	0.3	0.300	49	32	J	1.17	1.37	1.27	0.132	1600	yes		n
+GNIRS	LC	singleslit	0.3	0.300	49	32	H	1.49	1.8	1.645	0.166	1700	yes		n
+GNIRS	LC	singleslit	0.3	0.300	49	32	K	1.91	2.49	2.2	0.221	1700	yes		n
+GNIRS	LC	singleslit	0.3	0.300	49	32	L	2.8	4.2	3.5	0.332	1800	no		n
+GNIRS	LC	singleslit	0.3	0.300	49	32	M	4.4	6	4.8	0.66	1233	no		n
+GNIRS	LC	singleslit	0.45	0.450	49	32	X	1.03	1.17	1.1	0.11	1133	yes		n
+GNIRS	LC	singleslit	0.45	0.450	49	32	J	1.17	1.37	1.27	0.132	1067	yes		n
+GNIRS	LC	singleslit	0.45	0.450	49	32	H	1.49	1.8	1.645	0.166	1133	yes		n
+GNIRS	LC	singleslit	0.45	0.450	49	32	K	1.91	2.49	2.2	0.221	1133	yes		n
+GNIRS	LC	singleslit	0.45	0.450	49	32	L	2.8	4.2	3.5	0.332	1200	no		n
+GNIRS	LC	singleslit	0.45	0.450	49	32	M	4.4	6	4.8	0.66	822	no		n
+GNIRS	LC	singleslit	0.675	0.675	49	32	X	1.03	1.17	1.1	0.11	756	yes		n
+GNIRS	LC	singleslit	0.675	0.675	49	32	J	1.17	1.37	1.27	0.132	711	yes		n
+GNIRS	LC	singleslit	0.675	0.675	49	32	H	1.49	1.8	1.645	0.166	756	yes		n
+GNIRS	LC	singleslit	0.675	0.675	49	32	K	1.91	2.49	2.2	0.221	756	yes		n
+GNIRS	LC	singleslit	0.675	0.675	49	32	L	2.8	4.2	3.5	0.332	800	no		n
+GNIRS	LC	singleslit	0.675	0.675	49	32	M	4.4	6	4.8	0.66	548	no		n
+GNIRS	LC	singleslit	1.0	1.000	49	32	X	1.03	1.17	1.1	0.11	510	yes		n
+GNIRS	LC	singleslit	1.0	1.000	49	32	J	1.17	1.37	1.27	0.132	480	yes		n
+GNIRS	LC	singleslit	1.0	1.000	49	32	H	1.49	1.8	1.645	0.166	510	yes		n
+GNIRS	LC	singleslit	1.0	1.000	49	32	K	1.91	2.49	2.2	0.221	510	yes		n
+GNIRS	LC	singleslit	1.0	1.000	49	32	L	2.8	4.2	3.5	0.332	540	no		n
+GNIRS	LC	singleslit	1.0	1.000	49	32	M	4.4	6	4.8	0.66	370	no		n
+GNIRS	LC	singleslit	0.1	0.100	49	111	X	1.03	1.17	1.1	0.0316	17800	yes		n
+GNIRS	LC	singleslit	0.1	0.100	49	111	J	1.17	1.37	1.27	0.038	17000	yes		n
+GNIRS	LC	singleslit	0.1	0.100	49	111	H	1.49	1.8	1.645	0.0475	17800	yes		n
+GNIRS	LC	singleslit	0.1	0.100	49	111	K	1.91	2.49	2.2	0.0633	17800	yes		n
+GNIRS	LC	singleslit	0.1	0.100	49	111	L	2.8	4.2	3.5	0.0944	19000	no		n
+GNIRS	LC	singleslit	0.1	0.100	49	111	M	4.4	6	4.8	0.192	12800	no		n
+GNIRS	LC	singleslit	0.15	0.150	49	111	X	1.03	1.17	1.1	0.0316	11867	yes		n
+GNIRS	LC	singleslit	0.15	0.150	49	111	J	1.17	1.37	1.27	0.038	11333	yes		n
+GNIRS	LC	singleslit	0.15	0.150	49	111	H	1.49	1.8	1.645	0.0475	11867	yes		n
+GNIRS	LC	singleslit	0.15	0.150	49	111	K	1.91	2.49	2.2	0.0633	11867	yes		n
+GNIRS	LC	singleslit	0.15	0.150	49	111	L	2.8	4.2	3.5	0.0944	12667	no		n
+GNIRS	LC	singleslit	0.15	0.150	49	111	M	4.4	6	4.8	0.192	8533	no		n
+GNIRS	LC	singleslit	0.2	0.200	49	111	X	1.03	1.17	1.1	0.0316	8900	yes		n
+GNIRS	LC	singleslit	0.2	0.200	49	111	J	1.17	1.37	1.27	0.038	8500	yes		n
+GNIRS	LC	singleslit	0.2	0.200	49	111	H	1.49	1.8	1.645	0.0475	8900	yes		n
+GNIRS	LC	singleslit	0.2	0.200	49	111	K	1.91	2.49	2.2	0.0633	8900	yes		n
+GNIRS	LC	singleslit	0.2	0.200	49	111	L	2.8	4.2	3.5	0.0944	9500	no		n
+GNIRS	LC	singleslit	0.2	0.200	49	111	M	4.4	6	4.8	0.192	6400	no		n
+GNIRS	LC	singleslit	0.3	0.300	49	111	X	1.03	1.17	1.1	0.0316	5933	yes		n
+GNIRS	LC	singleslit	0.3	0.300	49	111	J	1.17	1.37	1.27	0.038	5667	yes		n
+GNIRS	LC	singleslit	0.3	0.300	49	111	H	1.49	1.8	1.645	0.0475	5933	yes		n
+GNIRS	LC	singleslit	0.3	0.300	49	111	K	1.91	2.49	2.2	0.0633	5933	yes		n
+GNIRS	LC	singleslit	0.3	0.300	49	111	L	2.8	4.2	3.5	0.0944	6333	no		n
+GNIRS	LC	singleslit	0.3	0.300	49	111	M	4.4	6	4.8	0.192	4267	no		n
+GNIRS	LC	singleslit	0.45	0.450	49	111	X	1.03	1.17	1.1	0.0316	3956	yes		n
+GNIRS	LC	singleslit	0.45	0.450	49	111	J	1.17	1.37	1.27	0.038	3778	yes		n
+GNIRS	LC	singleslit	0.45	0.450	49	111	H	1.49	1.8	1.645	0.0475	3956	yes		n
+GNIRS	LC	singleslit	0.45	0.450	49	111	K	1.91	2.49	2.2	0.0633	3956	yes		n
+GNIRS	LC	singleslit	0.45	0.450	49	111	L	2.8	4.2	3.5	0.0944	4222	no		n
+GNIRS	LC	singleslit	0.45	0.450	49	111	M	4.4	6	4.8	0.192	2844	no		n
+GNIRS	LC	singleslit	0.675	0.675	49	111	X	1.03	1.17	1.1	0.0316	2637	yes		n
+GNIRS	LC	singleslit	0.675	0.675	49	111	J	1.17	1.37	1.27	0.038	2519	yes		n
+GNIRS	LC	singleslit	0.675	0.675	49	111	H	1.49	1.8	1.645	0.0475	2637	yes		n
+GNIRS	LC	singleslit	0.675	0.675	49	111	K	1.91	2.49	2.2	0.0633	2637	yes		n
+GNIRS	LC	singleslit	0.675	0.675	49	111	L	2.8	4.2	3.5	0.0944	2815	no		n
+GNIRS	LC	singleslit	0.675	0.675	49	111	M	4.4	6	4.8	0.192	1896	no		n
+GNIRS	LC	singleslit	1.0	1.000	49	111	X	1.03	1.17	1.1	0.0316	1780	yes		n
+GNIRS	LC	singleslit	1.0	1.000	49	111	J	1.17	1.37	1.27	0.038	1700	yes		n
+GNIRS	LC	singleslit	1.0	1.000	49	111	H	1.49	1.8	1.645	0.0475	1780	yes		n
+GNIRS	LC	singleslit	1.0	1.000	49	111	K	1.91	2.49	2.2	0.0633	1780	yes		n
+GNIRS	LC	singleslit	1.0	1.000	49	111	L	2.8	4.2	3.5	0.0944	1900	no		n
+GNIRS	LC	singleslit	1.0	1.000	49	111	M	4.4	6	4.8	0.192	1280	no		n
+GNIRS	SC	singleslit	0.3	0.300	7	32	XD	0.85	2.5	1.675	2.5	1700	no		n
+GNIRS	LC	singleslit	0.1	0.100	5	32	XD	0.85	2.5	1.675	2.5	5000	yes		n
+GNIRS	LR-IFU	ifu	LR-IFU	3.150	4.8	32	X	1.03	1.17	1.1	0.331	1700	yes		n
+GNIRS	LR-IFU	ifu	LR-IFU	3.150	4.8	32	J	1.17	1.37	1.27	0.397	1600	yes		n
+GNIRS	LR-IFU	ifu	LR-IFU	3.150	4.8	32	H	1.49	1.8	1.645	0.496	1700	yes		n
+GNIRS	LR-IFU	ifu	LR-IFU	3.150	4.8	32	K	1.91	2.49	2.2	0.661	1700	yes		n
+GNIRS	LR-IFU	ifu	LR-IFU	3.150	4.8	32	L	2.8	4.2	3.5	0.992	1800	no		n
+GNIRS	LR-IFU	ifu	LR-IFU	3.150	4.8	111	X	1.03	1.17	1.1	0.094	6600	yes		n
+GNIRS	LR-IFU	ifu	LR-IFU	3.150	4.8	111	J	1.17	1.37	1.27	0.113	7200	yes		n
+GNIRS	LR-IFU	ifu	LR-IFU	3.150	4.8	111	H	1.49	1.8	1.645	0.142	5900	yes		n
+GNIRS	LR-IFU	ifu	LR-IFU	3.150	4.8	111	K	1.91	2.49	2.2	0.189	5900	yes		n
+GNIRS	LR-IFU	ifu	LR-IFU	3.150	4.8	111	L	2.8	4.2	3.5	0.28	6400	no		n
+GNIRS	LR-IFU	ifu	LR-IFU	3.150	4.8	111	M	4.4	6	4.8	0.575	4300	no		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	10	X	1.03	1.17	1.1	0.332	2100	yes		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	10	J	1.17	1.37	1.27	0.398	1600	yes		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	10	H	1.49	1.8	1.645	0.497	1700	yes		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	10	K	1.91	2.49	2.2	0.663	1700	yes		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	10	L	2.8	4.2	3.5	0.995	1800	no		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	32	X	1.03	1.17	1.1	0.11	5100	yes		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	32	J	1.17	1.37	1.27	0.132	4800	yes		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	32	H	1.49	1.8	1.645	0.166	5100	yes		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	32	K	1.91	2.49	2.2	0.221	5100	yes		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	32	L	2.8	4.2	3.5	0.332	5400	no		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	32	M	4.4	6	4.8	0.66	3700	no		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	111	X	1.03	1.17	1.1	0.0316	17800	yes		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	111	J	1.17	1.37	1.27	0.038	17000	yes		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	111	H	1.49	1.8	1.645	0.0475	17800	yes		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	111	K	1.91	2.49	2.2	0.0633	17800	yes		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	111	L	2.8	4.2	3.5	0.0944	19000	no		n
+GNIRS	HR-IFU	ifu	HR-IFU	1.250	1.8	111	M	4.4	6	4.8	0.192	12800	no		n

--- a/modules/phase0/src/main/resources/phase0/Phase0_Instrument_Matrix - Spectroscopy.tsv
+++ b/modules/phase0/src/main/resources/phase0/Phase0_Instrument_Matrix - Spectroscopy.tsv
@@ -160,6 +160,7 @@ GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	CaT	0.78	0.933	0.86	1.
 GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	CaT	0.78	0.933	0.86	1.219	210	no		n
 GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	CaT	0.78	0.933	0.86	1.219	158	no		n
 GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	CaT	0.78	0.933	0.86	1.219	63	no		n
+GMOS-N	B480 IFU1	ifu	IFU-R	3	5	B480	none	0.36	1.03	0.461	0.317	2500	no		n
 GMOS-N	B480 IFU2	ifu	IFU-2	5	7	B480	g	0.398	0.552	0.461	0.154	2500	no		n
 GMOS-S	B1200 0.25"	singleslit,multislit	0.25"	0.250	330	B1200	none	0.36	0.72	0.463	0.159	7488	no		s
 GMOS-S	B1200 0.50"	singleslit,multislit	0.50"	0.500	330	B1200	none	0.36	0.72	0.463	0.159	3744	no		s
@@ -371,9 +372,10 @@ GMOS-S	R150 1.0" CaT	singleslit,multislit	1.0"	1.000	330	R150	CaT	0.78	0.933	0.8
 GMOS-S	R150 1.5" CaT	singleslit,multislit	1.5"	1.500	330	R150	CaT	0.78	0.933	0.86	0.153	210	no		s
 GMOS-S	R150 2.0" CaT	singleslit,multislit	2.0"	2.000	330	R150	CaT	0.78	0.933	0.86	0.153	158	no		s
 GMOS-S	R150 5.0" CaT	singleslit,multislit	5.0"	5.000	330	R150	CaT	0.78	0.933	0.86	0.153	63	no		s
+GMOS-S	B600 IFU1	ifu	IFU-R	3	5	B600	none	0.36	1.03	0.461	0.307	2723	no		s
 GMOS-S	B600 IFU2	ifu	IFU-2	5	7	B600	g	0.398	0.552	0.461	0.154	2723	no		s
-GMOS-S	B600 IFU1 NS	ifu	IFU-NS-2	3	5	B600	none	0.36	1.03	0.461	0.307	2723	no	Nod&Shuffle	s
-GMOS-S	B600 IFU2 NS	ifu	IFU-NS-B	5	7	B600	g	0.398	0.552	0.461	0.154	2723	no	Nod&Shuffle	s
+GMOS-S	B600 IFU1 NS	ifu	IFU-NS-R	3	5	B600	none	0.36	1.03	0.461	0.307	2723	no	Nod&Shuffle	s
+GMOS-S	B600 IFU2 NS	ifu	IFU-NS-2	5	7	B600	g	0.398	0.552	0.461	0.154	2723	no	Nod&Shuffle	s
 GMOS-S	R150 NS1.0 GG455	singleslit,multislit	NS1.0"	1.000	330	R150	GG455	0.46	1.03	0.717	0.57	316	no	Nod&Shuffle	s
 GMOS-S	R150 NS1.0 OG515	singleslit,multislit	NS1.0"	1.000	330	R150	OG515	0.52	1.03	0.717	0.51	316	no	Nod&Shuffle	s
 GMOS-S	R831 NS1.0 CaT	singleslit,multislit	NS1.0"	1.000	330	R831	CaT	0.78	0.933	0.757	0.23	2198	no	Nod&Shuffle	s

--- a/modules/phase0/src/main/scala/lucuma/odb/phase0/Capability.scala
+++ b/modules/phase0/src/main/scala/lucuma/odb/phase0/Capability.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.phase0
+
+import lucuma.core.util.Enumerated
+
+enum Capability(val tag: String, val label: String) derives Enumerated:
+  case NodAndShuffle extends Capability("nodandshuffle", "Nod&Shuffle")
+  case Coronagraph   extends Capability("coronagraph",   "coronagraph")

--- a/modules/phase0/src/main/scala/lucuma/odb/phase0/FileReader.scala
+++ b/modules/phase0/src/main/scala/lucuma/odb/phase0/FileReader.scala
@@ -14,6 +14,9 @@ import fs2.Stream
 import fs2.text
 import lucuma.core.enums.Instrument
 
+/**
+ * Reads and parses the configuration file into instrument-specific rows.
+ */
 class FileReader[F[_]](fileName: String)(using ApplicativeError[F, Throwable]) {
 
   final class ReadException(
@@ -21,6 +24,10 @@ class FileReader[F[_]](fileName: String)(using ApplicativeError[F, Throwable]) {
     val error:      Parser.Error
   ) extends RuntimeException(s"$fileName, line ${lineNumber.value}:\n${error.show}")
 
+  // Representing the line number as a PosInt, so if there are more than MaxInt
+  // lines then there are `tooManyLines`.  This is a theoretical problem not an
+  // actual one, since in reality there are only hundreds of lines per
+  // instrument at most.
   def tooManyLines[A]: Stream[F, A] =
     Stream.raiseError(new RuntimeException(s"$fileName contains too many lines."))
 

--- a/modules/phase0/src/main/scala/lucuma/odb/phase0/FileReader.scala
+++ b/modules/phase0/src/main/scala/lucuma/odb/phase0/FileReader.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.phase0
+
+import cats.ApplicativeError
+import cats.parse.Parser
+import cats.syntax.eq.*
+import cats.syntax.functor.*
+import cats.syntax.show.*
+import eu.timepit.refined.types.numeric.PosInt
+import fs2.Pipe
+import fs2.Stream
+import fs2.text
+import lucuma.core.enums.Instrument
+
+class FileReader[F[_]](fileName: String)(using ApplicativeError[F, Throwable]) {
+
+  final class ReadException(
+    val lineNumber: PosInt,
+    val error:      Parser.Error
+  ) extends RuntimeException(s"$fileName, line ${lineNumber.value}:\n${error.show}")
+
+  def tooManyLines[A]: Stream[F, A] =
+    Stream.raiseError(new RuntimeException(s"$fileName contains too many lines."))
+
+  def zipWithLineNumber[A]: Pipe[F, A, (A, PosInt)] =
+    _.zipWithIndex
+     .map(_.map(_ + 1))
+     .flatMap { case (a, n) =>
+       Option
+         .when(n.isValidInt)(PosInt.unsafeFrom(n.toInt))
+         .fold(tooManyLines[(A, PosInt)]) { idx => Stream.emit((a, idx))}
+     }
+
+  val entryLines: Pipe[F, Byte, (String, PosInt)] =
+    _.through(text.utf8.decode)
+     .through(text.lines)
+     .map(_.trim)
+     .through(zipWithLineNumber)
+
+  def read[A](i: Instrument, p: Parser[List[A]]): Pipe[F, Byte, (A, PosInt)] =
+    _.through(entryLines)
+     .filter { case (s, _) => s.startsWith(i.shortName) }
+     .flatMap { case (s, idx) =>
+       p.parseAll(s) match {
+         case Left(e)   => Stream.raiseError[F](new ReadException(idx, e))
+         case Right(as) => Stream.emits[F, A](as)
+       }
+     }
+     .through(zipWithLineNumber)
+
+  val gmosNorth: Pipe[F, Byte, (GmosSpectroscopyRow.GmosNorth, PosInt)] =
+    read(Instrument.GmosNorth, GmosSpectroscopyRow.gmosNorth)
+      .andThen(_.filter(_._1.spec.fpuOption === FpuOption.Singleslit)) // for now only single slit
+      .andThen(_.filter(_._1.spec.capability.isEmpty))                 // for now no N&S
+
+  def gmosSouth: Pipe[F, Byte, (GmosSpectroscopyRow.GmosSouth, PosInt)] =
+    read(Instrument.GmosSouth, GmosSpectroscopyRow.gmosSouth)
+      .andThen(_.filter(_._1.spec.fpuOption === FpuOption.Singleslit)) // for now only single slit
+      .andThen(_.filter(_._1.spec.capability.isEmpty))                 // for now no N&S
+
+}

--- a/modules/phase0/src/main/scala/lucuma/odb/phase0/FpuOption.scala
+++ b/modules/phase0/src/main/scala/lucuma/odb/phase0/FpuOption.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.phase0
+
+import lucuma.core.util.Enumerated
+
+enum FpuOption(val tag: String, val label: String) derives Enumerated:
+  case Ifu        extends FpuOption("ifu", "ifu")
+  case Multislit  extends FpuOption("multiple_slit", "multislit")
+  case Singleslit extends FpuOption("single_slit", "singleslit")

--- a/modules/phase0/src/main/scala/lucuma/odb/phase0/GmosSpectroscopyRow.scala
+++ b/modules/phase0/src/main/scala/lucuma/odb/phase0/GmosSpectroscopyRow.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.phase0
+
+import cats.parse.*
+import cats.parse.Parser.*
+import cats.syntax.all.*
+import lucuma.core.enums.GmosNorthFilter
+import lucuma.core.enums.GmosNorthFpu
+import lucuma.core.enums.GmosNorthGrating
+import lucuma.core.enums.GmosSouthFilter
+import lucuma.core.enums.GmosSouthFpu
+import lucuma.core.enums.GmosSouthGrating
+import lucuma.core.enums.Instrument
+import lucuma.core.util.Enumerated
+
+case class GmosSpectroscopyRow[G, L, U](
+  spec:      SpectroscopyRow,
+  disperser: G,
+  filter:    Option[L],
+  fpu:       U
+)
+
+object GmosSpectroscopyRow {
+
+  type GmosNorth = GmosSpectroscopyRow[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu]
+  type GmosSouth = GmosSpectroscopyRow[GmosSouthGrating, GmosSouthFilter, GmosSouthFpu]
+
+  def gmos[G: Enumerated, L: Enumerated, U: Enumerated](
+    inst: Instrument,
+    g:    G => String,
+    l:    L => String,
+    u:    U => String
+  ): Parser[List[GmosSpectroscopyRow[G, L, U]]] =
+    SpectroscopyRow.rows.flatMap { rs =>
+      rs.traverse { r =>
+        val gn = for {
+          _ <- Either.raiseWhen(r.instrument =!= inst)(s"Cannot parse a ${r.instrument.tag} as ${inst.tag}")
+          g <- Enumerated[G].all.find(a => g(a) === r.disperser).toRight(s"Cannot parse disperser: ${r.disperser}")
+          l <- r.filter.traverse { f => Enumerated[L].all.find(a => l(a) === f).toRight(s"Cannot parse filter: $f") }
+          u <- Enumerated[U].all.find(a => u(a) === r.fpu).toRight(s"Cannot parse FPU: ${r.fpu}")
+        } yield GmosSpectroscopyRow(r, g, l, u)
+        gn.fold(Parser.failWith, Parser.pure)
+      }
+    }
+
+  val gmosNorth: Parser[List[GmosNorth]] =
+    gmos[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu](Instrument.GmosNorth, _.shortName, _.shortName, _.shortName)
+
+  val gmosSouth: Parser[List[GmosSouth]] =
+    gmos[GmosSouthGrating, GmosSouthFilter, GmosSouthFpu](Instrument.GmosSouth, _.shortName, _.shortName, _.shortName)
+
+}

--- a/modules/phase0/src/main/scala/lucuma/odb/phase0/SpectroscopyRow.scala
+++ b/modules/phase0/src/main/scala/lucuma/odb/phase0/SpectroscopyRow.scala
@@ -21,6 +21,10 @@ import lucuma.core.parser.MiscParsers.posInt
 Instrument	Config	Focal Plane	fpu	slit width	slit length	disperser	filter	wave min	wave max	wave optimal	wave coverage	resolution	AO	capabilities	site
 GMOS-N	B1200 0.25"	singleslit,multislit	0.25"	0.250	330	B1200	none	0.36	0.72	0.463	0.164	7488	no		n
  */
+
+/**
+ * Represents a single row in the spectroscopy instrument option "phase 0" table.
+ */
 case class SpectroscopyRow(
   instrument:     Instrument,
   description:    String,
@@ -93,6 +97,11 @@ object SpectroscopyRow {
       case _   => none
     }
 
+  /**
+   * A single line in the .tsv file is split into 1 or more rows according to the FPU option.  So a
+    * value of "singleslit,multislit" becames two rows identical in every respect except tht one is
+    * single slit and the other multislit (MOS).
+   */
   val rows: Parser[List[SpectroscopyRow]] = (
     (instrument <* htab) ~
     (string     <* htab) ~
@@ -115,18 +124,5 @@ object SpectroscopyRow {
       SpectroscopyRow(inst, desc, fpuOpt, fpu, slitWidth, slitLength, disp, filter, min, max, opt, cov, res, ao, capability, site)
     }
   }
-
-  def main(args: Array[String]): Unit =
-    val x = (
-      (instrument <* htab) ~
-      (string     <* htab) ~
-      (fpuOptions <* htab) ~
-      (string     <* htab) ~
-      (arcsec     <* htab)
-    )
-
-    println(x.parseAll("GMOS-N\tB1200 0.25\"\tsingleslit,multislit\t0.25\"\t0.250\t"))
-    val s = "GMOS-N\tB1200 0.25\"\tsingleslit,multislit\t0.25\"\t0.250\t330\tB1200\tnone\t0.36\t0.72\t0.463\t0.164\t7488\tno\t\tn"
-    println(rows.parseAll(s))
 
 }

--- a/modules/phase0/src/main/scala/lucuma/odb/phase0/SpectroscopyRow.scala
+++ b/modules/phase0/src/main/scala/lucuma/odb/phase0/SpectroscopyRow.scala
@@ -1,0 +1,132 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.phase0
+
+import cats.parse.*
+import cats.parse.Parser.*
+import cats.parse.Rfc5234.htab
+import cats.parse.Rfc5234.sp
+import cats.parse.Rfc5234.vchar
+import cats.syntax.all.*
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.enums.Instrument
+import lucuma.core.enums.Site
+import lucuma.core.math.Angle
+import lucuma.core.math.Wavelength
+import lucuma.core.parser.MiscParsers.posBigDecimal
+import lucuma.core.parser.MiscParsers.posInt
+
+/*
+Instrument	Config	Focal Plane	fpu	slit width	slit length	disperser	filter	wave min	wave max	wave optimal	wave coverage	resolution	AO	capabilities	site
+GMOS-N	B1200 0.25"	singleslit,multislit	0.25"	0.250	330	B1200	none	0.36	0.72	0.463	0.164	7488	no		n
+ */
+case class SpectroscopyRow(
+  instrument:     Instrument,
+  description:    String,
+  fpuOption:      FpuOption,
+  fpu:            String,
+  slitWidth:      Angle,
+  slitLength:     Angle,
+  disperser:      String,
+  filter:         Option[String],
+  wavelengthMin:  Wavelength,
+  wavelengthMax:  Wavelength,
+  wavelengthOpt:  Wavelength,
+  wavelengthCov:  Wavelength,
+  resolution:     PosInt,
+  ao:             Boolean,
+  capability:     Option[Capability],
+  site:           Site
+)
+
+object SpectroscopyRow {
+
+  val string: Parser[String] =
+    (vchar | sp).rep.string
+
+  val instrument: Parser[Instrument] =
+    string.mapFilter { s =>
+      Instrument.all.find { inst =>
+        inst.shortName === s || inst.longName === s || inst.tag === s
+      }
+    }
+
+  val filter: Parser[Option[String]] =
+    string.map { s => Option.when(s =!= "none")(s) }
+
+  val fpuOptions: Parser[Set[FpuOption]] =
+    string.map { s =>
+      Set.from(
+        s.split(',').toList.traverse { fpuOpt =>
+          FpuOption.values.find(_.label === fpuOpt)
+        }.toList.flatten
+      )
+    }
+
+  val arcsec: Parser0[Angle] =
+    posBigDecimal.map { bd =>
+      Angle.fromBigDecimalArcseconds(bd.value)
+    }
+
+  val µm: Parser0[Wavelength] =
+    posBigDecimal.mapFilter { bd =>
+      Wavelength.decimalMicrometers.getOption(bd.value)
+    }
+
+  val ao: Parser[Boolean] =
+    string.map {
+      case "yes" => true
+      case _     => false
+    }
+
+  val capability: Parser0[Option[Capability]] =
+    vchar.rep0.string.mapFilter {
+      case "" => none.some
+      case s  => Capability.values.find(_.label === s).map(_.some)
+    }
+
+  val site: Parser[Site] =
+    string.mapFilter {
+      case "n" => Site.GN.some
+      case "s" => Site.GS.some
+      case _   => none
+    }
+
+  val rows: Parser[List[SpectroscopyRow]] = (
+    (instrument <* htab) ~
+    (string     <* htab) ~
+    (fpuOptions <* htab) ~
+    (string     <* htab) ~
+    (arcsec     <* htab) ~
+    (arcsec     <* htab) ~
+    (string     <* htab) ~
+    (filter     <* htab) ~
+    (µm         <* htab) ~
+    (µm         <* htab) ~
+    (µm         <* htab) ~
+    (µm         <* htab) ~
+    (posInt     <* htab) ~
+    (ao         <* htab) ~
+    (capability <* htab) ~
+    site
+  ).map { case (((((((((((((((inst, desc), fpuOpts), fpu), slitWidth), slitLength), disp), filter), min), max), opt), cov), res), ao), capability), site) =>
+    fpuOpts.toList.map { fpuOpt =>
+      SpectroscopyRow(inst, desc, fpuOpt, fpu, slitWidth, slitLength, disp, filter, min, max, opt, cov, res, ao, capability, site)
+    }
+  }
+
+  def main(args: Array[String]): Unit =
+    val x = (
+      (instrument <* htab) ~
+      (string     <* htab) ~
+      (fpuOptions <* htab) ~
+      (string     <* htab) ~
+      (arcsec     <* htab)
+    )
+
+    println(x.parseAll("GMOS-N\tB1200 0.25\"\tsingleslit,multislit\t0.25\"\t0.250\t"))
+    val s = "GMOS-N\tB1200 0.25\"\tsingleslit,multislit\t0.25\"\t0.250\t330\tB1200\tnone\t0.36\t0.72\t0.463\t0.164\t7488\tno\t\tn"
+    println(rows.parseAll(s))
+
+}

--- a/modules/service/src/main/scala/db/migration/Phase0Loader.scala
+++ b/modules/service/src/main/scala/db/migration/Phase0Loader.scala
@@ -1,0 +1,70 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package db.migration
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.syntax.foldable.*
+import eu.timepit.refined.types.numeric.PosInt
+import fs2.Pipe
+import fs2.Stream
+import fs2.io.readInputStream
+import lucuma.core.enums.Instrument
+import lucuma.odb.phase0.FileReader
+import lucuma.odb.phase0.GmosSpectroscopyRow
+import lucuma.odb.phase0.SpectroscopyRow
+import org.postgresql.core.BaseConnection
+
+import java.io.InputStream
+
+/**
+ * Loads a Phase 0 configuration file into the corresponding table.
+ */
+class Phase0Loader[A](
+  val instrument: Instrument,
+  val pipe:       Pipe[IO, Byte, (A, PosInt)],
+  val specRow:    A => SpectroscopyRow,
+  val instTable:  Phase0Table[A]
+) {
+
+  def load(bc: BaseConnection, is: IO[InputStream]): IO[Unit] = {
+
+    def toInputStream(s: Stream[IO, String]): Resource[IO, InputStream] =
+      s.append(Stream("\\.\n"))
+       .intersperse("\n")
+       .through(fs2.text.utf8.encode)
+       .through(fs2.io.toInputStream[IO])
+       .compile
+       .resource
+       .lastOrError
+
+    val s: Stream[IO, (String, String)] =
+      readInputStream(is, ByteChunkSize, closeAfterUse = true)
+        .through(pipe)
+        .map { (a, idx) => (
+          Phase0Table.Spectroscopy.stdinLine(specRow(a), idx),
+          instTable.stdinLine(a, idx)
+        )}
+
+    for {
+      _  <- bc.ioUpdate(instTable.truncate)
+      _  <- bc.ioUpdate(Phase0Table.Spectroscopy.deleteFrom(instrument))
+      _  <- bc.ioCopyIn(Phase0Table.Spectroscopy.copyFromStdin, toInputStream(s.map(_._1)))
+      _  <- bc.ioCopyIn(instTable.copyFromStdin, toInputStream(s.map(_._2)))
+    } yield ()
+
+  }
+
+}
+
+object Phase0Loader {
+
+  def loadAll(bc: BaseConnection, fileName: String, is: IO[InputStream]): IO[Unit] =
+    val rdr = FileReader[IO](fileName)
+    List(
+      new Phase0Loader[GmosSpectroscopyRow.GmosNorth](Instrument.GmosNorth, rdr.gmosNorth, _.spec, Phase0Table.SpectroscopyGmosNorth),
+      new Phase0Loader[GmosSpectroscopyRow.GmosSouth](Instrument.GmosSouth, rdr.gmosSouth, _.spec, Phase0Table.SpectroscopyGmosSouth)
+    ).traverse_(_.load(bc, is))
+
+}

--- a/modules/service/src/main/scala/db/migration/Phase0Table.scala
+++ b/modules/service/src/main/scala/db/migration/Phase0Table.scala
@@ -1,0 +1,155 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package db.migration
+
+import cats.syntax.foldable.*
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.enums.GmosNorthFilter
+import lucuma.core.enums.GmosNorthFpu
+import lucuma.core.enums.GmosNorthGrating
+import lucuma.core.enums.GmosSouthFilter
+import lucuma.core.enums.GmosSouthFpu
+import lucuma.core.enums.GmosSouthGrating
+import lucuma.core.enums.Instrument
+import lucuma.odb.phase0.GmosSpectroscopyRow
+import lucuma.odb.phase0.SpectroscopyRow
+import lucuma.odb.util.Codecs.*
+import lucuma.odb.util.GmosCodecs.*
+import skunk.Encoder
+import skunk.codec.boolean.bool
+import skunk.codec.text.text
+
+trait Phase0Table[A] {
+
+  def name: String
+
+  def columns: List[String]
+
+  def indexColumn: String =
+    "c_index"
+
+  def encoder: Encoder[A]
+
+  def truncate: String =
+    s"TRUNCATE $name"
+
+  def copyFromStdin: String =
+    s"COPY $name ( ${(indexColumn :: columns).mkString("\n", ",", "\n")} ) FROM STDIN WITH ( DELIMITER '|', NULL 'NULL' )"
+
+  def stdinLine(a: A, index: PosInt): String =
+    (int4_pos *: encoder).encode((index, a)).map(_.getOrElse("NULL")).intercalate("|")
+
+  def deleteFrom(inst: Instrument): String =
+    s"""
+      DELETE FROM $name
+        WHERE c_instrument = '${inst.tag}';
+    """
+}
+
+object Phase0Table {
+
+  val Spectroscopy = new Phase0Table[SpectroscopyRow] {
+    override def name: String =
+      "t_spectroscopy_config_option"
+
+    override def columns: List[String] =
+      List(
+        "c_instrument",
+        "c_name",
+        "c_focal_plane",
+        "c_fpu_label",
+        "c_slit_width",
+        "c_slit_length",
+        "c_disperser_label",
+        "c_filter_label",
+        "c_wavelength_min",
+        "c_wavelength_max",
+        "c_wavelength_optimal",
+        "c_wavelength_coverage",
+        "c_resolution",
+        "c_ao",
+        "c_capability",
+        "c_site"
+      )
+
+    override def encoder: Encoder[SpectroscopyRow] =
+      (
+        instrument    *:
+        text          *:
+        text          *:
+        text          *:
+        angle_µas     *:
+        angle_µas     *:
+        text          *:
+        text.opt      *:
+        wavelength_pm *:
+        wavelength_pm *:
+        wavelength_pm *:
+        wavelength_pm *:
+        int4_pos      *:
+        bool          *:
+        text.opt      *:
+        site
+      ).contramap[SpectroscopyRow] { row => (
+        row.instrument,
+        row.description,
+        row.fpuOption.tag,
+        row.fpu,
+        row.slitWidth,
+        row.slitLength,
+        row.disperser,
+        row.filter,
+        row.wavelengthMin,
+        row.wavelengthMax,
+        row.wavelengthOpt,
+        row.wavelengthCov,
+        row.resolution,
+        row.ao,
+        row.capability.map(_.tag),
+        row.site
+      )}
+
+  }
+
+  trait GmosSpectroscopyTable[G, L, U, R <: GmosSpectroscopyRow[G, L, U]] extends Phase0Table[R] {
+
+    protected def enc(g: Encoder[G], l: Encoder[L], u: Encoder[U]): Encoder[R] =
+      (
+        instrument *:
+        g          *:
+        l.opt      *:
+        u
+      ).contramap[R] { row => (
+        row.spec.instrument,
+        row.disperser,
+        row.filter,
+        row.fpu
+      )}
+
+    override def columns: List[String] =
+      List(
+        "c_instrument",
+        "c_grating",
+        "c_filter",
+        "c_fpu"
+      )
+  }
+
+  val SpectroscopyGmosNorth = new GmosSpectroscopyTable[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu, GmosSpectroscopyRow.GmosNorth] {
+    override def name: String =
+      s"${Spectroscopy.name}_gmos_north"
+
+    override def encoder: Encoder[GmosSpectroscopyRow.GmosNorth] =
+      enc(gmos_north_grating, gmos_north_filter, gmos_north_fpu)
+  }
+
+  val SpectroscopyGmosSouth = new GmosSpectroscopyTable[GmosSouthGrating, GmosSouthFilter, GmosSouthFpu, GmosSpectroscopyRow.GmosSouth] {
+    override def name: String =
+      s"${Spectroscopy.name}_gmos_south"
+
+    override def encoder: Encoder[GmosSpectroscopyRow.GmosSouth] =
+      enc(gmos_south_grating, gmos_south_filter, gmos_south_fpu)
+  }
+
+}

--- a/modules/service/src/main/scala/db/migration/R__Phase0.scala
+++ b/modules/service/src/main/scala/db/migration/R__Phase0.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package db.migration
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import org.flywaydb.core.api.migration.Context
+import org.postgresql.core.BaseConnection
+
+import java.io.InputStream
+
+class R__Phase0 extends RepeatableMigration("Phase 0 Instrument Options") {
+
+  val fileName: String = "Phase0_Instrument_Matrix - Spectroscopy.tsv"
+
+  lazy val definitionFiles: NonEmptyList[(String, IO[InputStream])] =
+    filesFromClasspath("phase0", NonEmptyList.one(fileName))
+
+  override def ioMigrate(ctx: Context, bc: BaseConnection): IO[Unit] =
+    Phase0Loader.loadAll(bc, fileName, definitionFiles.head._2)
+
+}

--- a/modules/service/src/main/scala/db/migration/R__Phase0.scala
+++ b/modules/service/src/main/scala/db/migration/R__Phase0.scala
@@ -10,6 +10,10 @@ import org.postgresql.core.BaseConnection
 
 import java.io.InputStream
 
+/**
+ * A repeatable migration that is executed whenver the input .tsv file is
+ * changed.
+ */
 class R__Phase0 extends RepeatableMigration("Phase 0 Instrument Options") {
 
   val fileName: String = "Phase0_Instrument_Matrix - Spectroscopy.tsv"

--- a/modules/service/src/main/scala/db/migration/RepeatableMigration.scala
+++ b/modules/service/src/main/scala/db/migration/RepeatableMigration.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package db.migration
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.flywaydb.core.api.MigrationVersion
+
+import java.io.InputStream
+import scala.math.BigInt
+
+/**
+ * Performs a file-based repeatable migration which consists of reading the
+ * named `definitionFiles`, parsing them and updating the corresponding tables.
+ * Most of this work is delegated to loaders which could be used in other
+ * contexts.
+ *
+ * @param name identifies the migration in `getDescription`
+  */
+abstract class RepeatableMigration(val getDescription: String) extends IOMigration {
+
+  /**
+   * Returns `null` as required by the Flyway API for repeatable migrations.
+   * Repeatable migrations are always executed after versioned migrations but
+   * in any order thereafter. They are skipped if the checksum (see
+   * `getChecksum`) has not been updated since the last time it was executed.
+   */
+  override val getVersion: MigrationVersion =
+    null // required by the API for repeatable migrations
+
+  /**
+   * Computes a CRC checksum such that the migration will be skipped if the
+   * definition files have not been updated since the last time the migration
+   * was executed.
+   */
+  override def getChecksum: Integer = {
+    val bytes =
+      definitionFiles
+        .map { case (_, is) => fs2.io.readInputStream(is, ByteChunkSize, closeAfterUse = true) }
+        .reduce
+        .through(fs2.compression.checksum.crc32)
+        .compile
+        .to(Array)
+        .unsafeRunSync()
+
+    BigInt(bytes).intValue
+  }
+
+  /**
+   * List of the definition files.
+   */
+  def definitionFiles: NonEmptyList[(String, IO[InputStream])]
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("io.spray"           % "sbt-revolver"             % "0.10.0")
 addSbtPlugin("com.timushev.sbt"   % "sbt-updates"              % "0.6.4")
 addSbtPlugin("com.github.sbt"     % "sbt-native-packager"      % "1.10.0")
-addSbtPlugin("edu.gemini"         % "sbt-lucuma-lib"           % "0.11.17")
+addSbtPlugin("edu.gemini"         % "sbt-lucuma-lib"           % "0.12.0")


### PR DESCRIPTION
Updates the instrument configuration options, using a repeatable migration.  These are requested by explore and those that match the science requirements are presented in the UI for selection by the PI.

At the moment, the options are maintained by the science staff in a Google spreadsheet.  This can now be exported to a `.tsv` file and replaced in the codebase.  A redeployment will cause the repeatable migration to run, parse the `.tsv` file and update the tables.  This is how SmartGcal works for now as well.

We could automate this in the future to obviate the need for software involvement, but updates are anticipated only once per semester.  Ultimately, these could be computed directly from a query based on availability.