### PR TITLE
Add WhereProgramUser

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -11529,6 +11529,60 @@ input WhereEqPartner {
 }
 
 """
+Filters on equality (or not) of the partner link type. All supplied criteria
+must match, but usually only one is selected.
+"""
+input WhereEqPartnerLinkType {
+  """
+  Matches if the partner link type is exactly the supplied value.
+  """
+  EQ: PartnerLinkType
+
+  """
+  Matches if the partner link type is not the supplied value.
+  """
+  NEQ: PartnerLinkType
+
+  """
+  Matches if the partner link type is any of the supplied options.
+  """
+  IN: [PartnerLinkType!]
+
+  """
+  Matches if the partner link type is none of the supplied values.
+  """
+  NIN: [PartnerLinkType!]
+}
+
+"""
+Filters on equality (or not) of the program user role type and the supplied
+criteria. All supplied criteria must match, but usually only one is selected.
+"""
+input WhereEqProgramUserRole {
+
+  """
+  Matches if the role is exactly the supplied value.
+  """
+  EQ: ProgramUserRole
+
+  """
+  Matches if the role is not the supplied value.
+  """
+  NEQ: ProgramUserRole
+
+  """
+  Matches if the role is any of the supplied options.
+  """
+  IN: [ProgramUserRole!]
+
+  """
+  Matches if the role is none of the supplied values.
+  """
+  NIN: [ProgramUserRole!]
+
+}
+
+"""
 Filters on equality (or not) of the program type and the supplied criteria.
 All supplied criteria must match, but usually only one is selected.  E.g.
 'EQ = "CALIBRATION"' will match when the type is "CALIBRATION".
@@ -11660,6 +11714,34 @@ input WhereEqToOActivation {
   Matches if the property value is none of the supplied values.
   """
   NIN: [ToOActivation!]
+}
+
+"""
+Filters on equality (or not) of the user type value and the supplied criteria.
+All supplied criteria must match, but usually only one is selected.
+"""
+input WhereEqUserType {
+
+  """
+  Matches if the user type is exactly the supplied value.
+  """
+  EQ: UserType
+
+  """
+  Matches if the user type is not the supplied value.
+  """
+  NEQ: UserType
+
+  """
+  Matches if the user type is any of the supplied options.
+  """
+  IN: [UserType!]
+
+  """
+  Matches if the user type is none of the supplied values.
+  """
+  NIN: [UserType!]
+
 }
 
 """
@@ -11969,6 +12051,40 @@ input WhereOptionEqCalibrationRole {
   Matches if the property value is none of the supplied values.
   """
   NIN: [CalibrationRole!]
+}
+
+"""
+Filters on equality (or not) of the (optional) partner. All supplied criteria
+must match, but usually only one is selected.
+"""
+input WhereOptionEqPartner {
+
+  """
+  When `true`, matches if the partner is not defined. When `false` matches if
+  the partner is defined.
+  """
+  IS_NULL: Boolean
+
+  """
+  Matches if the partrner is exactly the supplied value.
+  """
+  EQ: Partner
+
+  """
+  Matches if the partner is not the supplied value.
+  """
+  NEQ: Partner
+
+  """
+  Matches if the partner is any of the supplied options.
+  """
+  IN: [Partner!]
+
+  """
+  Matches if the partner is none of the supplied values.
+  """
+  NIN: [Partner!]
+
 }
 
 """
@@ -12838,6 +12954,50 @@ input WhereOrderProgramId {
   LTE: ProgramId
 }
 
+input WhereOrderUserId {
+
+  """
+  Matches if the user id is exactly the supplied value.
+  """
+  EQ: UserId
+
+  """
+  Matches if the user id is not the supplied value.
+  """
+  NEQ: UserId
+
+  """
+  Matches if the user id is any of the supplied options.
+  """
+  IN: [UserId!]
+
+  """
+  Matches if the user id is none of the supplied values.
+  """
+  NIN: [UserId!]
+
+  """
+  Matches if the user id is ordered after (>) the supplied value.
+  """
+  GT: UserId
+
+  """
+  Matches if the user id is ordered before (<) the supplied value.
+  """
+  LT: UserId
+
+  """
+  Matches if the user id is ordered after or equal (>=) the supplied value.
+  """
+  GTE: UserId
+
+  """
+  Matches if the user id is ordered before or equal (<=) the supplied value.
+  """
+  LTE: UserId
+
+}
+
 input WhereProposalReference {
 
   "Matches if the proposal reference is not defined."
@@ -13195,6 +13355,24 @@ input WhereOrderTargetId {
 }
 
 """
+Partner link filter options.  All specified items much match.
+"""
+input WherePartnerLink {
+
+  """
+  Matches on equality of the link type.
+  """
+  linkType: WhereEqPartnerLinkType
+
+  """
+  Matches on the partner itself, if applicable.  Only `HAS_PARTNER` link types
+  will have a partner.  For other link types it will be `null`.
+  """
+  partner: WhereOptionEqPartner
+
+}
+
+"""
 Program filter options.  All specified items must match.
 """
 input WhereProgram {
@@ -13234,6 +13412,11 @@ input WhereProgram {
   reference: WhereProgramReference
 
   """
+  Matches the PI.
+  """
+  pi: WhereProgramUser
+
+  """
   Matches the proposalStatus.
   """
   proposalStatus: WhereEqProposalStatus
@@ -13271,6 +13454,48 @@ input WhereProgramReference {
 
   "Matches the science subtype in the program reference, if any."
   scienceSubtype: WhereEqScienceSubtype
+}
+
+"""
+Program user options.  All specified items must match.
+"""
+input WhereProgramUser {
+
+  """
+  A list of nested program user filters that all must match in order for the AND group as a whole to match.
+  """
+  AND: [WhereProgramUser!]
+
+  """
+  A list of nested program user filters where any one match causes the entire OR group as a whole to match.
+  """
+  OR: [WhereProgramUser!]
+
+  """
+  A nested program user filter that must not match in order for the NOT itself to match.
+  """
+  NOT: WhereProgramUser
+
+  """
+  Matches the program.
+  """
+  program: WhereProgram
+
+  """
+  Matches the user.
+  """
+  user: WhereUser
+
+  """
+  Matches the role.
+  """
+  role: WhereEqProgramUserRole
+
+  """
+  Matches the partner.
+  """
+  partnerLink: WherePartnerLink
+
 }
 
 """
@@ -13488,6 +13713,41 @@ input WhereTarget {
   Matches the calibration role.
   """
   calibrationRole: WhereOptionEqCalibrationRole
+}
+
+"""
+User filter options.  All specified items must match.
+"""
+input WhereUser {
+
+  """
+  A list of nested user filters that all must match in order for the AND group
+  as a whole to match.
+  """
+  AND:             [WhereUser!]
+
+  """
+  A list of nested user filters that all must match in order for the OR group
+  as a whole to match.
+  """
+  OR:              [WhereUser!]
+
+  """
+  A nested user filter that must not match in order for the NOT itself to match.
+  """
+  NOT:             WhereUser
+
+  "Matches the user Id."
+  id:              WhereOrderUserId
+
+  "Matches the user type."
+  type:            WhereEqUserType
+
+  orcidId:         WhereOptionString
+  orcidGivenName:  WhereOptionString
+  orcidCreditName: WhereOptionString
+  orcidFamilyName: WhereOptionString
+  orcidEmail:      WhereOptionString
 }
 
 input WhereWavelength {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/binding/UserTypeBinding.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/binding/UserTypeBinding.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.binding
+
+import lucuma.odb.data.UserType
+
+val UserTypeBinding: Matcher[UserType] =
+  enumeratedBinding

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WherePartnerLink.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WherePartnerLink.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import grackle.Path
+import grackle.Predicate
+import grackle.Predicate.*
+import lucuma.core.enums.Partner
+import lucuma.odb.data.PartnerLink.LinkType
+import lucuma.odb.graphql.binding.*
+
+object WherePartnerLink {
+
+  def binding(path: Path): Matcher[Predicate] =
+    val WherePartnerLinkType = WhereEq.binding[LinkType](path / "linkType", PartnerLinkTypeBinding)
+    val WherePartner         = WhereOptionEq.binding[Partner](path / "partner", PartnerBinding)
+
+    ObjectFieldsBinding.rmap {
+      case List(
+        WherePartnerLinkType.Option("linkType", rLinkType),
+        WherePartner.Option("partner", rPartner)
+      ) =>
+        (rLinkType, rPartner).parMapN { (linkType, partner) =>
+          and(List(
+            linkType,
+            partner
+          ).flatten)
+        }
+    }
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereProgram.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereProgram.scala
@@ -21,6 +21,7 @@ object WhereProgram {
     val WhereNameBinding             = WhereOptionString.binding(path / "name")
     val WhereTypeBinding             = WhereEq.binding[ProgramType](path / "type", ProgramTypeBinding)
     val WhereProgramReferenceBinding = WhereProgramReference.binding(path / "reference")
+    val WherePiBinding               = WhereProgramUser.binding(path / "pi")
     val WhereEqProposalStatus        = WhereUnorderedTag.binding(path / "proposalStatus", TagBinding)
     val WhereProposalBinding         = WhereProposal.binding(path / "proposal")
     val WhereCalibrationRoleBinding  = WhereOptionEq.binding[CalibrationRole](path / "calibrationRole", enumeratedBinding[CalibrationRole])
@@ -36,12 +37,13 @@ object WhereProgram {
         WhereNameBinding.Option("name", rName),
         WhereTypeBinding.Option("type", rType),
         WhereProgramReferenceBinding.Option("reference", rRef),
+        WherePiBinding.Option("pi", rPi),
         WhereEqProposalStatus.Option("proposalStatus", rPs),
         WhereProposalBinding.Option("proposal", rPro),
         WhereCalibrationRoleBinding.Option("calibrationRole", rCalibRole),
       ) =>
-          (rAND, rOR, rNOT, rId, rName, rType, rRef, rPs, rPro, rCalibRole).parMapN {
-            (AND, OR, NOT, id, name, ptype, ref, ps, pro, calib) =>
+          (rAND, rOR, rNOT, rId, rName, rType, rRef, rPi, rPs, rPro, rCalibRole).parMapN {
+            (AND, OR, NOT, id, name, ptype, ref, pi, ps, pro, calib) =>
               and(List(
                 AND.map(and),
                 OR.map(or),
@@ -50,6 +52,7 @@ object WhereProgram {
                 name,
                 ptype,
                 ref,
+                pi,
                 ps,
                 pro,
                 calib

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereProgramUser.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereProgramUser.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package input
+
+import cats.syntax.parallel.*
+import grackle.Path
+import grackle.Predicate
+import grackle.Predicate.*
+import lucuma.odb.data.ProgramUserRole
+import lucuma.odb.graphql.binding.*
+
+object WhereProgramUser {
+
+  def binding(path: Path): Matcher[Predicate] =
+    lazy val WhereProgramBinding = WhereProgram.binding(path / "program")
+    val WhereUserBinding         = WhereUser.binding(path / "user")
+    val WhereRoleBinding         = WhereEq.binding[ProgramUserRole](path / "role", ProgramUserRoleBinding)
+    val WherePartnerLinkBinding  = WherePartnerLink.binding(path)
+
+    lazy val WhereProgramUserBinding = binding(path)
+    ObjectFieldsBinding.rmap {
+      case List(
+        WhereProgramUserBinding.List.Option("AND", rAND),
+        WhereProgramUserBinding.List.Option("OR", rOR),
+        WhereProgramUserBinding.Option("NOT", rNOT),
+        WhereProgramBinding.Option("program", rProgram),
+        WhereUserBinding.Option("user", rUser),
+        WhereRoleBinding.Option("role", rRole),
+        WherePartnerLinkBinding.Option("partnerLink", rPartnerLink)
+      ) =>
+        (rAND, rOR, rNOT, rProgram, rUser, rRole, rPartnerLink).parMapN {
+          (AND, OR, NOT, program, user, role, partnerLink) =>
+            and(List(
+              AND.map(and),
+              OR.map(or),
+              NOT.map(Not(_)),
+              program,
+              user,
+              role,
+              partnerLink
+            ).flatten)
+        }
+    }
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereUser.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereUser.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package input
+
+import cats.syntax.parallel.*
+import grackle.Path
+import grackle.Predicate
+import grackle.Predicate.*
+import lucuma.core.model.User
+import lucuma.odb.data.UserType
+import lucuma.odb.graphql.binding.*
+
+object WhereUser {
+
+  def binding(path: Path): Matcher[Predicate] =
+    val WhereUserId          = WhereOrder.binding[User.Id](path / "id", UserIdBinding)
+    val WhereType            = WhereEq.binding[UserType](path / "type", UserTypeBinding)
+    val WhereOrcidId         = WhereOptionString.binding(path / "orcidId")
+    val WhereOrcidGivenName  = WhereOptionString.binding(path / "orcidGivenName")
+    val WhereOrcidCreditName = WhereOptionString.binding(path / "orcidCreditName")
+    val WhereOrcidFamilyName = WhereOptionString.binding(path / "orcidFamilyName")
+    val WhereOrcidEmail      = WhereOptionString.binding(path / "orcidEmail")
+
+    lazy val WhereUserBinding = binding(path)
+    ObjectFieldsBinding.rmap {
+      case List(
+        WhereUserBinding.List.Option("AND", rAND),
+        WhereUserBinding.List.Option("OR", rOR),
+        WhereUserBinding.Option("NOT", rNOT),
+        WhereUserId.Option("id", rId),
+        WhereType.Option("type", rType),
+        WhereOrcidId.Option("orcidId", rOrcidId),
+        WhereOrcidGivenName.Option("orcidGivenName", rOrcidGivenName),
+        WhereOrcidCreditName.Option("orcidCreditName", rOrcidCreditName),
+        WhereOrcidFamilyName.Option("orcidFamilyName", rOrcidFamilyName),
+        WhereOrcidEmail.Option("orcidEmail", rOrcidEmail)
+      ) =>
+        (rAND, rOR, rNOT, rId, rType, rOrcidId, rOrcidGivenName, rOrcidCreditName, rOrcidFamilyName, rOrcidEmail).parMapN {
+          (AND, OR, NOT, id, t, orcid, givenName, creditName, familyName, email) =>
+            and(List(
+              AND.map(and),
+              OR.map(or),
+              NOT.map(Not(_)),
+              id,
+              t,
+              orcid,
+              givenName,
+              creditName,
+              familyName,
+              email
+            ).flatten)
+        }
+    }
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/TestUsers.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/TestUsers.scala
@@ -42,17 +42,24 @@ object TestUsers {
 
   object Standard {
 
-    def apply(id: Long, role: StandardRole): StandardUser =
+    def apply(
+      id:           Long,
+      role:         StandardRole,
+      givenName:    Option[String] = None,
+      familyName:   Option[String] = None,
+      creditName:   Option[String] = None,
+      primaryEmail: Option[String] = None
+    ): StandardUser =
       StandardUser(
         id         = Gid[User.Id].fromLong.getOption(id).get,
         role       = role,
         otherRoles = Nil,
         profile    = OrcidProfile(
           orcidId      = orcidId(id),
-          givenName    = None,
-          familyName   = None,
-          creditName   = None,
-          primaryEmail = None,
+          givenName    = givenName,
+          familyName   = familyName,
+          creditName   = creditName,
+          primaryEmail = primaryEmail
         )
       )
 


### PR DESCRIPTION
Adds a `WhereProgramUser` and uses it to match program PIs.  This is part of a new mutation under development that will allow a user's partner to be updated.  It seems useful in its own right though and marks a reasonable size chunk for review. It is pretty much mechanical, but I haven't tested all the available options. In particular, there's no way to set the PI's partner yet so matching on that cannot be tested.