### PR TITLE
Add calibration time change and adjust the target when it changes

### DIFF
--- a/modules/calibrations/src/main/scala/lucuma/odb/calibrations/Main.scala
+++ b/modules/calibrations/src/main/scala/lucuma/odb/calibrations/Main.scala
@@ -153,11 +153,8 @@ object CMain extends MainParams {
             }.compile.drain.start.void)
       _  <- Resource.eval(Logger[F].info("Start listening for calibration time changes"))
       _  <- Resource.eval(calibTopic.subscribe(100).evalMap { elem =>
-              services.useTransactionally{
-                for {
-                  t <- Sync[F].delay(LocalDate.now(ZoneOffset.UTC))
-                  _ <- calibrationsService.recalculateCalibrationTarget(elem.programId, elem.observationId)
-                } yield ()
+              services.useTransactionally {
+                calibrationsService.recalculateCalibrationTarget(elem.programId, elem.observationId)
               }
             }.compile.drain.start.void)
     } yield ()

--- a/modules/calibrations/src/main/scala/lucuma/odb/calibrations/Main.scala
+++ b/modules/calibrations/src/main/scala/lucuma/odb/calibrations/Main.scala
@@ -18,6 +18,7 @@ import lucuma.core.model.Access
 import lucuma.core.model.User
 import lucuma.odb.Config
 import lucuma.odb.graphql.enums.Enums
+import lucuma.odb.graphql.topic.CalibTimeTopic
 import lucuma.odb.graphql.topic.ObservationTopic
 import lucuma.odb.sequence.util.CommitHash
 import lucuma.odb.service.Services
@@ -33,7 +34,10 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import skunk.{Command as _, *}
 
-import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneOffset
 import scala.concurrent.duration.*
 
 sealed trait MainParams {
@@ -122,23 +126,37 @@ object CMain extends MainParams {
       sso.get(Authorization(Credentials.Token(CIString("Bearer"), c.serviceJwt)))
 
   def topics[F[_]: Concurrent: Logger](pool: Resource[F, Session[F]]):
-   Resource[F, Topic[F, ObservationTopic.Element]] =
+   Resource[F, (Topic[F, ObservationTopic.Element], Topic[F, CalibTimeTopic.Element])] =
     for {
       sup <- Supervisor[F]
       ses <- pool
+      ctt <- Resource.eval(CalibTimeTopic(ses, 1024, sup))
       top <- Resource.eval(ObservationTopic(ses, 1024, sup))
-    } yield top
+    } yield (top, ctt)
 
   def runCalibrationsDaemon[F[_]: Async: Logger](
-    obsTopic: Topic[F, ObservationTopic.Element],  services: Resource[F, Services[F]]
+    obsTopic: Topic[F, ObservationTopic.Element], calibTopic: Topic[F, CalibTimeTopic.Element], services: Resource[F, Services[F]]
   ): Resource[F, Unit] =
     for {
       _  <- Resource.eval(Logger[F].info("Start listening for program changes"))
       _  <- Resource.eval(obsTopic.subscribe(100).evalMap { elem =>
               services.useTransactionally{
                 for {
-                  t <- Sync[F].delay(Instant.now())
-                  _ <- calibrationsService.recalculateCalibrations(elem.programId, t)
+                  t <- Sync[F].delay(LocalDate.now(ZoneOffset.UTC))
+                  _ <- calibrationsService
+                        .recalculateCalibrations(
+                          elem.programId,
+                          LocalDateTime.of(t, LocalTime.MIDNIGHT).toInstant(ZoneOffset.UTC)
+                        )
+                } yield ()
+              }
+            }.compile.drain.start.void)
+      _  <- Resource.eval(Logger[F].info("Start listening for calibration time changes"))
+      _  <- Resource.eval(calibTopic.subscribe(100).evalMap { elem =>
+              services.useTransactionally{
+                for {
+                  t <- Sync[F].delay(LocalDate.now(ZoneOffset.UTC))
+                  _ <- calibrationsService.recalculateCalibrationTarget(elem.programId, elem.observationId)
                 } yield ()
               }
             }.compile.drain.start.void)
@@ -168,14 +186,14 @@ object CMain extends MainParams {
    */
   def server[F[_]: Async: Logger: Trace: Console: Network]: Resource[F, ExitCode] =
     for {
-      c     <- Resource.eval(Config.fromCiris.load[F])
-      _     <- Resource.eval(banner[F](c))
-      ep    <- entryPointResource(c)
-      pool  <- databasePoolResource[F](c.database)
-      enums <- Resource.eval(pool.use(Enums.load))
-      obsT  <- topics(pool)
-      user  <- Resource.eval(serviceUser[F](c))
-      _     <- runCalibrationsDaemon(obsT, pool.evalMap(services(user, enums)))
+      c           <- Resource.eval(Config.fromCiris.load[F])
+      _           <- Resource.eval(banner[F](c))
+      ep          <- entryPointResource(c)
+      pool        <- databasePoolResource[F](c.database)
+      enums       <- Resource.eval(pool.use(Enums.load))
+      (obsT, ctT) <- topics(pool)
+      user        <- Resource.eval(serviceUser[F](c))
+      _           <- runCalibrationsDaemon(obsT, ctT, pool.evalMap(services(user, enums)))
     } yield ExitCode.Success
 
   /** Our logical entry point. */

--- a/modules/service/src/main/resources/db/migration/V0905__obs_time_channel.sql
+++ b/modules/service/src/main/resources/db/migration/V0905__obs_time_channel.sql
@@ -16,36 +16,3 @@ CREATE TRIGGER ch_obs_viz_time_trigger
   AFTER UPDATE OF c_observation_time ON t_observation
   FOR EACH ROW
   EXECUTE PROCEDURE ch_calib_obs_time();
-
--- Generate the view for the generator including observation_time
-DROP VIEW v_generator_params;
-
-CREATE VIEW v_generator_params AS
-SELECT
-  o.c_program_id,
-  o.c_observation_id,
-  o.c_calibration_role,
-  o.c_image_quality,
-  o.c_cloud_extinction,
-  o.c_sky_background,
-  o.c_water_vapor,
-  o.c_air_mass_min,
-  o.c_air_mass_max,
-  o.c_hour_angle_min,
-  o.c_hour_angle_max,
-  o.c_spec_signal_to_noise,
-  o.c_spec_signal_to_noise_at,
-  o.c_observing_mode_type,
-  o.c_observation_time,
-  t.c_target_id,
-  t.c_sid_rv,
-  t.c_source_profile
-FROM
-  t_observation o
-LEFT JOIN t_asterism_target a
-  ON o.c_observation_id = a.c_observation_id
-LEFT JOIN t_target t
-  ON a.c_target_id      = t.c_target_id
-ORDER BY
-  o.c_observation_id,
-  t.c_target_id;

--- a/modules/service/src/main/resources/db/migration/V0905__obs_time_channel.sql
+++ b/modules/service/src/main/resources/db/migration/V0905__obs_time_channel.sql
@@ -1,0 +1,51 @@
+-- Notify of obs time changes for calibrations
+CREATE OR REPLACE FUNCTION ch_calib_obs_time()
+RETURNS TRIGGER AS $$
+DECLARE
+  observation record;
+BEGIN
+    observation := COALESCE(NEW, OLD);
+    IF NEW.c_observation_time <> OLD.c_observation_time AND NEW.c_calibration_role IS NOT NULL THEN
+      PERFORM pg_notify('ch_calib_obs_time',  observation.c_program_id || ',' || observation.c_observation_id || ',' || 'UPDATE');
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER ch_obs_viz_time_trigger
+  AFTER UPDATE OF c_observation_time ON t_observation
+  FOR EACH ROW
+  EXECUTE PROCEDURE ch_calib_obs_time();
+
+-- Generate the view for the generator including observation_time
+DROP VIEW v_generator_params;
+
+CREATE VIEW v_generator_params AS
+SELECT
+  o.c_program_id,
+  o.c_observation_id,
+  o.c_calibration_role,
+  o.c_image_quality,
+  o.c_cloud_extinction,
+  o.c_sky_background,
+  o.c_water_vapor,
+  o.c_air_mass_min,
+  o.c_air_mass_max,
+  o.c_hour_angle_min,
+  o.c_hour_angle_max,
+  o.c_spec_signal_to_noise,
+  o.c_spec_signal_to_noise_at,
+  o.c_observing_mode_type,
+  o.c_observation_time,
+  t.c_target_id,
+  t.c_sid_rv,
+  t.c_source_profile
+FROM
+  t_observation o
+LEFT JOIN t_asterism_target a
+  ON o.c_observation_id = a.c_observation_id
+LEFT JOIN t_target t
+  ON a.c_target_id      = t.c_target_id
+ORDER BY
+  o.c_observation_id,
+  t.c_target_id;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationTimesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationTimesInput.scala
@@ -11,12 +11,12 @@ import lucuma.core.util.Timestamp
 import lucuma.odb.data.Nullable
 import lucuma.odb.graphql.binding.*
 
-case class ObservationTimesInput( observationTime:   Nullable[Timestamp])
+case class ObservationTimesInput(observationTime: Nullable[Timestamp])
 
 object ObservationTimesInput {
   val Empty: ObservationTimesInput =
     ObservationTimesInput(
-      observationTime =  Nullable.Absent,
+      observationTime = Nullable.Absent,
     )
 
   val Binding: Matcher[ObservationTimesInput] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/CalibTimeTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/CalibTimeTopic.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.topic
+
+import cats.effect.*
+import cats.effect.std.Supervisor
+import cats.implicits.*
+import fs2.Stream
+import fs2.concurrent.Topic
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.util.Gid
+import lucuma.odb.data.EditType
+import org.typelevel.log4cats.Logger
+import skunk.*
+import skunk.implicits.*
+
+object CalibTimeTopic {
+
+  /**
+   * @param observationId the id of the observation that was inserted or edited
+   * @param programId the observation's program's id
+   * @param editType determines creation vs update
+   */
+  case class Element(
+    programId:     Program.Id,
+    observationId: Observation.Id,
+    editType:      EditType,
+  )
+
+  /** Infinite stream of observation id, program id and edit type. */
+  def updates[F[_]: Logger](s: Session[F], maxQueued: Int): Stream[F, Element] =
+    s.channel(id"ch_calib_obs_time").listen(maxQueued).flatMap { n =>
+      n.value.split(",") match {
+        case Array(pid, oid, u) =>
+          (Gid[Program.Id].fromString.getOption(pid), Gid[Observation.Id].fromString.getOption(oid), EditType.fromTgOp(u)) match {
+            case (Some(pid), Some(oid), Some(up)) =>
+              Stream(Element(pid, oid, up))
+            case _                                =>
+              Stream.exec(Logger[F].warn(s"Invalid observation and/or event: $n"))
+          }
+        case _ => Stream.exec(Logger[F].warn(s"Invalid observation and/or event: $n"))
+      }
+    }
+
+  def elements[F[_]: Concurrent: Logger](
+    s:         Session[F],
+    maxQueued: Int,
+  ): Stream[F, Element] =
+    for {
+      oid   <- updates(s, maxQueued)
+      _     <- Stream.eval(Logger[F].info(s"CalibTimeChannel: $oid"))
+    } yield oid
+
+  def apply[F[_]: Concurrent: Logger](
+    s:         Session[F],
+    maxQueued: Int,
+    sup:       Supervisor[F]
+  ): F[Topic[F, Element]] =
+    for {
+      top <- Topic[F, Element]
+      els  = elements(s, maxQueued).through(top.publish)
+      _   <- sup.supervise(els.compile.drain.onError { case e => Logger[F].error(e)("Calibration Time Event Stream crashed!") } >> Logger[F].info("Calibration Time Event Stream terminated.") )
+      _   <- Logger[F].info("Started topic for ch_calib_obs_time")
+    } yield top
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/ObservationTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/ObservationTopic.scala
@@ -28,7 +28,6 @@ object ObservationTopic {
   /**
    * @param observationId the id of the observation that was inserted or edited
    * @param programId the observation's program's id
-   * @param eventId serial event id
    * @param editType determines creation vs update
    * @param users users associated with this program
    */

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -69,8 +69,8 @@ sealed trait Generator[F[_]] {
 
   /**
    * Looks up the parameters required to calculate the ExecutionDigest, and checks
-   * the cache. If not in the cache, it performs the calculation and caches the 
-   * results. If the observation is not completely defined (e.g., if missing the 
+   * the cache. If not in the cache, it performs the calculation and caches the
+   * results. If the observation is not completely defined (e.g., if missing the
    * observing mode), an Error is produced.
    */
   def digest(

--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -426,7 +426,7 @@ object CalibrationsService {
             c_observation_id,
             c_observation_time,
             c_observing_mode_type
-          FROM v_generator_params
+          FROM t_observation
           WHERE c_observation_id = $observation_id AND c_calibration_role IS NOT NULL
           """.query(observation_id *: core_timestamp.opt *: observing_mode_type.opt)
 

--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -6,6 +6,7 @@ package lucuma.odb.service
 import cats.Applicative
 import cats.MonadThrow
 import cats.data.Nested
+import cats.data.NonEmptyList
 import cats.effect.MonadCancelThrow
 import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
@@ -39,9 +40,11 @@ import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.SiderealTracking
 import lucuma.core.model.Target
+import lucuma.core.util.Timestamp
 import lucuma.odb.data.Existence
 import lucuma.odb.data.GroupTree
 import lucuma.odb.data.Nullable
+import lucuma.odb.data.ObservingModeType
 import lucuma.odb.data.PosAngleConstraintMode
 import lucuma.odb.graphql.input.ConstraintSetInput
 import lucuma.odb.graphql.input.CreateGroupInput
@@ -77,6 +80,11 @@ trait CalibrationsService[F[_]] {
   def recalculateCalibrations(
     pid: Program.Id,
     referenceInstant: Instant
+  )(using Transaction[F]): F[Unit]
+
+  def recalculateCalibrationTarget(
+    pid: Program.Id,
+    oid: Observation.Id,
   )(using Transaction[F]): F[Unit]
 }
 
@@ -336,6 +344,48 @@ object CalibrationsService {
           _                                <- generateCalibrations(pid, gnls, gsls, gnTgt, gsTgt).whenA(gnls.nonEmpty || gsls.nonEmpty)
         } yield ()
       }
+
+      // Recalcula the target of a calibration observation
+      def recalculateCalibrationTarget(
+        pid: Program.Id,
+        oid: Observation.Id,
+      )(using Transaction[F]): F[Unit] = {
+        Applicative[F].unit
+        for {
+          o <- session.execute(Statements.selectCalibrationTimeAndConf)(oid).map(_.headOption)
+          // Find the original target
+          otgs <- o.map(_._1).map { oid =>
+                    asterismService.getAsterism(pid, oid).map(_.map(_._1))
+                  }.getOrElse(List.empty.pure[F])
+          // Select a new target
+          tgts <- o match {
+                  case Some(oid, Some(ot), Some(ObservingModeType.GmosNorthLongSlit)) =>
+                    val gncoords = idealLocation(Site.GN, ot.toInstant)
+                    session
+                      .execute(Statements.selectCalibrationTargets)(CalibrationRole.SpectroPhotometric)
+                      .map(spectroPhotometricTargets(ot.toInstant).map(bestTarget(gncoords, _)))
+                  case Some(oid, Some(ot), Some(ObservingModeType.GmosSouthLongSlit)) =>
+                    val gscoords = idealLocation(Site.GS, ot.toInstant)
+                    session
+                      .execute(Statements.selectCalibrationTargets)(CalibrationRole.SpectroPhotometric)
+                      .map(spectroPhotometricTargets(ot.toInstant).map(bestTarget(gscoords, _)))
+                  case _ =>
+                    none.pure[F]
+               }
+            // Update the target on the calibration
+            _ <- (o.map(_._1), tgts).mapN { (oid, tgtid) =>
+                    for {
+                      ct <- Nested(targetService.cloneTargetInto(tgtid, pid)).map(_._2).value
+                      _  <- ct.traverse(ct => asterismService
+                              .updateAsterism(
+                                NonEmptyList.one(oid), 
+                                Some(NonEmptyList.one(ct)), 
+                                NonEmptyList.fromList(otgs))
+                              )
+                    } yield ()
+                }.getOrElse(Result.unit.pure[F])
+        } yield ()
+      }
     }
 
   object Statements {
@@ -369,6 +419,17 @@ object CalibrationsService {
             WHERE t_program.c_calibration_role=$calibration_role
               AND t_program.c_existence='present'
           """.query(target_id *: right_ascension *: declination *: epoch *: int8.opt *: int8.opt *: radial_velocity.opt *: parallax.opt)
+
+    val selectCalibrationTimeAndConf: Query[Observation.Id, (Observation.Id, Option[Timestamp], Option[ObservingModeType])] =
+      sql"""
+        SELECT
+            c_observation_id,
+            c_observation_time,
+            c_observing_mode_type
+          FROM v_generator_params
+          WHERE c_observation_id = $observation_id AND c_calibration_role IS NOT NULL
+          """.query(observation_id *: core_timestamp.opt *: observing_mode_type.opt)
+
   }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -131,6 +131,7 @@ sealed trait ObservationService[F[_]] {
     oid: Observation.Id,
     itcClient: ItcClient[F],
   )(using Transaction[F]): F[List[ObservationValidation]]
+
 }
 
 object ObservationService {
@@ -653,6 +654,7 @@ object ObservationService {
           bandVals      <- validateScienceBand
         } yield (genVals |+| itcVals |+| cfpVals |+| bandVals).toList
       }
+
     }
 
   object Statements {
@@ -1225,6 +1227,7 @@ object ObservationService {
             )
           )
       """.query(science_band)
+
   }
 
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/calibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/calibrations.scala
@@ -4,8 +4,10 @@
 package lucuma.odb.graphql
 package feature
 
+import cats.Eq
 import cats.effect.IO
 import cats.syntax.all.*
+import cats.derived.*
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Decoder
 import io.circe.Json
@@ -40,7 +42,7 @@ class calibrations extends OdbSuite {
   val when = LocalDateTime.of(2024, 1, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
 
   case class CalibTarget(id: Target.Id) derives Decoder
-  case class CalibTE(firstScienceTarget: Option[CalibTarget]) derives Decoder
+  case class CalibTE(firstScienceTarget: Option[CalibTarget]) derives Eq, Decoder
   case class CalibObs(id: Observation.Id, groupId: Option[Group.Id], calibrationRole: Option[CalibrationRole], targetEnvironment: Option[CalibTE]) derives Decoder
 
   private def queryGroup(gid: Group.Id): IO[(Group.Id, Boolean, NonEmptyString)] =
@@ -407,6 +409,78 @@ class calibrations extends OdbSuite {
             "uniform": null,
             "gaussian": null
           }
+      }"""),
+      ("BD+25  2534",
+        681652742505L,
+        90239867922L,
+        0.000,
+        """{
+          "sourceProfile": {
+            "point": {
+                "emissionLines": null,
+                "bandNormalized": {
+                    "sed": null,
+                    "brightnesses": [
+                        {
+                            "band": "U",
+                            "error": null,
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "8.922"
+                        },
+                        {
+                            "band": "B",
+                            "error": "0.03",
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "10.25"
+                        },
+                        {
+                            "band": "V",
+                            "error": "0.05",
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "10.58"
+                        },
+                        {
+                            "band": "R",
+                            "error": null,
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "10.656"
+                        },
+                        {
+                            "band": "I",
+                            "error": null,
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "10.831"
+                        },
+                        {
+                            "band": "J",
+                            "error": "0.026",
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "11.275"
+                        },
+                        {
+                            "band": "H",
+                            "error": "0.036",
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "11.438"
+                        },
+                        {
+                            "band": "K",
+                            "error": "0.028",
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "11.556"
+                        },
+                        {
+                            "band": "GAIA",
+                            "error": "0.002851",
+                            "units": "VEGA_MAGNITUDE",
+                            "value": "10.45304"
+                        }
+                    ]
+                }
+            },
+            "uniform": null,
+            "gaussian": null
+          }
       }""")
     )
 
@@ -610,6 +684,57 @@ class calibrations extends OdbSuite {
                   }
                 """.asRight
               )
+    } yield ()
+  }
+
+  test("calibration observations obs time can switch target") {
+    for {
+      pid  <- createProgramAs(pi)
+      tid1 <- createTargetAs(pi, pid, "One")
+      oid1 <- createObservationAs(pi, pid, ObservingModeType.GmosNorthLongSlit.some, tid1)
+      _    <- prepareObservation(oid1, tid1)
+      _    <- withServices(service) { services =>
+                services.session.transaction.use { xa =>
+                  services.calibrationsService.recalculateCalibrations(pid, when)(using xa)
+                }
+              }
+      ob   <- queryObservations(pid)
+      (cid1, ct1) = ob.collect {
+        case CalibObs(cid, _, Some(_), Some(ct1)) => (cid, ct1)
+      }.head
+      _    <- query(
+                user = pi,
+                query = s"""
+                  mutation {
+                    updateObservationsTimes(input: {
+                      SET: {
+                        observationTime: "2026-08-15T01:15:30Z"
+                      },
+                      WHERE: {
+                        id: { EQ: "$cid1" }
+                      }
+                    }) {
+                      observations {
+                        observationTime
+                      }
+                    }
+                  }
+                """
+              )
+      // In reality this is done listening to events but we can explicitly call the function here
+      _     <- withServices(service) { services =>
+                 services.session.transaction.use { xa =>
+                   services.calibrationsService.recalculateCalibrationTarget(pid, cid1)(using xa)
+                 }
+               }
+      ob2   <- queryObservations(pid)
+      (cid2, ct2) = ob2.collect {
+        case CalibObs(cid, _, Some(_), Some(ct2)) => (cid, ct2)
+      }.head
+      // Some observation
+      _     <- assertIOBoolean(IO(ob2.map(_.id) === ob.map(_.id)))
+      // Target changed
+      _     <- assertIOBoolean(IO(ct1 =!= ct2 && cid1 === cid2))
     } yield ()
   }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/calibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/calibrations.scala
@@ -5,9 +5,9 @@ package lucuma.odb.graphql
 package feature
 
 import cats.Eq
+import cats.derived.*
 import cats.effect.IO
 import cats.syntax.all.*
-import cats.derived.*
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Decoder
 import io.circe.Json


### PR DESCRIPTION
On this PR we add a new stream of events whenever a calibration observation time changes.
The calibration daemon listens to those changes and will update the target depending on the date

There is one missing part which is avoiding the creation of unneeded targets and deleting stale one but will be addressed in another PR