### PR TITLE
Delete orphan calibration targets

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -434,6 +434,8 @@ object CalibrationsService extends SpecPhotoCalibrations {
                               )
                     } yield ()
                 }.getOrElse(Result.unit.pure[F])
+            // targets may have been orphaned, delete those
+            _  <- targetService.deleteOrphanCalibrationTargets(pid)
         } yield ()
       }
     }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -825,7 +825,7 @@ trait DatabaseOperations { this: OdbSuite =>
     parentGroupId: Option[Group.Id] = None,
     parentIndex: Option[NonNegShort] = None,
     minRequired: Option[NonNegShort] = None,
-    initialContents: Option[List[Either[Group.Id, Observation.Id]]] = None 
+    initialContents: Option[List[Either[Group.Id, Observation.Id]]] = None
   ): IO[Group.Id] =
     query(
       user = user,
@@ -1478,6 +1478,12 @@ trait DatabaseOperations { this: OdbSuite =>
     val command = sql"update t_group set c_system = $bool where c_group_id = $group_id".command
     FMain.databasePoolResource[IO](databaseConfig).flatten
       .use(_.prepareR(command).use(_.execute(system, id).void))
+  }
+
+  def setTargetCalibratioRole(tid: Target.Id, role: CalibrationRole): IO[Unit] = {
+    val command = sql"update t_target set c_calibration_role = $calibration_role where c_target_id = $target_id".command
+    FMain.databasePoolResource[IO](databaseConfig).flatten
+      .use(_.prepareR(command).use(_.execute(role, tid).void))
   }
 
   def cloneGroupAs(user: User, gid: Group.Id): IO[Group.Id] =


### PR DESCRIPTION
When the observation time changes a new target may be assigned to calibration observations. When that happens the previous target remains though it is unused

This PR adds a query to delete unused targets and it is run an a program basis every time the obs time changes