### PR TITLE
Add ability to save guide target, change guideEnvironment

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -140,6 +140,7 @@ lazy val service = project
       "org.scalameta"  %% "munit"                              % munitVersion               % Test,
       "org.scalameta"  %% "munit-scalacheck"                   % munitVersion               % Test,
       "org.typelevel"  %% "discipline-munit"                   % munitDisciplineVersion     % Test,
+      "edu.gemini"     %% "lucuma-catalog-testkit"             % lucumaCatalogVersion       % Test,
       "edu.gemini"     %% "lucuma-core-testkit"                % lucumaCoreVersion          % Test,
       "org.typelevel"  %% "cats-time"                          % catsTimeVersion,
       "org.typelevel"  %% "log4cats-slf4j"                     % log4catsVersion,

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4186,17 +4186,13 @@ type SetupTime {
 
 """
 Input parameters for setting the guide star name for an observation.
+Identify the observation to clone by specifying either its id or reference.  If
+both are specified, they must refer to the same observation.  If neither is
+specified, an error will be returned.
 """
 input SetGuideTargetNameInput {
-  """
-  The program id for the observation being set.
-  """
-  programId: ProgramId!
-
-  """
-  The id of the observation to set.
-  """
-  observationId: ObservationId!
+  observationId: ObservationId
+  observationReference: ObservationReferenceLabel
 
   """
   The name of the guide star. This must satisfy the regular expression "^Gaia DR3 (-?\d+)$" where the

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -2928,6 +2928,11 @@ type Mutation {
   """
   setAllocations(input: SetAllocationsInput!): SetAllocationsResult!
 
+  """
+  Set the name of the guide target for an observation.
+  """
+  setGuideTargetName(input: SetGuideTargetNameInput!): SetGuideTargetNameResult!
+
   "Set the program reference."
   setProgramReference(input: SetProgramReferenceInput!): SetProgramReferenceResult!
 
@@ -3187,9 +3192,14 @@ Observation times properties
 """
 input ObservationTimesInput {
   """
-  Expected execution time used for time-dependent calculations such as average parallactic angle
+  Expected execution time used for time-dependent calculations such as average parallactic angle and guide star selection.
   """
   observationTime: Timestamp
+
+  """
+  Expected observation duration used in conjunction with observationTime. If not set, remaining observation time is used.
+  """
+  observationDuration: TimeSpanInput
 }
 
 type Offset {
@@ -4175,6 +4185,34 @@ type SetupTime {
 }
 
 """
+Input parameters for setting the guide star name for an observation.
+"""
+input SetGuideTargetNameInput {
+  """
+  The program id for the observation being set.
+  """
+  programId: ProgramId!
+
+  """
+  The id of the observation to set.
+  """
+  observationId: ObservationId!
+
+  """
+  The name of the guide star. This must satisfy the regular expression "^Gaia DR3 (-?\d+)$" where the
+  numeric part is the Gaia source_id. Omit or set to null to delete.
+  """
+  targetName: NonEmptyString
+}
+
+"""
+The result of setting the guide target name for an observation.
+"""
+type SetGuideTargetNameResult {
+  observation: Observation
+}
+
+"""
 Input for setting the program reference.  Identify the program to update with one
 of `programId`, `proposalReference` or `programReference`.  If more than one of
 these is specified, all must match.  Use `SET` to specify the new program
@@ -4973,7 +5011,6 @@ type UpdateGroupsResult {
   """
   hasMore: Boolean!
 }
-
 
 """
 Observation selection and update description.  Use `SET` to specify the changes, `WHERE` to select the observations to update, and `LIMIT` to control the size of the return value.
@@ -8289,9 +8326,16 @@ type Observation {
   scienceBand: ScienceBand
 
   """
-  Reference time used for execution and visualization and time-dependent calculations (e.g., average parallactic angle)
+  Reference time used for execution and visualization and time-dependent calculations 
+  (e.g., average parallactic angle and guide star selection)
   """
   observationTime: Timestamp
+
+  """
+  Used in conjunction with observationTime for time-dependentent calulations. If not
+  set, the remaining observation execution time will be used.
+  """
+  observationDuration: TimeSpan
 
   """
   Position angle constraint, if any.
@@ -10786,6 +10830,19 @@ type TargetEnvironment {
     """
     observationTime: Timestamp!
   ): [GuideEnvironment!]!
+
+  """
+  The guide star(s) and related information
+  """
+  guideEnvironment(
+    """
+    If this is set to false, a null will be returned if a guide star is not
+    already set or the current guide star has been invalidated by changes.
+    If this is set to true, gaia will be searched to find the best guide star
+    in the above scenario.
+    """
+    lookupIfUndefined: Boolean! = true
+  ): GuideEnvironment
 
   """
   Availability of guide stars during a specified time range.

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/HashBytes.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/HashBytes.scala
@@ -8,6 +8,7 @@ import eu.timepit.refined.types.numeric.PosLong
 import io.circe.Encoder
 import lucuma.core.util.Gid
 import lucuma.core.util.TimeSpan
+import lucuma.core.util.Timestamp
 
 import java.nio.charset.StandardCharsets.UTF_8
 import java.security.MessageDigest
@@ -71,9 +72,18 @@ object HashBytes {
       )
   }
 
+  given HashBytes[Timestamp] with {
+    def hashBytes(a: Timestamp): Array[Byte] =
+      HashBytes[Long].hashBytes(a.toEpochMilli)
+  }
+
   given HashBytes[TimeSpan] with {
     def hashBytes(a: TimeSpan): Array[Byte] =
       HashBytes[Long].hashBytes(a.toMicroseconds)
   }
 
+  given [A](using HashBytes[A]): HashBytes[Option[A]] with {
+    def hashBytes(opt: Option[A]): Array[Byte] =
+      opt.fold(Array.emptyByteArray)(HashBytes[A].hashBytes)
+  }
 }

--- a/modules/service/src/main/resources/db/migration/V0910__guide_stars_revisited.sql
+++ b/modules/service/src/main/resources/db/migration/V0910__guide_stars_revisited.sql
@@ -1,0 +1,26 @@
+CREATE DOMAIN d_guide_target_name as text
+CHECK(
+  -- For now, at least, we only support gaia
+  -- The same regex is used in GuideStarName.scala in lucuma-ags - changes should be synchronized.
+  VALUE ~  '^Gaia DR3 -?\d+$'
+);
+
+ALTER TABLE t_observation
+  ADD COLUMN c_observation_duration     interval             NULL,
+  ADD COLUMN c_guide_target_name        d_guide_target_name  NULL,
+  ADD COLUMN c_guide_target_hash        bytea                NULL;
+
+-- Re-create v_observation to include the new columns and synthetic id for observation duration
+DROP VIEW v_observation;
+CREATE OR REPLACE VIEW v_observation AS
+  SELECT o.*,
+  CASE WHEN c_explicit_ra              IS NOT NULL THEN c_observation_id END AS c_explicit_base_id,
+  CASE WHEN c_air_mass_min             IS NOT NULL THEN c_observation_id END AS c_air_mass_id,
+  CASE WHEN c_hour_angle_min           IS NOT NULL THEN c_observation_id END AS c_hour_angle_id,
+  CASE WHEN c_observing_mode_type      IS NOT NULL THEN c_observation_id END AS c_observing_mode_id,
+  CASE WHEN c_spec_wavelength          IS NOT NULL THEN c_observation_id END AS c_spec_wavelength_id,
+  CASE WHEN c_spec_signal_to_noise_at  IS NOT NULL THEN c_observation_id END AS c_spec_signal_to_noise_at_id,
+  CASE WHEN c_spec_wavelength_coverage IS NOT NULL THEN c_observation_id END AS c_spec_wavelength_coverage_id,
+  CASE WHEN c_spec_focal_plane_angle   IS NOT NULL THEN c_observation_id END AS c_spec_focal_plane_angle_id,
+  CASE WHEN c_observation_duration     IS NOT NULL THEN c_observation_id END AS c_observation_duration_id
+  FROM t_observation o;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -252,6 +252,7 @@ trait BaseMapping[F[_]]
   lazy val SequenceEventType                       = schema.ref("SequenceEvent")
   lazy val SequenceTypeType                        = schema.ref("SequenceType")
   lazy val SetAllocationsResultType                = schema.ref("SetAllocationsResult")
+  lazy val SetGuideTargetNameResultType            = schema.ref("SetGuideTargetNameResult")
   lazy val SetProgramReferenceResultType           = schema.ref("SetProgramReferenceResult")
   lazy val SetProposalStatusResultType             = schema.ref("SetProposalStatusResult")
   lazy val SiderealType                            = schema.ref("Sidereal")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -187,6 +187,7 @@ object OdbMapping {
           with RightAscensionMapping[F]
           with ScienceRequirementsMapping[F]
           with SetAllocationsResultMapping[F]
+          with SetGuideTargetNameResultMapping[F]
           with SetProgramReferenceResultMapping[F]
           with SetProposalStatusResultMapping[F]
           with SiderealMapping[F]
@@ -360,6 +361,7 @@ object OdbMapping {
                 SpectroscopyConfigOptionGmosSouthMapping,
                 SpectroscopyScienceRequirementsMapping,
                 SetAllocationsResultMapping,
+                SetGuideTargetNameResultMapping,
                 SetProgramReferenceResultMapping,
                 SetProposalStatusResultMapping,
                 SiderealMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationTimesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationTimesInput.scala
@@ -7,23 +7,29 @@ package input
 
 import cats.syntax.all.*
 import grackle.Result
+import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import lucuma.odb.data.Nullable
 import lucuma.odb.graphql.binding.*
 
-case class ObservationTimesInput(observationTime: Nullable[Timestamp])
+case class ObservationTimesInput(
+  observationTime:     Nullable[Timestamp],
+  observationDuration: Nullable[TimeSpan]
+)
 
 object ObservationTimesInput {
   val Empty: ObservationTimesInput =
     ObservationTimesInput(
-      observationTime = Nullable.Absent,
+      observationTime =     Nullable.Absent,
+      observationDuration = Nullable.Absent
     )
 
   val Binding: Matcher[ObservationTimesInput] =
     ObjectFieldsBinding.rmap {
       case List(
         TimestampBinding.Nullable("observationTime", rObservationTime),
+        TimeSpanInput.Binding.Nullable("observationDuration", rObservationDuration)
       ) =>
-        rObservationTime.map(ObservationTimesInput.apply)
+        (rObservationTime, rObservationDuration).parMapN(ObservationTimesInput.apply)
     }
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/SetGuideTargetNameInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/SetGuideTargetNameInput.scala
@@ -9,12 +9,12 @@ import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
 import grackle.Result
 import lucuma.core.model.Observation
-import lucuma.core.model.Program
+import lucuma.core.model.ObservationReference
 import lucuma.odb.graphql.binding.*
 
 final case class SetGuideTargetNameInput(
-  programId:     Program.Id,
-  observationId: Observation.Id,
+  observationId: Option[Observation.Id],
+  observationRef: Option[ObservationReference],
   targetName:    Option[NonEmptyString]
 )
 
@@ -22,9 +22,9 @@ object SetGuideTargetNameInput {
   val Binding: Matcher[SetGuideTargetNameInput] =
     ObjectFieldsBinding.rmap {
       case List(
-        ProgramIdBinding("programId", rPid),
-        ObservationIdBinding("observationId", rObsId),
+        ObservationIdBinding.Option("observationId", rObsId),
+        ObservationReferenceBinding.Option("observationReference", rObsRef),
         NonEmptyStringBinding.Option("targetName", rName)
-      ) => (rPid, rObsId, rName).parMapN(apply)
+      ) => (rObsId, rObsRef, rName).parMapN(apply)
     }
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/SetGuideTargetNameInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/SetGuideTargetNameInput.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package input
+
+import cats.syntax.all.*
+import eu.timepit.refined.types.string.NonEmptyString
+import grackle.Result
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.odb.graphql.binding.*
+
+final case class SetGuideTargetNameInput(
+  programId:     Program.Id,
+  observationId: Observation.Id,
+  targetName:    Option[NonEmptyString]
+)
+
+object SetGuideTargetNameInput {
+  val Binding: Matcher[SetGuideTargetNameInput] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        ProgramIdBinding("programId", rPid),
+        ObservationIdBinding("observationId", rObsId),
+        NonEmptyStringBinding.Option("targetName", rName)
+      ) => (rPid, rObsId, rName).parMapN(apply)
+    }
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -57,6 +57,7 @@ trait ObservationMapping[F[_]]
       SqlField("activeStatus", ObservationView.ActiveStatus),
       SqlField("scienceBand", ObservationView.ScienceBand),
       SqlField("observationTime", ObservationView.ObservationTime),
+      SqlObject("observationDuration"),
       SqlObject("posAngleConstraint"),
       SqlObject("targetEnvironment"),
       SqlObject("constraintSet"),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/SetGuideTargetNameResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/SetGuideTargetNameResultMapping.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package mapping
+
+import lucuma.odb.graphql.table.ObservationView
+
+trait SetGuideTargetNameResultMapping[F[_]] extends ObservationView[F] {
+
+  lazy val SetGuideTargetNameResultMapping =
+    ObjectMapping(SetGuideTargetNameResultType)(
+      SqlField("observationId", ObservationView.Id, key = true, hidden = true),
+      SqlObject("observation")
+    )
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TimeSpanMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TimeSpanMapping.scala
@@ -56,7 +56,8 @@ trait TimeSpanMapping[F[_]] extends AllocationTable[F]
       timeSpanMappingAtPath(TimeChargeInvoiceType / "finalCharge" / "partner", VisitTable.Final.PartnerTime)(VisitTable.Id),
       timeSpanMappingAtPath(TimeChargeInvoiceType / "finalCharge" / "program", VisitTable.Final.ProgramTime)(VisitTable.Id),
       timeSpanMappingAtPath(TimingWindowEndAfterType / "after", TimingWindowView.End.After)(TimingWindowView.End.SyntheticId),
-      timeSpanMappingAtPath(TimingWindowRepeatType / "period", TimingWindowView.End.Repeat.Period)(TimingWindowView.End.SyntheticId)
+      timeSpanMappingAtPath(TimingWindowRepeatType / "period", TimingWindowView.End.Repeat.Period)(TimingWindowView.End.SyntheticId),
+      timeSpanMappingAtPath(ObservationType / "observationDuration", ObservationView.ObservationDuration.ObservationDuration)(ObservationView.ObservationDuration.SyntheticId)
     )
 
   private def valueAs[A: io.circe.Encoder](name: String)(f: Format[A, TimeSpan]): CursorField[A] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
@@ -45,6 +45,7 @@ trait Predicates[F[_]] extends BaseMapping[F] {
     val proposalAttachment            = ProposalAttachmentPredicates(Path.from(ProposalAttachmentType))
     val recordDatasetResult           = RecordDatasetResultPredicates(Path.from(RecordDatasetResultType))
     val sequenceEvent                 = ExecutionEventPredicates(Path.from(SequenceEventType))
+    val setGuideTargetNameResult      = SetGuideTargetNameResultPredicates(Path.from(SetGuideTargetNameResultType))
     val setProgramReferenceResult     = SetProgramReferenceResult(Path.from(SetProgramReferenceResultType))
     val setProposalStatusResult       = SetProposalStatusResultPredicates(Path.from(SetProposalStatusResultType))
     val slewEvent                     = ExecutionEventPredicates(Path.from(SlewEventType))

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/SetGuideTargetNameResultPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/SetGuideTargetNameResultPredicates.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.predicate
+
+import grackle.Path
+import lucuma.core.model.Observation
+
+class SetGuideTargetNameResultPredicates(path: Path) {
+  val observationId = LeafPredicates[Observation.Id](path / "observationId")
+}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ObservationView.scala
@@ -12,22 +12,22 @@ import skunk.codec.all.*
 trait ObservationView[F[_]] extends BaseMapping[F] {
 
     object ObservationView extends TableDef("v_observation") {
-      val ProgramId: ColumnRef         = col("c_program_id",         program_id)
-      val Id: ColumnRef                = col("c_observation_id",     observation_id)
-      val ObservationIndex: ColumnRef  = col("c_observation_index",  int4_pos)
-      val Existence: ColumnRef         = col("c_existence",          existence)
-      val Title: ColumnRef             = col("c_title",              text_nonempty)
-      val Subtitle: ColumnRef          = col("c_subtitle",           text_nonempty.opt)
-      val Instrument: ColumnRef        = col("c_instrument",         instrument.opt)
-      val Status: ColumnRef            = col("c_status",             obs_status)
-      val ActiveStatus: ColumnRef      = col("c_active_status",      obs_active_status)
-      val ScienceBand: ColumnRef       = col("c_science_band",       science_band.opt)
-      val ObservationTime: ColumnRef   = col("c_observation_time",   core_timestamp.opt)
-      val AsterismGroup: ColumnRef     = col("c_asterism_group",     jsonb)
-      val GroupId: ColumnRef           = col("c_group_id",           group_id.opt)
-      val GroupIndex: ColumnRef        = col("c_group_index",        int2_nonneg)
-      val CalibrationRole: ColumnRef   = col("c_calibration_role",   calibration_role.opt)
-      val ObserverNotes: ColumnRef     = col("c_observer_notes",     text_nonempty.opt)
+      val ProgramId: ColumnRef           = col("c_program_id",           program_id)
+      val Id: ColumnRef                  = col("c_observation_id",       observation_id)
+      val ObservationIndex: ColumnRef    = col("c_observation_index",    int4_pos)
+      val Existence: ColumnRef           = col("c_existence",            existence)
+      val Title: ColumnRef               = col("c_title",                text_nonempty)
+      val Subtitle: ColumnRef            = col("c_subtitle",             text_nonempty.opt)
+      val Instrument: ColumnRef          = col("c_instrument",           instrument.opt)
+      val Status: ColumnRef              = col("c_status",               obs_status)
+      val ActiveStatus: ColumnRef        = col("c_active_status",        obs_active_status)
+      val ScienceBand: ColumnRef         = col("c_science_band",         science_band.opt)
+      val ObservationTime: ColumnRef     = col("c_observation_time",     core_timestamp.opt)
+      val AsterismGroup: ColumnRef       = col("c_asterism_group",       jsonb)
+      val GroupId: ColumnRef             = col("c_group_id",             group_id.opt)
+      val GroupIndex: ColumnRef          = col("c_group_index",          int2_nonneg)
+      val CalibrationRole: ColumnRef     = col("c_calibration_role",     calibration_role.opt)
+      val ObserverNotes: ColumnRef       = col("c_observer_notes",       text_nonempty.opt)
 
       object PlannedTime {
         val Pi        = col("c_pts_pi", time_span)
@@ -104,6 +104,11 @@ trait ObservationView[F[_]] extends BaseMapping[F] {
       object ObservingMode {
         val SyntheticId: ColumnRef = col("c_observing_mode_id", observation_id.embedded)
         val ObservingModeType: ColumnRef = col("c_observing_mode_type", observing_mode_type.embedded)
+      }
+
+      object ObservationDuration {
+        val SyntheticId: ColumnRef = col("c_observation_duration_id", observation_id.embedded)
+        val ObservationDuration: ColumnRef = col("c_observation_duration", time_span.embedded)
       }
 
     }

--- a/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
@@ -3,14 +3,18 @@
 
 package lucuma.odb.service
 
+import cats.Eq
 import cats.Order
 import cats.Order.*
-import cats.data.EitherT
 import cats.data.NonEmptyList
+import cats.derived.*
 import cats.effect.Concurrent
 import cats.syntax.all.*
 import fs2.Stream
 import fs2.text.utf8
+import grackle.Result
+import grackle.ResultT
+import grackle.syntax.*
 import io.circe.Encoder
 import io.circe.Json
 import io.circe.generic.semiauto.*
@@ -20,6 +24,7 @@ import lucuma.ags
 import lucuma.ags.*
 import lucuma.ags.AgsPosition
 import lucuma.ags.GuideStarCandidate
+import lucuma.ags.GuideStarName
 import lucuma.catalog.votable.*
 import lucuma.core.enums.GuideProbe
 import lucuma.core.enums.GuideSpeed
@@ -41,6 +46,8 @@ import lucuma.core.model.Observation
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Program
 import lucuma.core.model.SiderealTracking
+import lucuma.core.model.SourceProfile
+import lucuma.core.model.SpectralDefinition
 import lucuma.core.model.Target
 import lucuma.core.model.Target.Sidereal
 import lucuma.core.model.User
@@ -54,7 +61,10 @@ import lucuma.itc.client.ItcClient
 import lucuma.itc.client.json.given
 import lucuma.odb.data.ContiguousTimestampMap
 import lucuma.odb.data.Md5Hash
+import lucuma.odb.data.OdbError
+import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.data.PosAngleConstraintMode
+import lucuma.odb.graphql.input.SetGuideTargetNameInput
 import lucuma.odb.json.all.query.given
 import lucuma.odb.json.target
 import lucuma.odb.logic.Generator
@@ -64,7 +74,9 @@ import lucuma.odb.sequence.gmos
 import lucuma.odb.sequence.syntax.hash.*
 import lucuma.odb.sequence.util.CommitHash
 import lucuma.odb.sequence.util.HashBytes
+import lucuma.odb.syntax.resultT.*
 import lucuma.odb.util.Codecs.*
+import natchez.Trace
 import org.http4s.Header
 import org.http4s.Headers
 import org.http4s.Method
@@ -83,19 +95,36 @@ import Services.Syntax.*
 
 trait GuideService[F[_]] {
   import GuideService.AvailabilityPeriod
-  import GuideService.Error
   import GuideService.GuideEnvironment
+  import GuideService.GuideEnvironmentOptions
 
-  def getGuideEnvironment(pid: Program.Id, oid: Observation.Id, obsTime: Timestamp)(using
+  def getGuideEnvironments(pid: Program.Id, oid: Observation.Id, obsTime: Timestamp)(using
     NoTransaction[F]
-  ): F[Either[Error, List[GuideEnvironment]]]
+  ): F[Result[List[GuideEnvironment]]]
+
+  def getGuideEnvironment(pid: Program.Id, oid: Observation.Id, options: GuideEnvironmentOptions)(using
+    NoTransaction[F]
+  ): F[Result[Option[GuideEnvironment]]]
 
   def getGuideAvailability(pid: Program.Id, oid: Observation.Id, period: TimestampInterval)(using
     NoTransaction[F]
-  ): F[Either[Error, List[AvailabilityPeriod]]]
+  ): F[Result[List[AvailabilityPeriod]]]
+  
+  def setGuideTargetName(input: SetGuideTargetNameInput)(
+    using NoTransaction[F]): F[Result[Observation.Id]]
 }
 
 object GuideService {
+  case class GuideEnvironmentOptions(
+    // if the user only queried for the target name, we don't have to go to gaia, unless
+    // lookupIfUndefined is also true
+    queriedNameOnly: Boolean,
+    // For navigate, we need to go to gaia to get the prospective targets and default to the 
+    // best one if the guidestar name is not set or has been invalidated. However, for explore
+    // we can just return a null because it will do the gaia stuff.
+    lookupIfUndefined: Boolean
+  ) derives Eq
+
   // if any science target or guide star candidate moves more than this many milliarcseconds,
   // we consider it to potentially invalidate the availability.
   val invalidThreshold = 100.0
@@ -126,6 +155,19 @@ object GuideService {
 
   object GuideEnvironment {
     given Encoder[GuideEnvironment] = deriveEncoder
+
+    def forNameOnly(name: GuideStarName): GuideEnvironment =
+      val target =
+        Target.Sidereal(
+          name.toNonEmptyString,
+          SiderealTracking.const(Coordinates.Zero),
+          SourceProfile.Point(SpectralDefinition.BandNormalized(none, SortedMap.empty)),
+          none
+        )
+      GuideEnvironment(
+        posAngle = Angle.Angle0,
+        guideTargets = List(GuideTarget(GuideProbe.GmosOIWFS, target))
+      )
   }
 
   case class AvailabilityPeriod(
@@ -150,36 +192,40 @@ object GuideService {
       }
   }
 
-  sealed trait Error {
-    def format: String
-  }
+  private def generalError(error: String): OdbError =
+    OdbError.GuideEnvironmentError(error.some)
+  private def generatorError(error: Generator.Error): OdbError =
+    OdbError.GuideEnvironmentError(error.format.some)
+  private def gaiaError(error:String): OdbError =
+    OdbError.GuideEnvironmentError(s"Error calling Gaia: $error".some)
+  private def guideStarNameError(name: String): OdbError =
+    OdbError.InvalidArgument(s"Invalid guide target name '$name'".some)
 
-  object Error {
-    case class GeneralError(error: String) extends Error {
-      val format: String = error
-    }
-
-    case class GeneratorError(
-      error: Generator.Error
-    ) extends Error {
-      def format: String = error.format
-    }
-
-    case class GaiaError(error: String) extends Error {
-      val format: String = s"Error calling Gaia: '$error'"
-    }
-  }
 
   case class ObservationInfo(
     id:                 Observation.Id,
     constraints:        ConstraintSet,
     posAngleConstraint: PosAngleConstraint,
     optWavelength:      Option[Wavelength],
-    explicitBase:       Option[Coordinates]
+    explicitBase:       Option[Coordinates],
+    optObsTime:         Option[Timestamp],
+    optObsDuration:     Option[TimeSpan],
+    guideStarName:      Option[GuideStarName],
+    guideStarHash:      Option[Md5Hash]
   ) {
-    def wavelength: Either[Error, Wavelength] =
-      optWavelength.toRight(Error.GeneralError(s"No wavelength defined for observation $id."))
+    def wavelength: Result[Wavelength] =
+      optWavelength.toResult(generalError(s"No wavelength defined for observation $id.").asProblem)
 
+    def obsTime: Result[Timestamp] =
+      optObsTime.toResult(generalError(s"Observation time not set for observation $id.").asProblem)
+
+    def validGuideStarName(generatorHash:Md5Hash, remainingTime: TimeSpan): Option[GuideStarName] =
+      (guideStarName, guideStarHash).flatMapN { (name, hash) =>
+        val newHash = newGuideStarHash(generatorHash, remainingTime)
+        if (hash === newHash) guideStarName
+        else none
+       }
+    
     private val AllAngles =
       NonEmptyList.fromListUnsafe(
         (0 until 360 by 10).map(a => Angle.fromDoubleDegrees(a.toDouble)).toList
@@ -193,7 +239,7 @@ object GuideService {
         case PosAngleConstraint.AverageParallactic     => AllAngles
         case PosAngleConstraint.Unbounded              => AllAngles
 
-    def hash(generatorHash: Md5Hash): Md5Hash = {
+    def availabilityHash(generatorHash: Md5Hash): Md5Hash = {
       val md5 = MessageDigest.getInstance("MD5")
 
       md5.update(generatorHash.toByteArray)
@@ -214,6 +260,32 @@ object GuideService {
 
       Md5Hash.unsafeFromByteArray(md5.digest())
     }
+
+    def newGuideStarHash(generatorHash:Md5Hash, duration: TimeSpan): Md5Hash = {
+      val md5 = MessageDigest.getInstance("MD5")
+
+      md5.update(generatorHash.toByteArray)
+
+      given HashBytes[ConstraintSet] = HashBytes.forJsonEncoder
+      md5.update(constraints.hashBytes)
+
+      given Encoder[PosAngleConstraint] = deriveEncoder
+      given HashBytes[PosAngleConstraint] = HashBytes.forJsonEncoder
+      md5.update(posAngleConstraint.hashBytes)
+    
+      given HashBytes[Option[Wavelength]] = HashBytes.forJsonEncoder
+      md5.update(optWavelength.hashBytes)
+
+      given Encoder[Coordinates] = deriveEncoder
+      md5.update(HashBytes.forJsonEncoder[Option[Coordinates]].hashBytes(explicitBase))
+
+      // changing time or duration doesn't necessarily invalidate the guide star, but 
+      // we're not tracking what the "original" values are, so we can't say for sure...
+      md5.update(optObsTime.hashBytes)
+      md5.update(duration.hashBytes)
+
+      Md5Hash.unsafeFromByteArray(md5.digest())
+    }
   }
 
   private case class GeneratorInfo(
@@ -231,7 +303,7 @@ object GuideService {
 
   }
 
-  def instantiate[F[_]: Concurrent](
+  def instantiate[F[_]: Concurrent: Trace](
     httpClient:             Client[F],
     itcClient:              ItcClient[F],
     commitHash:             CommitHash,
@@ -241,7 +313,7 @@ object GuideService {
 
       def getAsterism(pid: Program.Id, oid: Observation.Id)(using
         NoTransaction[F]
-      ): F[Either[Error, NonEmptyList[Target]]] =
+      ): F[Result[NonEmptyList[Target]]] =
         asterismService
           .getAsterism(pid, oid)
           .map(l =>
@@ -249,19 +321,19 @@ object GuideService {
               .fromList(
                 l.map(_._2)
               )
-              .toRight(Error.GeneralError(s"No targets have been defined for observation $oid."))
+              .toResult(generalError(s"No targets have been defined for observation $oid.").asProblem)
           )
 
       def getObservationInfo(pid: Program.Id, oid: Observation.Id)(using
         NoTransaction[F]
-      ): F[Either[Error, ObservationInfo]] = {
+      ): F[Result[ObservationInfo]] = {
         val af = Statements.getObservationInfo(user, pid, oid)
         session
           .prepareR(
             af.fragment.query(Decoders.obsInfoDecoder)
           )
           .use(
-            _.option(af.argument).map(_.toRight(Error.GeneralError(s"Observation $oid not found.")))
+            _.option(af.argument).map(_.toResult(OdbError.InvalidObservation(oid).asProblem))
           )
       }
 
@@ -308,6 +380,18 @@ object GuideService {
           .use(_.execute(af.argument).void)
       }
 
+      def updateGuideTargetName(
+        pid: Program.Id,
+        oid: Observation.Id,
+        guideStarName: Option[GuideStarName],
+        guideStarHash: Option[Md5Hash]
+      ): F[Result[Observation.Id]] = 
+        val af = Statements.updateGuideTargetName(user, pid, oid, guideStarName, guideStarHash)
+        session
+          .prepareR(af.fragment.query(observation_id))
+          .use(_.option(af.argument))
+          .map(_.fold(OdbError.InvalidObservation(oid).asFailure)(_.success))
+
       def getFromCacheOrEmpty(pid: Program.Id, oid: Observation.Id, newHash: Md5Hash)(
         using NoTransaction[F]
       ): F[ContiguousTimestampMap[List[Angle]]] =
@@ -342,7 +426,7 @@ object GuideService {
         shapeConstraint: ShapeExpression,
         wavelength:      Wavelength,
         constraints:     ConstraintSet
-      ): Either[Error, ADQLQuery] =
+      ): Result[ADQLQuery] =
         (tracking.at(start.toInstant), tracking.at(end.toInstant))
           .mapN { (a, b) =>
             // If caching is implemented for the guide star results, `ags.widestConstraints` should be
@@ -355,16 +439,14 @@ object GuideService {
               brightnessConstraints.some
             )
           }
-          .toRight(
-            Error.GeneralError(
-              s"Unable to get tracking information for asterism for observation $oid."
-            )
+          .toResult(
+            generalError(s"Unable to get tracking information for asterism for observation $oid.").asProblem
           )
 
       def callGaia(
         oid:   Observation.Id,
         query: ADQLQuery
-      ): F[Either[Error, List[GuideStarCandidate]]] = {
+      ): F[Result[List[GuideStarCandidate]]] = {
         val MaxTargets                     = 100
         given catalog: CatalogAdapter.Gaia = CatalogAdapter.Gaia3Lite
         given ci: ADQLInterpreter          = ADQLInterpreter.nTarget(MaxTargets)
@@ -382,24 +464,67 @@ object GuideService {
           )
           .compile
           .toList
-          .map(_.asRight)
-          .handleError(e => Error.GaiaError(e.getMessage()).asLeft)
+          .map(_.success)
+          // Should we have access to a logger in Services so we can log this instead of passing details on to the user?
+          .handleError(e => gaiaError(e.getMessage()).asFailure)
       }
 
-      def getCandidates(
+      def getAllCandidates(
         oid:         Observation.Id,
         start:       Timestamp,
         end:         Timestamp,
         tracking:    ObjectTracking,
         wavelength:  Wavelength,
         constraints: ConstraintSet
-      ): F[Either[Error, List[GuideStarCandidate]]] =
+      ): F[Result[List[GuideStarCandidate]]] =
         (for {
-          query      <- EitherT.fromEither(
+          query      <- ResultT.fromResult(
                           getGaiaQuery(oid, start, end, tracking, probeArm.candidatesArea, wavelength, constraints)
                         )
-          candidates <- EitherT(callGaia(oid, query))
+          candidates <- ResultT(callGaia(oid, query))
         } yield candidates).value
+
+      def getAllCandidatesNonEmpty(
+        oid:         Observation.Id,
+        start:       Timestamp,
+        end:         Timestamp,
+        tracking:    ObjectTracking,
+        wavelength:  Wavelength,
+        constraints: ConstraintSet
+      ): F[Result[NonEmptyList[GuideStarCandidate]]] =
+        (for {
+          candidates <- ResultT(getAllCandidates(oid, start, end, tracking, wavelength, constraints))
+          nel        <- ResultT.fromResult(
+                          NonEmptyList.fromList(candidates)
+                            .toResult(generalError("No potential guidestars found on Gaia.").asProblem)
+                        )
+        } yield nel).value
+
+      def getGuideStarFromGaia(name: GuideStarName): F[Result[GuideStarCandidate]] =
+        ResultT.fromResult(guideStarIdFromName(name)).flatMap { id => 
+          given catalog: CatalogAdapter.Gaia = CatalogAdapter.Gaia3Lite
+          val request = Request[F](Method.GET, CatalogSearch.gaiaSearchUriById(id),
+                                  headers = Headers(("x-requested-with", "XMLHttpRequest"))
+          ) 
+          ResultT(
+            httpClient
+              .stream(request)
+              .flatMap(
+                _.body
+                  .through(utf8.decode)
+                  .through(CatalogSearch.guideStars[F](CatalogAdapter.Gaia3Lite))
+                  .collect { case Right(s) => GuideStarCandidate.siderealTarget.get(s)}
+              )
+              .compile
+              .toList
+              .map(
+                _.headOption
+                .toResult(gaiaError(s"Star with id $id not found on Gaia.").asProblem)
+              )
+              // Should we have access to a logger in Services so we can log this instead of passing details on to the user?
+              .handleError(e => gaiaError(e.getMessage()).asFailure)
+          )
+        }.value
 
       extension [D](steps: NonEmptyList[Step[D]])
         def offsets: List[Offset] = steps.collect { case Step(_, _, StepConfig.Science(offset, _), _, _, _) =>
@@ -427,21 +552,24 @@ object GuideService {
           }
         }
 
-      extension (usable: List[AgsAnalysis.Usable])
-        def toGuideEnvironments: List[GuideEnvironment] = usable.map { ags =>
-          val target = GuideStarCandidate.siderealTarget.reverseGet(ags.target)
-          GuideEnvironment(ags.vignetting.head._1, List(GuideTarget(ags.guideProbe, target)))
-        }
+      // TODO: Can go away after `guideEnvironments` is removed???
+      extension (usables: List[AgsAnalysis.Usable])
+        def toGuideEnvironments: List[GuideEnvironment] = usables.map(_.toGuideEnvironment)
+
+      extension (usable: AgsAnalysis.Usable)
+        def toGuideEnvironment: GuideEnvironment =
+          val target = GuideStarCandidate.siderealTarget.reverseGet(usable.target)
+          GuideEnvironment(usable.vignetting.head._1, List(GuideTarget(usable.guideProbe, target)))
 
       def getGeneratorInfo(
         pid: Program.Id,
         oid: Observation.Id
-      ): F[Either[Error, GeneratorInfo]] =
+      ): F[Result[GeneratorInfo]] =
         generator(commitHash, itcClient, timeEstimateCalculator)
           .digestWithParamsAndHash(pid, oid)
           .map {
-            _.leftMap(Error.GeneratorError(_))
-              .map((d, p, h) => GeneratorInfo(d, p, h))
+            case Right((d, p, h)) => GeneratorInfo(d, p, h).success
+            case Left(ge)         => generatorError(ge).asFailure
           }
 
       def getPositions(
@@ -453,6 +581,7 @@ object GuideService {
           off <- offsets.getOrElse(NonEmptyList.of(Offset.Zero))
         } yield AgsPosition(pa, off)
 
+      // TODO: Can go away after `guideEnvironments` is removed???
       def processCandidates(
         obsInfo:       ObservationInfo,
         wavelength:    Wavelength,
@@ -473,6 +602,28 @@ object GuideService {
           )
           .sortUsablePositions
           .collect { case usable: AgsAnalysis.Usable => usable }
+      
+      def chooseBestGuideStar(
+        obsInfo:       ObservationInfo,
+        wavelength:    Wavelength,
+        genInfo:       GeneratorInfo,
+        baseCoords:    Coordinates,
+        scienceCoords: List[Coordinates],
+        positions:     NonEmptyList[AgsPosition],
+        candidates:    NonEmptyList[GuideStarCandidate]
+      ): Option[AgsAnalysis.Usable] =
+        Ags
+          .agsAnalysis(obsInfo.constraints,
+                       wavelength,
+                       baseCoords,
+                       scienceCoords,
+                       positions,
+                       genInfo.agsParams,
+                       candidates.toList
+          )
+          .sortUsablePositions
+          .collect { case usable: AgsAnalysis.Usable => usable }
+          .headOption
 
       def buildAvailabilityAndCache(
         pid:             Program.Id,
@@ -482,26 +633,26 @@ object GuideService {
         genInfo:         GeneratorInfo,
         currentAvail:    ContiguousTimestampMap[List[Angle]],
         newHash:         Md5Hash
-      ): F[Either[Error, ContiguousTimestampMap[List[Angle]]]] = 
+      ): F[Result[ContiguousTimestampMap[List[Angle]]]] = 
         (for {
-          wavelength   <- EitherT.fromEither(obsInfo.wavelength)
-          asterism     <- EitherT(getAsterism(pid, obsInfo.id))
+          wavelength   <- ResultT.fromResult(obsInfo.wavelength)
+          asterism     <- ResultT(getAsterism(pid, obsInfo.id))
           tracking      = ObjectTracking.fromAsterism(asterism)
           candPeriod    = neededPeriods.tail.fold(neededPeriods.head)((a, b) => a.span(b))
-          candidates   <- EitherT(
-                           getCandidates(obsInfo.id, candPeriod.start, candPeriod.end, tracking, wavelength, obsInfo.constraints)
+          candidates   <- ResultT(
+                           getAllCandidates(obsInfo.id, candPeriod.start, candPeriod.end, tracking, wavelength, obsInfo.constraints)
                           )
           positions     = getPositions(obsInfo.availabilityAngles, genInfo.offsets)
-          neededLists  <- EitherT.fromEither(
+          neededLists  <- ResultT.fromResult(
                             neededPeriods.traverse(p => 
                               buildAvailabilityList(p, obsInfo, genInfo, wavelength, asterism, tracking, candidates, positions)
                             )
                           )
-          availability <- EitherT.fromEither(
+          availability <- ResultT.fromResult(
                             neededLists.foldLeft(currentAvail.some)((acc, ele) => acc.flatMap(_.union(ele)))
-                              .toRight(Error.GeneralError("Error creating guide availability"))
+                              .toResult(generalError("Error creating guide availability").asProblem)
                           )
-          _            <- EitherT.right(cacheAvailability(pid, obsInfo.id, newHash, availability))
+          _            <- ResultT.liftF(cacheAvailability(pid, obsInfo.id, newHash, availability))
         } yield availability).value
 
       def buildAvailabilityList(
@@ -513,21 +664,21 @@ object GuideService {
         tracking:   ObjectTracking,
         candidates: List[GuideStarCandidate],
         positions:  NonEmptyList[AgsPosition]
-      ): Either[Error, ContiguousTimestampMap[List[Angle]]] = {
+      ): Result[ContiguousTimestampMap[List[Angle]]] = {
         @scala.annotation.tailrec
-        def go(startTime: Timestamp, accum: ContiguousTimestampMap[List[Angle]]): Either[Error, ContiguousTimestampMap[List[Angle]]] = {
+        def go(startTime: Timestamp, accum: ContiguousTimestampMap[List[Angle]]): Either[OdbError, ContiguousTimestampMap[List[Angle]]] = {
           val eap =
             buildAvailabilityPeriod(startTime, period.end, obsInfo, genInfo, wavelength, asterism, tracking, candidates, positions)
           eap match
-            case Left(error)                      => error.asLeft
-            case Right(ap) if ap.period.end < period.end => go(ap.period.end, accum.unsafeAdd(ap.period, ap.posAngles))
-            case Right(ap)                        => 
-              val newPeriod = TimestampInterval.between(ap.period.start, period.end)
-              accum.unsafeAdd(newPeriod, ap.posAngles).asRight
+                      case Left(error)                      => error.asLeft
+                      case Right(ap) if ap.period.end < period.end => go(ap.period.end, accum.unsafeAdd(ap.period, ap.posAngles))
+                      case Right(ap)                        => 
+                        val newPeriod = TimestampInterval.between(ap.period.start, period.end)
+                        accum.unsafeAdd(newPeriod, ap.posAngles).asRight
         }
         candidates match
-          case Nil => ContiguousTimestampMap.single(period, List.empty).asRight
-          case _   => go(period.start, ContiguousTimestampMap.empty[List[Angle]])
+          case Nil => ContiguousTimestampMap.single(period, List.empty).success
+          case _   => go(period.start, ContiguousTimestampMap.empty[List[Angle]]).fold(_.asFailure, _.success)
       }
 
       def buildAvailabilityPeriod(
@@ -540,7 +691,7 @@ object GuideService {
         tracking:   ObjectTracking,
         candidates: List[GuideStarCandidate],
         positions:  NonEmptyList[AgsPosition],
-      ): Either[Error, AvailabilityPeriod] =
+      ): Either[OdbError, AvailabilityPeriod] =
         for {
           baseCoords      <- obsInfo.explicitBase
                                .orElse(
@@ -549,16 +700,12 @@ object GuideService {
                                    .map(_.value)
                                )
                                .toRight(
-                                 Error.GeneralError(
-                                   s"Unable to get coordinates for asterism in observation ${obsInfo.id}"
-                                 )
+                                 generalError(s"Unable to get coordinates for asterism in observation ${obsInfo.id}")
                                )
           scienceCoords   <- asterism.toList
                                .traverse(t => ObjectTracking.fromTarget(t).at(start.toInstant).map(_.value))
                                .toRight(
-                                 Error.GeneralError(
-                                   s"Unable to get coordinates for science targets in observation ${obsInfo.id}"
-                                 )
+                                 generalError(s"Unable to get coordinates for science targets in observation ${obsInfo.id}")
                                )
           scienceCutoff    = asterism.map(_.invalidDate(start)).toList.min
           // we can stop testing candidates when all angles being tested have invalid dates that are farther
@@ -620,74 +767,170 @@ object GuideService {
           .getOrElse(SortedMap.empty)
       }
 
-      override def getGuideEnvironment(pid: Program.Id, oid: Observation.Id, obsTime: Timestamp)(using
-        NoTransaction[F]
-      ): F[Either[Error, List[GuideEnvironment]]] =
+      def guideStarIdFromName(name: GuideStarName): Result[Long] = 
+        name.toGaiaSourceId.toResult(generalError(s"Invalid guide star name `$name`").asProblem)
+
+      def lookupGuideStar(
+        pid: Program.Id,
+        oid: Observation.Id,
+        oGuideStarName: Option[GuideStarName],
+        obsInfo: ObservationInfo,
+        genInfo: GeneratorInfo,
+        obsTime: Timestamp,
+        duration: TimeSpan
+      ): F[Result[GuideEnvironment]] = 
+        // If we got here, we either have the name but need to get all the details (they queried for more 
+        // than name), or the name wasn't set or wasn't valid and we need to find all the candidates and 
+        // select the best.
         (for {
-          obsInfo       <- EitherT(getObservationInfo(pid, oid))
-          wavelength    <- EitherT.fromEither(obsInfo.wavelength)
-          asterism      <- EitherT(getAsterism(pid, oid))
-          genInfo       <- EitherT(getGeneratorInfo(pid, oid))
+          wavelength    <- ResultT.fromResult(obsInfo.wavelength)
+          asterism      <- ResultT(getAsterism(pid, oid))
           baseTracking   = obsInfo.explicitBase.fold(ObjectTracking.fromAsterism(asterism))(ObjectTracking.constant)
-          visitEnd      <- EitherT.fromEither(
+          visitEnd      <- ResultT.fromResult(
                              obsTime
-                               .plusMicrosOption(genInfo.timeEstimate.toMicroseconds)
-                               .toRight(Error.GeneralError("Visit end time out of range"))
+                               .plusMicrosOption(duration.toMicroseconds)
+                               .toResult(generalError("Visit end time out of range").asProblem)
                            )
-          candidates    <- EitherT(
-                            getCandidates(oid, obsTime, visitEnd, baseTracking, wavelength, obsInfo.constraints)
-                          ).map(_.map(_.at(obsTime.toInstant)))
-          baseCoords    <- EitherT.fromEither(
+          candidates    <- ResultT(
+                             oGuideStarName.fold(
+                              getAllCandidatesNonEmpty(oid, obsTime, visitEnd, baseTracking, wavelength, obsInfo.constraints)
+                             )(gsn => getGuideStarFromGaia(gsn).map(_.map(NonEmptyList.one)))
+                           ).map(_.map(_.at(obsTime.toInstant)))
+          baseCoords    <- ResultT.fromResult(
                              baseTracking.at(obsTime.toInstant).map(_.value)
-                               .toRight(
-                                 Error.GeneralError(
+                               .toResult(
+                                 generalError(
                                    s"Unable to get coordinates for asterism in observation $oid"
-                                 )
+                                 ).asProblem
                                )
                            )
-          scienceCoords <- EitherT.fromEither(
+          scienceCoords <- ResultT.fromResult(
                              asterism.toList
                                .traverse(t => ObjectTracking.fromTarget(t).at(obsTime.toInstant).map(_.value))
-                               .toRight(
-                                 Error.GeneralError(
+                               .toResult(
+                                 generalError(
                                    s"Unable to get coordinates for science targets in observation $oid"
-                                 )
+                                 ).asProblem
                                )
                            )
-          angles        <- EitherT.fromEither(
+          angles        <- ResultT.fromResult(
                              obsInfo.posAngleConstraint
                               .anglesToTestAt(genInfo.site, baseTracking, obsTime.toInstant, genInfo.timeEstimate.toDuration)
-                              .toRight(Error.GeneralError(s"No angles to test for guide target candidates for observation $oid."))
+                              .toResult(generalError(s"No angles to test for guide target candidates for observation $oid.").asProblem)
+                           )
+          positions      = getPositions(angles, genInfo.offsets)
+          optUsable      = chooseBestGuideStar(obsInfo, wavelength, genInfo, baseCoords, scienceCoords, positions, candidates)
+          env           <- ResultT.fromResult(
+                             optUsable
+                              .map(_.toGuideEnvironment)
+                              .toResult (
+                                generalError(
+                                  oGuideStarName.fold("No usable guidestars are available.")(name =>
+                                    s"Guidestar $name is not usable.")
+                                ).asProblem
+                             )
+                           )
+        } yield env).value
+      
+      override def getGuideEnvironment(pid: Program.Id, oid: Observation.Id, options: GuideEnvironmentOptions)(
+        using NoTransaction[F]
+      ): F[Result[Option[GuideEnvironment]]] = 
+        Trace[F].span("getGuideEnvironment"):
+          (for {
+            obsInfo       <- ResultT(getObservationInfo(pid, oid))
+            obsTime       <- ResultT.fromResult(obsInfo.obsTime)
+            wavelength    <- ResultT.fromResult(obsInfo.wavelength)
+            asterism      <- ResultT(getAsterism(pid, oid))
+            genInfo       <- ResultT(getGeneratorInfo(pid, oid))
+            duration       = obsInfo.optObsDuration.getOrElse(genInfo.timeEstimate)
+            oGSName        = obsInfo.validGuideStarName(genInfo.hash, duration)
+            result        <- if ((oGSName.isDefined && !options.queriedNameOnly) || (oGSName.isEmpty && options.lookupIfUndefined))
+                              ResultT(lookupGuideStar(pid, oid, oGSName, obsInfo, genInfo, obsTime, duration)).map(_.some)
+                            else ResultT.pure(oGSName.map(GuideEnvironment.forNameOnly))
+          } yield result).value
+
+      // TODO: This can go away when Navigate is ready.
+      override def getGuideEnvironments(pid: Program.Id, oid: Observation.Id, obsTime: Timestamp)(
+        using NoTransaction[F]
+      ): F[Result[List[GuideEnvironment]]] =
+        (for {
+          obsInfo       <- ResultT(getObservationInfo(pid, oid))
+          wavelength    <- ResultT.fromResult(obsInfo.wavelength)
+          asterism      <- ResultT(getAsterism(pid, oid))
+          genInfo       <- ResultT(getGeneratorInfo(pid, oid))
+          baseTracking   = obsInfo.explicitBase.fold(ObjectTracking.fromAsterism(asterism))(ObjectTracking.constant)
+          visitEnd      <- ResultT.fromResult(
+                             obsTime
+                               .plusMicrosOption(genInfo.timeEstimate.toMicroseconds)
+                               .toResult(generalError("Visit end time out of range").asProblem)
+                           )
+          candidates    <- ResultT(
+                            getAllCandidates(oid, obsTime, visitEnd, baseTracking, wavelength, obsInfo.constraints)
+                          ).map(_.map(_.at(obsTime.toInstant)))
+          baseCoords    <- ResultT.fromResult(
+                             baseTracking.at(obsTime.toInstant).map(_.value)
+                               .toResult(
+                                 generalError(s"Unable to get coordinates for asterism in observation $oid").asProblem
+                               )
+                           )
+          scienceCoords <- ResultT.fromResult(
+                             asterism.toList
+                               .traverse(t => ObjectTracking.fromTarget(t).at(obsTime.toInstant).map(_.value))
+                               .toResult(
+                                 generalError(s"Unable to get coordinates for science targets in observation $oid").asProblem
+                               )
+                           )
+          angles        <- ResultT.fromResult(
+                             obsInfo.posAngleConstraint
+                              .anglesToTestAt(genInfo.site, baseTracking, obsTime.toInstant, genInfo.timeEstimate.toDuration)
+                              .toResult(generalError(s"No angles to test for guide target candidates for observation $oid.").asProblem)
                            )
           positions      = getPositions(angles, genInfo.offsets)
           usable         = processCandidates(obsInfo, wavelength, genInfo, baseCoords, scienceCoords, positions, candidates)
         } yield usable.toGuideEnvironments.toList).value
 
-      override def getGuideAvailability(pid: Program.Id, oid: Observation.Id, period: TimestampInterval)(using
-        NoTransaction[F]
-      ): F[Either[Error, List[AvailabilityPeriod]]] =
-        (for {
-          _             <- EitherT.fromEither(
-                             if (period.boundedTimeSpan <= maxAvailabilityPeriod) ().asRight
-                             else Error.GeneralError(
-                              s"Period for guide availability cannot be greater than $maxAvailabilityPeriodDays days."
-                             ).asLeft
-                           )
-          obsInfo       <- EitherT(getObservationInfo(pid, oid))
-          genInfo       <- EitherT(getGeneratorInfo(pid, oid))
-          newHash        = obsInfo.hash(genInfo.hash)
-          currentAvail  <- EitherT.right(getFromCacheOrEmpty(pid, oid, newHash))
-          missingPeriods = currentAvail.findMissingIntervals(period)
-          // only happens if we have disjoint periods too far apart. If so, we'll just replace the existing
-          (neededPeriods, startAvail) = if (missingPeriods.exists(_.boundedTimeSpan > maxAvailabilityPeriod)) 
-                             (NonEmptyList.of(period).some, ContiguousTimestampMap.empty[List[Angle]])
-                           else (NonEmptyList.fromList(missingPeriods), currentAvail)
-          // if we don't need anything, then we already have what we need
-          fullAvail     <- neededPeriods.fold(EitherT.pure(startAvail))(nel =>
-                             EitherT(buildAvailabilityAndCache(pid, period, nel, obsInfo, genInfo, startAvail, newHash))
-                           )
-          availability   = fullAvail.slice(period).intervals.toList.map(AvailabilityPeriod.fromTuple)
-        } yield availability).value
+      override def getGuideAvailability(pid: Program.Id, oid: Observation.Id, period: TimestampInterval)(
+        using NoTransaction[F]
+      ): F[Result[List[AvailabilityPeriod]]] =
+        Trace[F].span("getGuideAvailability"):
+          (for {
+            _             <- ResultT.fromResult(
+                              if (period.boundedTimeSpan <= maxAvailabilityPeriod) ().success
+                              else generalError(
+                                s"Period for guide availability cannot be greater than $maxAvailabilityPeriodDays days."
+                              ).asFailure
+                            )
+            obsInfo       <- ResultT(getObservationInfo(pid, oid))
+            genInfo       <- ResultT(getGeneratorInfo(pid, oid))
+            newHash        = obsInfo.availabilityHash(genInfo.hash)
+            currentAvail  <- ResultT.liftF(getFromCacheOrEmpty(pid, oid, newHash))
+            missingPeriods = currentAvail.findMissingIntervals(period)
+            // only happens if we have disjoint periods too far apart. If so, we'll just replace the existing
+            (neededPeriods, startAvail) = if (missingPeriods.exists(_.boundedTimeSpan > maxAvailabilityPeriod)) 
+                              (NonEmptyList.of(period).some, ContiguousTimestampMap.empty[List[Angle]])
+                            else (NonEmptyList.fromList(missingPeriods), currentAvail)
+            // if we don't need anything, then we already have what we need
+            fullAvail     <- neededPeriods.fold(ResultT.pure(startAvail))(nel =>
+                              ResultT(buildAvailabilityAndCache(pid, period, nel, obsInfo, genInfo, startAvail, newHash))
+                            )
+            availability   = fullAvail.slice(period).intervals.toList.map(AvailabilityPeriod.fromTuple)
+          } yield availability).value
+
+      override def setGuideTargetName(input: SetGuideTargetNameInput)(
+        using NoTransaction[F]): F[Result[Observation.Id]] = 
+          Trace[F].span("setGuideTargetName"):
+            input.targetName.fold(updateGuideTargetName(input.programId, input.observationId, none, none)){ name =>
+              (for {
+                gsn    <- ResultT.fromResult(
+                            GuideStarName.from(name.value).toOption.toResult(guideStarNameError(name.value).asProblem)
+                          )
+                obsInfo  <- ResultT(getObservationInfo(input.programId, input.observationId))
+                genInfo  <- ResultT(getGeneratorInfo(input.programId, input.observationId))
+                duration  = obsInfo.optObsDuration.getOrElse(genInfo.timeEstimate)
+                hash      = obsInfo.newGuideStarHash(genInfo.hash, duration)
+                result   <- ResultT(updateGuideTargetName(input.programId, input.observationId, gsn.some, hash.some))
+              } yield result).value
+            }
     }
 
   object Statements {
@@ -710,7 +953,11 @@ object GuideService {
           obs.c_pac_angle,
           obs.c_spec_wavelength,
           obs.c_explicit_ra,
-          obs.c_explicit_dec
+          obs.c_explicit_dec,
+          obs.c_observation_time,
+          obs.c_observation_duration,
+          obs.c_guide_target_name,
+          obs.c_guide_target_hash
         from t_observation obs
         where obs.c_program_id     = $program_id
           and obs.c_observation_id = $observation_id
@@ -790,6 +1037,24 @@ object GuideService {
         where c_program_id     = $program_id
           and c_observation_id = $observation_id
       """.apply(pid, oid) |+| andWhereUserAccess(user, pid)
+
+    // both guideStarName and guideStarHash should either have values or be empty.
+    def updateGuideTargetName(
+      user: User,
+      pid: Program.Id,
+      oid: Observation.Id,
+      guideStarName: Option[GuideStarName],
+      guideStarHash: Option[Md5Hash]
+    ): AppliedFragment =
+      sql"""
+        update t_observation
+        set
+          c_guide_target_name = ${guide_target_name.opt},
+          c_guide_target_hash = ${md5_hash.opt}
+        where c_program_id     = $program_id
+          and c_observation_id = $observation_id
+      """.apply(guideStarName, guideStarHash, pid, oid) |+| andWhereUserAccess(user, pid) |+|
+      void"""  returning c_observation_id"""
   }
 
   private object Decoders {
@@ -808,8 +1073,12 @@ object GuideService {
         angle_µas *:
         wavelength_pm.opt *:
         right_ascension.opt *:
-        declination.opt).emap {
-        case (id, cloud, image, sky, water, amMin, amMax, haMin, haMax, mode, angle, wavelength, ra, dec) =>
+        declination.opt *:
+        core_timestamp.opt *:
+        time_span.opt *:
+        guide_target_name.opt *:
+        md5_hash.opt).emap {
+        case (id, cloud, image, sky, water, amMin, amMax, haMin, haMax, mode, angle, wavelength, ra, dec, time, duration, guidestarName, guidestarHash) =>
           val paConstraint: PosAngleConstraint = mode match
             case PosAngleConstraintMode.Unbounded           => PosAngleConstraint.Unbounded
             case PosAngleConstraintMode.Fixed               => PosAngleConstraint.Fixed(angle)
@@ -841,7 +1110,7 @@ object GuideService {
             (ra, dec).mapN(Coordinates(_, _))
 
           elevRange.map(elev =>
-            ObservationInfo(id, ConstraintSet(image, cloud, sky, water, elev), paConstraint, wavelength, explicitBase)
+            ObservationInfo(id, ConstraintSet(image, cloud, sky, water, elev), paConstraint, wavelength, explicitBase, time, duration, guidestarName, guidestarHash)
           )
       }
 

--- a/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
@@ -15,6 +15,7 @@ import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.types.numeric.PosLong
 import eu.timepit.refined.types.numeric.PosShort
 import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.ags.GuideStarName
 import lucuma.core.data.EmailAddress
 import lucuma.core.enums.*
 import lucuma.core.enums.CalibrationRole
@@ -232,6 +233,9 @@ trait Codecs {
 
   val email_address: Codec[EmailAddress] =
     codecFromPrism(EmailAddress.from, Type("citext"))
+
+  val guide_target_name: Codec[GuideStarName] =
+    codecFromPrism(GuideStarName.from, Type("text"))
 
   val email_id: Codec[EmailId] =
     text.eimap(EmailId.fromString)(_.value.value)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -1547,7 +1547,6 @@ trait DatabaseOperations { this: OdbSuite =>
   
   def setGuideTargetName(
     user: User,
-    pid: Program.Id,
     oid: Observation.Id,
     guideTargetName: Option[String]
   ): IO[Unit] = {
@@ -1555,7 +1554,6 @@ trait DatabaseOperations { this: OdbSuite =>
       mutation {
         setGuideTargetName(
           input: {
-            programId: ${pid.asJson}
             observationId: ${oid.asJson}
             targetName: ${guideTargetName.asJson}
           }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setGuideTargetName.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setGuideTargetName.scala
@@ -1,0 +1,267 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package mutation
+
+import cats.effect.IO
+import cats.syntax.all.*
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.ags.GuideStarName
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.User
+import lucuma.core.util.Timestamp
+
+class setGuideTargetName extends query.ExecutionTestSupport {
+  val targetName1: String = GuideStarName.gaiaSourceId.reverseGet(1L).value.value
+
+  val Now: Timestamp = Timestamp.FromString.getOption("2024-08-25T00:00:00Z").get
+  val Later: Timestamp = Now.plusSecondsOption(120L).get
+
+  private val targetEnvQuery = """
+    targetEnvironment {
+      guideEnvironment(lookupIfUndefined: false) {
+        guideTargets { name }
+      }
+    }
+  """
+
+  private val idQuery = "id"
+
+  // If name is None, omit from mutation, if the string is empty, set to null, else set name
+  private def mutation(
+    pid: Program.Id,
+    oid: Observation.Id,
+    name: Option[String],
+    resultQuery: String = targetEnvQuery
+  ): String =
+    val update = name.fold(""){ n =>
+      val nn = if (n.isEmpty) "null" else s"\"$n\""
+      s"targetName: $nn"
+    }
+
+    s"""
+      mutation {
+        setGuideTargetName(
+          input: {
+            programId: ${pid.asJson}
+            observationId: ${oid.asJson}
+            $update
+          }
+        ) {
+          observation {
+            $resultQuery
+          }
+        }
+      }
+    """
+
+  private def justQuery(user: User, oid: Observation.Id, expectedName: Option[String]): IO[Unit] =
+    val guideEnv = expectedName.fold(Json.Null)(name =>
+      Json.obj("guideTargets" ->
+        Json.arr(Json.obj("name" -> name.asJson))
+      )
+    )
+    val expected = json"""
+      {
+        "observation": {
+          "targetEnvironment": {
+            "guideEnvironment": $guideEnv
+          }
+        }
+      }
+    """.asRight
+    val query = s"""
+      query {
+        observation(observationId: ${oid.asJson}) {
+          $targetEnvQuery
+        }
+      }
+    """
+    expect(user, query, expected)
+
+  private def expectName(guideStarName: String): Either[Nothing, Json] =
+    json"""
+      {
+        "setGuideTargetName": {
+          "observation": {
+            "targetEnvironment": {
+              "guideEnvironment": {
+                "guideTargets": [
+                  {
+                    "name": $guideStarName
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    """.asRight
+  
+  private val expectNull: Either[Nothing, Json] =
+    json"""
+      {
+        "setGuideTargetName": {
+          "observation": {
+            "targetEnvironment": {
+              "guideEnvironment": null
+            }
+          }
+        }
+      }
+    """.asRight
+
+  // for updates where the result query itself would cause an error
+  private def expectJustId(oid: Observation.Id): Either[Nothing, Json] =
+    json"""
+      {
+        "setGuideTargetName": {
+          "observation": {
+            "id": $oid
+          }
+        }
+      }
+    """.asRight
+
+  private def expectError(errors: String*): Either[List[String], Json] =
+    errors.toList.asLeft
+
+  private def expectObsError(errors: (Observation.Id => String)*): Observation.Id => Either[List[String], Json] =
+    obsId => errors.map(_(obsId)).toList.asLeft
+
+  private def setName(
+    user: User,
+    pid: Program.Id,
+    oid: Observation.Id,
+    name: Option[String],
+    expected: Either[List[String], Json],
+    resultQuery: String = targetEnvQuery
+  ): IO[Unit] =
+    expect(
+      user = user,
+      query = mutation(pid, oid, name, resultQuery),
+      expected = expected
+    )
+
+  test("invalid name") {
+    val name = targetName1 + "x"
+    val expected = expectError(s"Invalid guide target name '$name'")
+    for
+      pid <- createProgramAs(pi)
+      oid <- createObservationAs(pi, pid)
+      _   <- setName(staff, pid, oid, name.some, expected)
+    yield ()
+  }
+
+  test("missing target") {
+    val expected = expectObsError(oid => s"Could not generate a sequence from the observation $oid: target")
+    for
+      pid <- createProgramAs(pi)
+      oid <- createObservationAs(pi, pid)
+      _   <- setName(staff, pid, oid, targetName1.some, expected(oid))
+    yield ()
+  }
+
+  test("missing observing mode") {
+    val expected = expectObsError(oid => s"Could not generate a sequence from the observation $oid: observing mode")
+    for
+      pid <- createProgramAs(pi)
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createObservationAs(pi, pid, tid)
+      _   <- setName(staff, pid, oid, targetName1.some, expected(oid))
+    yield ()
+  }
+
+  test("missing observation time") {
+    val expected = expectObsError(oid => s"Observation time not set for observation $oid.")
+    for
+      pid <- createProgramAs(pi)
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- setName(staff, pid, oid, targetName1.some, expected(oid))
+    yield ()
+  }
+
+  test("valid set as staff") {
+    for
+      pid <- createProgramAs(pi)
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- setObservationTimeAndDuration(pi, oid, Now.some, none)
+      _   <- setName(staff, pid, oid, targetName1.some, expectName(targetName1))
+    yield ()
+  }
+
+  test("valid set as pi") {
+    for
+      pid <- createProgramAs(pi)
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- setObservationTimeAndDuration(pi, oid, Now.some, none)
+      _   <- setName(pi, pid, oid, targetName1.some, expectName(targetName1))
+    yield ()
+  }
+
+  test("omission unsets") {
+    for
+      pid <- createProgramAs(pi)
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- setObservationTimeAndDuration(pi, oid, Now.some, none)
+      _   <- setName(staff, pid, oid, targetName1.some, expectName(targetName1))
+      _   <- setName(pi, pid, oid, none, expectNull)
+    yield ()
+  }
+
+  test("null unsets") {
+    for
+      pid <- createProgramAs(pi)
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- setObservationTimeAndDuration(pi, oid, Now.some, none)
+      _   <- setName(staff, pid, oid, targetName1.some, expectName(targetName1))
+      _   <- setName(pi, pid, oid, "".some, expectNull)
+    yield ()
+  }
+
+  test("starts as null") {
+    for
+      pid <- createProgramAs(pi)
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- setObservationTimeAndDuration(pi, oid, Now.some, none)
+      _   <- justQuery(pi, oid, none)
+    yield ()
+  }
+
+  test("changing observation time resets") {
+    for
+      pid <- createProgramAs(pi)
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- setObservationTimeAndDuration(pi, oid, Now.some, none)
+      _   <- setName(staff, pid, oid, targetName1.some, expectName(targetName1))
+      _   <- setObservationTimeAndDuration(pi, oid, Later.some, none)
+      _   <- justQuery(pi, oid, none)
+    yield ()
+  }
+
+  test("Can always unset") {
+    for
+      pid <- createProgramAs(pi)
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- setObservationTimeAndDuration(pi, oid, Now.some, none)
+      _   <- setName(staff, pid, oid, targetName1.some, expectName(targetName1))
+      _   <- updateAsterisms(pi, List(oid), List.empty, List(tid), List(oid -> List.empty))
+      // only query the id in the response since asking for the target name would give an error
+      _   <- setName(staff, pid, oid, none, expectJustId(oid), idQuery)
+    yield ()
+  }
+
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
@@ -66,9 +66,10 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
   val pi: User   = TestUsers.Standard.pi(1, 30)
   val pi2: User  = TestUsers.Standard.pi(2, 32)
   val serviceUser: User = TestUsers.service(3)
+  val staff: User = TestUsers.Standard.staff(4, 33)
 
   override val validUsers: List[User] =
-    List(pi, pi2, serviceUser)
+    List(pi, pi2, serviceUser, staff)
 
   val createProgram: IO[Program.Id] =
     createProgramAs(pi, "Sequence Testing")

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
@@ -11,14 +11,27 @@ import fs2.Stream
 import fs2.text.utf8
 import io.circe.Json
 import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.ags.GuideStarName
 import lucuma.core.model.Observation
+import lucuma.core.util.Timestamp
 import org.http4s.Request
 import org.http4s.Response
 
 class guideEnvironment extends ExecutionTestSupport {
 
-  val aug2023 = "2023-08-30T00:00:00Z"
-  val aug3000 = "3000-08-30T00:00:00Z"
+  val gaiaSuccess = Timestamp.FromString.getOption("2023-08-30T00:00:00Z").get
+  val gaiaEmpty   = Timestamp.FromString.getOption("3000-01-30T04:00:00Z").get
+  // for tests in which gaia should not get called
+  val gaiaError   = Timestamp.FromString.getOption("4000-12-30T20:00:00Z").get
+
+  val invalidTargetId = 1L
+  val defaultTargetId = 3219118090462918016L
+  val otherTargetId = 3219142829474535424L
+
+  val invalidTargetName: String = GuideStarName.gaiaSourceId.reverseGet(invalidTargetId).value.value
+  val defaultTargetName: String = GuideStarName.gaiaSourceId.reverseGet(defaultTargetId).value.value
+  val otherTargetName: String = GuideStarName.gaiaSourceId.reverseGet(otherTargetId).value.value
 
   val gaiaReponseString =
   """<?xml version="1.0" encoding="UTF-8"?>
@@ -125,6 +138,172 @@ class guideEnvironment extends ExecutionTestSupport {
   |    </RESOURCE>
   |</VOTABLE>""".stripMargin
 
+  val gaiaDefaultNameReponseString =
+  """<?xml version="1.0" encoding="UTF-8"?>
+  |<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/v1.3">
+  |    <RESOURCE type="results">
+  |        <INFO name="QUERY_STATUS" value="OK" />
+  |        <INFO name="QUERY" value="SELECT TOP 100 source_id,ra,pmra,dec,pmdec,parallax,radial_velocity,phot_g_mean_mag,phot_rp_mean_mag 
+  |     FROM gaiadr3.gaia_source_lite
+  |     WHERE CONTAINS(POINT(&#039;ICRS&#039;,ra,dec),CIRCLE(&#039;ICRS&#039;, 86.55474, -0.10137, 0.08167))=1
+  |     and ((phot_rp_mean_mag &lt; 17.228) or (phot_g_mean_mag &lt; 17.228))
+  |     and (ruwe &lt; 1.4)
+  |     ORDER BY phot_g_mean_mag
+  |      ">
+  |            <![CDATA[SELECT TOP 100 source_id,ra,pmra,dec,pmdec,parallax,radial_velocity,phot_g_mean_mag,phot_rp_mean_mag 
+  |     FROM gaiadr3.gaia_source_lite
+  |     WHERE CONTAINS(POINT('ICRS',ra,dec),CIRCLE('ICRS', 86.55474, -0.10137, 0.08167))=1
+  |     and ((phot_rp_mean_mag < 17.228) or (phot_g_mean_mag < 17.228))
+  |     and (ruwe < 1.4)
+  |     ORDER BY phot_g_mean_mag
+  |      ]]>
+  |        </INFO>
+  |        <INFO name="CAPTION" value="How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html">
+  |            <![CDATA[How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html]]>
+  |        </INFO>
+  |        <INFO name="CITATION" value="How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html" ucd="meta.bib">
+  |            <![CDATA[How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html]]>
+  |        </INFO>
+  |        <INFO name="PAGE" value="" />
+  |        <INFO name="PAGE_SIZE" value="" />
+  |        <INFO name="JOBID" value="1693412462905O">
+  |            <![CDATA[1693412462905O]]>
+  |        </INFO>
+  |        <INFO name="JOBNAME" value="" />
+  |        <COOSYS ID="GAIADR3" epoch="J2016.0" system="ICRS" />
+  |        <RESOURCE>
+  |            <COOSYS ID="t14806478-coosys-1" epoch="J2016.0" system="ICRS"/>
+  |        </RESOURCE>
+  |        <TABLE>
+  |            <FIELD datatype="long" name="source_id" ucd="meta.id">
+  |                <DESCRIPTION>Unique source identifier (unique within a particular Data Release)</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="ra" ref="t14806478-coosys-1" ucd="pos.eq.ra;meta.main" unit="deg" utype="Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C1">
+  |                <DESCRIPTION>Right ascension</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="pmra" ucd="pos.pm;pos.eq.ra" unit="mas.yr**-1">
+  |                <DESCRIPTION>Proper motion in right ascension direction</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="dec" ref="t14806478-coosys-1" ucd="pos.eq.dec;meta.main" unit="deg" utype="Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C2">
+  |                <DESCRIPTION>Declination</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="pmdec" ucd="pos.pm;pos.eq.dec" unit="mas.yr**-1">
+  |                <DESCRIPTION>Proper motion in declination direction</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="parallax" ucd="pos.parallax.trig" unit="mas">
+  |                <DESCRIPTION>Parallax</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="float" name="radial_velocity" ucd="spect.dopplerVeloc.opt;em.opt.I" unit="km.s**-1">
+  |                <DESCRIPTION>Radial velocity</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="float" name="phot_g_mean_mag" ucd="phot.mag;em.opt" unit="mag">
+  |                <DESCRIPTION>G-band mean magnitude</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="float" name="phot_rp_mean_mag" ucd="phot.mag;em.opt.R" unit="mag">
+  |                <DESCRIPTION>Integrated RP mean magnitude</DESCRIPTION>
+  |            </FIELD>
+  |            <DATA>
+  |                <TABLEDATA>
+  |                    <TR>
+  |                        <TD>3219118090462918016</TD>
+  |                        <TD>86.5934741222927</TD>
+  |                        <TD>0.43862335651876644</TD>
+  |                        <TD>-0.14795707230703778</TD>
+  |                        <TD>-0.7414519014405084</TD>
+  |                        <TD>2.4315367202517466</TD>
+  |                        <TD>10.090042</TD>
+  |                        <TD>14.204175</TD>
+  |                        <TD>13.172072</TD>
+  |                    </TR>
+  |                </TABLEDATA>
+  |            </DATA>
+  |        </TABLE>
+  |    </RESOURCE>
+  |</VOTABLE>""".stripMargin
+
+  val gaiaOtherNameReponseString =
+  """<?xml version="1.0" encoding="UTF-8"?>
+  |<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/v1.3">
+  |    <RESOURCE type="results">
+  |        <INFO name="QUERY_STATUS" value="OK" />
+  |        <INFO name="QUERY" value="SELECT TOP 100 source_id,ra,pmra,dec,pmdec,parallax,radial_velocity,phot_g_mean_mag,phot_rp_mean_mag 
+  |     FROM gaiadr3.gaia_source_lite
+  |     WHERE CONTAINS(POINT(&#039;ICRS&#039;,ra,dec),CIRCLE(&#039;ICRS&#039;, 86.55474, -0.10137, 0.08167))=1
+  |     and ((phot_rp_mean_mag &lt; 17.228) or (phot_g_mean_mag &lt; 17.228))
+  |     and (ruwe &lt; 1.4)
+  |     ORDER BY phot_g_mean_mag
+  |      ">
+  |            <![CDATA[SELECT TOP 100 source_id,ra,pmra,dec,pmdec,parallax,radial_velocity,phot_g_mean_mag,phot_rp_mean_mag 
+  |     FROM gaiadr3.gaia_source_lite
+  |     WHERE CONTAINS(POINT('ICRS',ra,dec),CIRCLE('ICRS', 86.55474, -0.10137, 0.08167))=1
+  |     and ((phot_rp_mean_mag < 17.228) or (phot_g_mean_mag < 17.228))
+  |     and (ruwe < 1.4)
+  |     ORDER BY phot_g_mean_mag
+  |      ]]>
+  |        </INFO>
+  |        <INFO name="CAPTION" value="How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html">
+  |            <![CDATA[How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html]]>
+  |        </INFO>
+  |        <INFO name="CITATION" value="How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html" ucd="meta.bib">
+  |            <![CDATA[How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html]]>
+  |        </INFO>
+  |        <INFO name="PAGE" value="" />
+  |        <INFO name="PAGE_SIZE" value="" />
+  |        <INFO name="JOBID" value="1693412462905O">
+  |            <![CDATA[1693412462905O]]>
+  |        </INFO>
+  |        <INFO name="JOBNAME" value="" />
+  |        <COOSYS ID="GAIADR3" epoch="J2016.0" system="ICRS" />
+  |        <RESOURCE>
+  |            <COOSYS ID="t14806478-coosys-1" epoch="J2016.0" system="ICRS"/>
+  |        </RESOURCE>
+  |        <TABLE>
+  |            <FIELD datatype="long" name="source_id" ucd="meta.id">
+  |                <DESCRIPTION>Unique source identifier (unique within a particular Data Release)</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="ra" ref="t14806478-coosys-1" ucd="pos.eq.ra;meta.main" unit="deg" utype="Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C1">
+  |                <DESCRIPTION>Right ascension</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="pmra" ucd="pos.pm;pos.eq.ra" unit="mas.yr**-1">
+  |                <DESCRIPTION>Proper motion in right ascension direction</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="dec" ref="t14806478-coosys-1" ucd="pos.eq.dec;meta.main" unit="deg" utype="Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C2">
+  |                <DESCRIPTION>Declination</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="pmdec" ucd="pos.pm;pos.eq.dec" unit="mas.yr**-1">
+  |                <DESCRIPTION>Proper motion in declination direction</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="parallax" ucd="pos.parallax.trig" unit="mas">
+  |                <DESCRIPTION>Parallax</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="float" name="radial_velocity" ucd="spect.dopplerVeloc.opt;em.opt.I" unit="km.s**-1">
+  |                <DESCRIPTION>Radial velocity</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="float" name="phot_g_mean_mag" ucd="phot.mag;em.opt" unit="mag">
+  |                <DESCRIPTION>G-band mean magnitude</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="float" name="phot_rp_mean_mag" ucd="phot.mag;em.opt.R" unit="mag">
+  |                <DESCRIPTION>Integrated RP mean magnitude</DESCRIPTION>
+  |            </FIELD>
+  |            <DATA>
+  |                <TABLEDATA>
+  |                    <TR>
+  |                        <TD>3219142829474535424</TD>
+  |                        <TD>86.59328782338685</TD>
+  |                        <TD>-10.331736040138617</TD>
+  |                        <TD>-0.06075629321549123</TD>
+  |                        <TD>-29.666695525022078</TD>
+  |                        <TD>2.496796996582742</TD>
+  |                        <TD></TD>
+  |                        <TD>15.189251</TD>
+  |                        <TD>14.364465</TD>
+  |                    </TR>
+  |                </TABLEDATA>
+  |            </DATA>
+  |        </TABLE>
+  |    </RESOURCE>
+  |</VOTABLE>""".stripMargin
+
   val gaiaEmptyReponseString = 
   """<?xml version="1.0" encoding="UTF-8"?>
   |<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/v1.3">
@@ -197,13 +376,14 @@ class guideEnvironment extends ExecutionTestSupport {
   |    </RESOURCE>
   |</VOTABLE>""".stripMargin
 
-  def guideEnvironmentQuery(oid: Observation.Id, obsTime: String) =
+  def guideEnvironmentQuery(oid: Observation.Id, lookupIfUndefined: Option[Boolean] = none) =
+    val lookup = lookupIfUndefined.fold("")(b => s"lookupIfUndefined: $b")
     s"""
       query {
         observation(observationId: "$oid") {
           title
           targetEnvironment {
-            guideEnvironments(observationTime: "$obsTime") {
+            guideEnvironment($lookup) {
               posAngle {
                 degrees
               }
@@ -267,243 +447,221 @@ class guideEnvironment extends ExecutionTestSupport {
       }
     """
 
+  def guideTargetNameQuery(oid: Observation.Id, lookupIfUndefined: Option[Boolean] = none) =
+    val lookup = lookupIfUndefined.fold("")(b => s"lookupIfUndefined: $b")
+    s"""
+      query {
+        observation(observationId: "$oid") {
+          targetEnvironment {
+            guideEnvironment($lookup) {
+              guideTargets {
+                name
+              }
+            }
+          }
+        }
+      }
+    """
+
+  def guideTargetNameResult(expectedName: Option[String]): Either[Nothing, Json] =
+    val guideEnv = expectedName.fold(Json.Null)(name =>
+      Json.obj("guideTargets" ->
+        Json.arr(Json.obj("name" -> name.asJson))
+      )
+    )
+    json"""
+    {
+      "observation": {
+        "targetEnvironment": {
+          "guideEnvironment": $guideEnv
+        }
+      }
+    }
+    """.asRight
+
   val emptyGuideEnvironmentResults =
     json"""
     {
       "observation": {
         "title": "V1647 Orionis",
         "targetEnvironment": {
-          "guideEnvironments": [
-          ]
+          "guideEnvironments": null
         }
       }
     }
-    """
+    """.asRight
 
-  val guideEnvironmentResults =
+  val defaultGuideEnvironmentResults =
     json"""
     {
       "observation": {
         "title": "V1647 Orionis",
         "targetEnvironment": {
-          "guideEnvironments": [
-            {
-              "posAngle": {
-                "degrees": 160.000000
-              },
-              "guideTargets": [
-                {
-                  "name": "Gaia DR3 3219118090462918016",
-                  "probe": "GMOS_OIWFS",
-                  "sourceProfile": {
-                    "point": {
-                      "bandNormalized": {
-                        "brightnesses": [
-                          {
-                            "band": "GAIA_RP"
-                          }
-                        ]
-                      }
-                    }
-                  },
-                  "sidereal": {
-                    "catalogInfo": {
-                      "name": "GAIA",
-                      "id": "3219118090462918016",
-                      "objectType": null
-                    },
-                    "epoch": "J2023.660",
-                    "ra": {
-                      "microseconds": 20782434012,
-                      "hms": "05:46:22.434012",
-                      "hours": 5.772898336666666666666666666666667,
-                      "degrees": 86.59347505
-                    },
-                    "dec": {
-                      "dms": "-00:08:52.651136",
-                      "degrees": 359.8520413511111,
-                      "microarcseconds": 1295467348864
-                    },
-                    "radialVelocity": {
-                      "metersPerSecond": 0,
-                      "centimetersPerSecond": 0,
-                      "kilometersPerSecond": 0
-                    },
-                    "properMotion": {
-                      "ra": {
-                        "microarcsecondsPerYear": 438,
-                        "milliarcsecondsPerYear": 0.438
-                      },
-                      "dec": {
-                        "microarcsecondsPerYear": -741,
-                        "milliarcsecondsPerYear": -0.741
-                      }
-                    },
-                    "parallax": {
-                      "microarcseconds": 2432,
-                      "milliarcseconds": 2.432
-                    }
-                  },
-                  "nonsidereal": null
-                }
-              ]
+          "guideEnvironment": {
+            "posAngle": {
+              "degrees": 160.000000
             },
-            {
-              "posAngle": {
-                "degrees": 270.000000
-              },
-              "guideTargets": [
-                {
-                  "name": "Gaia DR3 3219118640218737920",
-                  "probe": "GMOS_OIWFS",
-                  "sourceProfile": {
-                    "point": {
-                      "bandNormalized": {
-                        "brightnesses": [
-                          {
-                            "band": "GAIA_RP"
-                          }
-                        ]
-                      }
+            "guideTargets": [
+              {
+                "name": "Gaia DR3 3219118090462918016",
+                "probe": "GMOS_OIWFS",
+                "sourceProfile": {
+                  "point": {
+                    "bandNormalized": {
+                      "brightnesses": [
+                        {
+                          "band": "GAIA_RP"
+                        }
+                      ]
                     }
+                  }
+                },
+                "sidereal": {
+                  "catalogInfo": {
+                    "name": "GAIA",
+                    "id": "3219118090462918016",
+                    "objectType": null
                   },
-                  "sidereal": {
-                    "catalogInfo": {
-                      "name": "GAIA",
-                      "id": "3219118640218737920",
-                      "objectType": null
-                    },
-                    "epoch": "J2023.660",
+                  "epoch": "J2023.660",
+                  "ra": {
+                    "microseconds": 20782434012,
+                    "hms": "05:46:22.434012",
+                    "hours": 5.772898336666666666666666666666667,
+                    "degrees": 86.59347505
+                  },
+                  "dec": {
+                    "dms": "-00:08:52.651136",
+                    "degrees": 359.8520413511111,
+                    "microarcseconds": 1295467348864
+                  },
+                  "radialVelocity": {
+                    "metersPerSecond": 0,
+                    "centimetersPerSecond": 0,
+                    "kilometersPerSecond": 0
+                  },
+                  "properMotion": {
                     "ra": {
-                      "microseconds": 20760248368,
-                      "hms": "05:46:00.248368",
-                      "hours": 5.766735657777777777777777777777778,
-                      "degrees": 86.50103486666666666666666666666667
+                      "microarcsecondsPerYear": 438,
+                      "milliarcsecondsPerYear": 0.438
                     },
                     "dec": {
-                      "dms": "-00:08:26.299165",
-                      "degrees": 359.8593613430556,
-                      "microarcseconds": 1295493700835
-                    },
-                    "radialVelocity": {
-                      "metersPerSecond": 0,
-                      "centimetersPerSecond": 0,
-                      "kilometersPerSecond": 0
-                    },
-                    "properMotion": {
-                      "ra": {
-                        "microarcsecondsPerYear": 806,
-                        "milliarcsecondsPerYear": 0.806
-                      },
-                      "dec": {
-                        "microarcsecondsPerYear": -1093,
-                        "milliarcsecondsPerYear": -1.093
-                      }
-                    },
-                    "parallax": {
-                      "microarcseconds": 2371,
-                      "milliarcseconds": 2.371
+                      "microarcsecondsPerYear": -741,
+                      "milliarcsecondsPerYear": -0.741
                     }
                   },
-                  "nonsidereal": null
-                }
-              ]
-            },
-            {
-              "posAngle": {
-                "degrees": 50.000000
-              },
-              "guideTargets": [
-                {
-                  "name": "Gaia DR3 3219142829474535424",
-                  "probe": "GMOS_OIWFS",
-                  "sourceProfile": {
-                    "point": {
-                      "bandNormalized": {
-                        "brightnesses": [
-                          {
-                            "band": "GAIA_RP"
-                          }
-                        ]
-                      }
-                    }
-                  },
-                  "sidereal": {
-                    "catalogInfo": {
-                      "name": "GAIA",
-                      "id": "3219142829474535424",
-                      "objectType": null
-                    },
-                    "epoch": "J2023.660",
-                    "ra": {
-                      "microseconds": 20782383800,
-                      "hms": "05:46:22.383800",
-                      "hours": 5.772884388888888888888888888888889,
-                      "degrees": 86.59326583333333333333333333333333
-                    },
-                    "dec": {
-                      "dms": "-00:03:38.949911",
-                      "degrees": 359.93918058027776,
-                      "microarcseconds": 1295781050089
-                    },
-                    "radialVelocity": {
-                      "metersPerSecond": 0,
-                      "centimetersPerSecond": 0,
-                      "kilometersPerSecond": 0
-                    },
-                    "properMotion": {
-                      "ra": {
-                        "microarcsecondsPerYear": -10331,
-                        "milliarcsecondsPerYear": -10.331
-                      },
-                      "dec": {
-                        "microarcsecondsPerYear": -29666,
-                        "milliarcsecondsPerYear": -29.666
-                      }
-                    },
-                    "parallax": {
-                      "microarcseconds": 2497,
-                      "milliarcseconds": 2.497
-                    }
-                  },
-                  "nonsidereal": null
-                }
-              ]
-            }
-          ]
+                  "parallax": {
+                    "microarcseconds": 2432,
+                    "milliarcseconds": 2.432
+                  }
+                },
+                "nonsidereal": null
+              }
+            ]
+          }
         }
       }
     }
-    """
+    """.asRight
+
+  val otherGuideEnvironmentResults =
+    json"""
+    {
+      "observation": {
+        "title": "V1647 Orionis",
+        "targetEnvironment": {
+          "guideEnvironment": {
+            "posAngle": {
+              "degrees": 50.000000
+            },
+            "guideTargets": [
+              {
+                "name": "Gaia DR3 3219142829474535424",
+                "probe": "GMOS_OIWFS",
+                "sourceProfile": {
+                  "point": {
+                    "bandNormalized": {
+                      "brightnesses": [
+                        {
+                          "band": "GAIA_RP"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "sidereal": {
+                  "catalogInfo": {
+                    "name": "GAIA",
+                    "id": "3219142829474535424",
+                    "objectType": null
+                  },
+                  "epoch": "J2023.660",
+                  "ra": {
+                    "microseconds": 20782383800,
+                    "hms": "05:46:22.383800",
+                    "hours": 5.772884388888888888888888888888889,
+                    "degrees": 86.59326583333333333333333333333333
+                  },
+                  "dec": {
+                    "dms": "-00:03:38.949911",
+                    "degrees": 359.93918058027776,
+                    "microarcseconds": 1295781050089
+                  },
+                  "radialVelocity": {
+                    "metersPerSecond": 0,
+                    "centimetersPerSecond": 0,
+                    "kilometersPerSecond": 0
+                  },
+                  "properMotion": {
+                    "ra": {
+                      "microarcsecondsPerYear": -10331,
+                      "milliarcsecondsPerYear": -10.331
+                    },
+                    "dec": {
+                      "microarcsecondsPerYear": -29666,
+                      "milliarcsecondsPerYear": -29.666
+                    }
+                  },
+                  "parallax": {
+                    "microarcseconds": 2497,
+                    "milliarcseconds": 2.497
+                  }
+                },
+                "nonsidereal": null
+              }
+            ]
+          }
+        }
+      }
+    }
+    """.asRight
 
   override def httpRequestHandler: Request[IO] => Resource[IO, Response[IO]] =
     req => {
-      val respStr =
-        if (req.uri.renderString.contains("20-0.10137")) gaiaReponseString else gaiaEmptyReponseString
-      Resource.eval(IO.pure(Response(body = Stream(respStr).through(utf8.encode))))
+      val renderStr = req.uri.renderString
+      if (renderStr.contains("20-0.10195")) {
+        Resource.eval(IO.raiseError(Exception("Test failure, unexpected call to Gaia!!!")))
+      } else {
+        val respStr =
+          if (renderStr.contains(defaultTargetId.toString)) gaiaDefaultNameReponseString
+          else if (renderStr.contains(otherTargetId.toString)) gaiaOtherNameReponseString
+          else if (renderStr.contains("20-0.10137")) gaiaReponseString
+          else gaiaEmptyReponseString
+        Resource.eval(IO.pure(Response(body = Stream(respStr).through(utf8.encode))))
+      }
     }
-
-  test("successfully obtain guide environment") {
-    val setup: IO[Observation.Id] =
-      for {
-        p <- createProgramAs(pi)
-        t <- createTargetWithProfileAs(pi, p)
-        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
-      } yield o
-    setup.flatMap { oid =>
-      expect(pi, guideEnvironmentQuery(oid, aug2023), expected = guideEnvironmentResults.asRight)
-    }
-  }
 
   test("no science targets") {
     val setup: IO[Observation.Id] =
       for {
         p <- createProgramAs(pi)
         o <- createGmosNorthLongSlitObservationAs(pi, p, List.empty)
+        _ <- setObservationTimeAndDuration(pi, o, gaiaError.some, none)
       } yield o
     setup.flatMap { oid =>
-      expect(pi, guideEnvironmentQuery(oid, aug2023),
-      expected = List(s"No targets have been defined for observation $oid.").asLeft)
+      expect(
+        pi,
+        guideEnvironmentQuery(oid),
+        expected = List(s"No targets have been defined for observation $oid.").asLeft)
     }
   }
 
@@ -513,9 +671,13 @@ class guideEnvironment extends ExecutionTestSupport {
         p <- createProgramAs(pi)
         t <- createTargetWithProfileAs(pi, p)
         o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, gaiaEmpty.some, none)
       } yield o
     setup.flatMap { oid =>
-      expect(pi, guideEnvironmentQuery(oid, aug3000), expected = emptyGuideEnvironmentResults.asRight)
+      expect(
+        pi,
+        guideEnvironmentQuery(oid),
+        expected = List("No potential guidestars found on Gaia.").asLeft)
     }
   }
 
@@ -525,10 +687,120 @@ class guideEnvironment extends ExecutionTestSupport {
         p <- createProgramAs(pi)
         t <- createTargetWithProfileAs(pi, p)
         o <- createObservationWithNoModeAs(pi, p, t)
+        _ <- setObservationTimeAndDuration(pi, o, gaiaError.some, none)
       } yield o
     setup.flatMap { oid =>
-      expect(pi, guideEnvironmentQuery(oid, aug3000),
-      expected = List(s"Could not generate a sequence from the observation $oid: observing mode").asLeft)
+      expect(
+        pi,
+        guideEnvironmentQuery(oid),
+        expected = List(s"Could not generate a sequence from the observation $oid: observing mode").asLeft)
     }
   }
+
+  test("no name set - successfully obtain guide environment") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
+      } yield o
+    setup.flatMap { oid =>
+      expect(pi, guideEnvironmentQuery(oid), expected = defaultGuideEnvironmentResults)
+    }
+  }
+
+  test("no name set - successfully obtain guide target name") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
+      } yield o
+    setup.flatMap { oid =>
+      expect(pi, guideEnvironmentQuery(oid), expected = defaultGuideEnvironmentResults)
+    }
+  }
+
+  test("non-existent name set - fail to get full results") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
+        _ <- setGuideTargetName(pi, p, o, invalidTargetName.some)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideEnvironmentQuery(oid),
+        expected = List(s"Error calling Gaia: Star with id $invalidTargetId not found on Gaia.").asLeft)
+    }
+  }
+
+  test("non-existent name set, lookup true - successfully get name only") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
+        _ <- setGuideTargetName(pi, p, o, invalidTargetName.some)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideTargetNameQuery(oid, true.some),
+        expected = guideTargetNameResult(invalidTargetName.some))
+    }
+  }
+
+  test("non-existent name set, lookup false - successfully get name only") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
+        _ <- setGuideTargetName(pi, p, o, invalidTargetName.some)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideTargetNameQuery(oid, false.some),
+        expected = guideTargetNameResult(invalidTargetName.some))
+    }
+  }
+
+  test("name set to default - call gaia") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
+        _ <- setGuideTargetName(pi, p, o, defaultTargetName.some)
+      } yield o
+    setup.flatMap { oid =>
+      expect(pi, guideEnvironmentQuery(oid), expected = defaultGuideEnvironmentResults)
+    }
+  }
+
+  test("name set to other usable - call gaia") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
+        _ <- setGuideTargetName(pi, p, o, otherTargetName.some)
+      } yield o
+    setup.flatMap { oid =>
+      expect(pi, guideEnvironmentQuery(oid), expected = otherGuideEnvironmentResults)
+    }
+  }
+
 }
+

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
@@ -730,7 +730,7 @@ class guideEnvironment extends ExecutionTestSupport {
         t <- createTargetWithProfileAs(pi, p)
         o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
         _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
-        _ <- setGuideTargetName(pi, p, o, invalidTargetName.some)
+        _ <- setGuideTargetName(pi, o, invalidTargetName.some)
       } yield o
     setup.flatMap { oid =>
       expect(
@@ -747,7 +747,7 @@ class guideEnvironment extends ExecutionTestSupport {
         t <- createTargetWithProfileAs(pi, p)
         o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
         _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
-        _ <- setGuideTargetName(pi, p, o, invalidTargetName.some)
+        _ <- setGuideTargetName(pi, o, invalidTargetName.some)
       } yield o
     setup.flatMap { oid =>
       expect(
@@ -764,7 +764,7 @@ class guideEnvironment extends ExecutionTestSupport {
         t <- createTargetWithProfileAs(pi, p)
         o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
         _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
-        _ <- setGuideTargetName(pi, p, o, invalidTargetName.some)
+        _ <- setGuideTargetName(pi, o, invalidTargetName.some)
       } yield o
     setup.flatMap { oid =>
       expect(
@@ -781,7 +781,7 @@ class guideEnvironment extends ExecutionTestSupport {
         t <- createTargetWithProfileAs(pi, p)
         o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
         _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
-        _ <- setGuideTargetName(pi, p, o, defaultTargetName.some)
+        _ <- setGuideTargetName(pi, o, defaultTargetName.some)
       } yield o
     setup.flatMap { oid =>
       expect(pi, guideEnvironmentQuery(oid), expected = defaultGuideEnvironmentResults)
@@ -795,7 +795,7 @@ class guideEnvironment extends ExecutionTestSupport {
         t <- createTargetWithProfileAs(pi, p)
         o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
         _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
-        _ <- setGuideTargetName(pi, p, o, otherTargetName.some)
+        _ <- setGuideTargetName(pi, o, otherTargetName.some)
       } yield o
     setup.flatMap { oid =>
       expect(pi, guideEnvironmentQuery(oid), expected = otherGuideEnvironmentResults)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironments.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironments.scala
@@ -1,0 +1,534 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package query
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.syntax.all.*
+import fs2.Stream
+import fs2.text.utf8
+import io.circe.Json
+import io.circe.literal.*
+import lucuma.core.model.Observation
+import org.http4s.Request
+import org.http4s.Response
+
+class guideEnvironments extends ExecutionTestSupport {
+
+  val aug2023 = "2023-08-30T00:00:00Z"
+  val aug3000 = "3000-08-30T00:00:00Z"
+
+  val gaiaReponseString =
+  """<?xml version="1.0" encoding="UTF-8"?>
+  |<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/v1.3">
+  |    <RESOURCE type="results">
+  |        <INFO name="QUERY_STATUS" value="OK" />
+  |        <INFO name="QUERY" value="SELECT TOP 100 source_id,ra,pmra,dec,pmdec,parallax,radial_velocity,phot_g_mean_mag,phot_rp_mean_mag 
+  |     FROM gaiadr3.gaia_source_lite
+  |     WHERE CONTAINS(POINT(&#039;ICRS&#039;,ra,dec),CIRCLE(&#039;ICRS&#039;, 86.55474, -0.10137, 0.08167))=1
+  |     and ((phot_rp_mean_mag &lt; 17.228) or (phot_g_mean_mag &lt; 17.228))
+  |     and (ruwe &lt; 1.4)
+  |     ORDER BY phot_g_mean_mag
+  |      ">
+  |            <![CDATA[SELECT TOP 100 source_id,ra,pmra,dec,pmdec,parallax,radial_velocity,phot_g_mean_mag,phot_rp_mean_mag 
+  |     FROM gaiadr3.gaia_source_lite
+  |     WHERE CONTAINS(POINT('ICRS',ra,dec),CIRCLE('ICRS', 86.55474, -0.10137, 0.08167))=1
+  |     and ((phot_rp_mean_mag < 17.228) or (phot_g_mean_mag < 17.228))
+  |     and (ruwe < 1.4)
+  |     ORDER BY phot_g_mean_mag
+  |      ]]>
+  |        </INFO>
+  |        <INFO name="CAPTION" value="How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html">
+  |            <![CDATA[How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html]]>
+  |        </INFO>
+  |        <INFO name="CITATION" value="How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html" ucd="meta.bib">
+  |            <![CDATA[How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html]]>
+  |        </INFO>
+  |        <INFO name="PAGE" value="" />
+  |        <INFO name="PAGE_SIZE" value="" />
+  |        <INFO name="JOBID" value="1693412462905O">
+  |            <![CDATA[1693412462905O]]>
+  |        </INFO>
+  |        <INFO name="JOBNAME" value="" />
+  |        <COOSYS ID="GAIADR3" epoch="J2016.0" system="ICRS" />
+  |        <RESOURCE>
+  |            <COOSYS ID="t14806478-coosys-1" epoch="J2016.0" system="ICRS"/>
+  |        </RESOURCE>
+  |        <TABLE>
+  |            <FIELD datatype="long" name="source_id" ucd="meta.id">
+  |                <DESCRIPTION>Unique source identifier (unique within a particular Data Release)</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="ra" ref="t14806478-coosys-1" ucd="pos.eq.ra;meta.main" unit="deg" utype="Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C1">
+  |                <DESCRIPTION>Right ascension</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="pmra" ucd="pos.pm;pos.eq.ra" unit="mas.yr**-1">
+  |                <DESCRIPTION>Proper motion in right ascension direction</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="dec" ref="t14806478-coosys-1" ucd="pos.eq.dec;meta.main" unit="deg" utype="Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C2">
+  |                <DESCRIPTION>Declination</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="pmdec" ucd="pos.pm;pos.eq.dec" unit="mas.yr**-1">
+  |                <DESCRIPTION>Proper motion in declination direction</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="parallax" ucd="pos.parallax.trig" unit="mas">
+  |                <DESCRIPTION>Parallax</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="float" name="radial_velocity" ucd="spect.dopplerVeloc.opt;em.opt.I" unit="km.s**-1">
+  |                <DESCRIPTION>Radial velocity</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="float" name="phot_g_mean_mag" ucd="phot.mag;em.opt" unit="mag">
+  |                <DESCRIPTION>G-band mean magnitude</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="float" name="phot_rp_mean_mag" ucd="phot.mag;em.opt.R" unit="mag">
+  |                <DESCRIPTION>Integrated RP mean magnitude</DESCRIPTION>
+  |            </FIELD>
+  |            <DATA>
+  |                <TABLEDATA>
+  |                    <TR>
+  |                        <TD>3219118090462918016</TD>
+  |                        <TD>86.5934741222927</TD>
+  |                        <TD>0.43862335651876644</TD>
+  |                        <TD>-0.14795707230703778</TD>
+  |                        <TD>-0.7414519014405084</TD>
+  |                        <TD>2.4315367202517466</TD>
+  |                        <TD>10.090042</TD>
+  |                        <TD>14.204175</TD>
+  |                        <TD>13.172072</TD>
+  |                    </TR>
+  |                    <TR>
+  |                        <TD>3219142829474535424</TD>
+  |                        <TD>86.59328782338685</TD>
+  |                        <TD>-10.331736040138617</TD>
+  |                        <TD>-0.06075629321549123</TD>
+  |                        <TD>-29.666695525022078</TD>
+  |                        <TD>2.496796996582742</TD>
+  |                        <TD></TD>
+  |                        <TD>15.189251</TD>
+  |                        <TD>14.364465</TD>
+  |                    </TR>
+  |                    <TR>
+  |                        <TD>3219118640218737920</TD>
+  |                        <TD>86.50103315602114</TD>
+  |                        <TD>0.8061180282403659</TD>
+  |                        <TD>-0.1406363314163743</TD>
+  |                        <TD>-1.0936840305376552</TD>
+  |                        <TD>2.3714995175435116</TD>
+  |                        <TD></TD>
+  |                        <TD>15.209204</TD>
+  |                        <TD>13.883842</TD>
+  |                    </TR>
+  |                </TABLEDATA>
+  |            </DATA>
+  |        </TABLE>
+  |    </RESOURCE>
+  |</VOTABLE>""".stripMargin
+
+  val gaiaEmptyReponseString = 
+  """<?xml version="1.0" encoding="UTF-8"?>
+  |<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/v1.3">
+  |    <RESOURCE type="results">
+  |        <INFO name="QUERY_STATUS" value="OK" />
+  |        <INFO name="QUERY" value="SELECT TOP 100 source_id,ra,pmra,dec,pmdec,parallax,radial_velocity,phot_g_mean_mag,phot_rp_mean_mag 
+  |     FROM gaiadr3.gaia_source_lite
+  |     WHERE CONTAINS(POINT(&#039;ICRS&#039;,ra,dec),CIRCLE(&#039;ICRS&#039;, 86.55474, -0.10137, 0.08167))=1
+  |     and ((phot_rp_mean_mag &lt; 17.228) or (phot_g_mean_mag &lt; 17.228))
+  |     and (ruwe &lt; 1.4)
+  |     ORDER BY phot_g_mean_mag
+  |      ">
+  |            <![CDATA[SELECT TOP 100 source_id,ra,pmra,dec,pmdec,parallax,radial_velocity,phot_g_mean_mag,phot_rp_mean_mag 
+  |     FROM gaiadr3.gaia_source_lite
+  |     WHERE CONTAINS(POINT('ICRS',ra,dec),CIRCLE('ICRS', 86.55474, -0.10137, 0.08167))=1
+  |     and ((phot_rp_mean_mag < 17.228) or (phot_g_mean_mag < 17.228))
+  |     and (ruwe < 1.4)
+  |     ORDER BY phot_g_mean_mag
+  |      ]]>
+  |        </INFO>
+  |        <INFO name="CAPTION" value="How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html">
+  |            <![CDATA[How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html]]>
+  |        </INFO>
+  |        <INFO name="CITATION" value="How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html" ucd="meta.bib">
+  |            <![CDATA[How to cite and acknowledge Gaia: https://gea.esac.esa.int/archive/documentation/credits.html]]>
+  |        </INFO>
+  |        <INFO name="PAGE" value="" />
+  |        <INFO name="PAGE_SIZE" value="" />
+  |        <INFO name="JOBID" value="1693412462905O">
+  |            <![CDATA[1693412462905O]]>
+  |        </INFO>
+  |        <INFO name="JOBNAME" value="" />
+  |        <COOSYS ID="GAIADR3" epoch="J2016.0" system="ICRS" />
+  |        <RESOURCE>
+  |            <COOSYS ID="t14806478-coosys-1" epoch="J2016.0" system="ICRS"/>
+  |        </RESOURCE>
+  |        <TABLE>
+  |            <FIELD datatype="long" name="source_id" ucd="meta.id">
+  |                <DESCRIPTION>Unique source identifier (unique within a particular Data Release)</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="ra" ref="t14806478-coosys-1" ucd="pos.eq.ra;meta.main" unit="deg" utype="Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C1">
+  |                <DESCRIPTION>Right ascension</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="pmra" ucd="pos.pm;pos.eq.ra" unit="mas.yr**-1">
+  |                <DESCRIPTION>Proper motion in right ascension direction</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="dec" ref="t14806478-coosys-1" ucd="pos.eq.dec;meta.main" unit="deg" utype="Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C2">
+  |                <DESCRIPTION>Declination</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="pmdec" ucd="pos.pm;pos.eq.dec" unit="mas.yr**-1">
+  |                <DESCRIPTION>Proper motion in declination direction</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="double" name="parallax" ucd="pos.parallax.trig" unit="mas">
+  |                <DESCRIPTION>Parallax</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="float" name="radial_velocity" ucd="spect.dopplerVeloc.opt;em.opt.I" unit="km.s**-1">
+  |                <DESCRIPTION>Radial velocity</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="float" name="phot_g_mean_mag" ucd="phot.mag;em.opt" unit="mag">
+  |                <DESCRIPTION>G-band mean magnitude</DESCRIPTION>
+  |            </FIELD>
+  |            <FIELD datatype="float" name="phot_rp_mean_mag" ucd="phot.mag;em.opt.R" unit="mag">
+  |                <DESCRIPTION>Integrated RP mean magnitude</DESCRIPTION>
+  |            </FIELD>
+  |            <DATA>
+  |                <TABLEDATA>
+  |                </TABLEDATA>
+  |            </DATA>
+  |        </TABLE>
+  |    </RESOURCE>
+  |</VOTABLE>""".stripMargin
+
+  def guideEnvironmentQuery(oid: Observation.Id, obsTime: String) =
+    s"""
+      query {
+        observation(observationId: "$oid") {
+          title
+          targetEnvironment {
+            guideEnvironments(observationTime: "$obsTime") {
+              posAngle {
+                degrees
+              }
+              guideTargets {
+                name
+                probe
+                sourceProfile {
+                  point {
+                    bandNormalized {
+                      brightnesses {
+                        band
+                      }
+                    }
+                  }
+                }
+                sidereal {
+                  catalogInfo {
+                    name
+                    id
+                    objectType
+                  }
+                  epoch
+                  ra {
+                    microseconds
+                    hms
+                    hours
+                    degrees
+                  }
+                  dec {
+                    dms
+                    degrees
+                    microarcseconds
+                  }
+                  radialVelocity {
+                    metersPerSecond
+                    centimetersPerSecond
+                    kilometersPerSecond
+                  }
+                  properMotion {
+                    ra {
+                      microarcsecondsPerYear
+                      milliarcsecondsPerYear
+                    }
+                    dec {
+                      microarcsecondsPerYear
+                      milliarcsecondsPerYear
+                    }
+                  }
+                  parallax {
+                    microarcseconds
+                    milliarcseconds
+                  }
+                }
+                nonsidereal {
+                  des
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+  val emptyGuideEnvironmentResults =
+    json"""
+    {
+      "observation": {
+        "title": "V1647 Orionis",
+        "targetEnvironment": {
+          "guideEnvironments": [
+          ]
+        }
+      }
+    }
+    """
+
+  val guideEnvironmentResults =
+    json"""
+    {
+      "observation": {
+        "title": "V1647 Orionis",
+        "targetEnvironment": {
+          "guideEnvironments": [
+            {
+              "posAngle": {
+                "degrees": 160.000000
+              },
+              "guideTargets": [
+                {
+                  "name": "Gaia DR3 3219118090462918016",
+                  "probe": "GMOS_OIWFS",
+                  "sourceProfile": {
+                    "point": {
+                      "bandNormalized": {
+                        "brightnesses": [
+                          {
+                            "band": "GAIA_RP"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "sidereal": {
+                    "catalogInfo": {
+                      "name": "GAIA",
+                      "id": "3219118090462918016",
+                      "objectType": null
+                    },
+                    "epoch": "J2023.660",
+                    "ra": {
+                      "microseconds": 20782434012,
+                      "hms": "05:46:22.434012",
+                      "hours": 5.772898336666666666666666666666667,
+                      "degrees": 86.59347505
+                    },
+                    "dec": {
+                      "dms": "-00:08:52.651136",
+                      "degrees": 359.8520413511111,
+                      "microarcseconds": 1295467348864
+                    },
+                    "radialVelocity": {
+                      "metersPerSecond": 0,
+                      "centimetersPerSecond": 0,
+                      "kilometersPerSecond": 0
+                    },
+                    "properMotion": {
+                      "ra": {
+                        "microarcsecondsPerYear": 438,
+                        "milliarcsecondsPerYear": 0.438
+                      },
+                      "dec": {
+                        "microarcsecondsPerYear": -741,
+                        "milliarcsecondsPerYear": -0.741
+                      }
+                    },
+                    "parallax": {
+                      "microarcseconds": 2432,
+                      "milliarcseconds": 2.432
+                    }
+                  },
+                  "nonsidereal": null
+                }
+              ]
+            },
+            {
+              "posAngle": {
+                "degrees": 270.000000
+              },
+              "guideTargets": [
+                {
+                  "name": "Gaia DR3 3219118640218737920",
+                  "probe": "GMOS_OIWFS",
+                  "sourceProfile": {
+                    "point": {
+                      "bandNormalized": {
+                        "brightnesses": [
+                          {
+                            "band": "GAIA_RP"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "sidereal": {
+                    "catalogInfo": {
+                      "name": "GAIA",
+                      "id": "3219118640218737920",
+                      "objectType": null
+                    },
+                    "epoch": "J2023.660",
+                    "ra": {
+                      "microseconds": 20760248368,
+                      "hms": "05:46:00.248368",
+                      "hours": 5.766735657777777777777777777777778,
+                      "degrees": 86.50103486666666666666666666666667
+                    },
+                    "dec": {
+                      "dms": "-00:08:26.299165",
+                      "degrees": 359.8593613430556,
+                      "microarcseconds": 1295493700835
+                    },
+                    "radialVelocity": {
+                      "metersPerSecond": 0,
+                      "centimetersPerSecond": 0,
+                      "kilometersPerSecond": 0
+                    },
+                    "properMotion": {
+                      "ra": {
+                        "microarcsecondsPerYear": 806,
+                        "milliarcsecondsPerYear": 0.806
+                      },
+                      "dec": {
+                        "microarcsecondsPerYear": -1093,
+                        "milliarcsecondsPerYear": -1.093
+                      }
+                    },
+                    "parallax": {
+                      "microarcseconds": 2371,
+                      "milliarcseconds": 2.371
+                    }
+                  },
+                  "nonsidereal": null
+                }
+              ]
+            },
+            {
+              "posAngle": {
+                "degrees": 50.000000
+              },
+              "guideTargets": [
+                {
+                  "name": "Gaia DR3 3219142829474535424",
+                  "probe": "GMOS_OIWFS",
+                  "sourceProfile": {
+                    "point": {
+                      "bandNormalized": {
+                        "brightnesses": [
+                          {
+                            "band": "GAIA_RP"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "sidereal": {
+                    "catalogInfo": {
+                      "name": "GAIA",
+                      "id": "3219142829474535424",
+                      "objectType": null
+                    },
+                    "epoch": "J2023.660",
+                    "ra": {
+                      "microseconds": 20782383800,
+                      "hms": "05:46:22.383800",
+                      "hours": 5.772884388888888888888888888888889,
+                      "degrees": 86.59326583333333333333333333333333
+                    },
+                    "dec": {
+                      "dms": "-00:03:38.949911",
+                      "degrees": 359.93918058027776,
+                      "microarcseconds": 1295781050089
+                    },
+                    "radialVelocity": {
+                      "metersPerSecond": 0,
+                      "centimetersPerSecond": 0,
+                      "kilometersPerSecond": 0
+                    },
+                    "properMotion": {
+                      "ra": {
+                        "microarcsecondsPerYear": -10331,
+                        "milliarcsecondsPerYear": -10.331
+                      },
+                      "dec": {
+                        "microarcsecondsPerYear": -29666,
+                        "milliarcsecondsPerYear": -29.666
+                      }
+                    },
+                    "parallax": {
+                      "microarcseconds": 2497,
+                      "milliarcseconds": 2.497
+                    }
+                  },
+                  "nonsidereal": null
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+    """
+
+  override def httpRequestHandler: Request[IO] => Resource[IO, Response[IO]] =
+    req => {
+      val respStr =
+        if (req.uri.renderString.contains("20-0.10137")) gaiaReponseString else gaiaEmptyReponseString
+      Resource.eval(IO.pure(Response(body = Stream(respStr).through(utf8.encode))))
+    }
+
+  test("successfully obtain guide environment") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      expect(pi, guideEnvironmentQuery(oid, aug2023), expected = guideEnvironmentResults.asRight)
+    }
+  }
+
+  test("no science targets") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List.empty)
+      } yield o
+    setup.flatMap { oid =>
+      expect(pi, guideEnvironmentQuery(oid, aug2023),
+      expected = List(s"No targets have been defined for observation $oid.").asLeft)
+    }
+  }
+
+  test("no guide stars") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      expect(pi, guideEnvironmentQuery(oid, aug3000), expected = emptyGuideEnvironmentResults.asRight)
+    }
+  }
+
+  test("no configuration") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationWithNoModeAs(pi, p, t)
+      } yield o
+    setup.flatMap { oid =>
+      expect(pi, guideEnvironmentQuery(oid, aug3000),
+      expected = List(s"Could not generate a sequence from the observation $oid: observing mode").asLeft)
+    }
+  }
+}

--- a/modules/service/src/test/scala/lucuma/odb/service/GuideServiceAvailabilityHashSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/GuideServiceAvailabilityHashSuite.scala
@@ -4,6 +4,8 @@
 package lucuma.odb.service
 
 import cats.syntax.all.*
+import lucuma.ags.GuideStarName
+import lucuma.ags.arb.ArbGuideStarName
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Wavelength
 import lucuma.core.math.arb.*
@@ -11,6 +13,8 @@ import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Observation
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.arb.*
+import lucuma.core.util.TimeSpan
+import lucuma.core.util.Timestamp
 import lucuma.core.util.arb.*
 import lucuma.odb.data.Md5Hash
 import lucuma.odb.data.arb.ArbMd5Hash
@@ -18,12 +22,15 @@ import lucuma.odb.service.GuideService.ObservationInfo
 import munit.ScalaCheckSuite
 import org.scalacheck.Prop.*
 
-class GuideServiceHashSuite  extends ScalaCheckSuite {
+class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
   import ArbConstraintSet.given
   import ArbCoordinates.given
   import ArbGid.given
+  import ArbGuideStarName.given
   import ArbMd5Hash.given
   import ArbPosAngleConstraint.given
+  import ArbTimeSpan.given
+  import ArbTimestamp.given
   import ArbWavelength.given
 
   test("hashes equal for info equal with different Observation.Id") {
@@ -34,11 +41,15 @@ class GuideServiceHashSuite  extends ScalaCheckSuite {
       pac:     PosAngleConstraint,
       ow:      Option[Wavelength],
       oc:      Option[Coordinates],
+      ot:      Option[Timestamp],
+      od:      Option[TimeSpan],
+      gs:      Option[GuideStarName],
+      gsHash:  Option[Md5Hash],
       genHash: Md5Hash
     ) =>
-      val obsInfo1 = ObservationInfo(obsId1, cs, pac, ow, oc)
-      val obsInfo2 = ObservationInfo(obsId2, cs, pac, ow, oc)
-      assertEquals(obsInfo1.hash(genHash), obsInfo2.hash(genHash))
+      val obsInfo1 = ObservationInfo(obsId1, cs, pac, ow, oc, ot, od, gs, gsHash)
+      val obsInfo2 = ObservationInfo(obsId2, cs, pac, ow, oc, ot, od, gs, gsHash)
+      assertEquals(obsInfo1.availabilityHash(genHash), obsInfo2.availabilityHash(genHash))
     }
   }
 
@@ -49,11 +60,15 @@ class GuideServiceHashSuite  extends ScalaCheckSuite {
       pac:      PosAngleConstraint,
       ow:       Option[Wavelength],
       oc:       Option[Coordinates],
+      ot:       Option[Timestamp],
+      od:       Option[TimeSpan],
+      gs:       Option[GuideStarName],
+      gsHash:   Option[Md5Hash],
       genHash1: Md5Hash,
       genHash2: Md5Hash
     ) =>
-      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc).hash(genHash1)
-      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc).hash(genHash2)
+      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od, gs, gsHash).availabilityHash(genHash1)
+      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od, gs, gsHash).availabilityHash(genHash2)
 
       if (genHash1 === genHash2)
         assertEquals(hash1, hash2)
@@ -70,10 +85,14 @@ class GuideServiceHashSuite  extends ScalaCheckSuite {
       pac:     PosAngleConstraint,
       ow:      Option[Wavelength],
       oc:      Option[Coordinates],
+      ot:      Option[Timestamp],
+      od:      Option[TimeSpan],
+      gs:      Option[GuideStarName],
+      gsHash:  Option[Md5Hash],
       genHash: Md5Hash
     ) =>
-      val hash1 = ObservationInfo(obsId, cs1, pac, ow, oc).hash(genHash)
-      val hash2 = ObservationInfo(obsId, cs2, pac, ow, oc).hash(genHash)
+      val hash1 = ObservationInfo(obsId, cs1, pac, ow, oc, ot, od, gs, gsHash).availabilityHash(genHash)
+      val hash2 = ObservationInfo(obsId, cs2, pac, ow, oc, ot, od, gs, gsHash).availabilityHash(genHash)
 
       if (cs1 === cs2)
         assertEquals(hash1, hash2)
@@ -90,13 +109,17 @@ class GuideServiceHashSuite  extends ScalaCheckSuite {
       pac2:    PosAngleConstraint,
       ow:      Option[Wavelength],
       oc:      Option[Coordinates],
+      ot:      Option[Timestamp],
+      od:      Option[TimeSpan],
+      gs:      Option[GuideStarName],
+      gsHash:  Option[Md5Hash],
       genHash: Md5Hash
     ) =>
-      val obsInfo1 = ObservationInfo(obsId, cs, pac1, ow, oc)
-      val obsInfo2 = ObservationInfo(obsId, cs, pac2, ow, oc)
+      val obsInfo1 = ObservationInfo(obsId, cs, pac1, ow, oc, ot, od, gs, gsHash)
+      val obsInfo2 = ObservationInfo(obsId, cs, pac2, ow, oc, ot, od, gs, gsHash)
 
-      val hash1 = obsInfo1.hash(genHash)
-      val hash2 = obsInfo2.hash(genHash)
+      val hash1 = obsInfo1.availabilityHash(genHash)
+      val hash2 = obsInfo2.availabilityHash(genHash)
 
       // hash just depends on the angles we need to check. So, for example,
       // unconstrained is the same as average parallactic
@@ -115,10 +138,14 @@ class GuideServiceHashSuite  extends ScalaCheckSuite {
       ow1:     Option[Wavelength],
       ow2:     Option[Wavelength],
       oc:      Option[Coordinates],
+      ot:      Option[Timestamp],
+      od:      Option[TimeSpan],
+      gs:      Option[GuideStarName],
+      gsHash:  Option[Md5Hash],
       genHash: Md5Hash
     ) =>
-      val hash1 = ObservationInfo(obsId, cs, pac, ow1, oc).hash(genHash)
-      val hash2 = ObservationInfo(obsId, cs, pac, ow2, oc).hash(genHash)
+      val hash1 = ObservationInfo(obsId, cs, pac, ow1, oc, ot, od, gs, gsHash).availabilityHash(genHash)
+      val hash2 = ObservationInfo(obsId, cs, pac, ow2, oc, ot, od, gs, gsHash).availabilityHash(genHash)
 
       if (ow1 === ow2)
         assertEquals(hash1, hash2)
@@ -135,10 +162,14 @@ class GuideServiceHashSuite  extends ScalaCheckSuite {
       ow:      Option[Wavelength],
       oc1:     Option[Coordinates],
       oc2:     Option[Coordinates],
+      ot:      Option[Timestamp],
+      od:      Option[TimeSpan],
+      gs:      Option[GuideStarName],
+      gsHash:  Option[Md5Hash],
       genHash: Md5Hash
     ) =>
-      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc1).hash(genHash)
-      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc2).hash(genHash)
+      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc1, ot, od, gs, gsHash).availabilityHash(genHash)
+      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc2, ot, od, gs, gsHash).availabilityHash(genHash)
 
       if (oc1 === oc2)
         assertEquals(hash1, hash2)
@@ -147,4 +178,26 @@ class GuideServiceHashSuite  extends ScalaCheckSuite {
     }
   }
 
+  test("hashes equal for other parameters differing") {
+    forAll { (
+      obsId:   Observation.Id,
+      cs:      ConstraintSet,
+      pac:     PosAngleConstraint,
+      ow:      Option[Wavelength],
+      oc:      Option[Coordinates],
+      ot1:     Option[Timestamp],
+      ot2:     Option[Timestamp],
+      od1:     Option[TimeSpan],
+      od2:     Option[TimeSpan],
+      gs1:     Option[GuideStarName],
+      gs2:     Option[GuideStarName],
+      gsHash1: Option[Md5Hash],
+      gsHash2: Option[Md5Hash],
+      genHash: Md5Hash
+    ) =>
+      val obsInfo1 = ObservationInfo(obsId, cs, pac, ow, oc, ot1, od1, gs1, gsHash1)
+      val obsInfo2 = ObservationInfo(obsId, cs, pac, ow, oc, ot2, od2, gs2, gsHash2)
+      assertEquals(obsInfo1.availabilityHash(genHash), obsInfo2.availabilityHash(genHash))
+    }
+  }
 }

--- a/modules/service/src/test/scala/lucuma/odb/service/GuideServiceAvailabilityHashSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/GuideServiceAvailabilityHashSuite.scala
@@ -12,6 +12,7 @@ import lucuma.core.math.arb.*
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Observation
 import lucuma.core.model.PosAngleConstraint
+import lucuma.core.model.Program
 import lucuma.core.model.arb.*
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
@@ -37,6 +38,7 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
     forAll { (
       obsId1:  Observation.Id,
       obsId2:  Observation.Id,
+      pid:     Program.Id,
       cs:      ConstraintSet,
       pac:     PosAngleConstraint,
       ow:      Option[Wavelength],
@@ -47,8 +49,8 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
       gsHash:  Option[Md5Hash],
       genHash: Md5Hash
     ) =>
-      val obsInfo1 = ObservationInfo(obsId1, cs, pac, ow, oc, ot, od, gs, gsHash)
-      val obsInfo2 = ObservationInfo(obsId2, cs, pac, ow, oc, ot, od, gs, gsHash)
+      val obsInfo1 = ObservationInfo(obsId1, pid, cs, pac, ow, oc, ot, od, gs, gsHash)
+      val obsInfo2 = ObservationInfo(obsId2, pid, cs, pac, ow, oc, ot, od, gs, gsHash)
       assertEquals(obsInfo1.availabilityHash(genHash), obsInfo2.availabilityHash(genHash))
     }
   }
@@ -56,6 +58,7 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
   test("hashes different for different generator hashes") {
     forAll { (
       obsId:    Observation.Id,
+      pid:     Program.Id,
       cs:       ConstraintSet,
       pac:      PosAngleConstraint,
       ow:       Option[Wavelength],
@@ -67,8 +70,8 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
       genHash1: Md5Hash,
       genHash2: Md5Hash
     ) =>
-      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od, gs, gsHash).availabilityHash(genHash1)
-      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od, gs, gsHash).availabilityHash(genHash2)
+      val hash1 = ObservationInfo(obsId, pid, cs, pac, ow, oc, ot, od, gs, gsHash).availabilityHash(genHash1)
+      val hash2 = ObservationInfo(obsId, pid, cs, pac, ow, oc, ot, od, gs, gsHash).availabilityHash(genHash2)
 
       if (genHash1 === genHash2)
         assertEquals(hash1, hash2)
@@ -80,6 +83,7 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
   test("hashes different for different constraint sets") {
     forAll { (
       obsId:   Observation.Id,
+      pid:     Program.Id,
       cs1:     ConstraintSet,
       cs2:     ConstraintSet,
       pac:     PosAngleConstraint,
@@ -91,8 +95,8 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
       gsHash:  Option[Md5Hash],
       genHash: Md5Hash
     ) =>
-      val hash1 = ObservationInfo(obsId, cs1, pac, ow, oc, ot, od, gs, gsHash).availabilityHash(genHash)
-      val hash2 = ObservationInfo(obsId, cs2, pac, ow, oc, ot, od, gs, gsHash).availabilityHash(genHash)
+      val hash1 = ObservationInfo(obsId, pid, cs1, pac, ow, oc, ot, od, gs, gsHash).availabilityHash(genHash)
+      val hash2 = ObservationInfo(obsId, pid, cs2, pac, ow, oc, ot, od, gs, gsHash).availabilityHash(genHash)
 
       if (cs1 === cs2)
         assertEquals(hash1, hash2)
@@ -104,6 +108,7 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
   test("hashes different for different position angle constraints") {
     forAll { (
       obsId:   Observation.Id,
+      pid:     Program.Id,
       cs:      ConstraintSet,
       pac1:    PosAngleConstraint,
       pac2:    PosAngleConstraint,
@@ -115,8 +120,8 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
       gsHash:  Option[Md5Hash],
       genHash: Md5Hash
     ) =>
-      val obsInfo1 = ObservationInfo(obsId, cs, pac1, ow, oc, ot, od, gs, gsHash)
-      val obsInfo2 = ObservationInfo(obsId, cs, pac2, ow, oc, ot, od, gs, gsHash)
+      val obsInfo1 = ObservationInfo(obsId, pid, cs, pac1, ow, oc, ot, od, gs, gsHash)
+      val obsInfo2 = ObservationInfo(obsId, pid, cs, pac2, ow, oc, ot, od, gs, gsHash)
 
       val hash1 = obsInfo1.availabilityHash(genHash)
       val hash2 = obsInfo2.availabilityHash(genHash)
@@ -133,6 +138,7 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
   test("hashes different for different wavelengths") {
     forAll { (
       obsId:   Observation.Id,
+      pid:     Program.Id,
       cs:      ConstraintSet,
       pac:     PosAngleConstraint,
       ow1:     Option[Wavelength],
@@ -144,8 +150,8 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
       gsHash:  Option[Md5Hash],
       genHash: Md5Hash
     ) =>
-      val hash1 = ObservationInfo(obsId, cs, pac, ow1, oc, ot, od, gs, gsHash).availabilityHash(genHash)
-      val hash2 = ObservationInfo(obsId, cs, pac, ow2, oc, ot, od, gs, gsHash).availabilityHash(genHash)
+      val hash1 = ObservationInfo(obsId, pid, cs, pac, ow1, oc, ot, od, gs, gsHash).availabilityHash(genHash)
+      val hash2 = ObservationInfo(obsId, pid, cs, pac, ow2, oc, ot, od, gs, gsHash).availabilityHash(genHash)
 
       if (ow1 === ow2)
         assertEquals(hash1, hash2)
@@ -157,6 +163,7 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
   test("hashes different for different explicit base coordinates") {
     forAll { (
       obsId:   Observation.Id,
+      pid:     Program.Id,
       cs:      ConstraintSet,
       pac:     PosAngleConstraint,
       ow:      Option[Wavelength],
@@ -168,8 +175,8 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
       gsHash:  Option[Md5Hash],
       genHash: Md5Hash
     ) =>
-      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc1, ot, od, gs, gsHash).availabilityHash(genHash)
-      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc2, ot, od, gs, gsHash).availabilityHash(genHash)
+      val hash1 = ObservationInfo(obsId, pid, cs, pac, ow, oc1, ot, od, gs, gsHash).availabilityHash(genHash)
+      val hash2 = ObservationInfo(obsId, pid, cs, pac, ow, oc2, ot, od, gs, gsHash).availabilityHash(genHash)
 
       if (oc1 === oc2)
         assertEquals(hash1, hash2)
@@ -181,6 +188,8 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
   test("hashes equal for other parameters differing") {
     forAll { (
       obsId:   Observation.Id,
+      pid1:    Program.Id,
+      pid2:    Program.Id,
       cs:      ConstraintSet,
       pac:     PosAngleConstraint,
       ow:      Option[Wavelength],
@@ -195,8 +204,8 @@ class GuideServiceAvailabilityHashSuite  extends ScalaCheckSuite {
       gsHash2: Option[Md5Hash],
       genHash: Md5Hash
     ) =>
-      val obsInfo1 = ObservationInfo(obsId, cs, pac, ow, oc, ot1, od1, gs1, gsHash1)
-      val obsInfo2 = ObservationInfo(obsId, cs, pac, ow, oc, ot2, od2, gs2, gsHash2)
+      val obsInfo1 = ObservationInfo(obsId, pid1, cs, pac, ow, oc, ot1, od1, gs1, gsHash1)
+      val obsInfo2 = ObservationInfo(obsId, pid2, cs, pac, ow, oc, ot2, od2, gs2, gsHash2)
       assertEquals(obsInfo1.availabilityHash(genHash), obsInfo2.availabilityHash(genHash))
     }
   }

--- a/modules/service/src/test/scala/lucuma/odb/service/GuideServiceGuideStarHash.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/GuideServiceGuideStarHash.scala
@@ -12,6 +12,7 @@ import lucuma.core.math.arb.*
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Observation
 import lucuma.core.model.PosAngleConstraint
+import lucuma.core.model.Program
 import lucuma.core.model.arb.*
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
@@ -37,6 +38,7 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
     forAll { (
       obsId1:        Observation.Id,
       obsId2:        Observation.Id,
+      pid:           Program.Id,
       cs:            ConstraintSet,
       pac:           PosAngleConstraint,
       ow:            Option[Wavelength],
@@ -48,8 +50,8 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       genHash:       Md5Hash,
       visitDuration: TimeSpan
     ) =>
-      val obsInfo1 = ObservationInfo(obsId1, cs, pac, ow, oc, ot, od, gs, gsHash)
-      val obsInfo2 = ObservationInfo(obsId2, cs, pac, ow, oc, ot, od, gs, gsHash)
+      val obsInfo1 = ObservationInfo(obsId1, pid, cs, pac, ow, oc, ot, od, gs, gsHash)
+      val obsInfo2 = ObservationInfo(obsId2, pid, cs, pac, ow, oc, ot, od, gs, gsHash)
       assertEquals(obsInfo1.newGuideStarHash(genHash, visitDuration), obsInfo2.newGuideStarHash(genHash, visitDuration))
     }
   }
@@ -57,6 +59,7 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
   test("hashes different for different generator hashes") {
     forAll { (
       obsId:         Observation.Id,
+      pid:           Program.Id,
       cs:            ConstraintSet,
       pac:           PosAngleConstraint,
       ow:            Option[Wavelength],
@@ -69,8 +72,8 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       genHash2:      Md5Hash,
       visitDuration: TimeSpan
     ) =>
-      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash1, visitDuration)
-      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash2, visitDuration)
+      val hash1 = ObservationInfo(obsId, pid, cs, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash1, visitDuration)
+      val hash2 = ObservationInfo(obsId, pid, cs, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash2, visitDuration)
 
       if (genHash1 === genHash2)
         assertEquals(hash1, hash2)
@@ -82,6 +85,7 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
   test("hashes different for different constraint sets") {
     forAll { (
       obsId:         Observation.Id,
+      pid:           Program.Id,
       cs1:           ConstraintSet,
       cs2:           ConstraintSet,
       pac:           PosAngleConstraint,
@@ -94,8 +98,8 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       genHash:       Md5Hash,
       visitDuration: TimeSpan
     ) =>
-      val hash1 = ObservationInfo(obsId, cs1, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
-      val hash2 = ObservationInfo(obsId, cs2, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash1 = ObservationInfo(obsId, pid, cs1, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash2 = ObservationInfo(obsId, pid, cs2, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
 
       if (cs1 === cs2)
         assertEquals(hash1, hash2)
@@ -107,6 +111,7 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
   test("hashes different for different position angle constraints") {
     forAll { (
       obsId:         Observation.Id,
+      pid:           Program.Id,
       cs:            ConstraintSet,
       pac1:          PosAngleConstraint,
       pac2:          PosAngleConstraint,
@@ -119,8 +124,8 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       genHash:       Md5Hash,
       visitDuration: TimeSpan
     ) =>
-      val obsInfo1 = ObservationInfo(obsId, cs, pac1, ow, oc, ot, od, gs, gsHash)
-      val obsInfo2 = ObservationInfo(obsId, cs, pac2, ow, oc, ot, od, gs, gsHash)
+      val obsInfo1 = ObservationInfo(obsId, pid, cs, pac1, ow, oc, ot, od, gs, gsHash)
+      val obsInfo2 = ObservationInfo(obsId, pid, cs, pac2, ow, oc, ot, od, gs, gsHash)
 
       val hash1 = obsInfo1.newGuideStarHash(genHash, visitDuration)
       val hash2 = obsInfo2.newGuideStarHash(genHash, visitDuration)
@@ -135,6 +140,7 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
   test("hashes different for different wavelengths") {
     forAll { (
       obsId:         Observation.Id,
+      pid:           Program.Id,
       cs:            ConstraintSet,
       pac:           PosAngleConstraint,
       ow1:           Option[Wavelength],
@@ -147,8 +153,8 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       genHash:       Md5Hash,
       visitDuration: TimeSpan
     ) =>
-      val hash1 = ObservationInfo(obsId, cs, pac, ow1, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
-      val hash2 = ObservationInfo(obsId, cs, pac, ow2, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash1 = ObservationInfo(obsId, pid, cs, pac, ow1, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash2 = ObservationInfo(obsId, pid, cs, pac, ow2, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
 
       if (ow1 === ow2)
         assertEquals(hash1, hash2)
@@ -160,6 +166,7 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
   test("hashes different for different explicit base coordinates") {
     forAll { (
       obsId:         Observation.Id,
+      pid:           Program.Id,
       cs:            ConstraintSet,
       pac:           PosAngleConstraint,
       ow:            Option[Wavelength],
@@ -172,8 +179,8 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       genHash:       Md5Hash,
       visitDuration: TimeSpan
     ) =>
-      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc1, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
-      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc2, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash1 = ObservationInfo(obsId, pid, cs, pac, ow, oc1, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash2 = ObservationInfo(obsId, pid, cs, pac, ow, oc2, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
 
       if (oc1 === oc2)
         assertEquals(hash1, hash2)
@@ -185,6 +192,7 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
   test("hashes different for different observation times") {
     forAll { (
       obsId:         Observation.Id,
+      pid:           Program.Id,
       cs:            ConstraintSet,
       pac:           PosAngleConstraint,
       ow:            Option[Wavelength],
@@ -197,8 +205,8 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       genHash:       Md5Hash,
       visitDuration: TimeSpan
     ) =>
-      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc, ot1, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
-      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc, ot2, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash1 = ObservationInfo(obsId, pid, cs, pac, ow, oc, ot1, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash2 = ObservationInfo(obsId, pid, cs, pac, ow, oc, ot2, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
 
       if (ot1 === ot2)
         assertEquals(hash1, hash2)
@@ -210,6 +218,7 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
   test("hashes different for different durations") {
     forAll { (
       obsId:          Observation.Id,
+      pid:           Program.Id,
       cs:             ConstraintSet,
       pac:            PosAngleConstraint,
       ow:             Option[Wavelength],
@@ -222,8 +231,8 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       visitDuration1: TimeSpan,
       visitDuration2: TimeSpan
     ) =>
-      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration1)
-      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration2)
+      val hash1 = ObservationInfo(obsId, pid, cs, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration1)
+      val hash2 = ObservationInfo(obsId, pid, cs, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration2)
 
       if (visitDuration1 === visitDuration2)
         assertEquals(hash1, hash2)
@@ -235,6 +244,8 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
   test("hashes equal for other parameters differing") {
     forAll { (
       obsId:         Observation.Id,
+      pid1:          Program.Id,
+      pid2:          Program.Id,
       cs:            ConstraintSet,
       pac:           PosAngleConstraint,
       ow:            Option[Wavelength],
@@ -249,8 +260,8 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       genHash:       Md5Hash,
       visitDuration: TimeSpan
     ) =>
-      val obsInfo1 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od1, gs1, gsHash1)
-      val obsInfo2 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od2, gs2, gsHash2)
+      val obsInfo1 = ObservationInfo(obsId, pid1, cs, pac, ow, oc, ot, od1, gs1, gsHash1)
+      val obsInfo2 = ObservationInfo(obsId, pid2, cs, pac, ow, oc, ot, od2, gs2, gsHash2)
       assertEquals(obsInfo1.newGuideStarHash(genHash, visitDuration), obsInfo2.newGuideStarHash(genHash, visitDuration))
     }
   }

--- a/modules/service/src/test/scala/lucuma/odb/service/GuideServiceGuideStarHash.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/GuideServiceGuideStarHash.scala
@@ -1,0 +1,258 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service
+
+import cats.syntax.all.*
+import lucuma.ags.GuideStarName
+import lucuma.ags.arb.ArbGuideStarName
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Wavelength
+import lucuma.core.math.arb.*
+import lucuma.core.model.ConstraintSet
+import lucuma.core.model.Observation
+import lucuma.core.model.PosAngleConstraint
+import lucuma.core.model.arb.*
+import lucuma.core.util.TimeSpan
+import lucuma.core.util.Timestamp
+import lucuma.core.util.arb.*
+import lucuma.odb.data.Md5Hash
+import lucuma.odb.data.arb.ArbMd5Hash
+import lucuma.odb.service.GuideService.ObservationInfo
+import munit.ScalaCheckSuite
+import org.scalacheck.Prop.*
+
+class GuideServiceGuideStarHash extends ScalaCheckSuite {
+  import ArbConstraintSet.given
+  import ArbCoordinates.given
+  import ArbGid.given
+  import ArbGuideStarName.given
+  import ArbMd5Hash.given
+  import ArbPosAngleConstraint.given
+  import ArbTimeSpan.given
+  import ArbTimestamp.given
+  import ArbWavelength.given
+
+  test("hashes equal for info equal with different Observation.Id") {
+    forAll { (
+      obsId1:        Observation.Id,
+      obsId2:        Observation.Id,
+      cs:            ConstraintSet,
+      pac:           PosAngleConstraint,
+      ow:            Option[Wavelength],
+      oc:            Option[Coordinates],
+      ot:            Option[Timestamp],
+      od:            Option[TimeSpan],
+      gs:            Option[GuideStarName],
+      gsHash:        Option[Md5Hash],
+      genHash:       Md5Hash,
+      visitDuration: TimeSpan
+    ) =>
+      val obsInfo1 = ObservationInfo(obsId1, cs, pac, ow, oc, ot, od, gs, gsHash)
+      val obsInfo2 = ObservationInfo(obsId2, cs, pac, ow, oc, ot, od, gs, gsHash)
+      assertEquals(obsInfo1.newGuideStarHash(genHash, visitDuration), obsInfo2.newGuideStarHash(genHash, visitDuration))
+    }
+  }
+
+  test("hashes different for different generator hashes") {
+    forAll { (
+      obsId:         Observation.Id,
+      cs:            ConstraintSet,
+      pac:           PosAngleConstraint,
+      ow:            Option[Wavelength],
+      oc:            Option[Coordinates],
+      ot:            Option[Timestamp],
+      od:            Option[TimeSpan],
+      gs:            Option[GuideStarName],
+      gsHash:        Option[Md5Hash],
+      genHash1:      Md5Hash,
+      genHash2:      Md5Hash,
+      visitDuration: TimeSpan
+    ) =>
+      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash1, visitDuration)
+      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash2, visitDuration)
+
+      if (genHash1 === genHash2)
+        assertEquals(hash1, hash2)
+      else
+        assertNotEquals(hash1, hash2)
+    }
+  }
+
+  test("hashes different for different constraint sets") {
+    forAll { (
+      obsId:         Observation.Id,
+      cs1:           ConstraintSet,
+      cs2:           ConstraintSet,
+      pac:           PosAngleConstraint,
+      ow:            Option[Wavelength],
+      oc:            Option[Coordinates],
+      ot:            Option[Timestamp],
+      od:            Option[TimeSpan],
+      gs:            Option[GuideStarName],
+      gsHash:        Option[Md5Hash],
+      genHash:       Md5Hash,
+      visitDuration: TimeSpan
+    ) =>
+      val hash1 = ObservationInfo(obsId, cs1, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash2 = ObservationInfo(obsId, cs2, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+
+      if (cs1 === cs2)
+        assertEquals(hash1, hash2)
+      else
+        assertNotEquals(hash1, hash2)
+    }
+  }
+
+  test("hashes different for different position angle constraints") {
+    forAll { (
+      obsId:         Observation.Id,
+      cs:            ConstraintSet,
+      pac1:          PosAngleConstraint,
+      pac2:          PosAngleConstraint,
+      ow:            Option[Wavelength],
+      oc:            Option[Coordinates],
+      ot:            Option[Timestamp],
+      od:            Option[TimeSpan],
+      gs:            Option[GuideStarName],
+      gsHash:        Option[Md5Hash],
+      genHash:       Md5Hash,
+      visitDuration: TimeSpan
+    ) =>
+      val obsInfo1 = ObservationInfo(obsId, cs, pac1, ow, oc, ot, od, gs, gsHash)
+      val obsInfo2 = ObservationInfo(obsId, cs, pac2, ow, oc, ot, od, gs, gsHash)
+
+      val hash1 = obsInfo1.newGuideStarHash(genHash, visitDuration)
+      val hash2 = obsInfo2.newGuideStarHash(genHash, visitDuration)
+
+      if (pac1 === pac2)
+        assertEquals(hash1, hash2)
+      else
+        assertNotEquals(hash1, hash2)
+    }
+  }
+
+  test("hashes different for different wavelengths") {
+    forAll { (
+      obsId:         Observation.Id,
+      cs:            ConstraintSet,
+      pac:           PosAngleConstraint,
+      ow1:           Option[Wavelength],
+      ow2:           Option[Wavelength],
+      oc:            Option[Coordinates],
+      ot:            Option[Timestamp],
+      od:            Option[TimeSpan],
+      gs:            Option[GuideStarName],
+      gsHash:        Option[Md5Hash],
+      genHash:       Md5Hash,
+      visitDuration: TimeSpan
+    ) =>
+      val hash1 = ObservationInfo(obsId, cs, pac, ow1, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash2 = ObservationInfo(obsId, cs, pac, ow2, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+
+      if (ow1 === ow2)
+        assertEquals(hash1, hash2)
+      else
+        assertNotEquals(hash1, hash2)
+    }
+  }
+
+  test("hashes different for different explicit base coordinates") {
+    forAll { (
+      obsId:         Observation.Id,
+      cs:            ConstraintSet,
+      pac:           PosAngleConstraint,
+      ow:            Option[Wavelength],
+      oc1:           Option[Coordinates],
+      oc2:           Option[Coordinates],
+      ot:            Option[Timestamp],
+      od:            Option[TimeSpan],
+      gs:            Option[GuideStarName],
+      gsHash:        Option[Md5Hash],
+      genHash:       Md5Hash,
+      visitDuration: TimeSpan
+    ) =>
+      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc1, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc2, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+
+      if (oc1 === oc2)
+        assertEquals(hash1, hash2)
+      else
+        assertNotEquals(hash1, hash2)
+    }
+  }
+
+  test("hashes different for different observation times") {
+    forAll { (
+      obsId:         Observation.Id,
+      cs:            ConstraintSet,
+      pac:           PosAngleConstraint,
+      ow:            Option[Wavelength],
+      oc:            Option[Coordinates],
+      ot1:           Option[Timestamp],
+      ot2:           Option[Timestamp],
+      od:            Option[TimeSpan],
+      gs:            Option[GuideStarName],
+      gsHash:        Option[Md5Hash],
+      genHash:       Md5Hash,
+      visitDuration: TimeSpan
+    ) =>
+      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc, ot1, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc, ot2, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+
+      if (ot1 === ot2)
+        assertEquals(hash1, hash2)
+      else
+        assertNotEquals(hash1, hash2)
+    }
+  }
+
+  test("hashes different for different durations") {
+    forAll { (
+      obsId:          Observation.Id,
+      cs:             ConstraintSet,
+      pac:            PosAngleConstraint,
+      ow:             Option[Wavelength],
+      oc:             Option[Coordinates],
+      ot:             Option[Timestamp],
+      od:             Option[TimeSpan],
+      gs:             Option[GuideStarName],
+      gsHash:         Option[Md5Hash],
+      genHash:        Md5Hash,
+      visitDuration1: TimeSpan,
+      visitDuration2: TimeSpan
+    ) =>
+      val hash1 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration1)
+      val hash2 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration2)
+
+      if (visitDuration1 === visitDuration2)
+        assertEquals(hash1, hash2)
+      else
+        assertNotEquals(hash1, hash2)
+    }
+  }
+
+  test("hashes equal for other parameters differing") {
+    forAll { (
+      obsId:         Observation.Id,
+      cs:            ConstraintSet,
+      pac:           PosAngleConstraint,
+      ow:            Option[Wavelength],
+      oc:            Option[Coordinates],
+      ot:            Option[Timestamp],
+      od1:           Option[TimeSpan],
+      od2:           Option[TimeSpan],
+      gs1:           Option[GuideStarName],
+      gs2:           Option[GuideStarName],
+      gsHash1:       Option[Md5Hash],
+      gsHash2:       Option[Md5Hash],
+      genHash:       Md5Hash,
+      visitDuration: TimeSpan
+    ) =>
+      val obsInfo1 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od1, gs1, gsHash1)
+      val obsInfo2 = ObservationInfo(obsId, cs, pac, ow, oc, ot, od2, gs2, gsHash2)
+      assertEquals(obsInfo1.newGuideStarHash(genHash, visitDuration), obsInfo2.newGuideStarHash(genHash, visitDuration))
+    }
+  }
+  
+}


### PR DESCRIPTION
This adds a `guideEnvironment` on the in the `targetEnvironment` of the observation. Instead of returning the ordered list of potential guide stars (as `guideEnvironments` does) only a single guide star, or an error, will be returned. If a guide star name has been set, that guide star will be returned. If not set, or the observation has changed since the name was set, gaia will be queried and the "best" available guide star will be returned. There is a `lookupIfUndefined` parameter on `guideEnvironment` that explore can set to false, such that a null can be returned when the guide star is not set. And, if only the name is requested in the query gaia will not be called unless the name is not set (or is invalid) AND lookupIfUndefined is true.

I left the old `guideEnvironments` query to make it easier for navigate to convert. Once navigate is on the new `guideEnvironment`, guideEnvironments will be removed.