### PR TITLE
Make separate guide target name query for Explore

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -10828,17 +10828,13 @@ type TargetEnvironment {
   ): [GuideEnvironment!]!
 
   """
-  The guide star(s) and related information
+  The guide target(s) and related information.
+  If a guide target has been set via `guideTargetName`, that target will be
+  returned. If it not found or not usable, an error will be returned.
+  If no guide target has been set, or it has been invalidated by observation/target
+  changes, Gaia will be searched for the best guide target available.
   """
-  guideEnvironment(
-    """
-    If this is set to false, a null will be returned if a guide star is not
-    already set or the current guide star has been invalidated by changes.
-    If this is set to true, gaia will be searched to find the best guide star
-    in the above scenario.
-    """
-    lookupIfUndefined: Boolean! = true
-  ): GuideEnvironment
+  guideEnvironment: GuideEnvironment!
 
   """
   Availability of guide stars during a specified time range.
@@ -10857,6 +10853,13 @@ type TargetEnvironment {
   When set, overrides the default base position of the target group
   """
   explicitBase: Coordinates
+
+  """
+  The name of the guide target, if any, set by `setGuideTargetName`.
+  If the name is no longer valid or a sequence cannot be generated, null will
+  be returned.
+  """
+  guideTargetName: NonEmptyString
 }
 
 type TargetEnvironmentGroup {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideTargetName.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideTargetName.scala
@@ -1,0 +1,223 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package query
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.syntax.all.*
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.ags.GuideStarName
+import lucuma.core.model.Observation
+import lucuma.core.util.TimeSpan
+import lucuma.core.util.Timestamp
+import org.http4s.Request
+import org.http4s.Response
+
+class guideTargetName extends ExecutionTestSupport {
+  
+  val targetName1: String = GuideStarName.gaiaSourceId.reverseGet(1L).value.value
+
+  val ObsTime: Timestamp = Timestamp.FromString.getOption("2024-08-25T00:00:00Z").get
+  val Later: Timestamp = ObsTime.plusSecondsOption(120L).get
+
+  val ObsDuration: TimeSpan = TimeSpan.fromSeconds(32).get
+
+  def guideTargetNameQuery(oid: Observation.Id) =
+    s"""
+      query {
+        observation(observationId: "$oid") {
+          targetEnvironment {
+            guideTargetName
+          }
+        }
+      }
+    """
+
+  def guideTargetNameResult(expectedName: Option[String]): Either[Nothing, Json] =
+    json"""
+    {
+      "observation": {
+        "targetEnvironment": {
+          "guideTargetName": ${expectedName.asJson}
+        }
+      }
+    }
+    """.asRight
+
+  // This just ensures that Gaia is never called
+  override def httpRequestHandler: Request[IO] => Resource[IO, Response[IO]] =
+    _ => Resource.eval(IO.raiseError(Exception("Test failure, unexpected call to Gaia!!!")))
+
+  test("no configuration returns null") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        o <- createObservationAs(pi, p)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideTargetNameQuery(oid),
+        expected = guideTargetNameResult(none))
+    }
+  }
+
+  test("no observation time returns null") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, none, ObsDuration.some)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideTargetNameQuery(oid),
+        expected = guideTargetNameResult(none))
+    }
+  }
+
+  test("no science targets returns null") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List.empty)
+        _ <- setObservationTimeAndDuration(pi, o, ObsTime.some, none)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideTargetNameQuery(oid),
+        expected = guideTargetNameResult(none))
+    }
+  }
+
+  test("no guide target name set returns null") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, ObsTime.some, none)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideTargetNameQuery(oid),
+        expected = guideTargetNameResult(none))
+    }
+  }
+
+  test("set guide target name returns name") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, ObsTime.some, none)
+        _ <- setGuideTargetName(pi, o, targetName1.some)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideTargetNameQuery(oid),
+        expected = guideTargetNameResult(targetName1.some))
+    }
+  }
+  test("removing targets invalidates name") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, ObsTime.some, none)
+        _ <- setGuideTargetName(pi, o, targetName1.some)
+        _ <- updateAsterisms(pi, List(o), add = List.empty, del = List(t), exp = List((o -> List.empty)))
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideTargetNameQuery(oid),
+        expected = guideTargetNameResult(none))
+    }
+  }
+
+  test("unsetting guide target name invalidates name") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, ObsTime.some, none)
+        _ <- setGuideTargetName(pi, o, targetName1.some)
+        _ <- setGuideTargetName(pi, o, none)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideTargetNameQuery(oid),
+        expected = guideTargetNameResult(none))
+    }
+  }
+
+  test("unsetting observation time invalidates name") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, ObsTime.some, none)
+        _ <- setGuideTargetName(pi, o, targetName1.some)
+        _ <- setObservationTimeAndDuration(pi, o, none, none)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideTargetNameQuery(oid),
+        expected = guideTargetNameResult(none))
+    }
+  }
+
+  test("changing observation time invalidates name") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, ObsTime.some, none)
+        _ <- setGuideTargetName(pi, o, targetName1.some)
+        _ <- setObservationTimeAndDuration(pi, o, Later.some, none)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideTargetNameQuery(oid),
+        expected = guideTargetNameResult(none))
+    }
+  }
+
+  test("changing observation duration invalidates name") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, ObsTime.some, none)
+        _ <- setGuideTargetName(pi, o, targetName1.some)
+        _ <- setObservationTimeAndDuration(pi, o, ObsTime.some, ObsDuration.some)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideTargetNameQuery(oid),
+        expected = guideTargetNameResult(none))
+    }
+  }
+
+}


### PR DESCRIPTION
I was trying to use the same query for Explore and Navigate, but their needs are quite different. This adds a query so Explore can get the target name without worrying about some of the errors that Navigate expects. It modifies the guideEnvironment to have the return value to be required.