### PR TITLE
GoaProperties

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -3455,13 +3455,10 @@ input ProgramPropertiesInput {
   name: NonEmptyString
 
   """
-  Set the proprietaryMonths for this program.  This property is only applicable
-  to normal science programs (i.e., not CAL, ENG, MON programs etc.). It is
-  automatically set (or reset) when/if the program's Call For Proposals is
-  assigned.  Otherwise it defaults to 0 months but may be changed via this
-  input.
+  Sets the GOA properties for this program.  If not specified on create,
+  default values are used.
   """
-  proprietaryMonths: NonNegInt
+  goa: GoaPropertiesInput
 
   """
   Whether the program is considered deleted (defaults to PRESENT) but may be edited
@@ -7648,6 +7645,57 @@ enum GmosYBinning {
   FOUR
 }
 
+"Gemini Observatory Archive properties for a particular program."
+type GoaProperties {
+
+  """
+  How many months to withhold public access to the data.  This property is
+  applicable to science programs, defaults to the proprietary period associated
+  with the Call for Proposals if any; 0 months otherwise.
+  """
+  proprietaryMonths: NonNegInt!
+
+  """
+  Whether the PI wishes to be notified when new data are received. This property
+  is applicable to science programs and defaults to true.
+  """
+  shouldNotify: Boolean!
+
+  """
+  Whether the header (as well as the data itself) should remain private.  This
+  property is applicable to science programs and defaults to false.
+  """
+  privateHeader: Boolean!
+
+}
+
+"""
+Gemini Observatory Archive properties creation and editing input for a
+particular program.
+"""
+input GoaPropertiesInput {
+
+  """
+  How many months to withhold public access to the data.  This property is
+  applicable to science programs, defaults to the proprietary period associated
+  with the Call for Proposals if any; 0 months otherwise.
+  """
+  proprietaryMonths: NonNegInt
+
+  """
+  Whether the PI wishes to be notified when new data are received. This property
+  is applicable to science programs and defaults to true.
+  """
+  shouldNotify: Boolean
+
+  """
+  Whether the header (as well as the data itself) should remain private.  This
+  property is applicable to science programs and defaults to false.
+  """
+  privateHeader: Boolean
+
+}
+
 "A group of observations and other groups."
 type Group {
 
@@ -8917,11 +8965,9 @@ type Program {
   calibrationRole: CalibrationRole
 
   """
-  How many months to withhold public access to the data.  This property is
-  applicable to science programs, defaults to the proprietary period associated
-  with the Call for Proposals if any; 0 months otherwise.
+  Observatory archive properties related to this program.
   """
-  proprietaryMonths: NonNegInt!
+  goa: GoaProperties!
 
 }
 

--- a/modules/service/src/main/resources/db/migration/V0921__goa_properties.sql
+++ b/modules/service/src/main/resources/db/migration/V0921__goa_properties.sql
@@ -1,0 +1,10 @@
+ALTER TABLE t_program
+  RENAME COLUMN c_proprietary TO c_goa_proprietary;
+
+ALTER TABLE t_program
+  ADD COLUMN c_goa_should_notify  bool NOT NULL DEFAULT true,
+  ADD COLUMN c_goa_private_header bool NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN t_program.c_goa_should_notify IS 'Whether the GOA should send notifications for new datasets.';
+
+COMMENT ON COLUMN t_program.c_goa_private_header IS 'Whether the header should be kept private as well during the proprietary period.';

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -159,6 +159,7 @@ trait BaseMapping[F[_]]
   lazy val GmosSouthStepType                       = schema.ref("GmosSouthStep")
   lazy val GmosXBinningType                        = schema.ref("GmosXBinning")
   lazy val GmosYBinningType                        = schema.ref("GmosYBinning")
+  lazy val GoaPropertiesType                       = schema.ref("GoaProperties")
   lazy val GroupType                               = schema.ref("Group")
   lazy val GroupIdType                             = schema.ref("GroupId")
   lazy val GroupEditType                           = schema.ref("GroupEdit")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -148,6 +148,7 @@ object OdbMapping {
           with GmosLongSlitMapping[F]
           with GmosNorthStaticMapping[F]
           with GmosSouthStaticMapping[F]
+          with GoaPropertiesMapping[F]
           with GroupMapping[F]
           with GroupEditMapping[F]
           with GroupElementMapping[F]
@@ -336,6 +337,7 @@ object OdbMapping {
                 GmosNorthStaticMapping,
                 GmosSouthLongSlitMapping,
                 GmosSouthStaticMapping,
+                GoaPropertiesMapping,
                 GroupMapping,
                 GroupEditMapping,
                 GroupElementMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CreateProgramInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CreateProgramInput.scala
@@ -14,7 +14,7 @@ object CreateProgramInput {
   val Binding: Matcher[CreateProgramInput] =
     ObjectFieldsBinding.rmap {
       case List(
-        ProgramPropertiesInput.CreateBinding.Option("SET", rInput)
+        ProgramPropertiesInput.Create.Binding.Option("SET", rInput)
       ) => rInput.map(apply)
     }
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GoaPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GoaPropertiesInput.scala
@@ -1,0 +1,60 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package input
+
+import cats.syntax.parallel.*
+import eu.timepit.refined.types.numeric.NonNegInt
+import lucuma.odb.graphql.binding.*
+
+object GoaPropertiesInput:
+
+  val DefaultProprietaryMonths: NonNegInt = NonNegInt.unsafeFrom(0)
+  val DefaultShouldNotify: Boolean        = true
+  val DefaultPrivateHeader: Boolean       = false
+
+  case class Create(
+    proprietaryMonths: NonNegInt,
+    shouldNotify:      Boolean,
+    privateHeader:     Boolean
+  )
+
+  object Create:
+    val Default: Create =
+      Create(
+        DefaultProprietaryMonths,
+        DefaultShouldNotify,
+        DefaultPrivateHeader
+      )
+
+    val Binding: Matcher[Create] =
+      ObjectFieldsBinding.rmap:
+        case List(
+          NonNegIntBinding.Option("proprietaryMonths", rProprietary),
+          BooleanBinding.Option("shouldNotify", rShouldNotify),
+          BooleanBinding.Option("privateHeader", rPrivateHeader)
+        ) => (rProprietary, rShouldNotify, rPrivateHeader).parTupled.map:
+          (proprietary, shouldNotify, headerPrivate) => Create(
+            proprietary.getOrElse(DefaultProprietaryMonths),
+            shouldNotify.getOrElse(DefaultShouldNotify),
+            headerPrivate.getOrElse(DefaultPrivateHeader)
+          )
+
+  case class Edit(
+    proprietaryMonths: Option[NonNegInt],
+    shouldNotify:      Option[Boolean],
+    privateHeader:     Option[Boolean]
+  )
+
+  object Edit:
+    val Default: Edit =
+      Edit(None, None, None)
+
+    val Binding: Matcher[GoaPropertiesInput.Edit] =
+      ObjectFieldsBinding.rmap:
+        case List(
+          NonNegIntBinding.Option("proprietaryMonths", rProprietary),
+          BooleanBinding.Option("shouldNotify", rShouldNotify),
+          BooleanBinding.Option("privateHeader", rPrivateHeader)
+        ) => (rProprietary, rShouldNotify, rPrivateHeader).parTupled.map(Edit.apply)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateProgramsInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateProgramsInput.scala
@@ -24,7 +24,7 @@ object UpdateProgramsInput {
     val WhereProgramBinding = WhereProgram.binding(path)
     ObjectFieldsBinding.rmap {
       case List(
-        ProgramPropertiesInput.EditBinding("SET", rSET),
+        ProgramPropertiesInput.Edit.Binding("SET", rSET),
         WhereProgramBinding.Option("WHERE", rWHERE),
         NonNegIntBinding.Option("LIMIT", rLIMIT),
         BooleanBinding.Option("includeDeleted", rIncludeDeleted)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GoaPropertiesMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GoaPropertiesMapping.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mapping
+
+import lucuma.odb.graphql.table.ProgramTable
+
+trait GoaPropertiesMapping[F[_]] extends ProgramTable[F]:
+
+  lazy val GoaPropertiesMapping: ObjectMapping =
+    ObjectMapping(GoaPropertiesType)(
+      SqlField("synthetic_id", ProgramTable.Id, key = true, hidden = true),
+      SqlField("proprietaryMonths", ProgramTable.Goa.Proprietary),
+      SqlField("shouldNotify", ProgramTable.Goa.ShouldNotify),
+      SqlField("privateHeader", ProgramTable.Goa.PrivateHeader)
+    )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
@@ -84,7 +84,7 @@ trait ProgramMapping[F[_]]
       SqlObject("userInvitations", Join(ProgramTable.Id, UserInvitationTable.ProgramId)),
       SqlObject("allocations", Join(ProgramTable.Id, AllocationTable.ProgramId)),
       SqlField("calibrationRole", ProgramTable.CalibrationRole),
-      SqlField("proprietaryMonths", ProgramTable.Proprietary)
+      SqlObject("goa")
     )
 
   lazy val ProgramElaborator: PartialFunction[(TypeRef, String, List[Binding]), Elab[Unit]] = {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ProgramTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ProgramTable.scala
@@ -7,33 +7,33 @@ package table
 
 import grackle.skunk.SkunkMapping
 import lucuma.odb.util.Codecs.*
+import skunk.codec.boolean.bool
 
-trait ProgramTable[F[_]] extends BaseMapping[F] {
+trait ProgramTable[F[_]] extends BaseMapping[F]:
 
-  object ProgramTable extends TableDef("t_program") {
+  object ProgramTable extends TableDef("t_program"):
     val Id              = col("c_program_id", program_id)
     val Existence       = col("c_existence", existence)
     val Name            = col("c_name", text_nonempty.opt)
     val ProposalStatus  = col("c_proposal_status", tag)
     val CalibrationRole = col("c_calibration_role", calibration_role.opt)
-    val Proprietary     = col("c_proprietary", int4_nonneg)
 
-    object PlannedTime {
+    object Goa:
+      val Proprietary   = col("c_goa_proprietary", int4_nonneg)
+      val ShouldNotify  = col("c_goa_should_notify", bool)
+      val PrivateHeader = col("c_goa_private_header", bool)
+
+    object PlannedTime:
       val Pi        = col("c_pts_pi", time_span)
       val Uncharged = col("c_pts_uncharged", time_span)
       val Execution = col("c_pts_execution", time_span)
-    }
 
     val ProgramType    = col("c_program_type", program_type)
 
-    object Reference {
+    object Reference:
       val Instrument        = col("c_instrument",         instrument.opt)
       val ProgramReference  = col("c_program_reference",  program_reference.opt)
       val ProposalReference = col("c_proposal_reference", proposal_reference.opt)
       val ScienceSubtype    = col("c_science_subtype",    science_subtype.opt)
       val Semester          = col("c_semester",           semester.opt)
       val SemesterIndex     = col("c_semester_index",     int4_pos.opt)
-    }
-  }
-
-}

--- a/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
@@ -486,8 +486,8 @@ object ProposalService {
                                      WHEN ${semester.opt} IS NULL THEN c_semester
                                      ELSE ${semester.opt}
                                    END,
-               c_proprietary     = CASE
-                                     WHEN ${int4_nonneg.opt} is NULL THEN c_proprietary
+               c_goa_proprietary = CASE
+                                     WHEN ${int4_nonneg.opt} is NULL THEN c_goa_proprietary
                                      ELSE ${int4_nonneg.opt}
                                    END
          WHERE c_program_id = $program_id
@@ -502,7 +502,7 @@ object ProposalService {
           prog.c_semester,
           prog.c_science_subtype,
           COALESCE((SELECT SUM(c_percent) FROM t_partner_split WHERE c_program_id = prog.c_program_id), 0) AS c_splits_sum,
-          prog.c_proprietary,
+          prog.c_goa_proprietary,
           cfp.c_cfp_id,
           cfp.c_type,
           cfp.c_semester,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -288,12 +288,12 @@ trait DatabaseOperations { this: OdbSuite =>
     query(user, s"""
       query {
         program(programId: "$pid") {
-          proprietaryMonths
+          goa { proprietaryMonths }
         }
       }
     """).flatMap: js =>
       js.hcursor
-        .downFields("program", "proprietaryMonths")
+        .downFields("program", "goa", "proprietaryMonths")
         .success
         .traverse(_.as[Int].map(NonNegInt.unsafeFrom))
         .leftMap(f => new RuntimeException(f.message))

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/calibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/calibrations.scala
@@ -468,7 +468,7 @@ class calibrations extends OdbSuite with SubscriptionUtils {
                 s.session.transaction.use { xa =>
                   s.programService
                     .insertCalibrationProgram(
-                      ProgramPropertiesInput.Create.Empty.some,
+                      ProgramPropertiesInput.Create.Default.some,
                       CalibrationRole.SpectroPhotometric,
                       Description.unsafeFrom("SPECTROTEST"))(using xa)
                 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneTarget.scala
@@ -180,7 +180,7 @@ class cloneTarget extends OdbSuite {
               s.session.transaction.use { xa =>
                 s.programService
                   .insertCalibrationProgram(
-                    ProgramPropertiesInput.Create.Empty.some,
+                    ProgramPropertiesInput.Create.Default.some,
                     CalibrationRole.Photometric,
                     Description.unsafeFrom("PHOTO"))(using xa)
               }
@@ -220,7 +220,7 @@ class cloneTarget extends OdbSuite {
                 s.session.transaction.use { xa =>
                   s.programService
                     .insertCalibrationProgram(
-                      ProgramPropertiesInput.Create.Empty.some,
+                      ProgramPropertiesInput.Create.Default.some,
                       CalibrationRole.Telluric,
                       Description.unsafeFrom("TELLURIC"))(using xa)
                 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updatePrograms.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updatePrograms.scala
@@ -218,7 +218,7 @@ class updatePrograms extends OdbSuite {
         updatePrograms(
           input: {
             SET: {
-              proprietaryMonths: 42
+              goa: { proprietaryMonths: 42 }
             }
             WHERE: {
               id: {
@@ -229,7 +229,7 @@ class updatePrograms extends OdbSuite {
         ) {
           programs {
             id
-            proprietaryMonths
+            goa { proprietaryMonths }
           }
         }
       }
@@ -247,7 +247,57 @@ class updatePrograms extends OdbSuite {
               "programs": [
                 {
                   "id": $pid,
-                  "proprietaryMonths": 42
+                  "goa": { "proprietaryMonths": 42 }
+                }
+              ]
+            }
+          }
+          """.asRight
+      )
+  }
+
+  test("can edit other GOA properties as pi") {
+    createProgramAs(pi).flatMap: pid =>
+      expect(
+        user = pi,
+        query = s"""
+          mutation {
+            updatePrograms(
+              input: {
+                SET: {
+                  goa: {
+                    shouldNotify: false,
+                    privateHeader: true
+                  }
+                }
+                WHERE: {
+                  id: {
+                    EQ: "$pid"
+                  }
+                }
+              }
+            ) {
+              programs {
+                id
+                goa {
+                  shouldNotify
+                  privateHeader
+                }
+              }
+            }
+          }
+        """,
+        expected =
+          json"""
+          {
+            "updatePrograms": {
+              "programs": [
+                {
+                  "id": $pid,
+                  "goa": {
+                    "shouldNotify": false,
+                    "privateHeader": true
+                  }
                 }
               ]
             }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateTargets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateTargets.scala
@@ -132,7 +132,7 @@ class updateTargets extends OdbSuite {
                 s.session.transaction.use { xa =>
                   s.programService
                     .insertCalibrationProgram(
-                      ProgramPropertiesInput.Create.Empty.some,
+                      ProgramPropertiesInput.Create.Default.some,
                       CalibrationRole.Photometric,
                       Description.unsafeFrom("PHOTO"))(using xa)
                 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programs.scala
@@ -106,7 +106,7 @@ class programs extends OdbSuite {
                 s.session.transaction.use { xa =>
                   s.programService
                     .insertCalibrationProgram(
-                      ProgramPropertiesInput.Create.Empty.some,
+                      ProgramPropertiesInput.Create.Default.some,
                       CalibrationRole.Telluric,
                       Description.unsafeFrom("TELLURIC2"))(using xa)
                 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/targets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/targets.scala
@@ -183,7 +183,7 @@ class targets extends OdbSuite {
               s.session.transaction.use { xa =>
                 s.programService
                   .insertCalibrationProgram(
-                    ProgramPropertiesInput.Create.Empty.some,
+                    ProgramPropertiesInput.Create.Default.some,
                     CalibrationRole.Telluric,
                     Description.unsafeFrom("TELLURIC1"))(using xa)
               }
@@ -233,7 +233,7 @@ class targets extends OdbSuite {
               s.session.transaction.use { xa =>
                 s.programService
                   .insertCalibrationProgram(
-                    ProgramPropertiesInput.Create.Empty.some,
+                    ProgramPropertiesInput.Create.Default.some,
                     CalibrationRole.Photometric,
                     Description.unsafeFrom("PHOTO"))(using xa)
               }
@@ -284,7 +284,7 @@ class targets extends OdbSuite {
                 s.session.transaction.use { xa =>
                   s.programService
                     .insertCalibrationProgram(
-                      ProgramPropertiesInput.Create.Empty.some,
+                      ProgramPropertiesInput.Create.Default.some,
                       CalibrationRole.Telluric,
                       Description.unsafeFrom("TELLURIC2"))(using xa)
                 }


### PR DESCRIPTION
This creates a new `GoaProperties` (Gemini Observatory Archive) object and associated input and moves the `proprietaryMonths` into it along with a couple of new properties:

```
"Gemini Observatory Archive properties for a particular program."
type GoaProperties {

  """
  How many months to withhold public access to the data.  This property is
  applicable to science programs, defaults to the proprietary period associated
  with the Call for Proposals if any; 0 months otherwise.
  """
  proprietaryMonths: NonNegInt!

  """
  Whether the PI wishes to be notified when new data are received. This property
  is applicable to science programs and defaults to true.
  """
  shouldNotify: Boolean!

  """
  Whether the header (as well as the data itself) should remain private.  This
  property is applicable to science programs and defaults to false.
  """
  privateHeader: Boolean!

}
```
All of these go into the FITS header and are used by the archive.

I originally put `proprietaryMonths` at the top level in `Program` but, since there are these other GOA properties as well, decided to group them all before anybody has had a chance to use it. 🤞 