### PR TITLE
Switch to UserInvitation.Id in OdbError.InvitationError

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ val pprintVersion              = "0.9.0"
 val skunkVersion               = "0.6.4"
 val testcontainersScalaVersion = "0.40.14" // check test output if you attempt to update this
 
-ThisBuild / tlBaseVersion      := "0.14"
+ThisBuild / tlBaseVersion      := "0.15"
 ThisBuild / scalaVersion       := "3.5.1"
 ThisBuild / crossScalaVersions := Seq("3.5.1")
 

--- a/modules/schema/src/main/scala/lucuma/odb/data/OdbError.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/OdbError.scala
@@ -18,6 +18,7 @@ import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.model.User
+import lucuma.core.model.UserInvitation
 import lucuma.core.model.Visit
 import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.Dataset
@@ -38,7 +39,7 @@ enum OdbError:
   case InvalidArgument(detail: Option[String] = None)      
   case NoAction(detail: Option[String] = None)          
   case NotAuthorized(userId: User.Id, detail: Option[String] = None)        
-  case InvitationError(invitationId: String, detail: Option[String] = None) // TODO: UserInvitation -> core, then we can have UserInvitation.Id here
+  case InvitationError(invitationId: UserInvitation.Id, detail: Option[String] = None)
   case InvalidProgram(programId: Program.Id, detail: Option[String] = None)       
   case InvalidObservation(observationId: Observation.Id, detail: Option[String] = None)   
   case InvalidObservationList(observationIds: NonEmptyList[Observation.Id], detail: Option[String] = None)
@@ -173,7 +174,7 @@ object OdbError:
       case Tag.InvalidArgument        => InvalidArgument(detail).asRight
       case Tag.NoAction               => NoAction(detail).asRight
       case Tag.NotAuthorized          => c.downField("userId").as[User.Id].map(NotAuthorized(_, detail))
-      case Tag.InvitationError        => c.downField("invitationId").as[String].map(InvitationError(_, detail))
+      case Tag.InvitationError        => c.downField("invitationId").as[UserInvitation.Id].map(InvitationError(_, detail))
       case Tag.InvalidProgram         => c.downField("programId").as[Program.Id].map(InvalidProgram(_, detail))
       case Tag.InvalidObservation     => c.downField("observationId").as[Observation.Id].map(InvalidObservation(_, detail))
       case Tag.InvalidObservationList => c.downField("observationIds").as[NonEmptyList[Observation.Id]].map(InvalidObservationList(_, detail))

--- a/modules/schema/src/test/scala/lucuma/odb/data/OdbErrorSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/data/OdbErrorSuite.scala
@@ -13,6 +13,7 @@ import io.circe.testing.ArbitraryInstances
 import io.circe.testing.CodecTests
 import lucuma.core.enums.Site
 import lucuma.core.model.*
+import lucuma.core.model.arb.ArbUserInvitation.given
 import lucuma.core.model.sequence.*
 import lucuma.core.model.sequence.Dataset.Filename
 import lucuma.core.util.Enumerated
@@ -69,7 +70,7 @@ class OdbErrorSuite extends DisciplineSuite with ArbitraryInstances:
           case Tag.InvalidArgument        => OdbError.InvalidArgument(detail).pure[Gen]
           case Tag.NoAction               => OdbError.NoAction(detail).pure[Gen]
           case Tag.NotAuthorized          => arbitrary[User.Id].map(OdbError.NotAuthorized(_, detail))
-          case Tag.InvitationError        => arbitrary[String].map(OdbError.InvitationError(_, detail))
+          case Tag.InvitationError        => arbitrary[UserInvitation.Id].map(OdbError.InvitationError(_, detail))
           case Tag.InvalidProgram         => arbitrary[Program.Id].map(OdbError.InvalidProgram(_, detail))
           case Tag.InvalidObservation     => arbitrary[Observation.Id].map(OdbError.InvalidObservation(_, detail))
           case Tag.InvalidObservationList => arbitrary[NonEmptyList[Observation.Id]].map(OdbError.InvalidObservationList(_, detail))

--- a/modules/service/src/main/scala/lucuma/odb/service/UserInvitationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/UserInvitationService.scala
@@ -55,11 +55,6 @@ trait UserInvitationService[F[_]]:
 
 object UserInvitationService:
 
-  // temporary
-  extension (self: OdbError.InvitationError.type)
-    def apply(id: UserInvitation.Id, detail: Option[String]): OdbError.InvitationError =
-      OdbError.InvitationError(UserInvitation.Id.fromString.reverseGet(id), detail)
-
   def instantiate[F[_]: MonadCancelThrow](emailConfig: Config.Email, httpClient: Client[F])(using Services[F]): UserInvitationService[F] =
     new UserInvitationService[F]:
 


### PR DESCRIPTION
A trivial improvement that was enabled when `UserInvitation` was moved to core.