### PR TITLE
Support Twilight Calibration Observation Sequence

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/SequenceGenerator.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/SequenceGenerator.scala
@@ -39,3 +39,18 @@ trait SequenceGenerator[D]:
    * Records a visit and returns an updated generator.
    */
   def recordVisit(visit: VisitRecord): SequenceGenerator[D]
+
+object SequenceGenerator:
+
+  /** A degenerate implementation that produces no atoms. */
+  def empty[D]: SequenceGenerator[D] =
+    new SequenceGenerator[D]:
+
+      override def generate(when:  Timestamp): Stream[Pure, Atom[D]] =
+        Stream.empty
+
+      override def recordStep(step:  StepRecord[D])(using Eq[D]): SequenceGenerator[D] =
+        this
+
+      override def recordVisit(visit:  VisitRecord): SequenceGenerator[D] =
+        this

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/LongSlit.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/LongSlit.scala
@@ -55,7 +55,7 @@ object LongSlit:
   ): F[Either[String, ExecutionConfigGenerator[StaticConfig.GmosNorth, DynamicConfig.GmosNorth]]] =
     instantiate(
       GmosNorthStatic,
-      Acquisition.gmosNorth(estimator, GmosNorthStatic, namespace, config, acquisitionItc.exposureTime),
+      Acquisition.gmosNorth(estimator, GmosNorthStatic, namespace, config, acquisitionItc.exposureTime, calRole),
       Science.gmosNorth(estimator, GmosNorthStatic, namespace, expander, config, scienceItc, calRole)
     )
 
@@ -70,7 +70,7 @@ object LongSlit:
   ): F[Either[String, ExecutionConfigGenerator[StaticConfig.GmosSouth, DynamicConfig.GmosSouth]]] =
     instantiate(
       GmosSouthStatic,
-      Acquisition.gmosSouth(estimator, GmosSouthStatic, namespace, config, acquisitionItc.exposureTime),
+      Acquisition.gmosSouth(estimator, GmosSouthStatic, namespace, config, acquisitionItc.exposureTime, calRole),
       Science.gmosSouth(estimator, GmosSouthStatic, namespace, expander, config, scienceItc, calRole)
     )
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionTwilight.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionTwilight.scala
@@ -1,0 +1,193 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.query
+
+import cats.effect.IO
+import cats.syntax.either.*
+import cats.syntax.option.*
+import eu.timepit.refined.types.numeric.PosInt
+import io.circe.Json
+import io.circe.literal.*
+import lucuma.core.enums.CalibrationRole
+import lucuma.core.math.SignalToNoise
+import lucuma.core.model.Observation
+import lucuma.core.syntax.timespan.*
+import lucuma.itc.IntegrationTime
+
+class executionTwilight extends ExecutionTestSupport {
+
+  override def fakeItcSpectroscopyResult: IntegrationTime =
+    IntegrationTime(
+      20.minTimeSpan,
+      PosInt.unsafeFrom(10),
+      SignalToNoise.unsafeFromBigDecimalExact(50.0)
+    )
+
+  val setup: IO[Observation.Id] =
+    for
+      p <- createProgram
+      t <- createTargetWithProfileAs(pi, p)
+      o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      _ <- withServices(serviceUser) { services =>
+             services.session.transaction.use: xa =>
+               services.calibrationsService.setCalibrationRole(o, CalibrationRole.Twilight.some)(using xa)
+           }
+    yield o
+
+  def query(sequenceType: String, oid: Observation.Id): String =
+    s"""
+       query {
+         observation(observationId: "$oid") {
+           execution {
+             config {
+               gmosNorth {
+                 $sequenceType {
+                   nextAtom {
+                     observeClass
+                     steps {
+                       observeClass
+                       instrumentConfig {
+                         exposure {
+                           seconds
+                         }
+                         readout {
+                           xBin
+                           yBin
+                           ampCount
+                           ampGain
+                           ampReadMode
+                         }
+                         dtax
+                         roi
+                         gratingConfig {
+                           grating
+                           order
+                           wavelength {
+                             nanometers
+                           }
+                         }
+                         filter
+                         fpu {
+                           builtin
+                           customMask { slitWidth }
+                         }
+                       }
+                       stepConfig {
+                         ... on Science {
+                           offset {
+                             p { arcseconds }
+                             q { arcseconds }
+                           }
+                         }
+                       }
+                     }
+                   }
+                   possibleFuture {
+                     steps {
+                       instrumentConfig {
+                         exposure {
+                           seconds
+                         }
+                       }
+                     }
+                   }
+                 }
+               }
+             }
+           }
+         }
+       }
+     """
+
+  test("twilight - science") {
+    setup.flatMap: oid =>
+      expect(
+        user  = pi,
+        query = query("science", oid),
+        expected =
+          json"""
+            {
+              "observation": {
+                "execution": {
+                  "config": {
+                    "gmosNorth": {
+                      "science": {
+                        "nextAtom": {
+                          "observeClass": "SCIENCE",
+                          "steps": [
+                            {
+                              "observeClass": "SCIENCE",
+                              "instrumentConfig": {
+                                "exposure": {
+                                  "seconds": 30.000000
+                                },
+                                "readout": {
+                                  "xBin": "ONE",
+                                  "yBin": "TWO",
+                                  "ampCount": "TWELVE",
+                                  "ampGain": "LOW",
+                                  "ampReadMode": "SLOW"
+                                },
+                                "dtax": "ZERO",
+                                "roi": "FULL_FRAME",
+                                "gratingConfig": {
+                                  "grating": "R831_G5302",
+                                  "order": "ONE",
+                                  "wavelength": {
+                                    "nanometers": 500.000
+                                  }
+                                },
+                                "filter": "R_PRIME",
+                                "fpu": {
+                                  "builtin": "LONG_SLIT_0_50",
+                                  "customMask": null
+                                }
+                              },
+                              "stepConfig": {
+                                "offset": {
+                                  "p": {
+                                    "arcseconds": 0.000000
+                                  },
+                                  "q": {
+                                    "arcseconds": 0.000000
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "possibleFuture": []
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          """.asRight
+      )
+  }
+
+  test("twilight - acquisition") {
+    setup.flatMap: oid =>
+      expect(
+        user  = pi,
+        query = query("acquisition", oid),
+        expected =
+          json"""
+            {
+              "observation": {
+                "execution": {
+                  "config": {
+                    "gmosNorth": {
+                      "acquisition": null
+                    }
+                  }
+                }
+              }
+            }
+          """.asRight
+      )
+  }
+
+}


### PR DESCRIPTION
Adds sequence generation for [twilight calibration observations](https://app.shortcut.com/lucuma/story/3410/create-twilight-calibration-observations).  These have a single 30 second exposure, no acquisition and no gcals.