### PR TITLE
suppress config request warnings unless proposal is accepted

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -139,7 +139,6 @@ trait ObservationMapping[F[_]]
         services.useTransactionally {
           observationService
             .observationValidations(pid, oid, itcClient)
-            .map(_.success)
         }
 
     effectHandler(readEnv, calculate)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observationValidations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observationValidations.scala
@@ -532,12 +532,33 @@ class observationValidations
     }
   }
 
+  test("no configuration request checks if proposal is not approved") {
+    val setup: IO[Observation.Id] =
+      for {
+        cfp <- createCallForProposalsAs(staff)
+        pid <- createProgramAs(pi)
+        _   <- addProposal(pi, pid, Some(cfp), None, "Foo")
+        tid <- createTargetWithProfileAs(pi, pid)
+        oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+        _   <- computeItcResult(oid)
+      } yield oid
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        validationQuery(oid),
+        expected = queryResult().asRight // no warnings!
+      )
+    }
+  }
+
   test("no configuration request") {
     val setup: IO[Observation.Id] =
       for {
         cfp <- createCallForProposalsAs(staff)
         pid <- createProgramAs(pi)
         _   <- addProposal(pi, pid, Some(cfp), None, "Foo")
+        _   <- addPartnerSplits(pi, pid)
+        _   <- setProposalStatus(staff, pid, "ACCEPTED")
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
         _   <- computeItcResult(oid)
@@ -561,6 +582,8 @@ class observationValidations
         cfp <- createCallForProposalsAs(staff)
         pid <- createProgramAs(pi)
         _   <- addProposal(pi, pid, Some(cfp), None, "Foo")
+        _   <- addPartnerSplits(pi, pid)
+        _   <- setProposalStatus(staff, pid, "ACCEPTED")
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
         _   <- createConfigurationRequestAs(pi, oid)
@@ -585,6 +608,8 @@ class observationValidations
         cfp <- createCallForProposalsAs(staff)
         pid <- createProgramAs(pi)
         _   <- addProposal(pi, pid, Some(cfp), None, "Foo")
+        _   <- addPartnerSplits(pi, pid)
+        _   <- setProposalStatus(staff, pid, "ACCEPTED")
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
         _   <- createConfigurationRequestAs(pi, oid).flatMap(denyConfigurationRequestHack)


### PR DESCRIPTION
Subtask for https://app.shortcut.com/lucuma/story/2955/observation-workflow … this skips the warnings about configuration requests unless the proposal has been accepted.