### PR TITLE
Don't require same ITC target for acquisition and science

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -173,9 +173,7 @@ object ItcService {
   case class AsterismResults private (
     acquisitionResult: Zipper[TargetResult],
     scienceResult: Zipper[TargetResult]
-  ) {
-    assert(acquisitionResult.focus.targetId === scienceResult.focus.targetId)
-  }
+  )
 
   object AsterismResults {
 


### PR DESCRIPTION
In an asterism, ITC may select different targets as the ones producing the shortest exposure time for acquisition and science.

This is actually OK, so I removed the assertion that the same target should be selected for both sequences.