### PR TITLE
Dont charge for twilight

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Science.scala
@@ -302,19 +302,21 @@ object Science:
         calRole:  Option[CalibrationRole]
       ): F[Either[String, NonEmptyList[BlockDefinition[D]]]] =
         Goal.compute(config.wavelengthDithers, config.spatialOffsets, time).traverse { g =>
+          val isTwilight = calRole.contains(CalibrationRole.Twilight)
+
           val λ = config.centralWavelength
           val (smartArc, smartFlat, science) = eval {
             for {
               _ <- setup(config, time)
               _ <- optics.wavelength := λ.offset(g.adjustment.Δλ).getOrElse(λ)
               o  = Offset(Offset.P.Zero, g.adjustment.q)
-              a <- arcStep(TelescopeConfig(o, StepGuideState.Disabled), ObserveClass.PartnerCal)
-              f <- flatStep(TelescopeConfig(o, StepGuideState.Disabled), ObserveClass.PartnerCal)
-              s <- scienceStep(TelescopeConfig(o, StepGuideState.Enabled), ObserveClass.Science)
+              a <- arcStep(TelescopeConfig(o, StepGuideState.Disabled), if isTwilight then ObserveClass.DayCal else ObserveClass.PartnerCal)
+              f <- flatStep(TelescopeConfig(o, StepGuideState.Disabled), if isTwilight then ObserveClass.DayCal else ObserveClass.PartnerCal)
+              s <- scienceStep(TelescopeConfig(o, StepGuideState.Enabled), if isTwilight then ObserveClass.DayCal else ObserveClass.Science)
             } yield (a, f, s)
           }
 
-          val includeFlats = !calRole.contains(CalibrationRole.Twilight)
+          val includeFlats = !isTwilight
           val includeArcs  = calRole.isEmpty
 
           (for {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionTwilight.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionTwilight.scala
@@ -349,8 +349,7 @@ class executionTwilight extends ExecutionTestSupport {
       (p1, _, c) <- setup
       t0         <- programTimeEstimate(p0)
       t1         <- programTimeEstimate(p1)
-      c0         <- obsTimeEstimate(c.specPhot)
-      c1         <- obsTimeEstimate(c.twilight)
-    yield (t0 +| c0 +| c1) === t1)
+      cSpecPhot  <- obsTimeEstimate(c.specPhot)
+    yield (t0.programTime +| cSpecPhot.programTime) === t1.programTime)
 
 }


### PR DESCRIPTION
Twilight flats are taken during ... twilight so there should be no program charge.  Time accounting after execution will handle this correctly, but this PR removes the twilight flat cost from the program charge estimate.

The program charge is used to calculate the time request (?) so this should lower the time request accordingly.