### PR TITLE
Exclude deleted targets from v_generator_params

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0932__generator_parms_no_deleted_targets.sql
+++ b/modules/service/src/main/resources/db/migration/V0932__generator_parms_no_deleted_targets.sql
@@ -1,0 +1,32 @@
+DROP VIEW v_generator_params;
+
+-- Recreate without deleted targets
+CREATE VIEW v_generator_params AS
+SELECT
+  o.c_program_id,
+  o.c_observation_id,
+  o.c_calibration_role,
+  o.c_image_quality,
+  o.c_cloud_extinction,
+  o.c_sky_background,
+  o.c_water_vapor,
+  o.c_air_mass_min,
+  o.c_air_mass_max,
+  o.c_hour_angle_min,
+  o.c_hour_angle_max,
+  o.c_spec_signal_to_noise,
+  o.c_spec_signal_to_noise_at,
+  o.c_observing_mode_type,
+  t.c_target_id,
+  t.c_sid_rv,
+  t.c_source_profile
+FROM
+  t_observation o
+LEFT JOIN t_asterism_target a
+  ON o.c_observation_id = a.c_observation_id
+LEFT JOIN t_target t
+  ON  a.c_target_id      = t.c_target_id
+  AND t.c_existence     <> 'deleted'
+ORDER BY
+  o.c_observation_id,
+  t.c_target_id;


### PR DESCRIPTION
Currently, deleted targets are still included when calculating times or sequences. https://app.shortcut.com/lucuma/story/3875/deleting-target-does-not-update-observation-duration-or-sequence
This excludes deleted targets.
