### PR TITLE
Exclude obsolete gratings and filters from instrument modes import

### DIFF
--- a/modules/service/src/main/scala/db/migration/R__Phase0.scala
+++ b/modules/service/src/main/scala/db/migration/R__Phase0.scala
@@ -18,6 +18,8 @@ class R__Phase0 extends RepeatableMigration("Phase 0 Instrument Options") {
 
   val fileName: String = "Phase0_Instrument_Matrix - Spectroscopy.tsv"
 
+  override val importForcingVersion: Int = 1
+
   lazy val definitionFiles: NonEmptyList[(String, IO[InputStream])] =
     filesFromClasspath("phase0", NonEmptyList.one(fileName))
 


### PR DESCRIPTION
The import was finding the first grating enum value with a matching short name, but was not taking into account obsolete gratings, so it was selecting an obsolete one. The same thing could have happened with the filters.

This also provides a way to force the migration to run without changing the import file.