### PR TITLE
Include emissions lines in check for target brightnesses

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -269,11 +269,11 @@ object GeneratorParamsService {
         val brightnesses = 
           sourceProf.flatMap: sp =>
             SourceProfile.integratedBrightnesses.getOption(sp).orElse(SourceProfile.surfaceBrightnesses.getOption(sp))
-              .map(_.size > 0)
+              .map(_.nonEmpty)
         val wavelengthLines =
           sourceProf.flatMap: sp =>
             SourceProfile.integratedWavelengthLines.getOption(sp).orElse(SourceProfile.surfaceWavelengthLines.getOption(sp))
-              .map(_.size > 0)
+              .map(_.nonEmpty)
         val validBrightness = brightnesses.orElse(wavelengthLines).getOrElse(false)
 
         targetParams.targetId.toValidNel(MissingParam.forObservation("target")).andThen: tid =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSci.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSci.scala
@@ -1030,10 +1030,11 @@ class executionSci extends ExecutionTestSupport {
   }
 
   test("select min x-binning") {
+    val gaussianProfile = gaussianBandNormalizedProfile(Angle.fromMicroarcseconds(647_200L))
     val setup: IO[Observation.Id] =
       for {
         p  <- createProgram
-        t0 <- createTargetWithGaussianAs(pi, p, Angle.fromMicroarcseconds(647_200L))  // X-binning of 4
+        t0 <- createTargetWithProfileAs(pi, p, gaussianProfile)  // X-binning of 4
         t1 <- createTargetWithProfileAs(pi, p)  // X-binning of 1
         o  <- createObservationWithModeAs(pi, p, List(t0, t1),
                // use a 5" slit so that won't be a factor


### PR DESCRIPTION
The ITC now supports emission lines, but GeneratorParamsService was returning an error. This includes emission lines in the brightness check.