### PR TITLE
CfP Creation Bug

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createCallForProposals.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createCallForProposals.scala
@@ -736,4 +736,30 @@ class createCallForProposals extends OdbSuite {
     )
   }
 
+  test("failure - too far in the future"):
+    expect(
+      user  = staff,
+      query = """
+        mutation {
+          createCallForProposals(
+            input: {
+              SET: {
+                type: REGULAR_SEMESTER
+                semester: "2099A"
+                activeStart: "2026-02-01"
+                activeEnd: "2026-07-31"
+                partners: [{ partner: CL }, { partner: US }]
+                instruments: [GMOS_NORTH, GMOS_SOUTH]
+              }
+            }
+          ) {
+            callForProposals {
+              id
+            }
+          }
+        }
+      """,
+      expected = List("The maximum semester is capped at the current year +1 (Semester(2099A) specified).").asLeft
+    )
+
 }


### PR DESCRIPTION
CfP semesters are capped at 1 year from the current year.  This is enforced by a Postgres `CHECK` on the semester domain. We were not checking for this though when creating a new CfP so using a semester far in advance would generate an Internal Server Error.