### PR TITLE
Program user unique indices

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0936__support_not_unique.sql
+++ b/modules/service/src/main/resources/db/migration/V0936__support_not_unique.sql
@@ -14,7 +14,7 @@ CREATE UNIQUE INDEX unique_program_user_investigator ON t_program_user (
 ) WHERE c_user_id IS NOT NULL
     AND c_role IN ('pi', 'coi', 'coi_ro');
 
--- And there can only be one pi.
+-- And there can only be one pi (whether linked to a user or not).
 CREATE UNIQUE INDEX unique_program_user_one_pi ON t_program_user (
   c_program_id
 ) WHERE c_role = 'pi';

--- a/modules/service/src/main/resources/db/migration/V0936__support_not_unique.sql
+++ b/modules/service/src/main/resources/db/migration/V0936__support_not_unique.sql
@@ -1,0 +1,20 @@
+DROP INDEX unique_program_user;
+
+-- A user cannot appear twice in the same role in the same program.
+CREATE UNIQUE INDEX unique_program_user_per_role ON t_program_user (
+    c_program_id,
+    c_user_id,
+    c_role
+) WHERE c_user_id IS NOT NULL;
+
+-- A user can only be the pi, coi or coi_ro, never two of these at once.
+CREATE UNIQUE INDEX unique_program_user_investigator ON t_program_user (
+  c_program_id,
+  c_user_id
+) WHERE c_user_id IS NOT NULL
+    AND c_role IN ('pi', 'coi', 'coi_ro');
+
+-- And there can only be one pi.
+CREATE UNIQUE INDEX unique_program_user_one_pi ON t_program_user (
+  c_program_id
+) WHERE c_role = 'pi';

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/ProgramTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/ProgramTopic.scala
@@ -66,7 +66,7 @@ object ProgramTopic {
   ): F[List[User.Id]] =
     val q =
       sql"""
-        select c_user_id from t_program_user where c_program_id = '#${pid.toString}' and c_user_id notnull
+        select distinct c_user_id from t_program_user where c_program_id = '#${pid.toString}' and c_user_id notnull
       """.query(user_id)
     s.execute(q)
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/linkUser.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/linkUser.scala
@@ -208,6 +208,15 @@ class linkUser extends OdbSuite:
           addProgramUserAs(staff, pid, role).flatMap: rid1 =>
             linkUserAs(staff, rid1, pi2.id)
 
+  test(s"[${ProgramUserRole.SupportPrimary}] same user can be both primary and secondary"):
+    createUsers(pi2, admin) >>
+    createProgramAs(pi).flatMap: pid =>
+      addProgramUserAs(staff, pid, ProgramUserRole.SupportPrimary).flatMap: rid0 =>
+        linkUserAs(admin, rid0, pi2.id) >>
+        addProgramUserAs(staff, pid, ProgramUserRole.SupportSecondary).flatMap: rid1 =>
+          linkUserAs(admin, rid0, pi2.id)
+
+
   // GENERAL RULES
 
   test("[general] can't link a guest user"):

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/linkUser.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/linkUser.scala
@@ -214,7 +214,7 @@ class linkUser extends OdbSuite:
       addProgramUserAs(staff, pid, ProgramUserRole.SupportPrimary).flatMap: rid0 =>
         linkUserAs(admin, rid0, pi2.id) >>
         addProgramUserAs(staff, pid, ProgramUserRole.SupportSecondary).flatMap: rid1 =>
-          linkUserAs(admin, rid0, pi2.id)
+          linkUserAs(admin, rid1, pi2.id)
 
 
   // GENERAL RULES


### PR DESCRIPTION
Per [ShortCut 3151](https://app.shortcut.com/lucuma/story/3151/allow-investigators-to-have-a-support-role), changes the uniqueness constraints on program user / user links such that:

* A user _cannot_ occupy the same role twice in the same program.
* A user _cannot_ be more than one of PI, CoI, CoI-RO in the same program.
* A user _can_ be one of Pi, CoI, CoI-RO and at the same time a support user.
* A user _can_ be both the primary and secondary support for a program.