### PR TITLE
Banded estimates

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7926,6 +7926,8 @@ type Group {
   """
   timeEstimateRange: CategorizedTimeRange
 
+  # bandedTimeEstimate: BandedTime!
+
   existence: Existence!
 
   system: Boolean!

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7926,7 +7926,13 @@ type Group {
   """
   timeEstimateRange: CategorizedTimeRange
 
-  # bandedTimeEstimate: BandedTime!
+  """
+  Prepared time by band ignoring `minimumRequired`, for observations that can be
+  calculated.  In order for an observation to have an estimate, it must be
+  fully defined such that a sequence can be generated for it.  All defined
+  observations in every band present in the group are included.
+  """
+  timeEstimateBanded: [BandedTime!]!
 
   existence: Existence!
 
@@ -9144,6 +9150,14 @@ type Program {
   cannot be calculated.
   """
   timeEstimateRange: CategorizedTimeRange
+
+  """
+  Prepared time by band ignoring `minimumRequired` in groups, for observations
+  that can be calculated.  In order for an observation to have an estimate, it
+  must be fully defined such that a sequence can be generated for it.  All
+  defined observations in every band present in the program are included.
+  """
+  timeEstimateBanded: [BandedTime!]!
 
   """
   Program-wide time charge, summing all corrected observation time charges.

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/GeneratorParams.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/GeneratorParams.scala
@@ -7,14 +7,14 @@ package data
 import cats.Eq
 import cats.syntax.either.*
 import lucuma.core.enums.CalibrationRole
+import lucuma.core.enums.ScienceBand
 import lucuma.odb.sequence.ObservingMode
 import lucuma.odb.sequence.syntax.all.*
 import lucuma.odb.sequence.util.HashBytes
 
-import java.nio.charset.StandardCharsets.UTF_8
-
 case class GeneratorParams(
   itcInput:        Either[MissingParamSet, ItcInput],
+  scienceBand:     Option[ScienceBand],
   observingMode:   ObservingMode,
   calibrationRole: Option[CalibrationRole]
 )
@@ -22,16 +22,19 @@ case class GeneratorParams(
 object GeneratorParams:
 
   given Eq[GeneratorParams] =
-    Eq.by { a => (
-      a.itcInput,
-      a.observingMode,
-      a.calibrationRole
-    )}
+    Eq.by: a =>
+      (
+        a.itcInput,
+        a.scienceBand,
+        a.observingMode,
+        a.calibrationRole
+      )
 
   given HashBytes[GeneratorParams] with
     def hashBytes(a: GeneratorParams): Array[Byte] =
       Array.concat(
         a.itcInput.bimap(_.hashBytes, _.hashBytes).merge,
+        a.scienceBand.hashBytes,
         a.observingMode.hashBytes,
-        a.calibrationRole.fold(Array.emptyByteArray)(_.tag.getBytes(UTF_8))
+        a.calibrationRole.hashBytes
       )

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/HashBytes.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/HashBytes.scala
@@ -6,6 +6,7 @@ package lucuma.odb.sequence.util
 import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.types.numeric.PosLong
 import io.circe.Encoder
+import lucuma.core.util.Enumerated
 import lucuma.core.util.Gid
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
@@ -85,5 +86,10 @@ object HashBytes {
   given [A](using HashBytes[A]): HashBytes[Option[A]] with {
     def hashBytes(opt: Option[A]): Array[Byte] =
       opt.fold(Array.emptyByteArray)(HashBytes[A].hashBytes)
+  }
+
+  given[A](using Enumerated[A]): HashBytes[A] with {
+    def hashBytes(a: A): Array[Byte] =
+      Enumerated[A].tag(a).getBytes(UTF_8)
   }
 }

--- a/modules/sequence/src/test/scala/lucuma/odb/sequence/data/arb/ArbGeneratorParams.scala
+++ b/modules/sequence/src/test/scala/lucuma/odb/sequence/data/arb/ArbGeneratorParams.scala
@@ -8,6 +8,7 @@ package arb
 import cats.data.NonEmptyList
 import cats.syntax.either.*
 import lucuma.core.enums.CalibrationRole
+import lucuma.core.enums.ScienceBand
 import lucuma.core.model.Target
 import lucuma.core.util.arb.ArbEnumerated
 import lucuma.core.util.arb.ArbGid
@@ -43,17 +44,19 @@ trait ArbGeneratorParams:
     for
       mo  <- arbitrary[InstrumentMode.GmosNorthSpectroscopy]
       itc <- genItcInput(mo)
+      bnd <- arbitrary[Option[ScienceBand]]
       cfg <- arbitrary[Config.GmosNorth]
       rol <- arbitrary[Option[CalibrationRole]]
-    yield GeneratorParams(Either.right(itc), cfg, rol)
+    yield GeneratorParams(Either.right(itc), bnd, cfg, rol)
 
   val genGmosSouthLongSlit: Gen[GeneratorParams] =
     for
       mo  <- arbitrary[InstrumentMode.GmosSouthSpectroscopy]
       itc <- genItcInput(mo)
+      bnd <- arbitrary[Option[ScienceBand]]
       cfg <- arbitrary[Config.GmosSouth]
       rol <- arbitrary[Option[CalibrationRole]]
-    yield GeneratorParams(Either.right(itc), cfg, rol)
+    yield GeneratorParams(Either.right(itc), bnd, cfg, rol)
 
   given Arbitrary[GeneratorParams] =
     Arbitrary:

--- a/modules/service/src/main/resources/db/migration/V0941__band_in_generator_params.sql
+++ b/modules/service/src/main/resources/db/migration/V0941__band_in_generator_params.sql
@@ -1,0 +1,33 @@
+DROP VIEW v_generator_params;
+
+-- Add science band
+CREATE VIEW v_generator_params AS
+SELECT
+  o.c_program_id,
+  o.c_observation_id,
+  o.c_calibration_role,
+  o.c_image_quality,
+  o.c_cloud_extinction,
+  o.c_sky_background,
+  o.c_water_vapor,
+  o.c_air_mass_min,
+  o.c_air_mass_max,
+  o.c_hour_angle_min,
+  o.c_hour_angle_max,
+  o.c_spec_signal_to_noise,
+  o.c_spec_signal_to_noise_at,
+  o.c_observing_mode_type,
+  o.c_science_band,
+  t.c_target_id,
+  t.c_sid_rv,
+  t.c_source_profile
+FROM
+  t_observation o
+LEFT JOIN t_asterism_target a
+  ON o.c_observation_id = a.c_observation_id
+LEFT JOIN t_target t
+  ON  a.c_target_id  = t.c_target_id
+  AND t.c_existence <> 'deleted'
+ORDER BY
+  o.c_observation_id,
+  t.c_target_id;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GroupMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GroupMapping.scala
@@ -78,7 +78,7 @@ trait GroupMapping[F[_]] extends GroupView[F] with ProgramTable[F] with GroupEle
     keyValueEffectHandler[Group.Id, Option[CategorizedTimeRange]]("id") { gid =>
       services.useNonTransactionally {
         timeEstimateService(commitHash, itcClient, timeEstimateCalculator)
-          .estimateGroup(gid)
+          .estimateGroupRange(gid)
       }
     }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GroupMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GroupMapping.scala
@@ -6,6 +6,8 @@ package lucuma.odb.graphql
 package mapping
 
 import cats.effect.Resource
+import cats.implicits.catsKernelOrderingForOrder
+import cats.syntax.functor.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import grackle.Query
 import grackle.Query.Binding
@@ -17,6 +19,7 @@ import grackle.TypeRef
 import grackle.skunk.SkunkMapping
 import lucuma.core.model.Group
 import lucuma.core.model.User
+import lucuma.core.model.sequence.BandedTime
 import lucuma.core.model.sequence.CategorizedTimeRange
 import lucuma.itc.client.ItcClient
 import lucuma.odb.graphql.binding.BooleanBinding
@@ -33,7 +36,7 @@ import lucuma.odb.service.Services
 import Services.Syntax.*
 
 
-trait GroupMapping[F[_]] extends GroupView[F] with ProgramTable[F] with GroupElementView[F] with KeyValueEffectHandler[F] with Predicates[F] {
+trait GroupMapping[F[_]] extends GroupView[F] with ProgramTable[F] with GroupElementView[F] with KeyValueEffectHandler[F] with Predicates[F]:
 
   def user: User
   def itcClient: ItcClient[F]
@@ -54,7 +57,8 @@ trait GroupMapping[F[_]] extends GroupView[F] with ProgramTable[F] with GroupEle
       SqlObject("maximumInterval"),
       SqlObject("elements", Join(GroupView.Id, GroupElementView.GroupId)),
       SqlObject("program", Join(GroupView.ProgramId, ProgramTable.Id)),
-      EffectField("timeEstimateRange", timeEstimateHandler, List("id")),
+      EffectField("timeEstimateRange", estimateRangeHandler, List("id")),
+      EffectField("timeEstimateBanded", estimateBandedHandler, List("id")),
       SqlField("existence", GroupView.Existence),
       SqlField("system", GroupView.System),
     )
@@ -74,13 +78,15 @@ trait GroupMapping[F[_]] extends GroupView[F] with ProgramTable[F] with GroupEle
           )
       }
 
-  private lazy val timeEstimateHandler: EffectHandler[F] =
-    keyValueEffectHandler[Group.Id, Option[CategorizedTimeRange]]("id") { gid =>
-      services.useNonTransactionally {
+  private lazy val estimateRangeHandler: EffectHandler[F] =
+    keyValueEffectHandler[Group.Id, Option[CategorizedTimeRange]]("id"): gid =>
+      services.useNonTransactionally:
         timeEstimateService(commitHash, itcClient, timeEstimateCalculator)
           .estimateGroupRange(gid)
-      }
-    }
 
-}
-
+  private lazy val estimateBandedHandler: EffectHandler[F] =
+    keyValueEffectHandler[Group.Id, List[BandedTime]]("id"): gid =>
+      services.useNonTransactionally:
+        timeEstimateService(commitHash, itcClient, timeEstimateCalculator)
+          .estimateGroupBanded(gid)
+          .map(_.toList.flatMap(_.toList.sortBy(_._1).map((b, t) => BandedTime(b, t))))

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
@@ -199,7 +199,7 @@ trait ProgramMapping[F[_]]
     keyValueEffectHandler[Program.Id, Option[CategorizedTimeRange]]("id") { pid =>
       services.useNonTransactionally {
         timeEstimateService(commitHash, itcClient, timeEstimateCalculator)
-          .estimateProgram(pid)
+          .estimateProgramRange(pid)
       }
     }
 

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -418,11 +418,11 @@ object Generator {
           .fromEither(Error.sequenceTooLong.asLeft[ExecutionDigest])
           .unlessA(ctx.scienceIntegrationTime.toOption.forall(_.exposureCount.value <= SequenceAtomLimit)) *>
         (ctx.params match
-          case GeneratorParams(_, config: gmos.longslit.Config.GmosNorth, role) =>
+          case GeneratorParams(_, _, config: gmos.longslit.Config.GmosNorth, role) =>
             gmosNorthLongSlit(ctx, config, role, false, when).flatMap: (p, e) =>
               EitherT.fromEither[F](executionDigest(p, e, calculator.gmosNorth.estimateSetup))
 
-          case GeneratorParams(_, config: gmos.longslit.Config.GmosSouth, role) =>
+          case GeneratorParams(_, _, config: gmos.longslit.Config.GmosSouth, role) =>
             gmosSouthLongSlit(ctx, config, role, false, when).flatMap: (p, e) =>
               EitherT.fromEither[F](executionDigest(p, e, calculator.gmosSouth.estimateSetup))
         )
@@ -446,11 +446,11 @@ object Generator {
         when:     Option[Timestamp]
       )(using NoTransaction[F]): EitherT[F, Error, InstrumentExecutionConfig] =
         ctx.params match
-          case GeneratorParams(_, config: gmos.longslit.Config.GmosNorth, role) =>
+          case GeneratorParams(_, _, config: gmos.longslit.Config.GmosNorth, role) =>
             gmosNorthLongSlit(ctx, config, role, resetAcq, when).map: (p, _) =>
               InstrumentExecutionConfig.GmosNorth(executionConfig(p, lim))
 
-          case GeneratorParams(_, config: gmos.longslit.Config.GmosSouth, role) =>
+          case GeneratorParams(_, _, config: gmos.longslit.Config.GmosSouth, role) =>
             gmosSouthLongSlit(ctx, config, role, resetAcq, when).map: (p, _) =>
               InstrumentExecutionConfig.GmosSouth(executionConfig(p, lim))
 

--- a/modules/service/src/main/scala/lucuma/odb/logic/TimeEstimateService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/TimeEstimateService.scala
@@ -58,10 +58,18 @@ sealed trait TimeEstimateService[F[_]]:
     groupId: Group.Id
   )(using NoTransaction[F]): F[Option[CategorizedTimeRange]]
 
+  /**
+   * Estimates the remaining time for all observations in the program by band,
+   * ignoring `minRequired` in groups.
+   */
   def estimateProgramBanded(
     programId: Program.Id
   )(using NoTransaction[F]): F[Option[Map[Option[ScienceBand], CategorizedTime]]]
 
+  /**
+   * Estimates the remaining time for all observations in the group by band,
+   * ignoring `minRequired`.
+   */
   def estimateGroupBanded(
     groupId: Group.Id
   )(using NoTransaction[F]): F[Option[Map[Option[ScienceBand], CategorizedTime]]]
@@ -214,7 +222,7 @@ object TimeEstimateService:
           case GroupTree.Branch(_, _, _, children, _, _, _, _, _) => parent(children)
           case GroupTree.Root(_, children)                        => parent(children)
 
-      def estimateProgramBanded(
+      override def estimateProgramBanded(
         pid: Program.Id
       )(using NoTransaction[F]): F[Option[Map[Option[ScienceBand], CategorizedTime]]] =
         load(pid).flatMap:

--- a/modules/service/src/main/scala/lucuma/odb/logic/TimeEstimateService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/TimeEstimateService.scala
@@ -14,7 +14,6 @@ import cats.syntax.foldable.*
 import cats.syntax.functor.*
 import cats.syntax.functorFilter.*
 import cats.syntax.option.*
-import cats.syntax.semigroup.*
 import cats.syntax.traverse.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import lucuma.core.enums.ScienceBand
@@ -215,7 +214,7 @@ object TimeEstimateService:
             obt.fold(empty)(bt => Map(bt.band -> bt.time))
 
         def parent(cs: List[GroupTree.Child]): F[Map[Option[ScienceBand], CategorizedTime]] =
-          cs.traverse(bandedTimeEstimate(pid, _, m)).map(_.foldLeft(empty)(_ |+| _))
+          cs.traverse(bandedTimeEstimate(pid, _, m)).map(_.combineAll)
 
         root match
           case GroupTree.Leaf(oid)                                => leaf(oid)

--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -158,7 +158,7 @@ object CalibrationsService extends CalibrationObservations {
         requiresItcInputs: Boolean
       ): PartialFunction[(Observation.Id, Either[GeneratorParamsService.Error, GeneratorParams]), (Observation.Id, Option[ItcInput], ObservingMode)] =
         {
-          case (oid, Right(GeneratorParams(itc, mode, _))) if itc.isRight || !requiresItcInputs => (oid, itc.toOption, mode)
+          case (oid, Right(GeneratorParams(itc, _, mode, _))) if itc.isRight || !requiresItcInputs => (oid, itc.toOption, mode)
         }
 
       // Find all active observations in the program

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -367,9 +367,9 @@ object ObservationWorkflowService {
 
         val generatorValidator: Validator = info =>
           info.generatorParams.foldMap:
-            case Left(error)                           => ObservationValidationMap.singleton(error.toObsValidation)
-            case Right(GeneratorParams(Left(m), _, _)) => ObservationValidationMap.singleton(m.toObsValidation)
-            case Right(ps)                             => ObservationValidationMap.empty
+            case Left(error)                              => ObservationValidationMap.singleton(error.toObsValidation)
+            case Right(GeneratorParams(Left(m), _, _, _)) => ObservationValidationMap.singleton(m.toObsValidation)
+            case Right(ps)                                => ObservationValidationMap.empty
 
         val cfpInstrumentValidator: Validator = info =>
           info.cfpInfo.foldMap: cfp =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
@@ -86,7 +86,7 @@ trait ObservingModeSetupOperations extends DatabaseOperations { this: OdbSuite =
               $ScienceRequirements,
               observingMode: {
                 $mode
-              },
+              }
             }
           }) {
             observation {


### PR DESCRIPTION
Following discussion from Andy about [ShortCut 3202](https://app.shortcut.com/lucuma/story/3202/support-planned-time-estimates-by-band), adds a `timeEstimateBanded` field to `Program` and `Group` that sums the prepared time by band (ignoring group `minRequired`).  In other words, this provides a sense of how much time has been prepared in each band across a group or program.  It's not clear how/whether this will be reflected in explore.  To make this convenient, I added the Science Band to the `GeneratorParams`.