### PR TITLE
ShortCut 4460

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4460.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4460.scala
@@ -1,0 +1,75 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package issue.shortcut
+
+import cats.effect.IO
+import cats.syntax.either.*
+import cats.syntax.option.*
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.enums.CallForProposalsType.RegularSemester
+import lucuma.core.enums.ProgramUserRole.CoiRO
+import lucuma.core.model.Observation
+import lucuma.core.model.User
+import lucuma.odb.graphql.query.ObservingModeSetupOperations
+
+class ShortCut_4460 extends OdbSuite with ObservingModeSetupOperations:
+
+  val pi:         User = TestUsers.Standard.pi(1, 101)
+  val staffCoiRo: User = TestUsers.Standard.staff(2, 102)
+  val staff:      User = TestUsers.Standard.staff(3, 103)
+
+  override val validUsers: List[User] =
+    List(pi, staffCoiRo, staff)
+
+  test("Staff as CoiRo can edit"):
+    val setup: IO[Observation.Id] =
+      for {
+        _ <- createUsers(pi, staffCoiRo, staff)
+        c <- createCallForProposalsAs(staff, RegularSemester)
+        p <- createProgramAs(pi, "ShortCut 4460")
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationWithNoModeAs(pi, p, t)
+        _ <- addProposal(pi, p, c.some)
+        _ <- addPartnerSplits(pi, p)
+        _ <- acceptProposal(staff, p)
+        r <- addProgramUserAs(pi, p, CoiRO)
+        _ <- linkUserAs(pi, r, staffCoiRo.id)
+      } yield o
+
+    def mutation(o: Observation.Id) = s"""
+      mutation {
+        updateObservations(input: {
+          SET: {
+            subtitle: "Foo"
+          },
+          WHERE: {
+            id: { EQ: ${o.asJson} }
+          }
+        }) {
+          observations {
+            subtitle
+          }
+        }
+      }
+    """
+
+    // Editing works for the COI-RO user because it is also a staff user.
+    setup.flatMap: o =>
+      expect(
+        user     = staffCoiRo,
+        query    = mutation(o),
+        expected = json"""
+          {
+            "updateObservations": {
+              "observations" : [
+                {
+                  "subtitle" : "Foo"
+                }
+              ]
+            }
+         }
+        """.asRight
+      )


### PR DESCRIPTION
This PR just adds a test case which, I think, indicates that the issue behind [ShortCut 4460](https://app.shortcut.com/lucuma/story/4460/staff-users-lose-elevated-permissions-when-read-only-coi#activity-4551) is not in the API implementation.  I'm not sure though, and fear I may be responsible in the end since I changed everything in #1522.

How / where do a user's `otherRoles` get set?  How does Explore determine whether to mark the UI as RO?