### PR TITLE
Fix bug on cache lookup

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/logic/TimeEstimateService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/TimeEstimateService.scala
@@ -81,8 +81,8 @@ object TimeEstimateService:
     asterismResults: Option[AsterismResults],
     executionDigest: Option[ExecutionDigest]
   ):
-    def cachedFullTimeEstimate: Option[CategorizedTime] =
-      executionDigest.map(_.fullTimeEstimate)
+    def cachedFullTimeEstimate: Option[BandedTime] =
+      executionDigest.map(dig => BandedTime(generatorParams.scienceBand, dig.fullTimeEstimate))
 
   private object ObservationData:
     def load[F[_]: Concurrent](
@@ -116,7 +116,7 @@ object TimeEstimateService:
         OptionT.fromOption(m.get(oid)).flatMap: data =>
           OptionT
             .fromOption(data.cachedFullTimeEstimate)  // try the cache first
-            .orElse
+            .orElse:
               // ExecutionDigest not in the cache, we'll need to calculate it.
               // For that we need the ITC results, which may be cached.  Use the
               // cached ITC AsterismResults if available, else call remote ITC.


### PR DESCRIPTION
This is a fix for a bug in which a time estimate query would:

* perform an execution digest cache lookup
* find a valid value
* ignore it and perform the calculation again
* proceed to update the cache
 
When the cache is updated, an observation edit event is now sent which in turn would prompt Explore to perform the query again ....

The problem boils down to significant whitespace and a missing `:` character.  I'm not sure why this compiled before.

We might want to add a comparison in the trigger function to ensure that the `OLD` and `NEW` records differ before sending an event as suggested.  If that had been done though, it would have masked this issue so I'm not sure.