### PR TITLE
Allow COI-RO to update its own progam user information

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/ProgramUserService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProgramUserService.scala
@@ -554,7 +554,11 @@ object ProgramUserService:
           sql"WHERE #$alias.c_program_user_id IN ("(Void) |+| which |+| void")"
 
         (correlatedExistsUserAccess(user, alias, "i").fold(up) { exists =>
-          up |+| void" AND " |+| exists
+          up |+| void" AND (" |+|
+            sql"#$alias.c_user_id = $user_id"(user.id) |+|   // updating our own user
+            void" OR " |+|
+            exists |+|                                       // user otherwise has access
+          void")"
         }) |+| sql" RETURNING #$alias.c_program_user_id"(Void)
 
     end updateProgramUsers


### PR DESCRIPTION
From [ShortCut 4461](https://app.shortcut.com/lucuma/story/4461/allow-read-only-co-investigators-to-edit-their-details?vc_group_by=day&ct_workflow=all&cf_workflow=500000071), allows any user to update their own `ProgramUser` attributes (except for their program user role).

(To make this work in Explore, I'm guessing there will need to be UI updates.)