### PR TITLE
ShortCut 4015: change program user role

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -667,6 +667,25 @@ type CategorizedTimeRange {
 }
 
 """
+Input used to change the role of a program user.
+"""
+input ChangeProgramUserRoleInput {
+
+  "Program user to update."
+  programUserId: ProgramUserId!
+
+  "New role they should assume."
+  newRole:       ProgramUserRole!
+}
+
+"""
+Result of the program user role update, which is the updated program user itself.
+"""
+type ChangeProgramUserRoleResult {
+  programUser: ProgramUser!
+}
+
+"""
 Describes an observation clone operation, making any edits in the `SET`
 parameter.  The observation status in the cloned observation defaults to NEW.
 Identify the observation to clone by specifying either its id or reference.  If
@@ -2843,6 +2862,13 @@ type Mutation {
   addTimeChargeCorrection(
     input: AddTimeChargeCorrectionInput!
   ): AddTimeChargeCorrectionResult!
+
+  """
+  Update the role of a program user.
+  """
+  changeProgramUserRole(
+    input: ChangeProgramUserRoleInput!
+  ): ChangeProgramUserRoleResult!
 
   cloneObservation(
     """

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -49,6 +49,7 @@ trait BaseMapping[F[_]]
   lazy val CategorizedTimeType                     = schema.ref("CategorizedTime")
   lazy val CatalogInfoType                         = schema.ref("CatalogInfo")
   lazy val CatalogNameType                         = schema.ref("CatalogName")
+  lazy val ChangeProgramUserRoleResultType         = schema.ref("ChangeProgramUserRoleResult")
   lazy val ChargeClassType                         = schema.ref("ChargeClass")
   lazy val ChronicleIdType                         = schema.ref("ChronicleId")
   lazy val ClassicalType                           = schema.ref("Classical")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -95,6 +95,7 @@ object OdbMapping {
           with AddAtomEventResultMapping[F]
           with AddConditionsEntryResultMapping[F]
           with AddDatasetEventResultMapping[F]
+          with AddProgramUserResultMapping[F]
           with AddSequenceEventResultMapping[F]
           with AddSlewEventResultMapping[F]
           with AddStepEventResultMapping[F]
@@ -110,6 +111,7 @@ object OdbMapping {
           with CallsForProposalsSelectResultMapping[F]
           with CatalogInfoMapping[F]
           with CategorizedTimeMapping[F]
+          with ChangeProgramUserRoleResultMapping[F]
           with CloneGroupResultMapping[F]
           with CloneObservationResultMapping[F]
           with CloneTargetResultMapping[F]
@@ -132,7 +134,6 @@ object OdbMapping {
           with CreateCallForProposalsResultMapping[F]
           with CreateGroupResultMapping[F]
           with CreateObservationResultMapping[F]
-          with AddProgramUserResultMapping[F]
           with CreateProgramResultMapping[F]
           with CreateProposalResultMapping[F]
           with CreateTargetResultMapping[F]
@@ -294,6 +295,7 @@ object OdbMapping {
                 AddAtomEventResultMapping,
                 AddConditionsEntryResultMapping,
                 AddDatasetEventResultMapping,
+                AddProgramUserResultMapping,
                 AddSequenceEventResultMapping,
                 AddSlewEventResultMapping,
                 AddStepEventResultMapping,
@@ -310,6 +312,7 @@ object OdbMapping {
                 CallForProposalsPartnerMapping,
                 CallsForProposalsSelectResultMapping,
                 CatalogInfoMapping,
+                ChangeProgramUserRoleResultMapping,
                 ClassicalMapping,
                 CloneGroupResultMapping,
                 CloneObservationResultMapping,
@@ -328,7 +331,6 @@ object OdbMapping {
                 CreateCallForProposalsResultMapping,
                 CreateGroupResultMapping,
                 CreateObservationResultMapping,
-                AddProgramUserResultMapping,
                 CreateProgramResultMapping,
                 CreateProposalResultMapping,
                 CreateTargetResultMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ChangeProgramUserRoleInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ChangeProgramUserRoleInput.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.input
+
+import cats.syntax.parallel.*
+import grackle.Result
+import grackle.syntax.*
+import lucuma.core.enums.ProgramUserRole
+import lucuma.core.model.ProgramUser
+import lucuma.odb.graphql.binding.*
+
+case class ChangeProgramUserRoleInput(
+  programUserId: ProgramUser.Id,
+  newRole:       ProgramUserRole
+)
+
+object ChangeProgramUserRoleInput:
+  def ensuringNotPi(role: ProgramUserRole): Result[ProgramUserRole] =
+    role match
+      case ProgramUserRole.Pi => Result.failure(s"PIs are added at program creation time.")
+      case _                  => role.success
+
+  val Binding: Matcher[ChangeProgramUserRoleInput] =
+    ObjectFieldsBinding.rmap:
+      case List(
+        ProgramUserIdBinding("programUserId", rProgramUserId),
+        ProgramUserRoleBinding("newRole", rNewRole)
+      ) => (
+        rProgramUserId,
+        rNewRole.flatMap(ensuringNotPi)
+      ).parMapN(ChangeProgramUserRoleInput.apply)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ChangeProgramUserRoleResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ChangeProgramUserRoleResultMapping.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mapping
+
+import grackle.skunk.SkunkMapping
+
+import table.ProgramUserTable
+
+trait ChangeProgramUserRoleResultMapping[F[_]] extends ProgramUserTable[F]:
+
+  lazy val ChangeProgramUserRoleResultMapping: ObjectMapping =
+    ObjectMapping(ChangeProgramUserRoleResultType)(
+      SqlField("id", ProgramUserTable.ProgramUserId, key = true, hidden = true),
+      SqlObject("programUser")
+    )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -78,6 +78,7 @@ trait MutationMapping[F[_]] extends Predicates[F] {
       AddSlewEvent,
       AddStepEvent,
       AddTimeChargeCorrection,
+      ChangeProgramUserRole,
       CloneGroup,
       CloneObservation,
       CloneTarget,
@@ -290,9 +291,9 @@ trait MutationMapping[F[_]] extends Predicates[F] {
   private lazy val AddProgramUser: MutationField =
     MutationField("addProgramUser", AddProgramUserInput.Binding): (input, child) =>
       services.useTransactionally:
-        programUserService.addProgramUser(input).map: r =>
-          r.map: pui =>
-            Unique(Filter(Predicates.programUser.id.eql(pui) , child))
+        programUserService.addProgramUser(input).map: m =>
+          m.map: pui =>
+            Unique(Filter(Predicates.programUser.id.eql(pui), child))
 
   private lazy val AddTimeChargeCorrection: MutationField =
     MutationField("addTimeChargeCorrection", AddTimeChargeCorrectionInput.Binding): (input, child) =>
@@ -302,6 +303,13 @@ trait MutationMapping[F[_]] extends Predicates[F] {
             Result(
               Filter(Predicates.addTimeChargeCorrectionResult.timeChargeInvoice.id.eql(input.visitId), child)
             )
+
+  private lazy val ChangeProgramUserRole: MutationField =
+    MutationField("changeProgramUserRole", ChangeProgramUserRoleInput.Binding): (input, child) =>
+      services.useTransactionally:
+        programUserService.changeProgramUserRole(input).map: m =>
+          m.map: pui =>
+            Unique(Filter(Predicates.programUser.id.eql(pui), child))
 
   private lazy val CloneGroup: MutationField =
     MutationField("cloneGroup", CloneGroupInput.Binding): (input, child) =>

--- a/modules/service/src/main/scala/lucuma/odb/service/ProgramUserService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProgramUserService.scala
@@ -162,7 +162,7 @@ object ProgramUserService:
 
         (for
           o  <- ResultT(insert)
-          id <- o.fold(ResultT.fromResult(OdbError.NotAuthorized(user.id, s"User ${user.id} is not authorized to perform this operation.".some).asFailure))(ResultT.pure)
+          id <- o.fold(ResultT.fromResult(OdbError.NotAuthorized(user.id).asFailure))(ResultT.pure)
           set = ProgramUserPropertiesInput.partnerLink.replace(link.some)(set0)
           _  <- ResultT(updateProperties(set, sql"$program_user_id"(id)))
         yield id).value
@@ -183,7 +183,7 @@ object ProgramUserService:
                   session.prepare(af.fragment.command).flatMap: pq =>
                     pq.execute(af.argument).map:
                       case Completion.Update(1) => input.programUserId.success
-                      case _                    => OdbError.NotAuthorized(user.id, s"User ${user.id} is not authorized to perform this operation.".some).asFailure
+                      case _                    => OdbError.NotAuthorized(user.id).asFailure
 
 
       override def deleteProgramUser(
@@ -201,7 +201,7 @@ object ProgramUserService:
                   session.prepare(af.fragment.command).flatMap: pq =>
                     pq.execute(af.argument).map:
                       case Completion.Delete(1) => true.success
-                      case _                    => OdbError.NotAuthorized(user.id, s"User ${user.id} is not authorized to perform this operation.".some).asFailure
+                      case _                    => OdbError.NotAuthorized(user.id).asFailure
 
       override def updateProperties(
         SET:   ProgramUserPropertiesInput,
@@ -249,7 +249,7 @@ object ProgramUserService:
                   pq.execute(af.argument)
                     .map:
                       case Completion.Update(1) => ().success
-                      case a                    => OdbError.NotAuthorized(user.id, s"User ${user.id} is not authorized to perform this operation.".some).asFailure
+                      case a                    => OdbError.NotAuthorized(user.id).asFailure
                     .recover:
                       case SqlState.UniqueViolation(_)     =>
                         OdbError.NoAction(s"User $targetUserId is already linked to program $pid.".some).asFailure
@@ -271,7 +271,7 @@ object ProgramUserService:
                   pq.execute(af.argument)
                     .map:
                       case Completion.Update(1) => uid.some.success
-                      case a                    => OdbError.NotAuthorized(user.id, s"User ${user.id} is not authorized to perform this operation.".some).asFailure
+                      case a                    => OdbError.NotAuthorized(user.id).asFailure
 
       override def userHasAccess(
         programId: Program.Id

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addProgramUser.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addProgramUser.scala
@@ -286,7 +286,7 @@ class addProgramUser extends OdbSuite:
           _   <- addProgramUserAs(u, pid, role, partnerLinkFor(role))
         yield ()
 
-  test(s"Nobody can add nother PI."):
+  test(s"Nobody can add another PI."):
     interceptOdbError {
       for
         _   <- createUsers(pi1, admin)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/changeProgramUserRole.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/changeProgramUserRole.scala
@@ -1,0 +1,264 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mutation
+
+import cats.syntax.either.*
+import cats.syntax.eq.*
+import io.circe.Json
+import io.circe.literal.*
+import lucuma.core.enums.Partner
+import lucuma.core.enums.ProgramUserRole
+import lucuma.core.enums.ScienceBand
+import lucuma.core.enums.TimeAccountingCategory
+import lucuma.core.model.PartnerLink
+import lucuma.core.model.ProgramUser
+import lucuma.core.syntax.string.*
+import lucuma.core.util.TimeSpan
+import lucuma.odb.data.OdbError
+
+
+class changeProgramUserRole extends OdbSuite:
+  val partner  = Partner.CA
+  val pi1      = TestUsers.Standard.pi(nextId, nextId)
+  val pi2      = TestUsers.Standard.pi(nextId, nextId)
+  val pi3      = TestUsers.Standard.pi(nextId, nextId)
+  val ngo      = TestUsers.Standard.ngo(nextId, nextId, Partner.CA)
+  val staff    = TestUsers.Standard.staff(nextId, nextId)
+  val admin    = TestUsers.Standard.admin(nextId, nextId)
+  val guest    = TestUsers.guest(nextId)
+  val service  = TestUsers.service(nextId)
+
+  lazy val validUsers = List(pi1, pi2, pi3, ngo, staff, admin, guest, service)
+
+  private def changeUserRoleQuery(puid: ProgramUser.Id, newRole: ProgramUserRole): String =
+    s"""
+      mutation {
+        changeProgramUserRole(
+          input: {
+            programUserId: "$puid"
+            newRole: ${newRole.tag.toScreamingSnakeCase}
+          }
+        ) {
+          programUser {
+            role
+          }
+        }
+      }
+    """
+
+  private def changeProgramUserRoleResult(newRole: ProgramUserRole): Json =
+    json"""
+      {
+        "changeProgramUserRole": {
+          "programUser": {
+            "role": $newRole
+          }
+        }
+      }
+    """
+
+  private def partnerLinkFor(role: ProgramUserRole): PartnerLink =
+    if (role === ProgramUserRole.SupportPrimary || role === ProgramUserRole.SupportSecondary) PartnerLink.HasUnspecifiedPartner
+    else PartnerLink.HasPartner(Partner.US)
+
+  test("canonical use case"):
+    createProgramAs(pi1).flatMap: pid =>
+      addProgramUserAs(pi1, pid, ProgramUserRole.CoiRO).flatMap: mid =>
+        expect(
+          user     = pi1,
+          query    = changeUserRoleQuery(mid, ProgramUserRole.Coi),
+          expected = changeProgramUserRoleResult(ProgramUserRole.Coi).asRight
+        )
+
+
+  // What can a PI do?
+
+  test("Cannot switch a COI to PI"):
+    createUsers(pi2) >>
+    createProgramAs(pi1).flatMap: pid =>
+      addProgramUserAs(pi1, pid, ProgramUserRole.Coi).flatMap: mid =>
+        linkUserAs(pi1, mid, pi2.id) >>
+        expect(
+          user     = pi1,
+          query    = changeUserRoleQuery(mid, ProgramUserRole.Pi),
+          expected = List(s"Argument 'input' is invalid: PIs are added at program creation time.").asLeft
+        )
+
+  List(
+    ProgramUserRole.CoiRO -> ProgramUserRole.Coi,
+    ProgramUserRole.Coi   -> ProgramUserRole.CoiRO
+  ).foreach: (from, to) =>
+    test(s"PI can change $from to $to"):
+      createProgramAs(pi1).flatMap: pid =>
+        addProgramUserAs(pi1, pid, from).flatMap: mid =>
+          expect(
+            user     = pi1,
+            query    = changeUserRoleQuery(mid, to),
+            expected = changeProgramUserRoleResult(to).asRight
+          )
+
+  List(
+    ProgramUserRole.CoiRO -> ProgramUserRole.SupportPrimary,
+    ProgramUserRole.CoiRO -> ProgramUserRole.SupportSecondary,
+    ProgramUserRole.Coi   -> ProgramUserRole.SupportPrimary,
+    ProgramUserRole.Coi   -> ProgramUserRole.SupportSecondary,
+    ProgramUserRole.SupportPrimary -> ProgramUserRole.CoiRO,
+    ProgramUserRole.SupportPrimary -> ProgramUserRole.Coi,
+    ProgramUserRole.SupportPrimary -> ProgramUserRole.SupportSecondary,
+    ProgramUserRole.SupportSecondary -> ProgramUserRole.CoiRO,
+    ProgramUserRole.SupportSecondary -> ProgramUserRole.Coi,
+    ProgramUserRole.SupportSecondary -> ProgramUserRole.SupportPrimary,
+  ).foreach: (from, to) =>
+    test(s"PI cannot change $from to $to"):
+      val action = from match
+        case ProgramUserRole.SupportPrimary | ProgramUserRole.SupportSecondary => "unassign"
+        case _                                                                 => "assign"
+      createProgramAs(pi1).flatMap: pid =>
+        addProgramUserAs(staff, pid, from).flatMap: mid =>
+          expect(
+            user     = pi1,
+            query    = changeUserRoleQuery(mid, to),
+            expected = List(s"Only admin, staff or service users may $action support users.").asLeft
+          )
+
+
+  // What can a COI do?
+
+  test("CoiRO can't change its own role"):
+    createUsers(pi2) >>
+    createProgramAs(pi1).flatMap: pid =>
+      addProgramUserAs(pi1, pid, ProgramUserRole.CoiRO).flatMap: mid =>
+        linkUserAs(pi1, mid, pi2.id) >>
+        expect(
+          user     = pi2,
+          query    = changeUserRoleQuery(mid, ProgramUserRole.Coi),
+          expected = List(s"User ${pi2.id} is not authorized to perform this operation.").asLeft
+        )
+
+  // N.B. I'm not sure what the rule should be for downgrading CoiRo.  As
+  // implemented it won't work though.  Would require a special case I think.
+  test("Coi can downgrade itself".ignore):
+    createUsers(pi2) >>
+    createProgramAs(pi1).flatMap: pid =>
+      addProgramUserAs(pi1, pid, ProgramUserRole.Coi).flatMap: mid =>
+        linkUserAs(pi1, mid, pi2.id) >>
+        expect(
+          user     = pi2,
+          query    = changeUserRoleQuery(mid, ProgramUserRole.CoiRO),
+          expected = changeProgramUserRoleResult(ProgramUserRole.CoiRO).asRight
+        )
+
+
+  // What can an NGO user do?
+
+  List(
+    ProgramUserRole.CoiRO -> ProgramUserRole.Coi,
+    ProgramUserRole.Coi   -> ProgramUserRole.CoiRO
+  ).foreach: (from, to) =>
+    test(s"Ngo (CA) can change $from to $to with allocated time."):
+      for
+        _   <- createUsers(pi1, pi2, admin, ngo)
+        pid <- createProgramAs(pi1)
+        _   <- setOneAllocationAs(admin, pid, TimeAccountingCategory.CA, ScienceBand.Band1, TimeSpan.Max) // so ngo can see the program
+        mid <- addProgramUserAs(pi1, pid, from, partnerLinkFor(from))
+        _   <- expect(
+          user     = ngo,
+          query    = changeUserRoleQuery(mid, to),
+          expected = changeProgramUserRoleResult(to).asRight
+        )
+      yield ()
+
+  List(
+    ProgramUserRole.CoiRO -> ProgramUserRole.Coi,
+    ProgramUserRole.Coi   -> ProgramUserRole.CoiRO
+  ).foreach: (from, to) =>
+    test(s"Ngo (CA) cannot change $from to $to without allocated time."):
+      interceptOdbError {
+        for
+          _   <- createUsers(pi1, pi2, admin, ngo)
+          pid <- createProgramAs(pi1)
+          mid <- addProgramUserAs(pi1, pid, from, partnerLinkFor(from))
+          _   <- query(
+            user     = ngo,
+            query    = changeUserRoleQuery(mid, to)
+          )
+        yield ()
+      } {
+        case OdbError.NotAuthorized(ngo.id, _) => // expected
+      }
+
+  List(
+    ProgramUserRole.CoiRO -> ProgramUserRole.SupportPrimary,
+    ProgramUserRole.Coi   -> ProgramUserRole.SupportPrimary,
+    ProgramUserRole.CoiRO -> ProgramUserRole.SupportSecondary,
+    ProgramUserRole.Coi   -> ProgramUserRole.SupportSecondary,
+    ProgramUserRole.SupportPrimary -> ProgramUserRole.CoiRO,
+    ProgramUserRole.SupportPrimary -> ProgramUserRole.Coi,
+    ProgramUserRole.SupportPrimary -> ProgramUserRole.SupportSecondary,
+    ProgramUserRole.SupportSecondary -> ProgramUserRole.CoiRO,
+    ProgramUserRole.SupportSecondary -> ProgramUserRole.Coi,
+    ProgramUserRole.SupportSecondary -> ProgramUserRole.SupportPrimary,
+  ).foreach: (from, to) =>
+    test(s"Ngo (CA) cannot change $from to $to even with allocated time."):
+      val action = from match
+        case ProgramUserRole.SupportPrimary | ProgramUserRole.SupportSecondary => "unassign"
+        case _                                                                 => "assign"
+      for
+        _   <- createUsers(pi1, pi2, admin, ngo)
+        pid <- createProgramAs(pi1)
+        _   <- setOneAllocationAs(admin, pid, TimeAccountingCategory.CA, ScienceBand.Band1, TimeSpan.Max) // so ngo can see the program
+        mid <- addProgramUserAs(staff, pid, from, partnerLinkFor(from))
+        _   <- expect(
+          user     = ngo,
+          query    = changeUserRoleQuery(mid, to),
+          expected = List(s"Only admin, staff or service users may $action support users.").asLeft
+        )
+      yield ()
+
+  // What can superusers do?
+
+  List(staff, admin, service).foreach: u =>
+    List(
+      ProgramUserRole.CoiRO -> ProgramUserRole.Coi,
+      ProgramUserRole.CoiRO -> ProgramUserRole.SupportPrimary,
+      ProgramUserRole.CoiRO -> ProgramUserRole.SupportSecondary,
+      ProgramUserRole.Coi   -> ProgramUserRole.CoiRO,
+      ProgramUserRole.Coi   -> ProgramUserRole.SupportPrimary,
+      ProgramUserRole.Coi   -> ProgramUserRole.SupportSecondary,
+      ProgramUserRole.SupportPrimary -> ProgramUserRole.CoiRO,
+      ProgramUserRole.SupportPrimary -> ProgramUserRole.Coi,
+      ProgramUserRole.SupportPrimary -> ProgramUserRole.SupportSecondary,
+      ProgramUserRole.SupportSecondary -> ProgramUserRole.CoiRO,
+      ProgramUserRole.SupportSecondary -> ProgramUserRole.Coi,
+      ProgramUserRole.SupportSecondary -> ProgramUserRole.SupportPrimary,
+    ).foreach: (from, to) =>
+      test(s"${u.role.access} can change $from to $to."):
+        for
+          _   <- createUsers(pi1, u)
+          pid <- createProgramAs(pi1)
+          _   <- setOneAllocationAs(u, pid, TimeAccountingCategory.CA, ScienceBand.Band1, TimeSpan.Max) // so ngo can see the program
+          mid <- addProgramUserAs(u, pid, from, partnerLinkFor(from))
+          _   <- expect(
+            user     = u,
+            query    = changeUserRoleQuery(mid, to),
+            expected = changeProgramUserRoleResult(to).asRight
+          )
+        yield ()
+
+  List(pi1, staff, admin, service).foreach: u =>
+    test(s"${u.role.access} cannot add another PI."):
+      interceptOdbError {
+        for
+          _   <- createUsers(pi1, admin)
+          pid <- createProgramAs(pi1)
+          mid <- addProgramUserAs(u, pid, ProgramUserRole.Coi, partnerLinkFor(ProgramUserRole.Coi))
+          _   <- query(
+            user    = u,
+            query   = changeUserRoleQuery(mid, ProgramUserRole.Pi)
+          )
+        yield ()
+      } {
+        case OdbError.InvalidArgument(Some("Argument 'input' is invalid: PIs are added at program creation time.")) => // ok
+      }


### PR DESCRIPTION
Updates the API to add a new mutation which [allows a program user role to be updated](https://app.shortcut.com/lucuma/story/4015/ability-to-update-collaborator-s-access-privileges?vc_group_by=day&ct_workflow=all&cf_workflow=500000071).  This could probably be folded into to `updateProgramUsers` but since the role is such an integral part of authorization this seemed much easier.