### PR TITLE
test for sc-3485

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -41,7 +41,6 @@ import lucuma.core.math.SignalToNoise
 import lucuma.core.math.Wavelength
 import lucuma.core.model.User
 import lucuma.core.syntax.timespan.*
-import lucuma.core.util.Gid
 import lucuma.itc.AsterismIntegrationTimeOutcomes
 import lucuma.itc.IntegrationTime
 import lucuma.itc.ItcVersions
@@ -328,20 +327,21 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
     FMain.singleSession(databaseConfig)
 
   private def transactionalClient(user: User)(svr: Server): IO[FetchClient[IO, Nothing]] =
-    for {
-      xbe <- JdkHttpClient.simple[IO].map(Http4sHttpBackend[IO](_))
-      uri  = svr.baseUri / "odb"
-      xc  <- Http4sHttpClient.of[IO, Nothing](uri, headers = Headers(Authorization(Credentials.Token(AuthScheme.Bearer, Gid[User.Id].fromString.reverseGet(user.id)))))(Async[IO], xbe, Logger[IO])
-    } yield xc
+    authorizationHeader(user).flatMap: auth =>
+      for {
+        xbe <- JdkHttpClient.simple[IO].map(Http4sHttpBackend[IO](_))
+        uri  = svr.baseUri / "odb"
+        xc  <- Http4sHttpClient.of[IO, Nothing](uri, headers = Headers(auth))(Async[IO], xbe, Logger[IO])
+      } yield xc
 
   private def streamingClient(user: User)(svr: Server): Resource[IO, WebSocketClient[IO, Nothing]] =
-    for {
-      sbe <- Resource.eval(JdkWSClient.simple[IO].map(Http4sWebSocketBackend[IO](_)))
-      uri  = (svr.baseUri / "ws").copy(scheme = Some(Http4sUri.Scheme.unsafeFromString("ws")))
-      sc  <- Resource.eval(Http4sWebSocketClient.of[IO, Nothing](uri)(using Async[IO], Logger[IO], sbe))
-      ps   = Map("Authorization" -> Json.fromString(s"Bearer ${Gid[User.Id].fromString.reverseGet(user.id)}"))
-      _   <- Resource.make(sc.connect(ps.pure[IO]))(_ => sc.disconnect())
-    } yield sc
+    Resource.eval(authorizationObject(user)).flatMap: ps =>
+      for {
+        sbe <- Resource.eval(JdkWSClient.simple[IO].map(Http4sWebSocketBackend[IO](_)))
+        uri  = (svr.baseUri / "ws").copy(scheme = Some(Http4sUri.Scheme.unsafeFromString("ws")))
+        sc  <- Resource.eval(Http4sWebSocketClient.of[IO, Nothing](uri)(using Async[IO], Logger[IO], sbe))
+        _   <- Resource.make(sc.connect(ps.pure[IO]))(_ => sc.disconnect())
+      } yield sc
 
   case class Operation(document: String) extends GraphQLOperation.Typed[Nothing, JsonObject, Json]
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/TestSsoClient.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/TestSsoClient.scala
@@ -6,29 +6,105 @@ package lucuma.odb.graphql
 import cats.data.OptionT
 import cats.effect.IO
 import cats.syntax.all.*
+import io.circe.Json
+import io.circe.syntax.*
 import lucuma.core.model.User
-import lucuma.core.util.Gid
 import lucuma.sso.client.SsoClient
+import lucuma.sso.client.SsoJwtReader
+import lucuma.sso.client.codec.user.*
+import lucuma.sso.client.util.JwtDecoder
 import org.http4s.*
+import org.http4s.Credentials
+import org.http4s.Request
 import org.http4s.headers.Authorization
 import org.typelevel.ci.CIString
+import pdi.jwt.Jwt
+import pdi.jwt.JwtAlgorithm
+import pdi.jwt.JwtClaim
+
+import java.security.KeyPairGenerator
+import java.security.SecureRandom
+import java.time.Instant
+import scala.concurrent.duration.*
 
 trait TestSsoClient:
+  import TestSsoClient.* 
+
+  export TestSsoClient.{ authorizationHeader, authorizationObject }
 
   def validUsers: List[User]
 
-  val Bearer: AuthScheme = CIString("Bearer")
-
-  def authHeader(user: User) = 
-    Authorization(Credentials.Token(AuthScheme.Bearer, Gid[User.Id].fromString.reverseGet(user.id)))
-
-  val invalidAuthHeader = Authorization(Credentials.Token(AuthScheme.Bearer, "***"))
+  // User by attachments tests
+  val invalidAuthHeader = 
+    Authorization(Credentials.Token(AuthScheme.Bearer, "***"))
 
   def ssoClient: SsoClient[IO, User] =
     new SsoClient.AbstractSsoClient[IO, User]:
-      def find(req: Request[IO]): IO[Option[User]] = OptionT.fromOption[IO](req.headers.get[Authorization]).flatMapF(get).value
+      def find(req: Request[IO]): IO[Option[User]] = 
+        OptionT.fromOption[IO](req.headers.get[Authorization]).flatMapF(get).value
       def get(authorization: Authorization): IO[Option[User]] =
         authorization match
-          case Authorization(Credentials.Token(Bearer, s)) =>
-            Gid[User.Id].fromString.getOption(s).flatMap(id => validUsers.find(_.id === id)).pure[IO]
+          case Authorization(Credentials.Token(Bearer, jwt)) =>
+            reader
+              .decodeClaim(jwt)
+              .map(_.getUser)
+              .flatMap:
+                case Left(t) => IO.raiseError(t)
+                case Right(u) => validUsers.find(_ === u).pure[IO]
           case _ => none.pure[IO]
+  
+private object TestSsoClient:
+
+  private val keyGen     = KeyPairGenerator.getInstance("RSA", "SunRsaSign")
+  private val random     = SecureRandom.getInstance("SHA1PRNG", "SUN")
+  private val keyPair    = { keyGen.initialize(1024, random); keyGen.generateKeyPair }
+  private val decoder    = JwtDecoder.withPublicKey[IO](keyPair.getPublic())
+  private val reader     = SsoJwtReader(decoder)
+  private val Bearer     = CIString("Bearer")
+  private val lucumaUser = "lucuma-user"
+  private val padSeconds = 10L
+  private val algorithm  = JwtAlgorithm.RS512
+  private val jwtTimeout = 1.minute
+
+  export reader.decodeClaim
+
+  private def encode(claim: JwtClaim): IO[String] =
+    IO(Jwt.encode(claim, keyPair.getPrivate(), algorithm))
+
+  private val now: IO[Instant] =
+    IO(Instant.now)
+
+  private def newClaim(content: String, subject: Option[String], timeout: FiniteDuration): IO[JwtClaim] =
+    now.map { inst =>
+      JwtClaim(
+        content    = content,
+        issuer     = Some("lucuma-sso"),
+        subject    = subject,
+        audience   = Some(Set("lucuma")),
+        expiration = Some(inst.plusSeconds(timeout.toSeconds).getEpochSecond),
+        notBefore  = Some(inst.getEpochSecond - padSeconds),
+        issuedAt   = Some(inst.getEpochSecond - padSeconds),
+      )
+    }
+
+  private def newClaim(user: User, timeout: FiniteDuration): IO[JwtClaim] =
+    newClaim(
+      content = Json.obj(lucumaUser -> user.asJson).spaces2,
+      subject = Some(user.id.value.toString()),
+      timeout = timeout,
+    )
+
+  private def newJwt(user: User, timeout: Option[FiniteDuration]): IO[String] =
+    newClaim(user, timeout.getOrElse(jwtTimeout)).flatMap(encode)
+
+  /** Map containing Authorization header, for WS. */
+  def authorizationObject(user: User): IO[Map[String, Json]] =
+    newJwt(user, None).map: jwt =>
+      Map("Authorization" -> Json.fromString(s"Bearer $jwt"))
+
+  /** Authorization header, for HTTP. */
+  def authorizationHeader(user: User): IO[Authorization] =
+    newJwt(user, None).map(jwt => Authorization(Credentials.Token(Bearer, jwt)))
+
+
+

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentRoutesSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentRoutesSuite.scala
@@ -38,7 +38,7 @@ abstract class AttachmentRoutesSuite extends CatsEffectSuite with TestSsoClient 
     else if (user === invalidFileUser) AttachmentException.InvalidRequest(invalidFileName).some
     else none
 
-  protected def headers(user: User): Headers = Headers(authHeader(user))
+  protected def headers(user: User): IO[Headers] = authorizationHeader(user).map(Headers(_))
 
   extension (resp: IO[Response[IO]])
     def assertResponse(expectedStatus: Status, expectedBody: Option[String]): IO[Unit] =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentsSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentsSuite.scala
@@ -79,21 +79,22 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
     programId: Program.Id,
     ta:        TestAttachment
   ): Resource[IO, Response[IO]] =
-    server.flatMap { svr =>
-      val uri =
-        (svr.baseUri / "attachment" / programId.toString)
-          .withQueryParam("fileName", ta.fileName)
-          .withQueryParam("attachmentType", ta.attachmentType)
-          .withOptionQueryParam("description", ta.description)
+    Resource.eval(authorizationHeader(user)).flatMap: auth =>
+      server.flatMap { svr =>
+        val uri =
+          (svr.baseUri / "attachment" / programId.toString)
+            .withQueryParam("fileName", ta.fileName)
+            .withQueryParam("attachmentType", ta.attachmentType)
+            .withOptionQueryParam("description", ta.description)
 
-      val request = Request[IO](
-        method = Method.POST,
-        uri = uri,
-        headers = Headers(authHeader(user))
-      ).withEntity(ta.content)
+        val request = Request[IO](
+          method = Method.POST,
+          uri = uri,
+          headers = Headers(auth)
+        ).withEntity(ta.content)
 
-      client.run(request)
-    }
+        client.run(request)
+      }
   
   def updateAttachment(
     user:         User,
@@ -101,36 +102,38 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
     attachmentId: Attachment.Id,
     ta:           TestAttachment
   ): Resource[IO, Response[IO]] =
-    server.flatMap { svr =>
-      val uri =
-        (svr.baseUri / "attachment" / programId.toString / attachmentId.toString)
-          .withQueryParam("fileName", ta.fileName)
-          .withOptionQueryParam("description", ta.description)
+    Resource.eval(authorizationHeader(user)).flatMap: auth =>
+      server.flatMap { svr =>
+        val uri =
+          (svr.baseUri / "attachment" / programId.toString / attachmentId.toString)
+            .withQueryParam("fileName", ta.fileName)
+            .withOptionQueryParam("description", ta.description)
 
-      val request = Request[IO](
-        method = Method.PUT,
-        uri = uri,
-        headers = Headers(authHeader(user))
-      ).withEntity(ta.content)
+        val request = Request[IO](
+          method = Method.PUT,
+          uri = uri,
+          headers = Headers(auth)
+        ).withEntity(ta.content)
 
-      client.run(request)
-    }
+        client.run(request)
+      }
 
   def getAttachment(
     user:         User,
     programId:    Program.Id,
     attachmentId: Attachment.Id
   ): Resource[IO, Response[IO]] =
-    server.flatMap { svr =>
-      val uri     = svr.baseUri / "attachment" / programId.toString / attachmentId.toString
-      val request = Request[IO](
-        method = Method.GET,
-        uri = uri,
-        headers = Headers(authHeader(user))
-      )
+    Resource.eval(authorizationHeader(user)).flatMap: auth =>
+      server.flatMap { svr =>
+        val uri     = svr.baseUri / "attachment" / programId.toString / attachmentId.toString
+        val request = Request[IO](
+          method = Method.GET,
+          uri = uri,
+          headers = Headers(auth)
+        )
 
-      client.run(request)
-    }
+        client.run(request)
+      }
 
   def getViaPresignedUrl(url: NonEmptyString): Resource[IO, Response[IO]] =
     server.flatMap { _ =>
@@ -148,32 +151,34 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
     programId:    Program.Id,
     attachmentId: Attachment.Id
   ): Resource[IO, Response[IO]] =
-    server.flatMap { svr =>
-      val uri     = svr.baseUri / "attachment" / "url" / programId.toString / attachmentId.toString
-      val request = Request[IO](
-        method = Method.GET,
-        uri = uri,
-        headers = Headers(authHeader(user))
-      )
+    Resource.eval(authorizationHeader(user)).flatMap: auth =>
+      server.flatMap { svr =>
+        val uri     = svr.baseUri / "attachment" / "url" / programId.toString / attachmentId.toString
+        val request = Request[IO](
+          method = Method.GET,
+          uri = uri,
+          headers = Headers(auth)
+        )
 
-      client.run(request)
-    }
+        client.run(request)
+      }
 
   def deleteAttachment(
     user:         User,
     programId:    Program.Id,
     attachmentId: Attachment.Id
   ): Resource[IO, Response[IO]] =
-    server.flatMap { svr =>
-      val uri     = svr.baseUri / "attachment" / programId.toString / attachmentId.toString
-      val request = Request[IO](
-        method = Method.DELETE,
-        uri = uri,
-        headers = Headers(authHeader(user))
-      )
+    Resource.eval(authorizationHeader(user)).flatMap: auth =>
+      server.flatMap { svr =>
+        val uri     = svr.baseUri / "attachment" / programId.toString / attachmentId.toString
+        val request = Request[IO](
+          method = Method.DELETE,
+          uri = uri,
+          headers = Headers(auth)
+        )
 
-      client.run(request)
-    }
+        client.run(request)
+      }
 
   def expectedAttachments(
     attachments: List[(Attachment.Id, TestAttachment)]

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachmentRoutes.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachmentRoutes.scala
@@ -133,241 +133,273 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   }
 
   test("valid GET returns file contents") {
-    val request =
-      Request[IO](method = Method.GET, uri = uri"attachment/p-1/a-1", headers = headers(pi))
-    routes.run(request).assertResponse(Status.Ok, fileContents.some)
+    headers(pi).flatMap: hs =>
+      val request =
+        Request[IO](method = Method.GET, uri = uri"attachment/p-1/a-1", headers = hs)
+      routes.run(request).assertResponse(Status.Ok, fileContents.some)
   }
 
   test("valid GETurl returns url") {
-    val request =
-      Request[IO](method = Method.GET, uri = uri"attachment/url/p-1/a-1", headers = headers(pi))
-    routes.run(request).assertResponse(Status.Ok, presignedUrl.some)
+    headers(pi).flatMap: hs =>
+      val request =
+        Request[IO](method = Method.GET, uri = uri"attachment/url/p-1/a-1", headers = hs)
+      routes.run(request).assertResponse(Status.Ok, presignedUrl.some)
   }
 
   test("valid POST returns attachment") {
-    val request = Request[IO](method = Method.POST,
-                              uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
-                              headers = headers(pi)
-    )
-    routes.run(request).assertResponse(Status.Ok, attachmentId.toString.some)
+    headers(pi).flatMap: hs =>
+      val request = Request[IO](method = Method.POST,
+                                uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.Ok, attachmentId.toString.some)
   }
 
   test("valid PUT returns Ok") {
-    val request = Request[IO](method = Method.PUT,
-                              uri = uri"attachment/p-1/a-1?fileName=/file.txt",
-                              headers = headers(pi)
-    )
-    routes.run(request).assertResponse(Status.Ok, none)
+    headers(pi).flatMap: hs =>
+      val request = Request[IO](method = Method.PUT,
+                                uri = uri"attachment/p-1/a-1?fileName=/file.txt",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.Ok, none)
   }
 
   test("valid DELETE returns Ok") {
-    val request =
-      Request[IO](method = Method.DELETE, uri = uri"attachment/p-1/a-1", headers = headers(pi))
-    routes.run(request).assertResponse(Status.Ok, none)
+    headers(pi).flatMap: hs =>
+      val request =
+        Request[IO](method = Method.DELETE, uri = uri"attachment/p-1/a-1", headers = hs)
+      routes.run(request).assertResponse(Status.Ok, none)
   }
 
   test("GET returns NotFound for invalid program id") {
-    val request =
-      Request[IO](method = Method.GET, uri = uri"attachment/p1/a-1", headers = headers(pi))
-    routes.run(request).assertResponse(Status.NotFound, notFound)
+    headers(pi).flatMap: hs =>
+      val request =
+        Request[IO](method = Method.GET, uri = uri"attachment/p1/a-1", headers = hs)
+      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("GET returns NotFound for invalid attachment id") {
-    val request =
-      Request[IO](method = Method.GET, uri = uri"attachment/p-1/a-x1", headers = headers(pi))
-    routes.run(request).assertResponse(Status.NotFound, notFound)
+    headers(pi).flatMap: hs =>
+      val request =
+        Request[IO](method = Method.GET, uri = uri"attachment/p-1/a-x1", headers = hs)
+      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("GETurl returns NotFound for invalid program id") {
-    val request =
-      Request[IO](method = Method.GET, uri = uri"attachment/url/p1/a-1", headers = headers(pi))
-    routes.run(request).assertResponse(Status.NotFound, notFound)
+    headers(pi).flatMap: hs =>
+      val request =
+        Request[IO](method = Method.GET, uri = uri"attachment/url/p1/a-1", headers = hs)
+      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("GETurl returns NotFound for invalid attachment id") {
-    val request =
-      Request[IO](method = Method.GET, uri = uri"attachment/url/p-1/a-x1", headers = headers(pi))
-    routes.run(request).assertResponse(Status.NotFound, notFound)
+    headers(pi).flatMap: hs =>
+      val request =
+        Request[IO](method = Method.GET, uri = uri"attachment/url/p-1/a-x1", headers = hs)
+      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("POST returns NotFound for invalid program id") {
-    val request = Request[IO](method = Method.POST,
-                              uri = uri"attachment/a-1?fileName=/file.txt/&attachmentType=finder",
-                              headers = headers(pi)
-    )
-    routes.run(request).assertResponse(Status.NotFound, notFound)
+    headers(pi).flatMap: hs =>
+      val request = Request[IO](method = Method.POST,
+                                uri = uri"attachment/a-1?fileName=/file.txt/&attachmentType=finder",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("POST returns NotFound for missing fileName") {
-    val request = Request[IO](method = Method.POST,
-                              uri = uri"attachment/p-1?attachmentType=finder",
-                              headers = headers(pi)
-    )
-    routes.run(request).assertResponse(Status.NotFound, notFound)
+    headers(pi).flatMap: hs =>
+      val request = Request[IO](method = Method.POST,
+                                uri = uri"attachment/p-1?attachmentType=finder",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("POST returns NotFound for missing attachmentType") {
-    val request = Request[IO](method = Method.POST,
-                              uri = uri"attachment/p-1?fileName=/file.txt/",
-                              headers = headers(pi)
-    )
-    routes.run(request).assertResponse(Status.NotFound, notFound)
+    headers(pi).flatMap: hs =>
+      val request = Request[IO](method = Method.POST,
+                                uri = uri"attachment/p-1?fileName=/file.txt/",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("PUT returns NotFound for invalid program id") {
-    val request = Request[IO](method = Method.PUT,
-                              uri = uri"attachment/z-1/a-1?fileName=/file.txt",
-                              headers = headers(pi)
-    )
-    routes.run(request).assertResponse(Status.NotFound, notFound)
+    headers(pi).flatMap: hs =>
+      val request = Request[IO](method = Method.PUT,
+                                uri = uri"attachment/z-1/a-1?fileName=/file.txt",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("PUT returns NotFound for invalid attachment id") {
-    val request = Request[IO](method = Method.PUT,
-                              uri = uri"attachment/p-1/q-1?fileName=/file.txt",
-                              headers = headers(pi)
-    )
-    routes.run(request).assertResponse(Status.NotFound, notFound)
+    headers(pi).flatMap: hs =>
+      val request = Request[IO](method = Method.PUT,
+                                uri = uri"attachment/p-1/q-1?fileName=/file.txt",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("PUT returns NotFound for missing fileName") {
-    val request = Request[IO](method = Method.PUT,
-                              uri = uri"attachment/p-1/a-1",
-                              headers = headers(pi)
-    )
-    routes.run(request).assertResponse(Status.NotFound, notFound)
+    headers(pi).flatMap: hs =>
+      val request = Request[IO](method = Method.PUT,
+                                uri = uri"attachment/p-1/a-1",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("DELETE returns NotFound for invalid program id") {
-    val request =
-      Request[IO](method = Method.DELETE, uri = uri"attachment/p/a-1", headers = headers(pi))
-    routes.run(request).assertResponse(Status.NotFound, notFound)
+    headers(pi).flatMap: hs =>
+      val request =
+        Request[IO](method = Method.DELETE, uri = uri"attachment/p/a-1", headers = hs)
+      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("DELETE returns NotFound for invalid attachment id") {
-    val request =
-      Request[IO](method = Method.DELETE, uri = uri"attachment/p-1/a", headers = headers(pi))
-    routes.run(request).assertResponse(Status.NotFound, notFound)
+    headers(pi).flatMap: hs =>
+      val request =
+        Request[IO](method = Method.DELETE, uri = uri"attachment/p-1/a", headers = hs)
+      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("GET returns Forbidden if service returns Forbidden") {
-    val request = Request[IO](method = Method.GET,
-                              uri = uri"attachment/p-1/a-1",
-                              headers = headers(forbiddenUser)
-    )
-    routes.run(request).assertResponse(Status.Forbidden, none)
+    headers(forbiddenUser).flatMap: hs =>
+      val request = Request[IO](method = Method.GET,
+                                uri = uri"attachment/p-1/a-1",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.Forbidden, none)
   }
 
   test("GET returns NotFound if service returns FileNotFound") {
-    val request = Request[IO](method = Method.GET,
-                              uri = uri"attachment/p-1/a-1",
-                              headers = headers(fileNotFoundUser)
-    )
-    routes.run(request).assertResponse(Status.NotFound, none)
+    headers(fileNotFoundUser).flatMap: hs =>
+      val request = Request[IO](method = Method.GET,
+                                uri = uri"attachment/p-1/a-1",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.NotFound, none)
   }
 
   test("GET returns BadRequest with message if service returns InvalidRequest") {
-    val request = Request[IO](method = Method.GET,
-                              uri = uri"attachment/p-1/a-1",
-                              headers = headers(invalidFileUser)
-    )
-    routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
+    headers(invalidFileUser).flatMap: hs =>
+      val request = Request[IO](method = Method.GET,
+                                uri = uri"attachment/p-1/a-1",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
   }
 
   test("GETurl returns Forbidden if service returns Forbidden") {
-    val request = Request[IO](method = Method.GET,
-                              uri = uri"attachment/url/p-1/a-1",
-                              headers = headers(forbiddenUser)
-    )
-    routes.run(request).assertResponse(Status.Forbidden, none)
+    headers(forbiddenUser).flatMap: hs =>
+      val request = Request[IO](method = Method.GET,
+                                uri = uri"attachment/url/p-1/a-1",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.Forbidden, none)
   }
 
   test("GETurl returns NotFound if service returns FileNotFound") {
-    val request = Request[IO](method = Method.GET,
-                              uri = uri"attachment/url/p-1/a-1",
-                              headers = headers(fileNotFoundUser)
-    )
-    routes.run(request).assertResponse(Status.NotFound, none)
+    headers(fileNotFoundUser).flatMap: hs =>
+      val request = Request[IO](method = Method.GET,
+                                uri = uri"attachment/url/p-1/a-1",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.NotFound, none)
   }
 
   test("GETurl returns BadRequest with message if service returns InvalidRequest") {
-    val request = Request[IO](method = Method.GET,
-                              uri = uri"attachment/url/p-1/a-1",
-                              headers = headers(invalidFileUser)
-    )
-    routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
+    headers(invalidFileUser).flatMap: hs =>
+      val request = Request[IO](method = Method.GET,
+                                uri = uri"attachment/url/p-1/a-1",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
   }
 
   test("POST returns Forbidden if service returns Forbidden") {
-    val request = Request[IO](method = Method.POST,
-                              uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
-                              headers = headers(forbiddenUser)
-    )
-    routes.run(request).assertResponse(Status.Forbidden, none)
+    headers(forbiddenUser).flatMap: hs =>
+      val request = Request[IO](method = Method.POST,
+                                uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.Forbidden, none)
   }
 
   test("POST returns NotFound if service returns FileNotFound") {
-    val request = Request[IO](method = Method.POST,
-                              uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
-                              headers = headers(fileNotFoundUser)
-    )
-    routes.run(request).assertResponse(Status.NotFound, none)
+    headers(fileNotFoundUser).flatMap: hs =>
+      val request = Request[IO](method = Method.POST,
+                                uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.NotFound, none)
   }
 
   test("POST returns BadRequest with message if service returns FileNotFound") {
-    val request = Request[IO](method = Method.POST,
-                              uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
-                              headers = headers(invalidFileUser)
-    )
-    routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
+    headers(invalidFileUser).flatMap: hs =>
+      val request = Request[IO](method = Method.POST,
+                                uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
   }
 
   test("PUT returns BadRequest with message if service returns InvalidRequest") {
-    val request = Request[IO](method = Method.PUT,
-                              uri = uri"attachment/p-1/a-1?fileName=/file.txt",
-                              headers = headers(invalidFileUser)
-    )
-    routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
+    headers(invalidFileUser).flatMap: hs =>
+      val request = Request[IO](method = Method.PUT,
+                                uri = uri"attachment/p-1/a-1?fileName=/file.txt",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
   }
 
   test("PUT returns Forbidden if service returns Forbidden") {
-    val request = Request[IO](method = Method.PUT,
-                              uri = uri"attachment/p-1/a-1?fileName=/file.txt",
-                              headers = headers(forbiddenUser)
-    )
-    routes.run(request).assertResponse(Status.Forbidden, none)
+    headers(forbiddenUser).flatMap: hs =>
+      val request = Request[IO](method = Method.PUT,
+                                uri = uri"attachment/p-1/a-1?fileName=/file.txt",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.Forbidden, none)
   }
 
   test("PUT returns NotFound if service returns FileNotFound") {
-    val request = Request[IO](method = Method.PUT,
-                              uri = uri"attachment/p-1/a-1?fileName=/file.txt",
-                              headers = headers(fileNotFoundUser)
-    )
-    routes.run(request).assertResponse(Status.NotFound, none)
+    headers(fileNotFoundUser).flatMap: hs =>
+      val request = Request[IO](method = Method.PUT,
+                                uri = uri"attachment/p-1/a-1?fileName=/file.txt",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.NotFound, none)
   }
 
   test("DELETE returns Forbidden if service returns Forbidden") {
-    val request = Request[IO](method = Method.DELETE,
-                              uri = uri"attachment/p-1/a-1",
-                              headers = headers(forbiddenUser)
-    )
-    routes.run(request).assertResponse(Status.Forbidden, none)
+    headers(forbiddenUser).flatMap: hs =>
+      val request = Request[IO](method = Method.DELETE,
+                                uri = uri"attachment/p-1/a-1",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.Forbidden, none)
   }
 
   test("DELETE returns NotFound if service returns FileNotFound") {
-    val request = Request[IO](method = Method.DELETE,
-                              uri = uri"attachment/p-1/a-1",
-                              headers = headers(fileNotFoundUser)
-    )
-    routes.run(request).assertResponse(Status.NotFound, none)
+    headers(fileNotFoundUser).flatMap: hs =>
+      val request = Request[IO](method = Method.DELETE,
+                                uri = uri"attachment/p-1/a-1",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.NotFound, none)
   }
 
   test("DELETE returns BadRequest with message if service returns InvalidRequest") {
-    val request = Request[IO](method = Method.DELETE,
-                              uri = uri"attachment/p-1/a-1",
-                              headers = headers(invalidFileUser)
-    )
-    routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
+    headers(invalidFileUser).flatMap: hs =>
+      val request = Request[IO](method = Method.DELETE,
+                                uri = uri"attachment/p-1/a-1",
+                                headers = hs
+      )
+      routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
   }
 
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/3485.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/3485.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package issue.shortcut
+
+import lucuma.core.model.StandardRole
+import lucuma.core.util.Gid
+import lucuma.odb.util.Codecs.*
+import skunk.codec.all.*
+import skunk.syntax.all.*
+
+class ShortCut_3485 extends OdbSuite:
+
+  val pi = TestUsers.Standard(
+    id    = 101, 
+    role  = StandardRole.Pi(Gid[StandardRole.Id].fromLong.getOption(102).get),
+    email = Some("pi@pi.org") 
+  )
+
+  val validUsers = List(pi)
+
+  test("user email should be included when canonicalized implicitly"):
+    for
+      _ <- query(pi, "query { callsForProposals { matches { id } } }")
+      e <- session.use(_.unique(sql"select c_orcid_email from t_user where c_user_id = $user_id".query(varchar.opt))(pi.id))
+    yield assert(e == Some("pi@pi.org"))
+


### PR DESCRIPTION
This updates the `TestSsoClient` used by `OdbSuite` to actually generate and exchange JWTs so we can test that this mechanism is working as expected ... and it is, which is annoying because I expected it to fail somehow. The added test demonstrates that the email address is correctly pulled from the JWT and saved in the database, so the problem is elsewhere. In any case this improves the test setup so we might as well keep it.