### PR TITLE
sc-4577 eng workflow

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -354,7 +354,7 @@ object ObservationWorkflowService {
               case Inactive   => List(executionState.getOrElse(validationStatus))
               case Undefined  => List(Inactive)
               case Unapproved => List(Inactive)
-              case Defined    => List(Inactive) ++ Option.when(isAccepted || info.tpe === ProgramType.Engineering)(Ready)
+              case Defined    => List(Inactive) ++ Option.when(isAccepted || info.tpe =!= ProgramType.Science)(Ready)
               case Ready      => List(Inactive, validationStatus)
               case Ongoing    => List(Inactive)
               case Completed  => Nil
@@ -370,7 +370,7 @@ object ObservationWorkflowService {
         type Validator = ObservationValidationInfo => ObservationValidationMap
 
         val (cals, other) = infos.partition(_._2.role.isDefined)
-        val (engineering, science) = other.partition(_._2.tpe === ProgramType.Engineering)
+        val (nonScience, science) = other.partition(_._2.tpe =!= ProgramType.Science)
 
         // Here are our simple validators
 
@@ -422,7 +422,7 @@ object ObservationWorkflowService {
         // And our validation results
 
         val engResults: Map[Observation.Id, ObservationValidationMap] =
-          engineering.view.mapValues(engValidator).toMap
+          nonScience.view.mapValues(engValidator).toMap
 
         val calibrationResults: Map[Observation.Id, ObservationValidationMap] =
           cals.view.mapValues(calibrationValidator).toMap

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow.scala
@@ -825,6 +825,28 @@ class observation_workflow
     }
   }
 
+  test("observartions in engineering programs are not validated and are immediately Defined") {
+    val setup: IO[Observation.Id] =
+      for {
+        pid <- createProgramAs(pi)
+        _   <- setProgramReference(staff, pid, """engineering: { semester: "2025B", instrument: GMOS_SOUTH }""")
+        oid <- createObservationAs(pi, pid)
+      } yield oid
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        workflowQuery(oid),
+        expected = workflowQueryResult(
+          ObservationWorkflow(          
+            ObservationWorkflowState.Defined,
+            List(ObservationWorkflowState.Inactive, ObservationWorkflowState.Ready),
+            Nil
+          )
+        ).asRight
+      )
+    }
+  }
+
   test("approved configuration request AND asterism outside limits") {      
 
     val oid1: IO[Observation.Id]  =


### PR DESCRIPTION
This changes the workflow for engineering programs such that they never generate validation errors, and thus always start in out as `Defined`. This may or may not be entirely correct. 

The logic here is starting to seem OT-like in its weirdness so we may want to refactor once the dust settles. I'm thinking maybe we also need to change the logic for other types of programs.