### PR TITLE
Generalize populate-db-from-dev to work for staging and production

### DIFF
--- a/populate-db-from-heroku.sh
+++ b/populate-db-from-heroku.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 set -e
+shopt -s extglob
 
-HEROKU_APP=lucuma-postgres-odb-dev
+function usage {
+  echo -e "Usage: $0 [dev|staging|production]"
+  exit 1
+}
+
+if [[ $1 != @(dev|staging|production) ]]; then
+  usage
+fi
+
+HEROKU_APP=lucuma-postgres-odb-$1
 SCRIPT_DIR=modules/service/src/main/resources/db/migration/
 PG_HOST=localhost
 PG_USER=jimmy
@@ -17,6 +27,8 @@ function clean_up {
   fi
 }
 trap clean_up EXIT
+
+echo "🍏 Populating local database from $HEROKU_APP."
 
 echo "🍏 Starting the database."
 docker-compose up -d > /dev/null 2>&1

--- a/populate-db-from-staging.sh
+++ b/populate-db-from-staging.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-heroku pg:backups:capture --app lucuma-postgres-odb-staging
-heroku pg:backups:download --app lucuma-postgres-odb-staging --output /tmp/lucuma-postgres-odb-staging.dump
-pg_restore --verbose --clean --no-acl --no-owner -h localhost -U jimmy -d lucuma-odb /tmp/lucuma-postgres-odb-staging.dump
-rm /tmp/lucuma-postgres-odb-staging.dump
-
-


### PR DESCRIPTION
The script for populating the local DB from odb dev worked. However, the one for staging did not work, and the one for production did not exist. This generalizes a single script to work for all 3.