### PR TITLE
ShortCut 4602: Fix import dependency issue

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0945__add_dependency_on_t_program_type.sql
+++ b/modules/service/src/main/resources/db/migration/V0945__add_dependency_on_t_program_type.sql
@@ -1,0 +1,8 @@
+-- Adds a FK dependency on t_program_type.  This should cause Postgres to dump
+-- and subsequently import the t_program_type table before the t_program table
+-- and fix an ordering with computing program references.  
+
+ALTER TABLE t_program
+  ADD CONSTRAINT t_program_c_program_type_fkey
+  FOREIGN KEY (c_program_type)
+  REFERENCES t_program_type (c_type);


### PR DESCRIPTION
Adds a FK reference from `t_program(c_program_type)` to `t_program_type(c_type)`.  In addition to being the right thing to do (I think), my theory is that this will cause the postgres dependency computation to order `t_program_type` imports before `t_program` imports and thereby fix the computation of program references when restoring from a backup.