### PR TITLE
Use graphql-inspector to detect breaking schema changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           schema: 'main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql'
           approve-label: expected-breaking-change
+          fail-on-breaking: false
 
       - name: Aggregate coverage reports
         run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' coverageReport coverageAggregate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,6 @@ jobs:
         with:
           schema: 'main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql'
           approve-label: expected-breaking-change
-          fail-on-breaking: false
 
       - name: Aggregate coverage reports
         run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' coverageReport coverageAggregate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,13 @@ jobs:
         with:
           path: modules/service/src/main/resources/db/migration/
 
+      - name: Validate GraphQL schema changes
+        if: github.event_name == 'pull_request'
+        uses: kamilkisiela/graphql-inspector@master
+        with:
+          schema: 'main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql'
+          approve-label: expected-breaking-change
+
       - name: Aggregate coverage reports
         run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' coverageReport coverageAggregate
 

--- a/build.sbt
+++ b/build.sbt
@@ -53,8 +53,9 @@ ThisBuild / githubWorkflowBuild +=
   WorkflowStep.Use(
     UseRef.Public("kamilkisiela", "graphql-inspector", "master"),
     name = Some("Validate GraphQL schema changes"),
-    params = Map("schema"        -> "main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql",
-                 "approve-label" -> "expected-breaking-change"
+    params = Map("schema"           -> "main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql",
+                 "approve-label"    -> "expected-breaking-change",
+                 "fail-on-breaking" -> "false"
     ),
     cond = Some("github.event_name == 'pull_request'")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -54,8 +54,7 @@ ThisBuild / githubWorkflowBuild +=
     UseRef.Public("kamilkisiela", "graphql-inspector", "master"),
     name = Some("Validate GraphQL schema changes"),
     params = Map("schema"           -> "main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql",
-                 "approve-label"    -> "expected-breaking-change",
-                 "fail-on-breaking" -> "false"
+                 "approve-label"    -> "expected-breaking-change"
     ),
     cond = Some("github.event_name == 'pull_request'")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -49,6 +49,16 @@ ThisBuild / githubWorkflowBuild +=
     cond = Some("github.event_name == 'pull_request'")
   )
 
+ThisBuild / githubWorkflowBuild +=
+  WorkflowStep.Use(
+    UseRef.Public("kamilkisiela", "graphql-inspector", "master"),
+    name = Some("Validate GraphQL schema changes"),
+    params = Map("schema"        -> "main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql",
+                 "approve-label" -> "expected-breaking-change"
+    ),
+    cond = Some("github.event_name == 'pull_request'")
+  )
+
 lazy val schema =
   crossProject(JVMPlatform, JSPlatform)
     .crossType(CrossType.Pure)


### PR DESCRIPTION
I'm using this tool to fail PRs that produce breaking schema changes. You can still override the behavior, adding a label `expected-breaking-change`

If it is too obtrusive we could make the action not fail breaking PRs.

You can see how it looks on ITC:
https://github.com/gemini-hlsw/lucuma-itc/pull/883/files#diff-bfc5dcd05e7282fc07897a390a0829a5c14bcb76898cfc1ddaf231545bc9fea4L10246

More info at
https://the-guild.dev/graphql/inspector/docs/products/action