### PR TITLE
ShortCut 1957: Add Missing Exposure Time Mode Migration

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0948__exposure_time_mode.sql
+++ b/modules/service/src/main/resources/db/migration/V0948__exposure_time_mode.sql
@@ -1,0 +1,5 @@
+-- Set the exposure time mode appropriately in existing observations.
+UPDATE t_observation
+   SET c_spec_exp_time_mode = 'signal_to_noise'
+ WHERE c_spec_signal_to_noise    IS NOT NULL
+   AND c_spec_signal_to_noise_at IS NOT NULL;


### PR DESCRIPTION
In #1597 I added support for the Time And Count exposure time mode.  There are several related exposure time fields now.  Depending on the particular mode, some will be set but others may not.  To make this easier to manage I added a discriminator which states which exposure time mode is in use.  Unfortunately I failed to update the existing observations, which are all Signal to Noise mode, to set the discriminator.  This PR adds the missing migration.