### PR TITLE
disallow submission with undefined observations

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -599,9 +599,9 @@ trait MutationMapping[F[_]] extends Predicates[F] {
 
   private lazy val SetProposalStatus =
     MutationField("setProposalStatus", SetProposalStatusInput.Binding): (input, child) =>
-      services.useTransactionally:
+      services.useNonTransactionally:
         requirePiAccess:
-          proposalService.setProposalStatus(input).nestMap: pid =>
+          proposalService.setProposalStatus(input, commitHash, itcClient, timeEstimateCalculator).nestMap: pid =>
             Unique(Filter(Predicates.setProposalStatusResult.programId.eql(pid), child))
 
   // An applied fragment that selects all observation ids that satisfy

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -1758,4 +1758,29 @@ trait DatabaseOperations { this: OdbSuite =>
     ).map: json =>
       json.hcursor.downFields("setObservationWorkflowState", "state").require[ObservationWorkflowState]
 
+
+  private def itcQuery(oids: Observation.Id*) = 
+    s"""
+      query {
+        observations(
+          WHERE: {
+            id: { IN: ${oids.asJson} }
+          }
+        ) {
+          matches {
+            itc {
+              science {
+                selected {
+                  targetId
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+  def computeItcResultAs(user: User, oid: Observation.Id): IO[Unit] =
+    query(user, itcQuery(oid)).void
+
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4460.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4460.scala
@@ -10,11 +10,11 @@ import cats.syntax.option.*
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.CallForProposalsType.RegularSemester
+import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.ProgramUserRole.CoiRO
 import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.odb.graphql.query.ObservingModeSetupOperations
-import lucuma.core.enums.ObservationWorkflowState
 
 class ShortCut_4460 extends OdbSuite with ObservingModeSetupOperations:
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4460.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4460.scala
@@ -14,6 +14,7 @@ import lucuma.core.enums.ProgramUserRole.CoiRO
 import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.odb.graphql.query.ObservingModeSetupOperations
+import lucuma.core.enums.ObservationWorkflowState
 
 class ShortCut_4460 extends OdbSuite with ObservingModeSetupOperations:
 
@@ -32,6 +33,7 @@ class ShortCut_4460 extends OdbSuite with ObservingModeSetupOperations:
         p <- createProgramAs(pi, "ShortCut 4460")
         t <- createTargetWithProfileAs(pi, p)
         o <- createObservationWithNoModeAs(pi, p, t)
+        _ <- setObservationWorkflowState(pi, o, ObservationWorkflowState.Inactive) // avoid submission check
         _ <- addProposal(pi, p, c.some)
         _ <- addPartnerSplits(pi, p)
         _ <- addCoisAs(pi, p)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/constraintSetGroup.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/constraintSetGroup.scala
@@ -17,6 +17,7 @@ import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Semester
 import lucuma.core.model.User
+import lucuma.core.enums.ObservationWorkflowState
 
 class constraintSetGroup extends OdbSuite {
 
@@ -125,7 +126,10 @@ class constraintSetGroup extends OdbSuite {
   test("should be able to use a proposal reference") {
     List(pi).traverse { user =>
       createProgramAs(user).flatMap { pid =>
-        def create2(iq: ImageQuality, sb: SkyBackground) = createObservation(user, pid, iq, sb).replicateA(2)
+        def create2(iq: ImageQuality, sb: SkyBackground) = 
+          createObservation(user, pid, iq, sb)
+            .flatTap(setObservationWorkflowState(user, _, ObservationWorkflowState.Inactive)) // avoid submission error
+            .replicateA(2)
         (
           create2(ImageQuality.OnePointFive, SkyBackground.Bright),
           create2(ImageQuality.PointOne, SkyBackground.Bright),

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/constraintSetGroup.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/constraintSetGroup.scala
@@ -12,12 +12,12 @@ import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.CallForProposalsType.DemoScience
 import lucuma.core.enums.ImageQuality
+import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.SkyBackground
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Semester
 import lucuma.core.model.User
-import lucuma.core.enums.ObservationWorkflowState
 
 class constraintSetGroup extends OdbSuite {
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow.scala
@@ -78,32 +78,6 @@ class observation_workflow
       }
     """
 
-  def itcQuery(oids: Observation.Id*) = 
-    s"""
-      query {
-        observations(
-          WHERE: {
-            id: { IN: ${oids.asJson} }
-          }
-        ) {
-          matches {
-            itc {
-              science {
-                selected {
-                  targetId
-                }
-              }
-            }
-          }
-        }
-      }
-    """
-
-  // Load up the cache with an ITC result
-  def computeItcResult(oid: Observation.Id): IO[Unit] =
-    query(pi, itcQuery(oid)).void
-
-
   def workflowQueryResult(wfs: ObservationWorkflow*): Json =
     val embed = wfs.map: wf =>
       json"""
@@ -337,7 +311,7 @@ class observation_workflow
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
         _   <- createConfigurationRequestAs(pi, oid).flatMap(approveConfigurationRequestHack)
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
       } yield oid
     setup.flatMap { oid =>
       expect(
@@ -390,7 +364,7 @@ class observation_workflow
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
         _   <- createConfigurationRequestAs(pi, oid).flatMap(approveConfigurationRequestHack)
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
       } yield oid
     setup.flatMap { oid =>
       expect(
@@ -441,7 +415,7 @@ class observation_workflow
         _   <- addProposal(pi, pid, cid.some)
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))     
-         _   <- computeItcResult(oid)
+         _   <- computeItcResultAs(pi, oid)
       } yield oid
     setup.flatMap { oid =>
       List((RaStart, DecStart), (RaEnd, DecEnd), (RaStart, DecEnd), (RaCenter, DecCenter)).traverse { (ra, dec) =>
@@ -470,7 +444,7 @@ class observation_workflow
         _   <- addProposal(pi, pid, cid.some)
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
       } yield oid
     setup.flatMap { oid =>
       List((RaStartWrap, DecStart), (RaEndWrap, DecEnd), (RaStartWrap, DecEnd), (RaCenterWrap, DecCenter)).traverse { (ra, dec) =>
@@ -555,7 +529,7 @@ class observation_workflow
         _   <- setTargetCoords(tid, RaCenter, DecCenter)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
         _   <- createConfigurationRequestAs(pi, oid).flatMap(approveConfigurationRequestHack)
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
       } yield oid
     setup.flatMap { oid =>
       expect(
@@ -639,7 +613,7 @@ class observation_workflow
         _   <- setAllocationsAs(staff, pid, allocations)
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosSouthLongSlitObservationAs(pi, pid, List(tid))
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
         _   <- setScienceBandAs(pi, oid, ScienceBand.Band1.some)
         _   <- setAllocationsAs(staff, pid, allocations.tail).intercept[ResponseException[Json]].void
       } yield oid
@@ -671,7 +645,7 @@ class observation_workflow
         _   <- addProposal(pi, pid, Some(cfp), None)
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
       } yield oid
     setup.flatMap { oid =>
       expect(
@@ -699,7 +673,7 @@ class observation_workflow
         _   <- setProposalStatus(staff, pid, "ACCEPTED")
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
       } yield oid
     setup.flatMap { oid =>
       expect(
@@ -728,7 +702,7 @@ class observation_workflow
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
         _   <- createConfigurationRequestAs(pi, oid)
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
       } yield oid
     setup.flatMap { oid =>
       expect(
@@ -757,7 +731,7 @@ class observation_workflow
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
         _   <- createConfigurationRequestAs(pi, oid).flatMap(denyConfigurationRequestHack)
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
       } yield oid
     setup.flatMap { oid =>
       expect(
@@ -786,7 +760,7 @@ class observation_workflow
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
         _   <- createConfigurationRequestAs(pi, oid).flatMap(approveConfigurationRequestHack)
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
       } yield oid
     setup.flatMap { oid =>
       expect(
@@ -860,7 +834,7 @@ class observation_workflow
         tid <- createTargetWithProfileAs(pi, pid)
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
         _   <- createConfigurationRequestAs(pi, oid).flatMap(approveConfigurationRequestHack)
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
       } yield oid
 
     val oid2: IO[Observation.Id] =
@@ -915,7 +889,7 @@ class observation_workflow
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
         _    <- updateCloudExtinctionAs(pi, oid, CloudExtinction.OnePointFive)  // ask for poor conditions
         _   <- createConfigurationRequestAs(pi, oid).flatMap(approveConfigurationRequestHack)
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
       } yield oid
 
     setup.flatMap { oid =>
@@ -931,7 +905,7 @@ class observation_workflow
         ).asRight
       ) >>
       updateCloudExtinctionAs(pi, oid, CloudExtinction.PointFive) >>  // ask for better conditions
-      computeItcResult(oid) >> // recompute ITC
+      computeItcResultAs(pi, oid) >> // recompute ITC
       expect(
         pi,
         workflowQuery(oid),
@@ -961,7 +935,7 @@ class observation_workflow
         oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
         _    <- updateCloudExtinctionAs(pi, oid, CloudExtinction.OnePointFive)  // ask for poor conditions
         _   <- createConfigurationRequestAs(pi, oid).flatMap(approveConfigurationRequestHack)
-        _   <- computeItcResult(oid)
+        _   <- computeItcResultAs(pi, oid)
         _   <- setObservationWorkflowState(pi, oid, ObservationWorkflowState.Ready)
       } yield oid
 
@@ -978,7 +952,7 @@ class observation_workflow
         ).asRight
       ) >>
       updateCloudExtinctionAs(pi, oid, CloudExtinction.PointFive) >>  // ask for better conditions
-      computeItcResult(oid) >> // recompute ITC
+      computeItcResultAs(pi, oid) >> // recompute ITC
       expect(
         pi,
         workflowQuery(oid),

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/configurationRequestEdit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/configurationRequestEdit.scala
@@ -139,6 +139,7 @@ class configurationRequestEdit extends OdbSuite with SubscriptionUtils with Obse
       _   <- addCoisAs(pi, pid)
       tid <- createTargetWithProfileAs(pi, pid)
       oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- computeItcResultAs(pi, oid)
     yield (pid, oid)
 
   test("insert and update") {


### PR DESCRIPTION
This adds a check to `setProposalStatus` to ensure that the proposed program contains no observations in the `Undefined` state. It also factors out `computeItcResult`, which had been duplicated a few times in test code.

Update: turns out someone already did the refactoring, but with a different name. In any case, resolved.