### PR TITLE
Allow staff users to call `observationsByWorkflowState`

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
@@ -174,7 +174,7 @@ trait QueryMapping[F[_]] extends Predicates[F] {
 
         // I can't believe this works.
         services.useNonTransactionally:
-          requireServiceAccess: // N.B. this is only for services, at least for now
+          requireStaffAccess: // N.B. this is only for staff or better, at least for now
             go.value
 
       case other =>


### PR DESCRIPTION
This needs to be called from the Navigate and Observe *clients* so I can't require service access here. Should be fine.