### PR TITLE
ShortCut 3897: allow multiple GOA users and staff

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -9742,7 +9742,7 @@ type Query {
   has GOA data-download access privileges.  These will be those for which the
   user is a ProgramUser of any role with the `hasDataAccess` flag set.
 
-  This query is for use by the GOA and will fail for other users.
+  This query is for use by staff and the GOA and will fail for other users.
   """
   goaDataDownloadAccess(orcidId: String!): [ProgramReferenceLabel!]!
 

--- a/modules/service/src/main/scala/lucuma/odb/Config.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Config.scala
@@ -49,7 +49,7 @@ case class Config(
   corsOverHttps: Boolean,          // Whether to require CORS over HTTPS
   domain:        List[String],     // Domains, for CORS headers
   commitHash:    CommitHash,       // From Heroku Dyno Metadata
-  goaUser:       Option[User.Id]   // Gemini Observatory Archive user id
+  goaUsers:      Set[User.Id]      // Gemini Observatory Archive user id(s)
 ) {
 
   // People send us their JWTs. We need to be able to extract them from the request, decode them,
@@ -277,6 +277,10 @@ object Config {
   private given [A](using Gid[A]): ConfigDecoder[String, A] =
     ConfigDecoder[String].mapOption("Gid[A]")(Gid[A].fromString.getOption)
 
+  private given [A](using ConfigDecoder[String, A]): ConfigDecoder[String, List[A]] =
+    ConfigDecoder[String].map(_.split(",").map(_.trim).toList).mapEither: (key, ss) =>
+      ss.traverse(ConfigDecoder[String, A].decode(key, _))
+
   private def envOrProp(name: String): ConfigValue[Effect, String] =
     env(name) or prop(name)
 
@@ -290,9 +294,9 @@ object Config {
     Aws.fromCiris,
     Email.fromCirrus,
     envOrProp("CORS_OVER_HTTPS").as[Boolean].default(true), // By default require https
-    envOrProp("ODB_DOMAIN").map(_.split(",").map(_.trim).toList).as[List[String]],
+    envOrProp("ODB_DOMAIN").as[List[String]],
     envOrProp("HEROKU_SLUG_COMMIT").as[CommitHash].default(CommitHash.Zero),
-    envOrProp("GOA_USER_ID").as[User.Id].option
+    envOrProp("GOA_USER_IDS").as[List[User.Id]].map(_.toSet).default(Set.empty)
   ).parMapN(Config.apply)
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -207,7 +207,7 @@ object FMain extends MainParams {
       config.email,
       config.itcClient,
       config.commitHash,
-      config.goaUser,
+      config.goaUsers,
       config.ssoClient,
       config.corsOverHttps,
       config.domain,
@@ -223,7 +223,7 @@ object FMain extends MainParams {
     emailConfig:          Config.Email,
     itcClientResource:    Resource[F, ItcClient[F]],
     commitHash:           CommitHash,
-    goaUser:              Option[User.Id],
+    goaUsers:             Set[User.Id],
     ssoClientResource:    Resource[F, SsoClient[F, User]],
     corsOverHttps:        Boolean,
     domain:               List[String],
@@ -240,7 +240,7 @@ object FMain extends MainParams {
       middleware        <- Resource.eval(ServerMiddleware(corsOverHttps, domain, ssoClient, userSvc))
       enums             <- Resource.eval(pool.use(Enums.load))
       ptc               <- Resource.eval(pool.use(TimeEstimateCalculatorImplementation.fromSession(_, enums)))
-      graphQLRoutes     <- GraphQLRoutes(itcClient, commitHash, goaUser, ssoClient, pool, SkunkMonitor.noopMonitor[F], GraphQLServiceTTL, userSvc, enums, ptc, httpClient, emailConfig)
+      graphQLRoutes     <- GraphQLRoutes(itcClient, commitHash, goaUsers, ssoClient, pool, SkunkMonitor.noopMonitor[F], GraphQLServiceTTL, userSvc, enums, ptc, httpClient, emailConfig)
       s3ClientOps       <- s3OpsResource
       s3Presigner       <- s3PresignerResource
       s3FileService      = S3FileService.fromS3ConfigAndClient(awsConfig, s3ClientOps, s3Presigner)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
@@ -54,7 +54,7 @@ object GraphQLRoutes {
   def apply[F[_]: Async: Parallel: Trace: Logger](
     itcClient:    ItcClient[F],
     commitHash:   CommitHash,
-    goaUser:      Option[User.Id],
+    goaUsers:     Set[User.Id],
     ssoClient:    SsoClient[F, User],
     pool:         Resource[F, Session[F]],
     monitor:      SkunkMonitor[F],
@@ -103,7 +103,7 @@ object GraphQLRoutes {
                       _    <- OptionT.liftF(Services.asSuperUser(userSvc.canonicalizeUser(user).retryOnInvalidCursorName))
 
                       _    <- OptionT.liftF(info(user, s"New service instance."))
-                      map   = OdbMapping(pool, monitor, user, topics, itcClient, commitHash, goaUser, enums, ptc, httpClient, emailConfig)
+                      map   = OdbMapping(pool, monitor, user, topics, itcClient, commitHash, goaUsers, enums, ptc, httpClient, emailConfig)
                       svc   = new GraphQLService(map) {
                         override def query(request: Operation): F[Result[Json]] =
                           super.query(request).retryOnInvalidCursorName

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -83,7 +83,7 @@ object OdbMapping {
     topics0:       Topics[F],
     itcClient0:    ItcClient[F],
     commitHash0:   CommitHash,
-    goaUser0:      Option[User.Id],
+    goaUsers0:     Set[User.Id],
     enums:         Enums,
     tec:           TimeEstimateCalculatorImplementation.ForInstrumentMode,
     httpClient0:   Client[F],
@@ -263,7 +263,7 @@ object OdbMapping {
 
           // Our services and resources needed by various mappings.
           override val commitHash = commitHash0
-          override val goaUser = goaUser0
+          override val goaUsers = goaUsers0
           override val itcClient = itcClient0
           override val user: User = user0
           override val topics: Topics[F] = topics0
@@ -280,7 +280,7 @@ object OdbMapping {
                   topics0,
                   itcClient0,
                   commitHash0,
-                  goaUser0,
+                  goaUsers0,
                   enums,
                   tec,
                   httpClient0,
@@ -581,7 +581,7 @@ object OdbMapping {
       def timeEstimateCalculator = sys.error("OdbMapping.forMetadata: no timeEstimateCalculator available")
       def itcClient = sys.error("OdbMapping.forMetadata: no itcClient available")
       def commitHash = sys.error("OdbMapping.forMetadata: no commitHash available")
-      def goaUser = sys.error("OdbMapping.forMetadata: no goaUser available")
+      def goaUsers = sys.error("OdbMapping.forMetadata: no goaUsers available")
 
       // Our schema
       val schema: Schema =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -293,8 +293,8 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
   protected def s3PresignerResource: Resource[IO, S3Presigner] =
     S3FileService.s3PresignerResource[IO](awsConfig)
 
-  protected def goaUser: Option[User.Id] =
-    none
+  protected def goaUsers: Set[User.Id] =
+    Set.empty
 
   private def httpApp: Resource[IO, WebSocketBuilder2[IO] => HttpApp[IO]] =
     FMain.routesResource[IO](
@@ -303,7 +303,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
       emailConfig,
       itcClient.pure[Resource[IO, *]],
       CommitHash.Zero,
-      goaUser,
+      goaUsers,
       ssoClient.pure[Resource[IO, *]],
       true,
       List("unused"),
@@ -322,7 +322,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
       itc  = itcClient
       enm <- db.evalMap(Enums.load)
       ptc <- db.evalMap(TimeEstimateCalculatorImplementation.fromSession(_, enm))
-      map  = OdbMapping(db, mon, usr, top, itc, CommitHash.Zero, goaUser, enm, ptc, httpClient, emailConfig)
+      map  = OdbMapping(db, mon, usr, top, itc, CommitHash.Zero, goaUsers, enm, ptc, httpClient, emailConfig)
     } yield map
 
   protected def server: Resource[IO, Server] =


### PR DESCRIPTION
A small update to #1609, opening up the `goaDataDownloadAccess` query to multiple GOA users (according to configuration) and to users with `Staff` access or better.  The intent is to simplify maintenance and testing.