### PR TITLE
ShortCut 3897: Control access to hasDataAccess flag

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -3599,7 +3599,11 @@ input ProgramUserPropertiesInput {
   "The user's reported gender."
   gender: Gender
 
-  "Whether the user has data access."
+  """
+  Whether the user has data access.  This property may be changed only by the
+  PI (or staff).  If a COI attempts to change the data access flag, the entire
+  update is ignored.
+  """
   hasDataAccess: Boolean
 }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProgramUsers.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProgramUsers.scala
@@ -447,6 +447,23 @@ class updateProgramUsers extends OdbSuite:
           expected = expectedDataAccess((pid, pi3, false)).asRight
         )
 
+  test("coi cannot update hasDataAccess flag"):
+    createProgramAs(pi3) >> createProgramAs(pi).flatMap: pid =>
+      addProgramUserAs(pi, pid, partnerLink = PartnerLink.HasUnspecifiedPartner).flatMap: mid =>
+        linkUserAs(pi, mid, pi3.id) >>
+        expect(
+          user     = pi3,
+          query    = updateUserDataAccess(pid, pi3, false),
+          expected =
+            json"""
+              {
+                "updateProgramUsers": {
+                  "programUsers": []
+                }
+              }
+            """.asRight
+        )
+
   val GavriloPrincip: UserProfile =
     UserProfile(
       "Gavrilo".some,


### PR DESCRIPTION
This PR is another tweak to #1609.  When setting the `hasDataAccessFlag` we check that the user is the PI or else has staff (or better) access. Otherwise, the update is skipped.  This seems a bit suboptimal in that an error isn't reported but it is also a bit of an edge case?