### PR TITLE
Test Case for Subscription Event Bug

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/ConfigurationRequestTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/ConfigurationRequestTopic.scala
@@ -3,6 +3,8 @@
 
 package lucuma.odb.graphql.topic
 
+import cats.Eq
+import cats.derived.*
 import cats.effect.*
 import cats.effect.std.Supervisor
 import cats.implicits.*
@@ -23,7 +25,7 @@ object ConfigurationRequestTopic:
     programId: Program.Id,
     editType: EditType,
     users: List[User.Id]
-  ) extends TopicElement
+  ) extends TopicElement derives Eq
 
   private val topic =
     OdbTopic.define[(ConfigurationRequest.Id, Program.Id, EditType), Element](

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/ExecutionEventAddedTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/ExecutionEventAddedTopic.scala
@@ -3,6 +3,7 @@
 
 package lucuma.odb.graphql.topic
 
+import cats.derived.*
 import cats.effect.Concurrent
 import cats.effect.std.Supervisor
 import cats.syntax.apply.*
@@ -27,7 +28,7 @@ object ExecutionEventAddedTopic:
     visitId:         Visit.Id,
     eventType:       ExecutionEventType,
     users:           List[User.Id]
-  ) extends TopicElement
+  ) extends TopicElement derives cats.Eq
 
   private val topic =
     OdbTopic.define[(ExecutionEvent.Id, Program.Id, Observation.Id, Visit.Id, ExecutionEventType), Element](

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/GroupTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/GroupTopic.scala
@@ -3,6 +3,8 @@
 
 package lucuma.odb.graphql.topic
 
+import cats.Eq
+import cats.derived.*
 import cats.effect.*
 import cats.effect.std.Supervisor
 import cats.implicits.*
@@ -30,7 +32,7 @@ object GroupTopic:
     programId: Program.Id,
     editType:  EditType,
     users:     List[User.Id]
-  ) extends TopicElement
+  ) extends TopicElement derives Eq
 
   private val topic =
     OdbTopic.define[(Option[Group.Id], Program.Id, EditType), Element](

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/ObservationTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/ObservationTopic.scala
@@ -3,6 +3,8 @@
 
 package lucuma.odb.graphql.topic
 
+import cats.Eq
+import cats.derived.*
 import cats.effect.*
 import cats.effect.std.Supervisor
 import cats.implicits.*
@@ -29,7 +31,7 @@ object ObservationTopic:
     programId:     Program.Id,
     editType:      EditType,
     users:         List[User.Id]
-  ) extends TopicElement
+  ) extends TopicElement derives Eq
 
   private val topic =
     OdbTopic.define[(Observation.Id, Program.Id, EditType), Element](

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/OdbTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/OdbTopic.scala
@@ -37,7 +37,7 @@ object OdbTopic:
   ): F[List[User.Id]] =
     s.execute(
       sql"""
-        select c_user_id from t_program_user where c_program_id = '#${pid.toString}' and c_user_id notnull
+        select c_user_id from t_program_user where c_program_id = '#${pid.toString}' and c_user_id notnull order by c_user_id
       """.query(user_id)
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/ProgramTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/ProgramTopic.scala
@@ -3,6 +3,8 @@
 
 package lucuma.odb.graphql.topic
 
+import cats.Eq
+import cats.derived.*
 import cats.effect.*
 import cats.effect.std.Supervisor
 import cats.implicits.*
@@ -24,8 +26,8 @@ object ProgramTopic:
   case class Element(
     programId: Program.Id,
     editType:  EditType,
-    users:     List[User.Id],
-  ) extends TopicElement
+    users:     List[User.Id]
+  ) extends TopicElement derives Eq
 
   private val topic =
     OdbTopic.define[(Program.Id, EditType), Element](

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/TargetTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/TargetTopic.scala
@@ -3,6 +3,8 @@
 
 package lucuma.odb.graphql.topic
 
+import cats.Eq
+import cats.derived.*
 import cats.effect.*
 import cats.effect.std.Supervisor
 import cats.implicits.*
@@ -30,7 +32,7 @@ object TargetTopic:
     programId: Program.Id,
     editType:  EditType,
     users:     List[User.Id]
-  ) extends TopicElement
+  ) extends TopicElement derives Eq
 
   private val topic =
     OdbTopic.define[(Target.Id, Program.Id, EditType), Element](

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEditSn.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEditSn.scala
@@ -1,0 +1,138 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.subscription
+
+import cats.effect.IO
+import cats.syntax.show.*
+import io.circe.Json
+import io.circe.syntax.*
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.odb.data.EditType
+import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ObservingModeSetupOperations
+
+class observationEditSn extends ExecutionTestSupport with ObservingModeSetupOperations with SubscriptionUtils:
+
+  def subscriptionQuery(pid: Program.Id) =
+    s"""
+      subscription {
+        observationEdit(input: { programId: "${pid.show}" }) {
+          observationId
+          editType
+          value {
+            id
+            execution {
+              config {
+                gmosNorth {
+                  science {
+                    nextAtom {
+                      observeClass
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+  def subscriptionResponse(oid: Observation.Id): Json =
+      Json.obj(
+        "observationEdit" -> Json.obj(
+          "observationId" -> Json.fromString(oid.show),
+          "editType"      -> Json.fromString(EditType.Updated.tag.toUpperCase),
+          "value" -> Json.obj(
+            "id"          -> oid.asJson,
+            "execution" -> Json.obj(
+              "config" -> Json.obj(
+                "gmosNorth" -> Json.obj(
+                  "science" -> Json.obj(
+                    "nextAtom" -> Json.obj(
+                      "observeClass" -> "SCIENCE".asJson
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+
+  def updateSn(
+    oid: Observation.Id
+  ): IO[Unit] =
+    query(
+      user = pi,
+      query = s"""
+        mutation {
+          updateObservations(input: {
+            SET: {
+              scienceRequirements: {
+                spectroscopy: {
+                  exposureTimeMode: {
+                    signalToNoise: {
+                      value: 99
+                      at: { nanometers: 500 }
+                    }
+                  }
+                }
+              }
+            },
+            WHERE: {
+              id: { EQ: "$oid" }
+            }
+          }) {
+            observations {
+              scienceRequirements {
+                spectroscopy {
+                  exposureTimeMode {
+                    signalToNoise {
+                      value
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      """
+    ).void
+
+  test("triggers for editing s/n"):
+    for
+      pid <- createProgram(pi, "foo")
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- generateOrFail(pid, oid)
+      // expect two responses, one from editing the S/N, one because our query
+      // requests the sequence which requires a cache update
+      _   <- subscriptionExpect(
+        user      = pi,
+        query     = subscriptionQuery(pid),
+        mutations = Right(sleep >> updateSn(oid)),
+        expected  = List(subscriptionResponse(oid), subscriptionResponse(oid))
+      )
+    yield ()
+
+  test("does not trigger for subsequent generation"):
+    for
+      pid <- createProgram(pi, "foo")
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- generateOrFail(pid, oid)
+      _   <- subscriptionExpect(
+        user      = pi,
+        query     = subscriptionQuery(pid),
+        mutations = Right(
+                      sleep                         >>
+                      updateSn(oid)                 >>
+                      generateOrFail(pid, oid).void >>
+                      generateOrFail(pid, oid).void >>
+                      sleep
+                    ),
+        expected  = List(subscriptionResponse(oid), subscriptionResponse(oid))
+      )
+    yield ()


### PR DESCRIPTION
There's a report that a simple update to S/N requirements generates up to 13 observation edit events.  This PR will attempt to find the issue.