### PR TITLE
ShortCut 3347: Count non-partner as US

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
@@ -538,7 +538,17 @@ object ProposalService {
             0
           ) AS c_splits_sum,
           COALESCE(
-            (SELECT ARRAY_AGG(DISTINCT c_partner) FROM t_program_user WHERE c_program_id = prog.c_program_id AND c_partner IS NOT NULL),
+            (SELECT
+               ARRAY_AGG(DISTINCT
+                 CASE
+                   WHEN c_partner_link = 'has_non_partner' THEN 'us'::d_tag
+                   ELSE c_partner
+                 END
+               )
+             FROM t_program_user
+             WHERE c_program_id = prog.c_program_id
+               AND (c_partner IS NOT NULL OR c_partner_link = 'has_non_partner')
+            ),
             '{}'
           ) AS c_available_partners,
           COALESCE(


### PR DESCRIPTION
In [ShortCut 3347](https://app.shortcut.com/lucuma/story/3347/warning-if-time-request-does-not-match-partners#activity-4713) Andy points out that specifying "No Partner" in the UI should still allow you to request time from the US. To handle this case, we can treat the partner link type `has_non_partner` as if the PI/COI were affiliated with the US for the purpose of validation.