### PR TITLE
ShortCut 3202: specphot science band

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -100,6 +100,11 @@ object CalibrationsService extends CalibrationObservations {
     def map[B](f: A => B): ObsExtract[B] =
       copy(data = f(data))
 
+  case class CalObsProps(
+    wavelengthAt: Option[Wavelength],
+    band:         Option[ScienceBand]
+  )
+
   private def targetCoordinates(when: Instant)(
     rows: List[(Target.Id, String, CalibrationRole, RightAscension, Declination, Epoch, Option[Long], Option[Long], Option[RadialVelocity], Option[Parallax])]
   ): List[(Target.Id, String, CalibrationRole, Coordinates)] =
@@ -193,38 +198,39 @@ object CalibrationsService extends CalibrationObservations {
       private def toConfigForCalibration(all: List[ObsExtract[ObservingMode]]): List[ObsExtract[CalibrationConfigSubset]] =
         all.map(_.map(_.toConfigSubset))
 
-      private def configAtWavelength(
+      private def calObsProps(
         calibConfigs: List[ObsExtract[CalibrationConfigSubset]]
-      ): Map[CalibrationConfigSubset, Option[Wavelength]] =
+      ): Map[CalibrationConfigSubset, CalObsProps] =
         calibConfigs.groupBy(_.data).map { case (k, v) =>
-          val lw = v.map(_.itc.map(_.spectroscopy.exposureTimeMode.at)).flattenOption
-          val meanWv = if (lw.isEmpty) None
-          else
-            // there must be a way to sum in wavelength space :/
-            val pm = lw.map(_.toPicometers.value.value).combineAll / lw.size
-            PosInt.from(pm).map(Wavelength(_)).toOption
-          k -> meanWv
+          val w = v.map(_.itc.map(_.spectroscopy.exposureTimeMode.at)).flattenOption match
+            case Nil =>
+               none[Wavelength]
+            case ws  =>
+              // there must be a way to sum in wavelength space :/
+              val pm = ws.map(_.toPicometers.value.value).combineAll / ws.size
+              PosInt.from(pm).map(Wavelength(_)).toOption
+          k -> CalObsProps(w, v.map(_.band).max)
         }
 
       private def uniqueConfiguration(
         all: List[ObsExtract[ObservingMode]]
-      ): List[(CalibrationConfigSubset, Option[ScienceBand])] =
-        toConfigForCalibration(all).groupMapReduce(_.data)(_.band)(_ max _).toList
+      ): List[CalibrationConfigSubset] =
+        all.map(_.data.toConfigSubset).distinct
 
       private def calibObservation(
         calibRole: CalibrationRole,
-        site: Site,
-        pid: Program.Id,
-        gid: Group.Id,
-        wvAt: Map[CalibrationConfigSubset, Option[Wavelength]],
-        configs: List[CalibrationConfigSubset],
-        tid: Target.Id
+        site:      Site,
+        pid:       Program.Id,
+        gid:       Group.Id,
+        props:     Map[CalibrationConfigSubset, CalObsProps],
+        configs:   List[CalibrationConfigSubset],
+        tid:       Target.Id
       )(using Transaction[F]): F[List[Observation.Id]] =
         calibRole match {
           case CalibrationRole.SpectroPhotometric =>
             site match {
-              case Site.GN => gmosLongSlitSpecPhotObs(pid, gid, tid, wvAt, configs.collect { case c: GmosNConfigs => c })
-              case Site.GS => gmosLongSlitSpecPhotObs(pid, gid, tid, wvAt, configs.collect { case c: GmosSConfigs => c })
+              case Site.GN => gmosLongSlitSpecPhotObs(pid, gid, tid, props, configs.collect { case c: GmosNConfigs => c })
+              case Site.GS => gmosLongSlitSpecPhotObs(pid, gid, tid, props, configs.collect { case c: GmosSConfigs => c })
             }
           case CalibrationRole.Twilight =>
             site match
@@ -234,12 +240,12 @@ object CalibrationsService extends CalibrationObservations {
         }
 
       private def gmosCalibrations(
-        pid: Program.Id,
-        gid: Group.Id,
-        wvAt: Map[CalibrationConfigSubset, Option[Wavelength]],
+        pid:     Program.Id,
+        gid:     Group.Id,
+        props:   Map[CalibrationConfigSubset, CalObsProps],
         configs: List[CalibrationConfigSubset],
-        gnCalc: CalibrationIdealTargets,
-        gsCalc: CalibrationIdealTargets
+        gnCalc:  CalibrationIdealTargets,
+        gsCalc:  CalibrationIdealTargets
       )(using Transaction[F]): F[List[(CalibrationRole, Observation.Id)]] = {
         def newCalibs(site: Site, ct: CalibrationRole, idealTarget: CalibrationIdealTargets): Option[F[List[(CalibrationRole, Observation.Id)]]] =
           idealTarget.bestTarget(ct).map(tgtid =>
@@ -247,7 +253,7 @@ object CalibrationsService extends CalibrationObservations {
             if (configs.nonEmpty) {
               (for {
                 cta <- Nested(targetService.cloneTargetInto(tgtid, pid)).map(_._2).value
-                o   <- cta.traverse(calibObservation(ct, site, pid, gid, wvAt, configs, _))
+                o   <- cta.traverse(calibObservation(ct, site, pid, gid, props, configs, _))
               } yield o).orError.map(_.map((ct, _)))
             } else {
               List.empty.pure[F]
@@ -266,11 +272,11 @@ object CalibrationsService extends CalibrationObservations {
         session.executeCommand(Statements.setCalibRole(oids, calibrationRole)).void
 
       private def generateGMOSLSCalibrations(
-        pid: Program.Id,
-        wvAt: Map[CalibrationConfigSubset, Option[Wavelength]],
+        pid:     Program.Id,
+        props:   Map[CalibrationConfigSubset, CalObsProps],
         configs: List[CalibrationConfigSubset],
-        gnTgt: CalibrationIdealTargets,
-        gsTgt: CalibrationIdealTargets
+        gnTgt:   CalibrationIdealTargets,
+        gsTgt:   CalibrationIdealTargets
       )(using Transaction[F]): F[List[Observation.Id]] = {
         if (configs.isEmpty) {
           List.empty.pure[F]
@@ -278,7 +284,7 @@ object CalibrationsService extends CalibrationObservations {
           for {
             cg   <- calibrationsGroup(pid, configs.size)
             oids <- cg.map(g =>
-                      gmosCalibrations(pid, g, wvAt, configs, gnTgt, gsTgt).flatTap { oids =>
+                      gmosCalibrations(pid, g, props, configs, gnTgt, gsTgt).flatTap { oids =>
                         oids.groupBy(_._1).toList.traverse { case (role, oids) =>
                           setCalibRoleAndGroup(oids.map(_._2), role).whenA(oids.nonEmpty)
                         }
@@ -301,20 +307,25 @@ object CalibrationsService extends CalibrationObservations {
 
       // Update the signal to noise at wavelength for each calbiration observation depending
       // on the average wavelength of the configuration
-      private def updateWvAt(
+      private def updatePropsAt(
         calibrations: List[ObsExtract[CalibrationConfigSubset]],
         removed:      List[Observation.Id],
-        atWavelength: Map[CalibrationConfigSubset, Option[Wavelength]],
+        props:        Map[CalibrationConfigSubset, CalObsProps],
         role:         CalibrationRole
       )(using Transaction[F]): F[Unit] =
         calibrations
           .filterNot { o => removed.contains(o.id) }
-          .map { o => (o.id, atWavelength.get(o.data).flatten) }
-          .collect { case (oid, Some(w)) => (oid, w) }
-          .traverse { (oid, w) =>
+          .map { o => (o.id, props.get(o.data)) }
+          .collect { case (oid, Some(props)) if props.band.isDefined || props.wavelengthAt.isDefined => (oid, props) }
+          .traverse { (oid, props) =>
+            val bandFragment = props.band.map(sql"c_science_band <> $science_band")
+            val waveFragment = props.wavelengthAt.map(sql"c_spec_signal_to_noise_at <> $wavelength_pm")
+            val needsUpdate  = List(bandFragment, waveFragment).flatten.intercalate(void" OR ")
+
             services.observationService.updateObservations(
               ObservationPropertiesInput.Edit.Empty.copy(
-                scienceRequirements = Some(
+                scienceBand         = Nullable.orAbsent(props.band),
+                scienceRequirements = props.wavelengthAt.map: w =>
                   ScienceRequirementsInput(
                     mode         = None,
                     spectroscopy = Some(
@@ -328,11 +339,16 @@ object CalibrationsService extends CalibrationObservations {
                       )
                     )
                   )
-                )
               ),
               // Important: Only update the obs that need it or it will produce a cascade of infinite updates
               // TODO: This could be slightly optimized by grouping obs per configuration and updating in batches
-              sql"select $observation_id where c_calibration_role = $calibration_role and c_spec_signal_to_noise_at <> $wavelength_pm".apply(oid, role, w)
+              sql"""
+                SELECT $observation_id
+                  FROM t_observation
+                 WHERE c_observation_id = $observation_id
+                   AND c_calibration_role = $calibration_role
+                   AND ("""(oid, oid, role) |+| needsUpdate |+| void")"
+//              sql"select $observation_id where c_calibration_role = $calibration_role and c_spec_signal_to_noise_at <> $wavelength_pm".apply(oid, role, w)
             )
           }.void
 
@@ -361,17 +377,17 @@ object CalibrationsService extends CalibrationObservations {
           uniqueCalibs  = uniqueConfiguration(allCalibs)
           calibs        = toConfigForCalibration(allCalibs)
           // Average s/n wavelength at each configuration
-          configWvAt    = configAtWavelength(toConfigForCalibration(allSci))
+          props         = calObsProps(toConfigForCalibration(allSci))
           // Get all unique configurations
-          configs       = uniqueSci.map(_._1).diff(uniqueCalibs.map(_._1))
+          configs       = uniqueSci.diff(uniqueCalibs)
           // Remove calibrations that are not needed, basically when a config is removed
-          removedOids  <- removeUnnecessaryCalibrations(uniqueSci.map(_._1), calibs.map {
+          removedOids  <- removeUnnecessaryCalibrations(uniqueSci, calibs.map {
                             case ObsExtract(oid, _, _, c) => (oid, c)
                           })
           // Generate new calibrations for each unique configuration
-          addedOids    <- generateGMOSLSCalibrations(pid, configWvAt, configs, gnTgt, gsTgt)
+          addedOids    <- generateGMOSLSCalibrations(pid, props, configs, gnTgt, gsTgt)
           // Update wavelength at for each remaining calib
-          _            <- updateWvAt(calibs, removedOids, configWvAt, CalibrationRole.SpectroPhotometric)
+          _            <- updatePropsAt(calibs, removedOids, props, CalibrationRole.SpectroPhotometric)
           _            <- targetService.deleteOrphanCalibrationTargets(pid)
         yield (addedOids, removedOids)
 


### PR DESCRIPTION
This task arose from [a comment in ShortCut 3202](https://app.shortcut.com/lucuma/story/3202/support-planned-time-estimates-by-band#activity-4670), though not directly related to time estimates per se. 

> Would it be possible for the spectrophotometric standards to inherit the band of their associated science observations? If a specphot standard is associated with multiple science observations and those science observations have different bands then inherit the highest band (under the assumption that we are more likely to execute the higher band observations).

I updated the calibrations service to do this, in theory.  It adds the science band to the calibration observation properties to set (along with the average wavelength of the science observations).

I think I'll leave it here until Carlos is back and can take a look.  I didn't find any relevant tests for the `CalibrationService` and I'm not sure what we do for testing.


