### PR TITLE
Don't advance ids for opposite sequence type

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Acquisition.scala
@@ -175,13 +175,13 @@ object Acquisition:
       AcquisitionState.ExpectCcd2(visitId, calcState, tracker, builder, steps)
 
     override def recordStep(step: StepRecord[D])(using Eq[D]): SequenceGenerator[D] =
-      if updatesVisit(step) then
+      if step.isScienceSequence then
+        reset(step.visitId)
+      else if updatesVisit(step) then
         reset(step.visitId).recordStep(step)
       else
         val a = updateTracker(calcState.next(step.protoStep), tracker.record(step))
-        if !step.isAcquisitionSequence     then a.reset(step.visitId)
-        else if step.successfullyCompleted then a.recordCompleted(step)
-        else a
+        if step.successfullyCompleted then a.recordCompleted(step) else a
 
     // when a new visit is recorded, we reset the acquisition so that it begins
     // at the first step.

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/IndexTracker.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/IndexTracker.scala
@@ -28,7 +28,7 @@ object IndexTracker:
     override def stepCount: Int = 0
 
     override def record[D](step: StepRecord[D]): IndexTracker =
-      Recording(0, step.atomId, 0, step.id)
+      Recording(0, step.atomId, 1, step.id)
 
   case class Recording(
     atomCount: Int,
@@ -40,4 +40,4 @@ object IndexTracker:
     override def record[D](step: StepRecord[D]): IndexTracker =
       if stepId === step.id then this
       else if atomId === step.atomId then copy(stepCount = stepCount + 1, stepId = step.id)
-      else Recording(atomCount + 1, step.atomId, stepCount = 0, step.id)
+      else Recording(atomCount + 1, step.atomId, stepCount = 1, step.id)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcq.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcq.scala
@@ -6,6 +6,7 @@ package query
 
 import cats.effect.IO
 import cats.syntax.either.*
+import cats.syntax.option.*
 import io.circe.Json
 import io.circe.literal.*
 import lucuma.core.enums.DatasetQaState
@@ -14,6 +15,8 @@ import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.SequenceType
 import lucuma.core.enums.StepGuideState
 import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.sequence.Step
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.TelescopeConfig
 import lucuma.odb.json.all.transport.given
@@ -439,4 +442,44 @@ class executionAcq extends ExecutionTestSupport {
     }
   }
 
+  def firstScienceStepId(p: Program.Id, o: Observation.Id): IO[Step.Id] =
+    import lucuma.odb.testsyntax.execution.*
+    generateOrFail(p, o, 5.some).map(_.gmosNorthScience.nextAtom.steps.head.id)
+
+  test("science step ids do not change while executing acquisition"):
+    val execAcq: IO[Set[Step.Id]] =
+      for
+        p  <- createProgram
+        t  <- createTargetWithProfileAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        v  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        x0 <- firstScienceStepId(p, o)
+
+        // First atom with 3 steps.
+        a0 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s0 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(0), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s0)
+
+        x1 <- firstScienceStepId(p, o)
+
+        s1 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(1), StepConfig.Science, acqTelescopeConfig(10), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s1)
+
+        x1 <- firstScienceStepId(p, o)
+
+        s2 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(2), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s2)
+
+        x2 <- firstScienceStepId(p, o)
+
+        // Second atom with just the last acq step
+        a1 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s3 <- recordStepAs(serviceUser, a1, Instrument.GmosNorth, gmosNorthAcq(2), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s3)
+
+        x3 <- firstScienceStepId(p, o)
+      yield Set(x0, x1, x2, x3)
+
+    assertIO(execAcq.map(_.size), 1)
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSci.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSci.scala
@@ -1265,4 +1265,54 @@ class executionSci extends ExecutionTestSupport {
           """.asRight
       )
     }
+
+  def firstAcquisitionStepId(p: Program.Id, o: Observation.Id): IO[Step.Id] =
+    import lucuma.odb.testsyntax.execution.*
+    generateOrFail(p, o, 5.some).map(_.gmosNorthAcquisition.nextAtom.steps.head.id)
+
+  test("acquisition step ids do not change while executing science"):
+    val execSci: IO[Set[Step.Id]] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        v <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        x0 <- firstAcquisitionStepId(p, o)
+
+        a0 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Science)
+        s0 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthArc(0), ArcStep, gcalTelescopeConfig(0), ObserveClass.PartnerCal)
+        _  <- addEndStepEvent(s0)
+
+        x1 <- firstAcquisitionStepId(p, o)
+
+        s1 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthFlat(0), FlatStep, gcalTelescopeConfig(0), ObserveClass.PartnerCal)
+        _  <- addEndStepEvent(s1)
+
+        x2 <- firstAcquisitionStepId(p, o)
+
+        s2 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, sciTelescopeConfig(0), ObserveClass.Science)
+        _  <- addEndStepEvent(s2)
+
+        x3 <- firstAcquisitionStepId(p, o)
+
+        s3 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, sciTelescopeConfig(0), ObserveClass.Science)
+        _  <- addEndStepEvent(s3)
+
+        x4 <- firstAcquisitionStepId(p, o)
+
+        s4 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, sciTelescopeConfig(0), ObserveClass.Science)
+        _  <- addEndStepEvent(s4)
+
+        x5 <- firstAcquisitionStepId(p, o)
+
+        a1 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Science)
+        s5 <- recordStepAs(serviceUser, a1, Instrument.GmosNorth, gmosNorthArc(5), ArcStep, gcalTelescopeConfig(0), ObserveClass.PartnerCal)
+        _  <- addEndStepEvent(s5)
+
+        x5 <- firstAcquisitionStepId(p, o)
+      yield Set(x0, x1, x2, x3, x4, x5)
+
+    assertIO(execSci.map(_.size), 1)
+
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSci.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSci.scala
@@ -3,6 +3,7 @@
 
 package lucuma.odb.graphql.query
 
+import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.syntax.either.*
 import cats.syntax.option.*
@@ -1314,5 +1315,64 @@ class executionSci extends ExecutionTestSupport {
       yield Set(x0, x1, x2, x3, x4, x5)
 
     assertIO(execSci.map(_.size), 1)
+
+  def nextAtomStepIds(p: Program.Id, o: Observation.Id): IO[NonEmptyList[Step.Id]] =
+    import lucuma.odb.testsyntax.execution.*
+    generateOrFail(p, o, 5.some).map(_.gmosNorthScience.nextAtom.steps.map(_.id))
+
+  test("nextAtom step ids don't change while executing"):
+    val setup: IO[(List[NonEmptyList[Step.Id]], List[NonEmptyList[Step.Id]])] =
+      for
+        p  <- createProgram
+        t  <- createTargetWithProfileAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+
+        v  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        x0 <- nextAtomStepIds(p, o)
+
+        a0 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Science)
+        s0 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthArc(0), ArcStep, gcalTelescopeConfig(0), ObserveClass.PartnerCal)
+        _  <- addEndStepEvent(s0)
+
+        x1 <- nextAtomStepIds(p, o)
+
+        s1 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthFlat(0), FlatStep, gcalTelescopeConfig(0), ObserveClass.PartnerCal)
+        _  <- addEndStepEvent(s1)
+
+        x2 <- nextAtomStepIds(p, o)
+
+        s2 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, sciTelescopeConfig(0), ObserveClass.Science)
+        _  <- addEndStepEvent(s2)
+
+        x3 <- nextAtomStepIds(p, o)
+
+        s3 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, sciTelescopeConfig(0), ObserveClass.Science)
+        _  <- addEndStepEvent(s3)
+
+        x4 <- nextAtomStepIds(p, o)
+
+        s4 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, sciTelescopeConfig(0), ObserveClass.Science)
+        _  <- addEndStepEvent(s4)
+
+        // Next atom
+
+        x5 <- nextAtomStepIds(p, o)
+
+        a1 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Science)
+        s5 <- recordStepAs(serviceUser, a1, Instrument.GmosNorth, gmosNorthArc(5), ArcStep, gcalTelescopeConfig(15), ObserveClass.PartnerCal)
+        _  <- addEndStepEvent(s5)
+
+        x6 <- nextAtomStepIds(p, o)
+
+      yield (List(x0, x1, x2, x3, x4), List(x5, x6))
+
+    setup.map: (atom0Ids, atom1Ids) =>
+      def checkAtom(atom: String, ids: List[NonEmptyList[Step.Id]]): Unit =
+        ids.zip(ids.tail).foreach: (before, after) =>
+          assertEquals(before.tail, after.toList, s"atom $atom, before: $before, after: $after")
+
+      checkAtom("Atom 0", atom0Ids)
+      checkAtom("Atom 1", atom1Ids)
 
 }


### PR DESCRIPTION
Makes an adjustment to sequence generation to avoid changing the generated ids of the opposite sequence type while executing.  For example, now while doing acquisition the future science step IDs shouldn't change and vice versa.