### PR TITLE
fix decoding error

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4822.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4822.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+// package lucuma.odb.graphql.issue.shortcut
+
+// import lucuma.odb.graphql.OdbSuite
+// import cats.effect.IO
+// import lucuma.odb.Config
+// import lucuma.odb.graphql.TestUsers
+
+// N.B. this needs to be run with a local copy of the dev database
+// class ShortCut_4822 extends OdbSuite:
+
+//   val admin = TestUsers.Standard.admin(1, 101)
+//   val validUsers = List(admin)
+
+//   override def databaseConfig: Config.Database =
+//     Config.Database(
+//       maxConnections = 10,
+//       maxCalibrationConnections = 10,
+//       host     = "localhost",
+//       port     = 5432,
+//       user     = "jimmy",
+//       password = "banana",
+//       database = "lucuma-odb",
+//     )
+
+//   test("foo") {
+//     query(
+//       user = admin,
+//       query = """
+//         query {
+//           observationsByWorkflowState(
+//             states: [ UNDEFINED ]
+//           ) {
+//             id
+//             workflow {
+//               state
+//             }
+//           }
+//         }
+//       """
+//     ).flatTap(IO.println)
+//   }
+


### PR DESCRIPTION
This fixes an error with `observationsByWorkflowState` that I couldn't easily reproduce locally but it happens with a copy of the dev database. In the interest of unblocking @rpiaggio I'd like to merge this and will follow up with a test that runs locally.