### PR TITLE
ShortCut 4838: Restrict `WhereProgramUser` to PI

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereProgram.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereProgram.scala
@@ -11,6 +11,7 @@ import grackle.Predicate
 import grackle.Predicate.*
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.ProgramType
+import lucuma.core.enums.ProgramUserRole
 import lucuma.core.model.Program
 import lucuma.odb.graphql.binding.*
 import org.typelevel.cats.time.given
@@ -22,7 +23,7 @@ object WhereProgram {
     val WhereNameBinding             = WhereOptionString.binding(path / "name")
     val WhereTypeBinding             = WhereEq.binding[ProgramType](path / "type", ProgramTypeBinding)
     val WhereProgramReferenceBinding = WhereProgramReference.binding(path / "reference")
-    val WherePiBinding               = WhereProgramUser.binding(path / "pi")
+    val WherePiBinding               = WhereProgramUser.binding(path / "pi", ProgramUserRole.Pi.some)
     val WhereEqProposalStatus        = WhereUnorderedTag.binding(path / "proposalStatus", TagBinding)
     val WhereProposalBinding         = WhereProposal.binding(path / "proposal")
     val WhereCalibrationRoleBinding  = WhereOptionEq.binding[CalibrationRole](path / "calibrationRole", enumeratedBinding[CalibrationRole])

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereProgramUser.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereProgramUser.scala
@@ -16,7 +16,12 @@ import lucuma.odb.graphql.binding.*
 
 object WhereProgramUser {
 
-  def binding(path: Path): Matcher[Predicate] =
+  /**
+   * @param path path to program user
+   * @param onlyRole set to restrict to a particular role even if the "role"
+   *                 field is not set
+   */
+  def binding(path: Path, onlyRole: Option[ProgramUserRole] = None): Matcher[Predicate] =
 
     val WhereOrderProgramUserId       = WhereOrder.binding[ProgramUser.Id](path / "id", ProgramUserIdBinding)
     lazy val WhereProgramBinding      = WhereProgram.binding(path / "program")
@@ -29,7 +34,7 @@ object WhereProgramUser {
     val WhereGenderBinding            = WhereOptionEq.binding(path / "gender", GenderBinding)
     val WhereHasDataAccessBinding     = WhereBoolean.binding(path / "hasDataAccess", BooleanBinding)
 
-    lazy val WhereProgramUserBinding = binding(path)
+    lazy val WhereProgramUserBinding = binding(path, onlyRole)
     ObjectFieldsBinding.rmap {
       case List(
         WhereProgramUserBinding.List.Option("AND", rAND),
@@ -56,6 +61,7 @@ object WhereProgramUser {
               program,
               user,
               role,
+              onlyRole.map(r => Eql(path / "role", Const(r))),
               partnerLink,
               fallbackProfile,
               educationalStatus,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programs.scala
@@ -153,6 +153,8 @@ class programs extends OdbSuite {
 
   test("program selection via PI email") {
     createProgramAs(piCharles).replicateA(2).flatMap { pids =>
+      // Add a program where Charles Guiteau is the COI.  It
+      // shouldn't match the `WHERE` filter below.
       createProgramAs(piLeon).flatMap { pid =>
         addProgramUserAs(piLeon, pid, partnerLink = PartnerLink.HasPartner(Partner.BR)).flatMap { mid =>
           linkUserAs(piLeon, mid, piCharles.id)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programs.scala
@@ -9,6 +9,8 @@ import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.CalibrationRole
+import lucuma.core.enums.Partner
+import lucuma.core.model.PartnerLink
 import lucuma.core.model.Program
 import lucuma.core.model.ProgramReference.Description
 import lucuma.core.model.StandardRole
@@ -150,8 +152,12 @@ class programs extends OdbSuite {
   }
 
   test("program selection via PI email") {
-    createProgramAs(piLeon) >>
     createProgramAs(piCharles).replicateA(2).flatMap { pids =>
+      createProgramAs(piLeon).flatMap { pid =>
+        addProgramUserAs(piLeon, pid, partnerLink = PartnerLink.HasPartner(Partner.BR)).flatMap { mid =>
+          linkUserAs(piLeon, mid, piCharles.id)
+        }
+      } >>
       expect(
         user = staff,
         query = s"""


### PR DESCRIPTION
Fixes a bug where the a search on program PI was not limited to the PI but instead would match any role.


```
query {
  programs(
    WHERE: { pi: { user: { profile: { familyName: { EQ: "Walker" } } } } }
  ) {
    ...
  }
}
```