### PR TITLE
ShortCut 3202: Select the highest priority (lowest ordinal) band.

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -209,7 +209,7 @@ object CalibrationsService extends CalibrationObservations {
               // there must be a way to sum in wavelength space :/
               val pm = ws.map(_.toPicometers.value.value).combineAll / ws.size
               PosInt.from(pm).map(Wavelength(_)).toOption
-          k -> CalObsProps(w, v.map(_.band).max)
+          k -> CalObsProps(w, v.map(_.band).min)
         }
 
       private def uniqueConfiguration(


### PR DESCRIPTION
I made a mistake in #1616 in which I selected the `max` `ScienceBand` which turns out to be the lowest priority band since the `Order` is done starting with `Band 1` and continuing through `Band 4`.  We might want to reverse the `Order`.

