### PR TITLE
Remove program id from attachment endpoints

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/AttachmentRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/AttachmentRoutes.scala
@@ -95,10 +95,10 @@ object AttachmentRoutes {
     object DescriptionMatcher    extends OptionalQueryParamDecoderMatcher[String]("description")
 
     val routes = HttpRoutes.of[F] {
-      case req @ GET -> Root / "attachment" / ProgramId(programId) / AttachmentId(attachmentId) =>
+      case req @ GET -> Root / "attachment" / AttachmentId(attachmentId) =>
         ssoClient.require(req) { user =>
           service(user) { s =>
-            s.getAttachment(user, programId, attachmentId)
+            s.getAttachment(user, attachmentId)
               .toResponse(s => Response(Status.Ok, body = s).pure)
           }
         }
@@ -118,13 +118,13 @@ object AttachmentRoutes {
           }
         }
 
-      case req @ PUT -> Root / "attachment" / ProgramId(programId) / AttachmentId(attachmentId)
+      case req @ PUT -> Root / "attachment" / AttachmentId(attachmentId)
           :? FileNameMatcher(fileName) +& DescriptionMatcher(optDesc) =>
         ssoClient.require(req) { user =>
           service(user) { s =>
             val description = optDesc.flatMap(d => NonEmptyString.from(d).toOption)
             s
-              .updateAttachment(user, programId, attachmentId, fileName, description, req.body)
+              .updateAttachment(user, attachmentId, fileName, description, req.body)
               .toResponse(_ => Ok())
               .recoverWith {
                 case EntityLimiter.EntityTooLarge(_) =>
@@ -133,20 +133,20 @@ object AttachmentRoutes {
           }
         }
 
-      case req @ DELETE -> Root / "attachment" / ProgramId(programId) / AttachmentId(attachmentId) =>
+      case req @ DELETE -> Root / "attachment" / AttachmentId(attachmentId) =>
         ssoClient.require(req) { user =>
           service(user) { s =>
             s
-              .deleteAttachment(user, programId, attachmentId)
+              .deleteAttachment(user, attachmentId)
               .toResponse(Ok(_))
           }
         }
 
-      case req @ GET -> Root / "attachment" / "url" / ProgramId(programId) / AttachmentId(attachmentId) =>
+      case req @ GET -> Root / "attachment" / "url" / AttachmentId(attachmentId) =>
         ssoClient.require(req) { user =>
           service(user) { s =>
             s
-              .getPresignedUrl(user, programId, attachmentId)
+              .getPresignedUrl(user, attachmentId)
               .toResponse(Ok(_))
           }
         }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentsSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentsSuite.scala
@@ -82,7 +82,8 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
     Resource.eval(authorizationHeader(user)).flatMap: auth =>
       server.flatMap { svr =>
         val uri =
-          (svr.baseUri / "attachment" / programId.toString)
+          (svr.baseUri / "attachment")
+            .withQueryParam("programId", programId.toString)
             .withQueryParam("fileName", ta.fileName)
             .withQueryParam("attachmentType", ta.attachmentType)
             .withOptionQueryParam("description", ta.description)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentsSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentsSuite.scala
@@ -98,14 +98,13 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
   
   def updateAttachment(
     user:         User,
-    programId:    Program.Id,
     attachmentId: Attachment.Id,
     ta:           TestAttachment
   ): Resource[IO, Response[IO]] =
     Resource.eval(authorizationHeader(user)).flatMap: auth =>
       server.flatMap { svr =>
         val uri =
-          (svr.baseUri / "attachment" / programId.toString / attachmentId.toString)
+          (svr.baseUri / "attachment" / attachmentId.toString)
             .withQueryParam("fileName", ta.fileName)
             .withOptionQueryParam("description", ta.description)
 
@@ -120,12 +119,11 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
 
   def getAttachment(
     user:         User,
-    programId:    Program.Id,
     attachmentId: Attachment.Id
   ): Resource[IO, Response[IO]] =
     Resource.eval(authorizationHeader(user)).flatMap: auth =>
       server.flatMap { svr =>
-        val uri     = svr.baseUri / "attachment" / programId.toString / attachmentId.toString
+        val uri     = svr.baseUri / "attachment" / attachmentId.toString
         val request = Request[IO](
           method = Method.GET,
           uri = uri,
@@ -148,12 +146,11 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
 
   def getPresignedUrl(
     user:         User,
-    programId:    Program.Id,
     attachmentId: Attachment.Id
   ): Resource[IO, Response[IO]] =
     Resource.eval(authorizationHeader(user)).flatMap: auth =>
       server.flatMap { svr =>
-        val uri     = svr.baseUri / "attachment" / "url" / programId.toString / attachmentId.toString
+        val uri     = svr.baseUri / "attachment" / "url" / attachmentId.toString
         val request = Request[IO](
           method = Method.GET,
           uri = uri,
@@ -165,12 +162,11 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
 
   def deleteAttachment(
     user:         User,
-    programId:    Program.Id,
     attachmentId: Attachment.Id
   ): Resource[IO, Response[IO]] =
     Resource.eval(authorizationHeader(user)).flatMap: auth =>
       server.flatMap { svr =>
-        val uri     = svr.baseUri / "attachment" / programId.toString / attachmentId.toString
+        val uri     = svr.baseUri / "attachment" / attachmentId.toString
         val request = Request[IO](
           method = Method.DELETE,
           uri = uri,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachmentRoutes.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachmentRoutes.scala
@@ -73,7 +73,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
 
   test("POST requires authorization") {
     val request = Request[IO](method = Method.POST,
-                              uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder"
+                              uri = uri"attachment?programId=p-1&fileName=/file.txt/&attachmentType=finder"
     )
     routes.run(request).assertResponse(Status.Forbidden, none)
   }
@@ -108,7 +108,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
 
   test("POST requires valid user") {
     val request = Request[IO](method = Method.POST,
-                              uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
+                              uri = uri"attachment?programId=p-1&fileName=/file.txt/&attachmentType=finder",
                               headers = Headers(invalidAuthHeader)
     )
     routes.run(request).assertResponse(Status.Forbidden, none)
@@ -147,7 +147,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("valid POST returns attachment") {
     headers(pi).flatMap: hs =>
       val request = Request[IO](method = Method.POST,
-                                uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
+                                uri = uri"attachment?programId=p-1&fileName=/file.txt/&attachmentType=finder",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.Ok, attachmentId.toString.some)
@@ -186,7 +186,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("POST returns NotFound for invalid program id") {
     headers(pi).flatMap: hs =>
       val request = Request[IO](method = Method.POST,
-                                uri = uri"attachment/a-1?fileName=/file.txt/&attachmentType=finder",
+                                uri = uri"attachment?programId=a-1&fileName=/file.txt/&attachmentType=finder",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.NotFound, notFound)
@@ -195,7 +195,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("POST returns NotFound for missing fileName") {
     headers(pi).flatMap: hs =>
       val request = Request[IO](method = Method.POST,
-                                uri = uri"attachment/p-1?attachmentType=finder",
+                                uri = uri"attachment?programId=p-1&attachmentType=finder",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.NotFound, notFound)
@@ -204,7 +204,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("POST returns NotFound for missing attachmentType") {
     headers(pi).flatMap: hs =>
       val request = Request[IO](method = Method.POST,
-                                uri = uri"attachment/p-1?fileName=/file.txt/",
+                                uri = uri"attachment?programId=p-1&fileName=/file.txt/",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.NotFound, notFound)
@@ -292,7 +292,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("POST returns Forbidden if service returns Forbidden") {
     headers(forbiddenUser).flatMap: hs =>
       val request = Request[IO](method = Method.POST,
-                                uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
+                                uri = uri"attachment?programId=p-1&fileName=/file.txt/&attachmentType=finder",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.Forbidden, none)
@@ -301,7 +301,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("POST returns NotFound if service returns FileNotFound") {
     headers(fileNotFoundUser).flatMap: hs =>
       val request = Request[IO](method = Method.POST,
-                                uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
+                                uri = uri"attachment?programId=p-1&fileName=/file.txt/&attachmentType=finder",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.NotFound, none)
@@ -310,7 +310,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("POST returns BadRequest with message if service returns FileNotFound") {
     headers(invalidFileUser).flatMap: hs =>
       val request = Request[IO](method = Method.POST,
-                                uri = uri"attachment/p-1?fileName=/file.txt/&attachmentType=finder",
+                                uri = uri"attachment?programId=p-1&fileName=/file.txt/&attachmentType=finder",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachmentRoutes.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachmentRoutes.scala
@@ -27,7 +27,6 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   private val service: AttachmentFileService[IO] = new AttachmentFileService[IO] {
     def getAttachment(
       user:         User,
-      programId:    Program.Id,
       attachmentId: Attachment.Id
     )(using NoTransaction[IO]): IO[Either[AttachmentException, Stream[IO, Byte]]] = {
       val either = getError(user).fold(responseStream(fileContents).asRight)(_.asLeft)
@@ -46,7 +45,6 @@ class attachmentRoutes extends AttachmentRoutesSuite {
 
     def updateAttachment(
       user: User,
-      programId: Program.Id,
       attachmentId: Attachment.Id,
       fileName: String,
       description: Option[NonEmptyString],
@@ -54,22 +52,22 @@ class attachmentRoutes extends AttachmentRoutesSuite {
     )(using NoTransaction[IO]): IO[Either[AttachmentException, Unit]] =
       getError(user).fold(().asRight.pure[IO])(_.asLeft.pure)
 
-    def deleteAttachment(user: User, programId: Program.Id, attachmentId: Attachment.Id)(using NoTransaction[IO]): IO[Either[AttachmentException, Unit]] =
+    def deleteAttachment(user: User, attachmentId: Attachment.Id)(using NoTransaction[IO]): IO[Either[AttachmentException, Unit]] =
       getError(user).fold(().asRight.pure[IO])(_.asLeft.pure)
 
-    def getPresignedUrl(user: User, programId: Program.Id, attachmentId: Attachment.Id)(using NoTransaction[IO]): IO[Either[AttachmentException, String]] =
+    def getPresignedUrl(user: User, attachmentId: Attachment.Id)(using NoTransaction[IO]): IO[Either[AttachmentException, String]] =
       getError(user).fold(presignedUrl.asRight.pure[IO])(_.asLeft.pure)
   }
 
   private val routes: HttpApp[IO] = AttachmentRoutes(service, ssoClient, 1).orNotFound
 
   test("GET requires authorization") {
-    val request = Request[IO](method = Method.GET, uri = uri"attachment/p-1/a-1")
+    val request = Request[IO](method = Method.GET, uri = uri"attachment/a-1")
     routes.run(request).assertResponse(Status.Forbidden, none)
   }
 
   test("GETurl requires authorization") {
-    val request = Request[IO](method = Method.GET, uri = uri"attachment/url/p-1/a-1")
+    val request = Request[IO](method = Method.GET, uri = uri"attachment/url/a-1")
     routes.run(request).assertResponse(Status.Forbidden, none)
   }
 
@@ -82,19 +80,19 @@ class attachmentRoutes extends AttachmentRoutesSuite {
 
   test("PUT requires authorization") {
     val request = Request[IO](method = Method.PUT,
-                              uri = uri"attachment/p-1/a-1?fileName=/file.txt"
+                              uri = uri"attachment/a-1?fileName=/file.txt"
     )
     routes.run(request).assertResponse(Status.Forbidden, none)
   }
 
   test("DELETE requires authorization") {
-    val request = Request[IO](method = Method.DELETE, uri = uri"attachment/p-1/a-1")
+    val request = Request[IO](method = Method.DELETE, uri = uri"attachment/a-1")
     routes.run(request).assertResponse(Status.Forbidden, none)
   }
 
   test("GET requires valid user") {
     val request = Request[IO](method = Method.GET,
-                              uri = uri"attachment/p-1/a-1",
+                              uri = uri"attachment/a-1",
                               headers = Headers(invalidAuthHeader)
     )
     routes.run(request).assertResponse(Status.Forbidden, none)
@@ -102,7 +100,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
 
   test("GETurl requires valid user") {
     val request = Request[IO](method = Method.GET,
-                              uri = uri"attachment/url/p-1/a-1",
+                              uri = uri"attachment/url/a-1",
                               headers = Headers(invalidAuthHeader)
     )
     routes.run(request).assertResponse(Status.Forbidden, none)
@@ -118,7 +116,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
 
   test("PUT requires valid user") {
     val request = Request[IO](method = Method.PUT,
-                              uri = uri"attachment/p-1/a-1?fileName=/file.txt",
+                              uri = uri"attachment/a-1?fileName=/file.txt",
                               headers = Headers(invalidAuthHeader)
     )
     routes.run(request).assertResponse(Status.Forbidden, none)
@@ -126,7 +124,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
 
   test("DELETE requires valid user") {
     val request = Request[IO](method = Method.DELETE,
-                              uri = uri"attachment/p-1/a-1",
+                              uri = uri"attachment/a-1",
                               headers = Headers(invalidAuthHeader)
     )
     routes.run(request).assertResponse(Status.Forbidden, none)
@@ -135,14 +133,14 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("valid GET returns file contents") {
     headers(pi).flatMap: hs =>
       val request =
-        Request[IO](method = Method.GET, uri = uri"attachment/p-1/a-1", headers = hs)
+        Request[IO](method = Method.GET, uri = uri"attachment/a-1", headers = hs)
       routes.run(request).assertResponse(Status.Ok, fileContents.some)
   }
 
   test("valid GETurl returns url") {
     headers(pi).flatMap: hs =>
       val request =
-        Request[IO](method = Method.GET, uri = uri"attachment/url/p-1/a-1", headers = hs)
+        Request[IO](method = Method.GET, uri = uri"attachment/url/a-1", headers = hs)
       routes.run(request).assertResponse(Status.Ok, presignedUrl.some)
   }
 
@@ -158,7 +156,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("valid PUT returns Ok") {
     headers(pi).flatMap: hs =>
       val request = Request[IO](method = Method.PUT,
-                                uri = uri"attachment/p-1/a-1?fileName=/file.txt",
+                                uri = uri"attachment/a-1?fileName=/file.txt",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.Ok, none)
@@ -167,35 +165,21 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("valid DELETE returns Ok") {
     headers(pi).flatMap: hs =>
       val request =
-        Request[IO](method = Method.DELETE, uri = uri"attachment/p-1/a-1", headers = hs)
+        Request[IO](method = Method.DELETE, uri = uri"attachment/a-1", headers = hs)
       routes.run(request).assertResponse(Status.Ok, none)
-  }
-
-  test("GET returns NotFound for invalid program id") {
-    headers(pi).flatMap: hs =>
-      val request =
-        Request[IO](method = Method.GET, uri = uri"attachment/p1/a-1", headers = hs)
-      routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("GET returns NotFound for invalid attachment id") {
     headers(pi).flatMap: hs =>
       val request =
-        Request[IO](method = Method.GET, uri = uri"attachment/p-1/a-x1", headers = hs)
-      routes.run(request).assertResponse(Status.NotFound, notFound)
-  }
-
-  test("GETurl returns NotFound for invalid program id") {
-    headers(pi).flatMap: hs =>
-      val request =
-        Request[IO](method = Method.GET, uri = uri"attachment/url/p1/a-1", headers = hs)
+        Request[IO](method = Method.GET, uri = uri"attachment/a-x1", headers = hs)
       routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("GETurl returns NotFound for invalid attachment id") {
     headers(pi).flatMap: hs =>
       val request =
-        Request[IO](method = Method.GET, uri = uri"attachment/url/p-1/a-x1", headers = hs)
+        Request[IO](method = Method.GET, uri = uri"attachment/url/a-x1", headers = hs)
       routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
@@ -226,19 +210,10 @@ class attachmentRoutes extends AttachmentRoutesSuite {
       routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
-  test("PUT returns NotFound for invalid program id") {
-    headers(pi).flatMap: hs =>
-      val request = Request[IO](method = Method.PUT,
-                                uri = uri"attachment/z-1/a-1?fileName=/file.txt",
-                                headers = hs
-      )
-      routes.run(request).assertResponse(Status.NotFound, notFound)
-  }
-
   test("PUT returns NotFound for invalid attachment id") {
     headers(pi).flatMap: hs =>
       val request = Request[IO](method = Method.PUT,
-                                uri = uri"attachment/p-1/q-1?fileName=/file.txt",
+                                uri = uri"attachment/q-1?fileName=/file.txt",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.NotFound, notFound)
@@ -247,30 +222,23 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("PUT returns NotFound for missing fileName") {
     headers(pi).flatMap: hs =>
       val request = Request[IO](method = Method.PUT,
-                                uri = uri"attachment/p-1/a-1",
+                                uri = uri"attachment/a-1",
                                 headers = hs
       )
-      routes.run(request).assertResponse(Status.NotFound, notFound)
-  }
-
-  test("DELETE returns NotFound for invalid program id") {
-    headers(pi).flatMap: hs =>
-      val request =
-        Request[IO](method = Method.DELETE, uri = uri"attachment/p/a-1", headers = hs)
       routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("DELETE returns NotFound for invalid attachment id") {
     headers(pi).flatMap: hs =>
       val request =
-        Request[IO](method = Method.DELETE, uri = uri"attachment/p-1/a", headers = hs)
+        Request[IO](method = Method.DELETE, uri = uri"attachment/a", headers = hs)
       routes.run(request).assertResponse(Status.NotFound, notFound)
   }
 
   test("GET returns Forbidden if service returns Forbidden") {
     headers(forbiddenUser).flatMap: hs =>
       val request = Request[IO](method = Method.GET,
-                                uri = uri"attachment/p-1/a-1",
+                                uri = uri"attachment/a-1",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.Forbidden, none)
@@ -279,7 +247,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("GET returns NotFound if service returns FileNotFound") {
     headers(fileNotFoundUser).flatMap: hs =>
       val request = Request[IO](method = Method.GET,
-                                uri = uri"attachment/p-1/a-1",
+                                uri = uri"attachment/a-1",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.NotFound, none)
@@ -288,7 +256,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("GET returns BadRequest with message if service returns InvalidRequest") {
     headers(invalidFileUser).flatMap: hs =>
       val request = Request[IO](method = Method.GET,
-                                uri = uri"attachment/p-1/a-1",
+                                uri = uri"attachment/a-1",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
@@ -297,7 +265,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("GETurl returns Forbidden if service returns Forbidden") {
     headers(forbiddenUser).flatMap: hs =>
       val request = Request[IO](method = Method.GET,
-                                uri = uri"attachment/url/p-1/a-1",
+                                uri = uri"attachment/url/a-1",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.Forbidden, none)
@@ -306,7 +274,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("GETurl returns NotFound if service returns FileNotFound") {
     headers(fileNotFoundUser).flatMap: hs =>
       val request = Request[IO](method = Method.GET,
-                                uri = uri"attachment/url/p-1/a-1",
+                                uri = uri"attachment/url/a-1",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.NotFound, none)
@@ -315,7 +283,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("GETurl returns BadRequest with message if service returns InvalidRequest") {
     headers(invalidFileUser).flatMap: hs =>
       val request = Request[IO](method = Method.GET,
-                                uri = uri"attachment/url/p-1/a-1",
+                                uri = uri"attachment/url/a-1",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
@@ -351,7 +319,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("PUT returns BadRequest with message if service returns InvalidRequest") {
     headers(invalidFileUser).flatMap: hs =>
       val request = Request[IO](method = Method.PUT,
-                                uri = uri"attachment/p-1/a-1?fileName=/file.txt",
+                                uri = uri"attachment/a-1?fileName=/file.txt",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)
@@ -360,7 +328,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("PUT returns Forbidden if service returns Forbidden") {
     headers(forbiddenUser).flatMap: hs =>
       val request = Request[IO](method = Method.PUT,
-                                uri = uri"attachment/p-1/a-1?fileName=/file.txt",
+                                uri = uri"attachment/a-1?fileName=/file.txt",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.Forbidden, none)
@@ -369,7 +337,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("PUT returns NotFound if service returns FileNotFound") {
     headers(fileNotFoundUser).flatMap: hs =>
       val request = Request[IO](method = Method.PUT,
-                                uri = uri"attachment/p-1/a-1?fileName=/file.txt",
+                                uri = uri"attachment/a-1?fileName=/file.txt",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.NotFound, none)
@@ -378,7 +346,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("DELETE returns Forbidden if service returns Forbidden") {
     headers(forbiddenUser).flatMap: hs =>
       val request = Request[IO](method = Method.DELETE,
-                                uri = uri"attachment/p-1/a-1",
+                                uri = uri"attachment/a-1",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.Forbidden, none)
@@ -387,7 +355,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("DELETE returns NotFound if service returns FileNotFound") {
     headers(fileNotFoundUser).flatMap: hs =>
       val request = Request[IO](method = Method.DELETE,
-                                uri = uri"attachment/p-1/a-1",
+                                uri = uri"attachment/a-1",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.NotFound, none)
@@ -396,7 +364,7 @@ class attachmentRoutes extends AttachmentRoutesSuite {
   test("DELETE returns BadRequest with message if service returns InvalidRequest") {
     headers(invalidFileUser).flatMap: hs =>
       val request = Request[IO](method = Method.DELETE,
-                                uri = uri"attachment/p-1/a-1",
+                                uri = uri"attachment/a-1",
                                 headers = hs
       )
       routes.run(request).assertResponse(Status.BadRequest, invalidFileName.some)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachments.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachments.scala
@@ -114,11 +114,11 @@ class attachments extends AttachmentsSuite {
       fileKey = awsConfig.fileKey(path)
       _      <- assertS3(fileKey, mosMask1A.content)
       _      <- assertAttachmentsGql(pi, pid, (aid, mosMask1A))
-      _      <- getAttachment(pi, pid, aid).expectBody(mosMask1A.content)
-      _      <- deleteAttachment(pi, pid, aid).expectOk
+      _      <- getAttachment(pi, aid).expectBody(mosMask1A.content)
+      _      <- deleteAttachment(pi, aid).expectOk
       _      <- assertS3NotThere(fileKey)
       _      <- assertAttachmentsGql(pi, pid)
-      _      <- getAttachment(pi, pid, aid).withExpectation(Status.NotFound)
+      _      <- getAttachment(pi, aid).withExpectation(Status.NotFound)
     } yield ()
   }
 
@@ -130,7 +130,7 @@ class attachments extends AttachmentsSuite {
       fileKey = awsConfig.fileKey(path)
       _      <- assertS3(fileKey, mosMask1A.content)
       _      <- assertAttachmentsGql(pi, pid, (aid, mosMask1A))
-      url    <- getPresignedUrl(pi, pid, aid).toNonEmptyString
+      url    <- getPresignedUrl(pi, aid).toNonEmptyString
       _      <- getViaPresignedUrl(url).expectBody(mosMask1A.content)
     } yield ()
   }
@@ -147,11 +147,11 @@ class attachments extends AttachmentsSuite {
       fk2   = awsConfig.fileKey(pth2)
       _    <- assertS3(fk2, mosMask2.content)
       _    <- assertAttachmentsGql(pi, pid, (aid2, mosMask2), (aid1, mosMask1A))
-      _    <- getAttachment(pi, pid, aid1).expectBody(mosMask1A.content)
-      _    <- getAttachment(pi, pid, aid2).expectBody(mosMask2.content)
-      _    <- deleteAttachment(pi, pid, aid1).expectOk
-      _    <- getAttachment(pi, pid, aid1).withExpectation(Status.NotFound)
-      _    <- getAttachment(pi, pid, aid2).expectBody(mosMask2.content)
+      _    <- getAttachment(pi, aid1).expectBody(mosMask1A.content)
+      _    <- getAttachment(pi, aid2).expectBody(mosMask2.content)
+      _    <- deleteAttachment(pi, aid1).expectOk
+      _    <- getAttachment(pi, aid1).withExpectation(Status.NotFound)
+      _    <- getAttachment(pi, aid2).expectBody(mosMask2.content)
       _    <- assertS3NotThere(fk1)
       _    <- assertS3(fk2, mosMask2.content)
       _    <- assertAttachmentsGql(pi, pid, (aid2, mosMask2))
@@ -232,15 +232,15 @@ class attachments extends AttachmentsSuite {
       fileKey = awsConfig.fileKey(path)
       _      <- assertS3(fileKey, mosMask1A.content)
       _      <- assertAttachmentsGql(pi, pid, (aid, mosMask1A))
-      _      <- getAttachment(pi, pid, aid).expectBody(mosMask1A.content)
-      _      <- updateAttachment(pi, pid, aid, mosMask2).expectOk
+      _      <- getAttachment(pi, aid).expectBody(mosMask1A.content)
+      _      <- updateAttachment(pi, aid, mosMask2).expectOk
       path2  <- getRemotePathFromDb(aid)
       _       = assertNotEquals(path, path2)
       fk2     = awsConfig.fileKey(path2)
       _      <- assertS3(fk2, mosMask2.content)
       _      <- assertS3NotThere(fileKey)
       _      <- assertAttachmentsGql(pi, pid, (aid, mosMask2.copy(attachmentType = mosMask1A.attachmentType)))
-      _      <- getAttachment(pi, pid, aid).expectBody(mosMask2.content)
+      _      <- getAttachment(pi, aid).expectBody(mosMask2.content)
     } yield ()
   }
 
@@ -252,15 +252,15 @@ class attachments extends AttachmentsSuite {
       fileKey = awsConfig.fileKey(path)
       _      <- assertS3(fileKey, mosMask1A.content)
       _      <- assertAttachmentsGql(pi, pid, (aid, mosMask1A))
-      _      <- getAttachment(pi, pid, aid).expectBody(mosMask1A.content)
-      _      <- updateAttachment(pi, pid, aid, mosMask1B).expectOk
+      _      <- getAttachment(pi, aid).expectBody(mosMask1A.content)
+      _      <- updateAttachment(pi, aid, mosMask1B).expectOk
       path2  <- getRemotePathFromDb(aid)
       _       = assertNotEquals(path, path2)
       fk2     = awsConfig.fileKey(path2)
       _      <- assertS3(fk2, mosMask1B.content)
       _      <- assertS3NotThere(fileKey)
       _      <- assertAttachmentsGql(pi, pid, (aid, mosMask1B.copy(attachmentType = mosMask1A.attachmentType)))
-      _      <- getAttachment(pi, pid, aid).expectBody(mosMask1B.content)
+      _      <- getAttachment(pi, aid).expectBody(mosMask1B.content)
     } yield ()
   }
 
@@ -268,7 +268,7 @@ class attachments extends AttachmentsSuite {
     for {
       pid <- createProgramAs(pi)
       aid  = Attachment.Id.fromLong(100L).get
-      _   <- updateAttachment(pi, pid, aid, mosMask1A).withExpectation(Status.NotFound)
+      _   <- updateAttachment(pi, aid, mosMask1A).withExpectation(Status.NotFound)
     } yield ()
   }
 
@@ -283,7 +283,7 @@ class attachments extends AttachmentsSuite {
       _      <- insertAttachment(pi, pid, mosMask1B).withExpectation(Status.BadRequest, AttachmentFileService.DuplicateFileNameMsg)
       _      <- assertS3(fileKey, mosMask1A.content)
       _      <- assertAttachmentsGql(pi, pid, (aid, mosMask1A))
-      _      <- getAttachment(pi, pid, aid).expectBody(mosMask1A.content)
+      _      <- getAttachment(pi, aid).expectBody(mosMask1A.content)
     } yield ()
   }
 
@@ -297,9 +297,9 @@ class attachments extends AttachmentsSuite {
       path2  <- getRemotePathFromDb(aid2)
       fk2     = awsConfig.fileKey(path2)
       _      <- assertAttachmentsGql(pi, pid, (aid, mosMask1A), (aid2, mosMask2))
-      _      <- updateAttachment(pi, pid, aid2, mosMask1B).withExpectation(Status.BadRequest, AttachmentFileService.DuplicateFileNameMsg)
+      _      <- updateAttachment(pi, aid2, mosMask1B).withExpectation(Status.BadRequest, AttachmentFileService.DuplicateFileNameMsg)
       _      <- assertAttachmentsGql(pi, pid, (aid, mosMask1A), (aid2, mosMask2))
-      _      <- getAttachment(pi, pid, aid2).expectBody(mosMask2.content)
+      _      <- getAttachment(pi, aid2).expectBody(mosMask2.content)
     } yield ()
   }
 
@@ -318,7 +318,7 @@ class attachments extends AttachmentsSuite {
       fileKey = awsConfig.fileKey(path)
       _      <- assertS3(fileKey, mosMask1A.content)
       _      <- assertAttachmentsGql(pi, pid, (aid, mosMask1A))
-      _      <- updateAttachment(pi, pid, aid, emptyFile).withExpectation(Status.BadRequest, "File cannot be empty")
+      _      <- updateAttachment(pi, aid, emptyFile).withExpectation(Status.BadRequest, "File cannot be empty")
       _      <- assertS3(fileKey, mosMask1A.content)
       _      <- assertAttachmentsGql(pi, pid, (aid, mosMask1A))
     } yield ()
@@ -349,7 +349,7 @@ class attachments extends AttachmentsSuite {
     for {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
-      _   <- updateAttachment(pi, pid, aid, missingFileName).withExpectation(Status.BadRequest, "File name is required")
+      _   <- updateAttachment(pi, aid, missingFileName).withExpectation(Status.BadRequest, "File name is required")
     } yield ()
   }
 
@@ -364,7 +364,7 @@ class attachments extends AttachmentsSuite {
     for {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
-      _   <- updateAttachment(pi, pid, aid, fileWithPath).withExpectation(Status.BadRequest, "File name cannot include a path")
+      _   <- updateAttachment(pi, aid, fileWithPath).withExpectation(Status.BadRequest, "File name cannot include a path")
     } yield ()
   }
 
@@ -379,7 +379,7 @@ class attachments extends AttachmentsSuite {
     for {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, finderJPG).toAttachmentId
-      _   <- updateAttachment(pi, pid, aid, missingFinderExt).withExpectation(Status.BadRequest, invalidFinderMsg)
+      _   <- updateAttachment(pi, aid, missingFinderExt).withExpectation(Status.BadRequest, invalidFinderMsg)
     } yield ()
   }
 
@@ -394,7 +394,7 @@ class attachments extends AttachmentsSuite {
     for {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
-      _   <- updateAttachment(pi, pid, aid, emptyMosMaskExt).withExpectation(Status.BadRequest, invalidFitsMsg)
+      _   <- updateAttachment(pi, aid, emptyMosMaskExt).withExpectation(Status.BadRequest, invalidFitsMsg)
     } yield ()
   }
 
@@ -409,7 +409,7 @@ class attachments extends AttachmentsSuite {
     for {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, finderJPG).toAttachmentId
-      _   <- updateAttachment(pi, pid, aid, missingFinderExt).withExpectation(Status.BadRequest, invalidFinderMsg)
+      _   <- updateAttachment(pi, aid, missingFinderExt).withExpectation(Status.BadRequest, invalidFinderMsg)
     } yield ()
   }
 
@@ -424,7 +424,7 @@ class attachments extends AttachmentsSuite {
     for {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
-      _   <- updateAttachment(pi, pid, aid, invalidMosMaskExt).withExpectation(Status.BadRequest, invalidFitsMsg)
+      _   <- updateAttachment(pi, aid, invalidMosMaskExt).withExpectation(Status.BadRequest, invalidFitsMsg)
     } yield ()
   }
 
@@ -439,7 +439,7 @@ class attachments extends AttachmentsSuite {
     for {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, preImaging).toAttachmentId
-      _   <- updateAttachment(pi, pid, aid, invalidPreImgExt).withExpectation(Status.BadRequest, invalidFitsMsg)
+      _   <- updateAttachment(pi, aid, invalidPreImgExt).withExpectation(Status.BadRequest, invalidFitsMsg)
     } yield ()
   }
 
@@ -473,7 +473,7 @@ class attachments extends AttachmentsSuite {
     for {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
-      _   <- updateAttachment(pi2, pid, aid, mosMask2).withExpectation(Status.Forbidden)
+      _   <- updateAttachment(pi2, aid, mosMask2).withExpectation(Status.NotFound)
     } yield ()
   }
 
@@ -502,8 +502,8 @@ class attachments extends AttachmentsSuite {
       fk2   = awsConfig.fileKey(pth2)
       _    <- assertS3(fk2, mosMask2.content)
       _    <- assertAttachmentsGql(pi2, pid2, (aid2, mosMask2))
-      _    <- getAttachment(pi, pid2, aid2).withExpectation(Status.Forbidden)
-      _    <- getAttachment(pi2, pid1, aid1).withExpectation(Status.Forbidden)
+      _    <- getAttachment(pi, aid2).withExpectation(Status.NotFound)
+      _    <- getAttachment(pi2, aid1).withExpectation(Status.NotFound)
     } yield ()
   }
 
@@ -521,8 +521,8 @@ class attachments extends AttachmentsSuite {
       fk2   = awsConfig.fileKey(pth2)
       _    <- assertS3(fk2, mosMask2.content)
       _    <- assertAttachmentsGql(pi2, pid2, (aid2, mosMask2))
-      _    <- deleteAttachment(pi, pid2, aid2).withExpectation(Status.Forbidden)
-      _    <- deleteAttachment(pi2, pid1, aid1).withExpectation(Status.Forbidden)
+      _    <- deleteAttachment(pi, aid2).withExpectation(Status.NotFound)
+      _    <- deleteAttachment(pi2, aid1).withExpectation(Status.NotFound)
     } yield ()
   }
 
@@ -534,14 +534,14 @@ class attachments extends AttachmentsSuite {
       fileKey = awsConfig.fileKey(path)
       _      <- assertS3(fileKey, mosMask1A.content)
       _      <- assertAttachmentsGql(service, pid, (aid, mosMask1A))
-      _      <- getAttachment(service, pid, aid).expectBody(mosMask1A.content)
-      _      <- updateAttachment(service, pid, aid, mosMask2).expectOk
+      _      <- getAttachment(service, aid).expectBody(mosMask1A.content)
+      _      <- updateAttachment(service, aid, mosMask2).expectOk
       path2  <- getRemotePathFromDb(aid)
       _       = assertNotEquals(path, path2)
       fk2     = awsConfig.fileKey(path2)
       _      <- assertS3(fk2, mosMask2.content)
       _      <- assertS3NotThere(fileKey)
-      _      <- deleteAttachment(service, pid, aid).expectOk
+      _      <- deleteAttachment(service, aid).expectOk
       _      <- assertS3NotThere(fk2)
       _      <- assertAttachmentsGql(service, pid)
     } yield ()

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/obsAttachmentsAssignments.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/obsAttachmentsAssignments.scala
@@ -343,7 +343,7 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       aid2 <- insertAttachment(pi, pid, finder).toAttachmentId
       oid  <- createObservation(pi, pid, (aid1, mosMask), (aid2, finder))
       _    <- assertObservation(pi, pid, oid, (aid1, mosMask), (aid2, finder))
-      _    <- deleteAttachment(pi, pid, aid1).expectOk
+      _    <- deleteAttachment(pi, aid1).expectOk
       _    <- assertObservation(pi, pid, oid, (aid2, finder))
     } yield ()
   }


### PR DESCRIPTION
This is support of Custom SEDs. They are attachments and the ITC needs to call the endpoints. This removes the need for it to know the program id. Only the GET endpoints needed changed for this, but all were changed for the sake of consistency.