### PR TITLE
Shortcut 4839: Fix datasetId mapping

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/SubscriptionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/SubscriptionMapping.scala
@@ -100,7 +100,10 @@ trait SubscriptionMapping[F[_]] extends Predicates[F] {
           input.flatMap(_.isWritten).forall(_ === e.isWritten)
         .map(e => Result(
           Environment(
-            Env("editType" -> e.editType),
+            Env(
+              "editType"  -> e.editType,
+              "datasetId" -> e.datasetId
+            ),
             Unique(Filter(Predicates.datasetEdit.value.id.eql(e.datasetId), child))
           )
         ))


### PR DESCRIPTION
I neglected to add the `datasetId` to the environment, leaving the `DatasetEdit` -> `datasetId` mapping unaccounted for.