### PR TITLE
Shortcut 4836: Add GMOS acquisition breakpoints

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Acquisition.scala
@@ -18,6 +18,7 @@ import fs2.Pure
 import fs2.Stream
 import lucuma.core.data.Zipper
 import lucuma.core.enums.Band
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.GmosGratingOrder
 import lucuma.core.enums.GmosNorthFilter
@@ -130,6 +131,7 @@ object Acquisition:
 
           _  <- optics.exposure      := lastExpTime(exposureTime)
           s2 <- scienceStep(0.arcsec, 0.arcsec, ObserveClass.Acquisition)
+                  .map(ProtoStep.breakpoint.replace(Breakpoint.Enabled))
 
         } yield Acquisition.Steps(s0, s1, s2)
       }

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/AtomBuilder.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/AtomBuilder.scala
@@ -77,7 +77,8 @@ object AtomBuilder:
                 protoStep.stepConfig,
                 protoStep.telescopeConfig,
                 estimate,
-                protoStep.observeClass
+                protoStep.observeClass,
+                protoStep.breakpoint
               )
             }
           )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
@@ -13,6 +13,7 @@ import eu.timepit.refined.types.numeric.PosLong
 import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.DatasetQaState
 import lucuma.core.enums.DatasetStage
@@ -271,6 +272,7 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
           guiding
         }
         observeClass
+        breakpoint
       }
     """
 
@@ -426,7 +428,8 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
           "arcs" : ${arc.gcalConfig.lamp.arcs.map(_.toList) }
         },
         "telescopeConfig": ${expectedTelescopeConfig(p, q, StepGuideState.Disabled)},
-        "observeClass" : "PARTNER_CAL"
+        "observeClass" : "PARTNER_CAL",
+        "breakpoint": "DISABLED"
       }
     """
 
@@ -440,7 +443,8 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
           "arcs" : []
         },
         "telescopeConfig": ${expectedTelescopeConfig(p, q, StepGuideState.Disabled)},
-        "observeClass" : "PARTNER_CAL"
+        "observeClass" : "PARTNER_CAL",
+        "breakpoint": "DISABLED"
       }
     """
 
@@ -450,17 +454,19 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
         "instrumentConfig" : ${gmosNorthExpectedInstrumentConfig(gmosNorthScience(ditherNm))},
         "stepConfig" : { "stepType": "SCIENCE" },
         "telescopeConfig": ${expectedTelescopeConfig(p, q, StepGuideState.Enabled)},
-        "observeClass" : "SCIENCE"
+        "observeClass" : "SCIENCE",
+        "breakpoint": "DISABLED"
       }
     """
 
-  protected def gmosNorthExpectedAcq(step: Int, p: Int): Json =
+  protected def gmosNorthExpectedAcq(step: Int, p: Int, breakpoint: Breakpoint = Breakpoint.Disabled): Json =
     json"""
       {
         "instrumentConfig" : ${gmosNorthExpectedInstrumentConfig(gmosNorthAcq(step))},
         "stepConfig" : { "stepType":  "SCIENCE" },
         "telescopeConfig": ${expectedTelescopeConfig(p, 0, StepGuideState.Enabled)},
-        "observeClass" : "ACQUISITION"
+        "observeClass" : "ACQUISITION",
+        "breakpoint": ${breakpoint.tag.toScreamingSnakeCase.asJson}
       }
     """
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcq.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcq.scala
@@ -10,6 +10,7 @@ import cats.syntax.either.*
 import cats.syntax.option.*
 import io.circe.Json
 import io.circe.literal.*
+import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.DatasetQaState
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.ObserveClass
@@ -41,7 +42,7 @@ class executionAcq extends ExecutionTestSupport {
                     "steps": [
                       ${gmosNorthExpectedAcq(0,  0)},
                       ${gmosNorthExpectedAcq(1, 10)},
-                      ${gmosNorthExpectedAcq(2,  0)}
+                      ${gmosNorthExpectedAcq(2,  0, Breakpoint.Enabled)}
                     ]
                   },
                   "possibleFuture": [
@@ -49,7 +50,7 @@ class executionAcq extends ExecutionTestSupport {
                       "description": "Fine Adjustments",
                       "observeClass": "ACQUISITION",
                       "steps": [
-                        ${gmosNorthExpectedAcq(2, 0)}
+                        ${gmosNorthExpectedAcq(2, 0, Breakpoint.Enabled)}
                       ]
                     }
                   ],
@@ -74,7 +75,7 @@ class executionAcq extends ExecutionTestSupport {
                     "description": "Fine Adjustments",
                     "observeClass": "ACQUISITION",
                     "steps": [
-                      ${gmosNorthExpectedAcq(2, 0)}
+                      ${gmosNorthExpectedAcq(2, 0, Breakpoint.Enabled)}
                     ]
                   },
                   "possibleFuture": [
@@ -82,7 +83,7 @@ class executionAcq extends ExecutionTestSupport {
                       "description": "Fine Adjustments",
                       "observeClass": "ACQUISITION",
                       "steps": [
-                        ${gmosNorthExpectedAcq(2, 0)}
+                        ${gmosNorthExpectedAcq(2, 0, Breakpoint.Enabled)}
                       ]
                     }
                   ],
@@ -222,7 +223,7 @@ class executionAcq extends ExecutionTestSupport {
                           "observeClass": "ACQUISITION",
                           "steps": [
                             ${gmosNorthExpectedAcq(1, 10)},
-                            ${gmosNorthExpectedAcq(2,  0)}
+                            ${gmosNorthExpectedAcq(2,  0, Breakpoint.Enabled)}
                           ]
                         },
                         "possibleFuture": [
@@ -230,7 +231,7 @@ class executionAcq extends ExecutionTestSupport {
                             "description": "Fine Adjustments",
                             "observeClass": "ACQUISITION",
                             "steps": [
-                              ${gmosNorthExpectedAcq(2, 0)}
+                              ${gmosNorthExpectedAcq(2, 0, Breakpoint.Enabled)}
                             ]
                           }
                         ],
@@ -419,7 +420,7 @@ class executionAcq extends ExecutionTestSupport {
                           "observeClass": "ACQUISITION",
                           "steps": [
                             ${gmosNorthExpectedAcq(1, 10)},
-                            ${gmosNorthExpectedAcq(2,  0)}
+                            ${gmosNorthExpectedAcq(2,  0, Breakpoint.Enabled)}
                           ]
                         },
                         "possibleFuture": [
@@ -427,7 +428,7 @@ class executionAcq extends ExecutionTestSupport {
                             "description": "Fine Adjustments",
                             "observeClass": "ACQUISITION",
                             "steps": [
-                              ${gmosNorthExpectedAcq(2, 0)}
+                              ${gmosNorthExpectedAcq(2, 0, Breakpoint.Enabled)}
                             ]
                           }
                         ],


### PR DESCRIPTION
Adds breakpoints in the GMOS acquisition sequence, as stipulated in [Shortcut 4836](https://app.shortcut.com/lucuma/story/4836/add-breakpoints-to-acquisitions).