### PR TITLE
Migration to add fluxDensitiesAttachment

### DIFF
--- a/modules/service/src/main/resources/db/migration/V0966__add_fluxDensitiesAttachment.sql
+++ b/modules/service/src/main/resources/db/migration/V0966__add_fluxDensitiesAttachment.sql
@@ -1,0 +1,6 @@
+UPDATE t_target SET c_source_profile = jsonb_set(c_source_profile, '{point,bandNormalized,sed,fluxDensitiesAttachment}', 'null')
+	WHERE (c_source_profile #> '{point}') <> 'null';
+UPDATE t_target SET c_source_profile = jsonb_set(c_source_profile, '{uniform,bandNormalized,sed,fluxDensitiesAttachment}', 'null')
+	WHERE (c_source_profile #> '{uniform}') <> 'null';
+UPDATE t_target SET c_source_profile = jsonb_set(c_source_profile, '{gaussian,bandNormalized,sed,fluxDensitiesAttachment}', 'null')
+	WHERE (c_source_profile #> '{gaussian}') <> 'null';


### PR DESCRIPTION
Turns out we did need to add the new fluxDensitiesAttachment to existing targets.

This PR does so in a safe way by manipulating at the JSON level.