### PR TITLE
Shortcut 4671: Program Notes Update

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -3130,6 +3130,15 @@ type Mutation {
     input: UpdateProgramsInput!
   ): UpdateProgramsResult!
 
+  "Updates existing program notes."
+  updateProgramNotes(
+    """
+    Parameters for identifying program notes to update along with the changes to
+    make.
+    """
+    input: UpdateProgramNotesInput!
+  ): UpdateProgramNotesResult!
+
   "Updates existing program users."
   updateProgramUsers(
 
@@ -5461,6 +5470,51 @@ type UpdateProgramUsersResult {
   programUsers: [ProgramUser!]!
 
   "Whether there were additional updated program users that were not returned."
+  hasMore: Boolean!
+}
+
+"""
+Program note selection and update description.  Use `SET" to specify the changes,
+`WHERE` to select the programs to update, and `LIMIT` to control the size of the
+return value.
+"""
+input UpdateProgramNotesInput {
+
+  "Describes the program note values to modify."
+  SET: ProgramNotePropertiesInput!
+
+  """
+  Filters the program notes to be updated according to those that match the
+  given constraints.
+  """
+  WHERE: WhereProgramNote
+
+  """
+  Caps the number of results returned to the given value (if additional notes
+  match the WHERE clause they will be updated but not returned).
+  """
+  LIMIT: NonNegInt
+
+  """
+  Set to `true` to include deleted notes.
+  """
+  includeDeleted: Boolean = false
+}
+
+"""
+The result of updating the selected notes, up to `LIMIT` or the maximum of
+(1000).  If `hasMore` is true, additional notes were modified and not included
+here.
+"""
+type UpdateProgramNotesResult {
+  """
+  The edited notes, up to the specified LIMIT or the default maximum of 1000.
+  """
+  programNotes: [ProgramNote!]!
+
+  """
+  `true` when there were additional edits that were not returned.
+  """
   hasMore: Boolean!
 }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -341,6 +341,7 @@ trait BaseMapping[F[_]]
   lazy val UpdateGroupsResultType                  = schema.ref("UpdateGroupsResult")
   lazy val UpdateObservationsResultType            = schema.ref("UpdateObservationsResult")
   lazy val UpdateProgramsResultType                = schema.ref("UpdateProgramsResult")
+  lazy val UpdateProgramNotesResultType            = schema.ref("UpdateProgramNotesResult")
   lazy val UpdateProgramUsersResultType            = schema.ref("UpdateProgramUsersResult")
   lazy val UpdateProposalResultType                = schema.ref("UpdateProposalResult")
   lazy val UpdateTargetsResultType                 = schema.ref("UpdateTargetsResult")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -245,6 +245,7 @@ object OdbMapping {
           with UpdateGroupsResultMapping[F]
           with UpdateAttachmentsResultMapping[F]
           with UpdateObservationsResultMapping[F]
+          with UpdateProgramNotesResultMapping[F]
           with UpdateProgramsResultMapping[F]
           with UpdateProgramUsersResultMapping[F]
           with UpdateProposalResultMapping[F]
@@ -469,6 +470,7 @@ object OdbMapping {
                 UpdateDatasetsResultMapping,
                 UpdateGroupsResultMapping,
                 UpdateObservationsResultMapping,
+                UpdateProgramNotesResultMapping,
                 UpdateProgramsResultMapping,
                 UpdateProgramUsersResultMapping,
                 UpdateProposalResultMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateProgramNotesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/UpdateProgramNotesInput.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.input
+
+import cats.syntax.parallel.*
+import eu.timepit.refined.types.numeric.NonNegInt
+import grackle.Path
+import grackle.Predicate
+import lucuma.odb.graphql.binding.*
+
+final case class UpdateProgramNotesInput(
+  SET:            ProgramNotePropertiesInput.Edit,
+  WHERE:          Option[Predicate],
+  LIMIT:          Option[NonNegInt],
+  includeDeleted: Option[Boolean]
+)
+
+object UpdateProgramNotesInput:
+
+  def binding(path: Path): Matcher[UpdateProgramNotesInput] =
+    val WhereProgramNoteBinding = WhereProgramNote.binding(path)
+    ObjectFieldsBinding.rmap {
+      case List(
+        ProgramNotePropertiesInput.Edit.Binding("SET", rSET),
+        WhereProgramNoteBinding.Option("WHERE", rWHERE),
+        NonNegIntBinding.Option("LIMIT", rLIMIT),
+        BooleanBinding.Option("includeDeleted", rIncludeDeleted)
+      ) =>
+        (rSET, rWHERE, rLIMIT, rIncludeDeleted).parMapN(apply)
+    }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
@@ -17,6 +17,7 @@ import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.model.Access
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
+import lucuma.core.model.ProgramNote
 import lucuma.core.model.ProgramReference
 import lucuma.core.model.ProposalReference
 import lucuma.core.model.Target
@@ -34,6 +35,7 @@ import lucuma.odb.graphql.input.TargetPropertiesInput
 import lucuma.odb.graphql.input.UpdateAsterismsInput
 import lucuma.odb.graphql.input.UpdateObservationsInput
 import lucuma.odb.graphql.input.UpdateObservationsTimesInput
+import lucuma.odb.graphql.input.UpdateProgramNotesInput
 import lucuma.odb.graphql.input.UpdateTargetsInput
 import lucuma.odb.graphql.predicate.Predicates
 import lucuma.odb.logic.TimeEstimateCalculatorImplementation
@@ -494,5 +496,41 @@ trait AccessControl[F[_]] extends Predicates[F] {
               Services.asSuperUser:
                 ResultT.pure(AccessControl.unchecked(input.SET, pid, program_id))
     ).value
+
+  private def selectForProgramNoteUpdateImpl(
+    includeDeleted: Option[Boolean],
+    WHERE:          Option[Predicate]
+  )(using Services[F], NoTransaction[F]): F[Result[List[ProgramNote.Id]]] =
+    val whereNote: Predicate =
+      and(List(
+        Predicates.programNote.isWritableBy(user),
+        Predicates.programNote.existence.includeDeleted(includeDeleted.getOrElse(false)),
+        WHERE.getOrElse(True)
+      ))
+
+    MappedQuery(
+      Filter(whereNote, Select("id", None, Query.Empty)),
+      Context(QueryType, List("programNotes"), List("programNotes"), List(ProgramNoteType))
+    )
+      .flatMap(_.fragment)
+      .flatTraverse: af =>
+        session.prepareR(af.fragment.query(program_note_id)).use: pq =>
+          pq.stream(af.argument, 1024)
+            .compile
+            .toList
+            .map(Result.success)
+
+
+  def selectForUpdate(
+    input: UpdateProgramNotesInput
+  )(using Services[F]): F[Result[AccessControl.CheckedWithIds[ProgramNotePropertiesInput.Edit, ProgramNote.Id]]] =
+    if input.SET.isPrivate.contains(true) && user.role.access < Access.Staff then
+      Result(AccessControl.Checked.Empty).pure
+    else
+      selectForProgramNoteUpdateImpl(input.includeDeleted, input.WHERE)
+        .map(_.map { nids =>
+           Services.asSuperUser:
+             AccessControl.unchecked(input.SET, nids, program_note_id)
+        })
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -37,6 +37,7 @@ import lucuma.core.model.ExecutionEvent
 import lucuma.core.model.Group
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
+import lucuma.core.model.ProgramNote
 import lucuma.core.model.ProgramUser
 import lucuma.core.model.Target
 import lucuma.core.model.User
@@ -118,6 +119,7 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
       UpdateGroups,
       UpdateObservations,
       UpdateObservationsTimes,
+      UpdateProgramNotes,
       UpdatePrograms,
       UpdateProgramUsers,
       UpdateProposal,
@@ -247,6 +249,15 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
       order = OrderSelection[Observation.Id](ObservationType / "id"),
       limit = limit,
       collectionField = "observations",
+      child
+    )
+
+  def programNoteResultSubquery(nids: List[ProgramNote.Id], limit: Option[NonNegInt], child: Query) =
+    mutationResultSubquery(
+      predicate       = Predicates.programNote.id.in(nids),
+      order           = OrderSelection[ProgramNote.Id](ProgramNoteType / "id"),
+      limit           = limit,
+      collectionField = "programNotes",
       child
     )
 
@@ -745,6 +756,16 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
         }
       }
     }
+
+  private lazy val UpdateProgramNotes: MutationField =
+    MutationField("updateProgramNotes", UpdateProgramNotesInput.binding(Path.from(ProgramNoteType))): (input, child) =>
+      services.useTransactionally:
+        ResultT(selectForUpdate(input)).flatMap: checked =>
+          ResultT:
+            programNoteService
+              .updateNotes(checked).map: nids =>
+                programNoteResultSubquery(nids, input.LIMIT, child)
+        .value
 
   private lazy val UpdateObservations: MutationField =
     MutationField("updateObservations", UpdateObservationsInput.binding(Path.from(ObservationType))) { (input, child) =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/UpdateProgramNotesResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/UpdateProgramNotesResultMapping.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.mapping
+
+trait UpdateProgramNotesResultMapping[F[_]] extends ResultMapping[F]:
+
+  lazy val UpdateProgramNotesResultMapping: ObjectMapping =
+    updateResultMapping(UpdateProgramNotesResultType, "programNotes")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/ProgramNotePredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/ProgramNotePredicates.scala
@@ -25,3 +25,6 @@ class ProgramNotePredicates(path: Path):
         if user.role.access >= Staff then True else False
       )
     )
+
+  def isWritableBy(user: User): Predicate =
+    isVisibleTo(user)

--- a/modules/service/src/main/scala/lucuma/odb/service/ProgramNoteService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProgramNoteService.scala
@@ -3,9 +3,13 @@
 
 package lucuma.odb.service
 
+import cats.data.NonEmptyList
 import cats.effect.Concurrent
+import cats.syntax.applicative.*
 import cats.syntax.flatMap.*
+import cats.syntax.foldable.*
 import cats.syntax.functor.*
+import cats.syntax.traverse.*
 import eu.timepit.refined.types.string.NonEmptyString
 import grackle.Result
 import grackle.syntax.*
@@ -15,6 +19,7 @@ import lucuma.odb.data.Existence
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.graphql.input.ProgramNotePropertiesInput.Create
+import lucuma.odb.graphql.input.ProgramNotePropertiesInput.Edit
 import lucuma.odb.graphql.mapping.AccessControl
 import lucuma.odb.util.Codecs.*
 import natchez.Trace
@@ -29,6 +34,10 @@ trait ProgramNoteService[F[_]]:
     input: AccessControl.CheckedWithId[Create, Program.Id]
   )(using Transaction[F]): F[Result[ProgramNote.Id]]
 
+  def updateNotes(
+    update: AccessControl.Checked[Edit]
+  )(using Transaction[F]): F[List[ProgramNote.Id]]
+
 object ProgramNoteService:
 
   def instantiate[F[_]: Concurrent : Trace](using Services[F]): ProgramNoteService[F] =
@@ -42,6 +51,16 @@ object ProgramNoteService:
           input.foldWithId(
             OdbError.InvalidArgument().asFailureF
           )((set, pid) => session.unique(Statements.InsertNote)(pid, set).map(_.success))
+
+      override def updateNotes(
+        update: AccessControl.Checked[Edit]
+      )(using Transaction[F]): F[List[ProgramNote.Id]] =
+        Trace[F].span("updateNotes"):
+          update.fold(List.empty.pure[F]): (SET, which) =>
+            Statements.updateNotes(SET, which).traverse: af =>
+              session.prepareR(af.fragment.query(program_note_id)).use: pq =>
+                pq.stream(af.argument, chunkSize = 1024).compile.toList
+            .map(_.toList.flatten)
 
   object Statements:
 
@@ -70,3 +89,24 @@ object ProgramNoteService:
           input.text,
           input.isPrivate
         )
+
+    def updates(SET: Edit): Option[NonEmptyList[AppliedFragment]] =
+      NonEmptyList.fromList(
+        List(
+          SET.existence.map(sql"c_existence = $existence"),
+          SET.title.map(sql"c_title = $text_nonempty"),
+          SET.text.foldPresent(sql"c_text = ${text_nonempty.opt}"),
+          SET.isPrivate.map(sql"c_private = $bool"),
+        ).flatten
+      )
+
+    def updateNotes(
+      SET:   Edit,
+      which: AppliedFragment
+    ): Option[AppliedFragment] =
+
+      updates(SET).map: ups =>
+        void"UPDATE t_program_note "                              |+|
+        void"SET " |+| ups.intercalate(void", ") |+| void" "      |+|
+        void"WHERE c_program_note_id IN (" |+| which |+| void") " |+|
+        void"RETURNING c_program_note_id"

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProgramNotes.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProgramNotes.scala
@@ -1,0 +1,254 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mutation
+
+import cats.syntax.either.*
+import cats.syntax.option.*
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.model.User
+
+class updateProgramNotes extends OdbSuite:
+
+  val pi    = TestUsers.Standard.pi(1, 101)
+  val pi2   = TestUsers.Standard.pi(2, 102)
+  val staff = TestUsers.Standard.staff(3, 103)
+
+  val validUsers = List(pi, pi2, staff)
+
+  test("simple edit"):
+    createProgramAs(pi).flatMap: pid =>
+      createProgramNoteAs(pi, pid, "Foo", "Bar".some) *>
+      expect(
+        user     = pi,
+        query    = s"""
+          mutation {
+            updateProgramNotes(input: {
+              SET: {
+                title: "Baz"
+              }
+              WHERE: {
+                title: { EQ: "Foo" }
+              }
+            }) {
+              hasMore
+              programNotes {
+                title
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "updateProgramNotes": {
+              "hasMore": false,
+              "programNotes": [
+                {
+                  "title": "Baz"
+                }
+              ]
+            }
+          }
+        """.asRight
+      )
+
+  test("pi cannot make a private note visible"):
+    createProgramAs(pi).flatMap: pid =>
+      createProgramNoteAs(staff, pid, "Private Foo", "Bar".some, isPrivate = true.some) *>
+      expect(
+        user     = pi,
+        query    = s"""
+          mutation {
+            updateProgramNotes(input: {
+              SET: {
+                isPrivate: false
+              }
+              WHERE: {
+                title: { EQ: "Private Foo" }
+              }
+            }) {
+              hasMore
+              programNotes {
+                title
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "updateProgramNotes": {
+              "hasMore": false,
+              "programNotes": []
+            }
+          }
+        """.asRight
+      )
+
+  test("staff can make a private note visible"):
+    createProgramAs(pi).flatMap: pid =>
+      createProgramNoteAs(staff, pid, "Private Foo 2", "Bar".some, isPrivate = true.some) *>
+      expect(
+        user     = staff,
+        query    = s"""
+          mutation {
+            updateProgramNotes(input: {
+              SET: {
+                isPrivate: false
+              }
+              WHERE: {
+                title: { EQ: "Private Foo 2" }
+              }
+            }) {
+              hasMore
+              programNotes {
+                title
+                isPrivate
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "updateProgramNotes": {
+              "hasMore": false,
+              "programNotes": [
+                {
+                  "title": "Private Foo 2",
+                  "isPrivate": false
+                }
+              ]
+            }
+          }
+        """.asRight
+      )
+
+  test("pis cannot see another pi's notes"):
+    createProgramAs(pi).flatMap: pid =>
+      createProgramNoteAs(pi, pid, "Quz", "Bar".some) *>
+      createProgramAs(pi2).flatMap: pid2 =>
+        createProgramNoteAs(pi2, pid2, "Quz", "Bar".some).flatMap: nid =>
+          expect(
+            user     = pi2,
+            query    = s"""
+              mutation {
+                updateProgramNotes(input: {
+                  SET: {
+                    title: "Quo"
+                  }
+                  WHERE: {
+                    title: { EQ: "Quz" }
+                  }
+                }) {
+                  hasMore
+                  programNotes {
+                    id
+                  }
+                }
+              }
+            """,
+            expected = json"""
+              {
+                "updateProgramNotes": {
+                  "hasMore": false,
+                  "programNotes": [
+                    {
+                      "id": ${nid.asJson}
+                    }
+                  ]
+                }
+              }
+            """.asRight
+          )
+
+  test("can delete text"):
+    createProgramAs(pi).flatMap: pid =>
+      createProgramNoteAs(pi, pid, "Foo", "Bar".some).flatMap: nid =>
+        expect(
+          user     = pi,
+          query    = s"""
+            mutation {
+              updateProgramNotes(input: {
+                SET: {
+                  text: null
+                }
+                WHERE: {
+                  id: { EQ: "$nid" }
+                }
+              }) {
+                hasMore
+                programNotes {
+                  text
+                }
+              }
+            }
+          """,
+          expected = json"""
+            {
+              "updateProgramNotes": {
+                "hasMore": false,
+                "programNotes": [
+                  {
+                    "text": null
+                  }
+                ]
+              }
+            }
+          """.asRight
+        )
+
+  test("can delete notes"):
+    createProgramAs(pi).flatMap: pid =>
+      createProgramNoteAs(pi, pid, "Foo", "Bar".some).flatMap: nid =>
+        expect(
+          user     = pi,
+          query    = s"""
+            mutation {
+              updateProgramNotes(input: {
+                SET: {
+                  existence: DELETED
+                }
+                WHERE: {
+                  id: { EQ: "$nid" }
+                }
+              }) {
+                hasMore
+                programNotes {
+                  existence
+                }
+              }
+            }
+          """,
+          expected = json"""
+            {
+              "updateProgramNotes": {
+                "hasMore": false,
+                "programNotes": [
+                  {
+                    "existence": "DELETED"
+                  }
+                ]
+              }
+            }
+          """.asRight
+        ) *>
+        expect(
+          user  = pi,
+          query = s"""
+            query {
+              program(programId: "$pid") {
+                notes { title }
+              }
+            }
+          """,
+          expected = json"""
+            {
+              "program": {
+                "notes": []
+              }
+            }
+          """.asRight
+        )
+


### PR DESCRIPTION
Standard update implementation for program notes.  Adds `updateProgramNotes` mutation along with associated types and inputs. 