### PR TITLE
Shortcut 4836: Acquisition breakpoint update

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ProtoStep.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ProtoStep.scala
@@ -29,6 +29,12 @@ case class ProtoStep[A](
     stepConfig      === step.stepConfig       &&
     telescopeConfig === step.telescopeConfig
 
+  def withoutBreakpoint: ProtoStep[A] =
+    copy(breakpoint = Breakpoint.Disabled)
+
+  def withBreakpoint: ProtoStep[A] =
+    copy(breakpoint = Breakpoint.Enabled)
+
 object ProtoStep:
 
   def smartGcal[A](a: A, s: SmartGcalType, t: TelescopeConfig): ProtoStep[A] =

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Acquisition.scala
@@ -18,7 +18,6 @@ import fs2.Pure
 import fs2.Stream
 import lucuma.core.data.Zipper
 import lucuma.core.enums.Band
-import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.GmosGratingOrder
 import lucuma.core.enums.GmosNorthFilter
@@ -87,7 +86,7 @@ object Acquisition:
     slit: ProtoStep[D]
   ):
     val initialAtom: NonEmptyList[ProtoStep[D]] =
-      NonEmptyList.of(ccd2, p10, slit)
+      NonEmptyList.of(ccd2, p10, slit.withBreakpoint)
 
     val repeatingAtom: NonEmptyList[ProtoStep[D]] =
       NonEmptyList.of(slit)
@@ -111,8 +110,8 @@ object Acquisition:
         Acquisition.MaxExpTimeLastStep min
           TimeSpan.unsafeFromMicroseconds(exposureTime.toMicroseconds * 3)
 
-      eval {
-        for {
+      eval:
+        for
           _  <- optics.exposure      := exposureTime
           _  <- optics.filter        := filter.some
           _  <- optics.fpu           := none[GmosFpuMask[U]]
@@ -131,10 +130,7 @@ object Acquisition:
 
           _  <- optics.exposure      := lastExpTime(exposureTime)
           s2 <- scienceStep(0.arcsec, 0.arcsec, ObserveClass.Acquisition)
-                  .map(ProtoStep.breakpoint.replace(Breakpoint.Enabled))
-
-        } yield Acquisition.Steps(s0, s1, s2)
-      }
+        yield Acquisition.Steps(s0, s1, s2)
 
     end compute
   end StepComputer
@@ -264,7 +260,7 @@ object Acquisition:
     case class ExpectP10[D](visitId: Visit.Id, calcState: TimeEstimateCalculator.Last[D], tracker: IndexTracker, builder: AtomBuilder[D], steps: Steps[D]) extends AcquisitionState[D]:
 
       override def generate(ignore: Timestamp): Stream[Pure, Atom[D]] =
-        gen(builder, NonEmptyList.of(steps.p10, steps.slit).some, steps.slit, calcState, tracker)
+        gen(builder, NonEmptyList.of(steps.p10, steps.slit.withBreakpoint).some, steps.slit, calcState, tracker)
 
       override def updateTracker(calcState: TimeEstimateCalculator.Last[D], tracker: IndexTracker): AcquisitionState[D] =
         copy(calcState = calcState, tracker = tracker)
@@ -278,7 +274,7 @@ object Acquisition:
     case class ExpectSlit[D](visitId: Visit.Id, calcState: TimeEstimateCalculator.Last[D], tracker: IndexTracker, builder: AtomBuilder[D], steps: Steps[D], initialAtom: Boolean) extends AcquisitionState[D]:
 
       override def generate(ignore: Timestamp): Stream[Pure, Atom[D]] =
-        gen(builder, Option.when(initialAtom)(NonEmptyList.one(steps.slit)), steps.slit, calcState, tracker)
+        gen(builder, Option.when(initialAtom)(NonEmptyList.one(steps.slit.withBreakpoint)), steps.slit, calcState, tracker)
 
       override def updateTracker(calcState: TimeEstimateCalculator.Last[D], tracker: IndexTracker): AcquisitionState[D] =
         copy(calcState = calcState, tracker = tracker)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcq.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcq.scala
@@ -50,7 +50,7 @@ class executionAcq extends ExecutionTestSupport {
                       "description": "Fine Adjustments",
                       "observeClass": "ACQUISITION",
                       "steps": [
-                        ${gmosNorthExpectedAcq(2, 0, Breakpoint.Enabled)}
+                        ${gmosNorthExpectedAcq(2, 0)}
                       ]
                     }
                   ],
@@ -75,7 +75,7 @@ class executionAcq extends ExecutionTestSupport {
                     "description": "Fine Adjustments",
                     "observeClass": "ACQUISITION",
                     "steps": [
-                      ${gmosNorthExpectedAcq(2, 0, Breakpoint.Enabled)}
+                      ${gmosNorthExpectedAcq(2, 0, Breakpoint.Disabled)}
                     ]
                   },
                   "possibleFuture": [
@@ -83,7 +83,7 @@ class executionAcq extends ExecutionTestSupport {
                       "description": "Fine Adjustments",
                       "observeClass": "ACQUISITION",
                       "steps": [
-                        ${gmosNorthExpectedAcq(2, 0, Breakpoint.Enabled)}
+                        ${gmosNorthExpectedAcq(2, 0, Breakpoint.Disabled)}
                       ]
                     }
                   ],
@@ -231,7 +231,7 @@ class executionAcq extends ExecutionTestSupport {
                             "description": "Fine Adjustments",
                             "observeClass": "ACQUISITION",
                             "steps": [
-                              ${gmosNorthExpectedAcq(2, 0, Breakpoint.Enabled)}
+                              ${gmosNorthExpectedAcq(2, 0, Breakpoint.Disabled)}
                             ]
                           }
                         ],
@@ -428,7 +428,7 @@ class executionAcq extends ExecutionTestSupport {
                             "description": "Fine Adjustments",
                             "observeClass": "ACQUISITION",
                             "steps": [
-                              ${gmosNorthExpectedAcq(2, 0, Breakpoint.Enabled)}
+                              ${gmosNorthExpectedAcq(2, 0)}
                             ]
                           }
                         ],


### PR DESCRIPTION
Though correct to pause before each image through the slit, Observe is already stopping the sequence and asking if another step should be taken after the initial image.  Having a breakpoint programmed into the sequence in this case causes an awkward interaction in which the user responds "Yes, take another image." only to be immediately stopped by a breakpoint.

I think the long-term solution might be to just let Observe handle acquisitions and not try to generate the acquisition sequence.  This PR should improve the situation in the meantime.