### PR TITLE
Fix duration used for parallactic angle calculation

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
@@ -791,7 +791,7 @@ object GuideService {
                            )
           angles        <- ResultT.fromResult(
                              obsInfo.posAngleConstraint
-                              .anglesToTestAt(genInfo.site, baseTracking, obsTime.toInstant, genInfo.timeEstimate.toDuration)
+                              .anglesToTestAt(genInfo.site, baseTracking, obsTime.toInstant, duration.toDuration)
                               .toResult(generalError(s"No angles to test for guide target candidates for observation $oid.").asProblem)
                            )
           positions      = getPositions(angles, genInfo.offsets)


### PR DESCRIPTION
When calculating the parallactic angle, an explicitly set observation duration was being ignored and the full remaining time was always being used.