### PR TITLE
Validate migrations and schema before running the build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,19 @@ jobs:
       - name: Docker compose up
         run: docker compose up -d
 
+      - name: Validate Migrations
+        if: github.event_name == 'pull_request'
+        uses: gemini-hlsw/migration-validator-action@main
+        with:
+          path: modules/service/src/main/resources/db/migration/
+
+      - name: Validate GraphQL schema changes
+        if: github.event_name == 'pull_request'
+        uses: kamilkisiela/graphql-inspector@master
+        with:
+          schema: 'main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql'
+          approve-label: expected-breaking-change
+
       - name: Check that workflows are up to date
         run: sbt -v -J-Xmx6g githubWorkflowCheck
 
@@ -78,19 +91,6 @@ jobs:
       - name: Generate API documentation
         if: matrix.java == 'temurin@17' && matrix.os == 'ubuntu-22.04'
         run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' doc
-
-      - name: Validate Migrations
-        if: github.event_name == 'pull_request'
-        uses: gemini-hlsw/migration-validator-action@main
-        with:
-          path: modules/service/src/main/resources/db/migration/
-
-      - name: Validate GraphQL schema changes
-        if: github.event_name == 'pull_request'
-        uses: kamilkisiela/graphql-inspector@master
-        with:
-          schema: 'main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql'
-          approve-label: expected-breaking-change
 
       - name: Aggregate coverage reports
         run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' coverageReport coverageAggregate

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ ThisBuild / Test / parallelExecution := false
 
 ThisBuild / githubWorkflowSbtCommand := "sbt -v -J-Xmx6g"
 
-ThisBuild / githubWorkflowBuild +=
+ThisBuild / githubWorkflowBuildPreamble +=
   WorkflowStep.Use(
     UseRef.Public("gemini-hlsw", "migration-validator-action", "main"),
     name = Some("Validate Migrations"),
@@ -49,7 +49,7 @@ ThisBuild / githubWorkflowBuild +=
     cond = Some("github.event_name == 'pull_request'")
   )
 
-ThisBuild / githubWorkflowBuild +=
+ThisBuild / githubWorkflowBuildPreamble +=
   WorkflowStep.Use(
     UseRef.Public("kamilkisiela", "graphql-inspector", "master"),
     name = Some("Validate GraphQL schema changes"),


### PR DESCRIPTION
This change seems to work and we can fail for these validations without waiting for all of the tests to pass...