### PR TITLE
Shortcut 4428: restore original GMOS Smart Gcal definition files

### DIFF
--- a/modules/smartgcal/src/main/resources/smartgcal/GMOS-N_ARC.csv
+++ b/modules/smartgcal/src/main/resources/smartgcal/GMOS-N_ARC.csv
@@ -147,6 +147,69 @@ $R400.*,$.*,IFU *,4,1,950-1200,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,
 #,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+$B600.*,$.*,IFU *,2,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+$B600.*,$.*,IFU *,4,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,555 - 690,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$B600.*,$.*,IFU *,2,1,555 - 690,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+$B600.*,$.*,IFU *,4,1,555 - 690,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,9,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,9,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,690 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+$B600.*,$.*,IFU *,2,1,690 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$B600.*,$.*,IFU *,4,1,690 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,3,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,800 - 860,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$B600.*,$.*,IFU *,2,1,800 - 860,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$B600.*,$.*,IFU *,4,1,800 - 860,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,860 - 1000,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+$B600.*,$.*,IFU *,2,1,860 - 1000,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$B600.*,$.*,IFU *,4,1,860 - 1000,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,1000 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$B600.*,$.*,IFU *,2,1,1000 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$B600.*,$.*,IFU *,4,1,1000 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
@@ -494,6 +557,69 @@ $R400.*,$.*,IFU *,4,1,950-1200,1,High,,,,1,        GMOS balance,Visible,CuAr arc
 #,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,180,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,100,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,100,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
+$B600.*,$.*,IFU *,2,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
+$B600.*,$.*,IFU *,4,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,320,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,555 - 690,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
+$B600.*,$.*,IFU *,2,1,555 - 690,1,High,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$B600.*,$.*,IFU *,4,1,555 - 690,1,High,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,140,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,34,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,34,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,34,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,690 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,14,1,Day
+$B600.*,$.*,IFU *,2,1,690 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+$B600.*,$.*,IFU *,4,1,690 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,100,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,800 - 860,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+$B600.*,$.*,IFU *,2,1,800 - 860,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$B600.*,$.*,IFU *,4,1,800 - 860,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,860 - 1000,1,High,,,,1,         None,Visible,CuAr arc,Closed,6,1,Day
+$B600.*,$.*,IFU *,2,1,860 - 1000,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$B600.*,$.*,IFU *,4,1,860 - 1000,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B600.*,$.*,IFU *,1,1,1000 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
+$B600.*,$.*,IFU *,2,1,1000 - 1200,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+$B600.*,$.*,IFU *,4,1,1000 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day

--- a/modules/smartgcal/src/main/resources/smartgcal/GMOS-N_FLAT.csv
+++ b/modules/smartgcal/src/main/resources/smartgcal/GMOS-N_FLAT.csv
@@ -46,6 +46,7 @@
 #  Instrument Configuration from OT,,,,,,,,,,,,GCAL configuration,,,,,,
 Disperser,Filter,Focal Plane Unit,Xbin,Ybin,Central Wavelength,Order,Gain ,,,/=>/,Calibration Observe,Calibration Filter,Calibration Diffuser,Calibration Lamps,Calibration Shutter,Calibration Exposure Time,Calibration Coadds,Calibration Basecal
 #
+Mirror,$u_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Day
 Mirror,$g_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,24,1,Day
 Mirror,$r_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
 Mirror,$i_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
@@ -73,6 +74,7 @@ Mirror,$r_G.{4} [+] RG610_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Qu
 # Mirror,$i_G.{4} [+] RG780_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
 Mirror,$i_G.{4} [+] CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
 Mirror,$z_G.{4} [+] CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,1,1,Day
+Mirror,$u_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
 Mirror,$g_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
 Mirror,$r_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
 Mirror,$i_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,1,1,Day
@@ -102,6 +104,7 @@ Mirror,$z_G.{4} [+] CaT_G.{4},$[^(IFU)].*,2,2,Any ,*,Low,,,,1,ND4-5,Visible,Quar
 #
 # Imaging with IFU in the beam
 #
+Mirror,$u_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
 Mirror,$g_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
 Mirror,$r_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
 Mirror,$i_G.{4},$IFU.*,1,1,Any ,*,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
@@ -607,6 +610,296 @@ $R400.*,$CaT.*,$IFU.* 2 Slits,1,1,780 - 933,1,Low,,,,1,GMOS balance,Visible,Quar
 $R400.*,$CaT.*,$IFU.* 2 Slits,2,1,780 - 933,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,13,1,Night
 $R400.*,$CaT.*,$IFU.* 2 Slits,4,1,780 - 933,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
 #,,,,,,,,,,,,,,,,,,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,18,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,9,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,9,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,675-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300-675,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,675-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,13,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,725-775,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,725-775,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,725-775,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,525-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,400-525,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,525-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,525-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,775-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,400-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,525-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,725-775,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,775-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+#$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,500-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,7,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300-425,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,425-500,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,500-535,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,725-825,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,825-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,725-825,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,725-825,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,825-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,825-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,500-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,500-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,500-625,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,625-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,725-800,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,725-800,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,725-800,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,800-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300-500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,500-625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,500-625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,625-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,625-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,725-825,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,725-825,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,825-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,825-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400-530,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-625,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,725-825,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,825-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+#$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300-375,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,375-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300-400,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400-475,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400-475,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,475-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,475-525,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300-400,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400-475,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,475-525,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,525-625,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,625-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,725-1200,1,Low,,,,1,ND4-5,Visible,Quartz Halogen,Closed,30,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,1,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,65,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,2,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,4,1,700 - 900,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,1,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,65,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,2,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,4,1,900 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
 #,,,,,,,,,,,,,,,,,,Night
 $B480.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
@@ -1744,6 +2037,7 @@ $B1200.*,$g.* OG515.*,$IFU.* 2 Slits,4,1,450 - 750,1,Low,,,,1,none,Visible,Quart
 # Mirror,$i.{6},none,2,2,Any ,0,High,,,,5,ND1.0,IR,IR grey body - high,Open,20,1,Day
 # Mirror,$z.{6},none,2,2,Any ,0,High,,,,5,ND3.0,IR,IR grey body - high,Open,30,1,Day
 # Mirror,$g.*,none,2,2,Any ,0,High,,,,5,ND4.0,IR,Quartz Halogen,Closed,40,1,Day
+Mirror,$u_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
 Mirror,$g_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Day
 Mirror,$r_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Day
 Mirror,$i_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,2,1,Day
@@ -1771,6 +2065,7 @@ Mirror,$r_G.{4} [+] RG610_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Q
 # Mirror,$i_G.{4} [+] RG780_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
 Mirror,$i_G.{4} [+] CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
 Mirror,$z_G.{4} [+] CaT_G.{4},$[^(IFU)].*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$u_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Day
 Mirror,$g_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Day
 Mirror,$r_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,8,1,Day
 Mirror,$i_G.{4},$IFU.*,1,1,Any ,*,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,4,1,Day
@@ -1798,6 +2093,7 @@ Mirror,$r_G.{4} [+] RG610.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz H
 # Mirror,$i_G.{4} [+] RG780.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
 Mirror,$i_G.{4} [+] CaT.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
 Mirror,$z_G.{4} [+] CaT.{6},$IFU.*,1,1,Any ,*,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Day
+Mirror,$u_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4.0,IR,Quartz Halogen,Closed,1,1,Day
 Mirror,$g_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4.0,IR,Quartz Halogen,Closed,1,1,Day
 Mirror,$r_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4-5,IR,Quartz Halogen,Closed,1,1,Day
 Mirror,$i_G.{4},$[^(IFU)].*,2,2,Any ,*,High,,,,1,ND4-5,IR,Quartz Halogen,Closed,1,1,Day
@@ -2279,6 +2575,296 @@ $R400.*,$CaT.*,$IFU.* 2 Slits,1,1,780 - 933,1,High,,,,1,GMOS balance,Visible,Qua
 $R400.*,$CaT.*,$IFU.* 2 Slits,2,1,780 - 933,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
 $R400.*,$CaT.*,$IFU.* 2 Slits,4,1,780 - 933,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
 #,,,,,,,,,,,,,,,,,,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,104,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,80,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,96,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+#$B600.*,$.*one|.*G.*,$.* 0.25 arcsec,4,4,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,52,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,40,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$B600.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,48,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,36,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,18,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,18,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,400-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,675-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300-675,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,675-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$B600.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,26,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,20,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,725-775,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,725-775,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,725-775,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,525-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,2,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,400-525,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,525-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,525-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,775-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,400-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,525-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,725-775,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,775-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+#$B600.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,500-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,14,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300-425,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,425-500,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,500-535,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+#$B600.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,535-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,725-825,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,825-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,400-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,725-825,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,725-825,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,825-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,825-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,500-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,500-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,500-625,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,625-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,725-800,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,725-800,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,725-800,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,800-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300-500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,500-625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,500-625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,625-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,625-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,725-825,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,725-825,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,825-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,825-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300-400,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,400-530,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-625,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,725-825,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,825-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+#$B600.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,530-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300-375,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,375-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,400-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300-400,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,400-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,400-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,400-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300-400,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300-400,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,400-475,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,400-475,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,475-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,475-525,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300-400,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,400-475,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,475-525,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,525-625,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,625-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B600.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,725-1200,1,High,,,,1,ND4-5,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,400,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,280,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B600.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,400,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$B600.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,260,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$B600.*,$r.{6},$IFU.* 2 Slits,4,1,560 - 700,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,1,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,2,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B600.*,$i.*|CaT.*,$IFU.* 2 Slits,4,1,700 - 900,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,1,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,2,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night
+$B600.*,$z.*|CaT.*,$IFU.* 2 Slits,4,1,900 - 1000,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
 #,,,,,,,,,,,,,,,,,,Night
 $B480.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,96,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.25 arcsec,1,1,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,64,1,Night

--- a/modules/smartgcal/src/main/scala/lucuma/odb/smartgcal/parsers/Availability.scala
+++ b/modules/smartgcal/src/main/scala/lucuma/odb/smartgcal/parsers/Availability.scala
@@ -1,0 +1,75 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.smartgcal.parsers
+
+import cats.Monad
+import cats.syntax.functor.*
+
+/**
+ * Availability is a small ADT, isomorphic with Option, that is used for parsing
+ * smart gcal files in which one or more entries refer to obsolete values.
+ * Here an `Obsolete` instance is like `None` and `Current` is like `Some`. We
+ * use this to skip entries that refer to obsolete values while still generating
+ * an error for unknown entries.
+ *
+ * For example the `u_G0309` GMOS North filter is obsolete.  Entries that refer
+ * to it should not generate an error and yet do not parse to any existing
+ * filter value.
+ */
+sealed trait Availability[+A]:
+  import Availability.Current
+  import Availability.Obsolete
+
+  def fold[B](ifObsolete: => B, ifCurrent: A => B): B =
+    this match
+      case Obsolete   => ifObsolete
+      case Current(a) => ifCurrent(a)
+
+  def isObsolete: Boolean =
+    fold(true, _ => false)
+
+  def isCurrent: Boolean =
+    !isObsolete
+
+  def map[B](f: A => B): Availability[B] =
+    this match
+      case Obsolete   => Obsolete
+      case Current(a) => Current(f(a))
+
+  def flatMap[B](f: A => Availability[B]): Availability[B] =
+    this match
+      case Obsolete   => Obsolete
+      case Current(a) => f(a)
+
+  def toOption: Option[A] =
+    this match
+      case Obsolete   => None
+      case Current(a) => Some(a)
+
+  @inline final def getOrElse[B >: A](default: => B): B =
+    this match
+      case Obsolete   => default
+      case Current(a) => a
+
+
+object Availability:
+
+  case object Obsolete extends Availability[Nothing]
+
+  case class Current[A](a: A) extends Availability[A]
+
+  extension [A](a: A)
+    def current:  Availability[A] = Current(a)
+
+  given Monad[Availability] with
+    def pure[A](a: A): Availability[A] = Current(a)
+
+    def flatMap[A, B](fa: Availability[A])(f: A => Availability[B]): Availability[B] =
+      fa.flatMap(f)
+
+    def tailRecM[A, B](a: A)(f: A => Availability[Either[A, B]]): Availability[B] =
+      f(a) match
+        case Obsolete           => Obsolete
+        case Current(Left(a1))  => tailRecM(a1)(f)
+        case Current(Right(b))  => Current(b)

--- a/modules/smartgcal/src/main/scala/lucuma/odb/smartgcal/parsers/gmosNorth.scala
+++ b/modules/smartgcal/src/main/scala/lucuma/odb/smartgcal/parsers/gmosNorth.scala
@@ -5,20 +5,20 @@ package lucuma.odb.smartgcal.parsers
 
 import cats.data.NonEmptyList
 import cats.parse.Parser
-import cats.syntax.option.*
+import cats.syntax.all.*
 import lucuma.core.enums.GmosNorthFilter
 import lucuma.core.enums.GmosNorthFpu
 import lucuma.core.enums.GmosNorthGrating
 import lucuma.odb.smartgcal.data.Gmos.FileEntry
 import lucuma.odb.smartgcal.data.Gmos.FileKey
 
-trait GmosNorthParsers extends GmosCommonParsers {
+trait GmosNorthParsers extends GmosCommonParsers:
   import common.*
   import util.*
 
-  val filter: Parser[NonEmptyList[Option[GmosNorthFilter]]] =
-    Parser.string("none").as(NonEmptyList.one(none[GmosNorthFilter])) | // "none" found in existing .csv files
-      manyOfOption("None",
+  val filter: Parser[Availability[NonEmptyList[Option[GmosNorthFilter]]]] =
+    Parser.string("none").as(NonEmptyList.one(none[GmosNorthFilter]).pure[Availability]) | // "none" found in existing .csv files
+      manyOfObsoletableOption("None", Set("u_G0309"),
         "g_G0301"                   -> GmosNorthFilter.GPrime,
         "r_G0303"                   -> GmosNorthFilter.RPrime,
         "i_G0302"                   -> GmosNorthFilter.IPrime,
@@ -47,7 +47,6 @@ trait GmosNorthParsers extends GmosCommonParsers {
         "r_G0303 + RG610_G0307"     -> GmosNorthFilter.RPrime_RG610,
         "i_G0302 + CaT_G0309"       -> GmosNorthFilter.IPrime_CaT,
         "z_G0304 + CaT_G0309"       -> GmosNorthFilter.ZPrime_CaT
-//        "u_G0308"                   -> GmosNorthFilter.GPrime  // u' was removed
       ).withContext("GMOS North filter")
 
   val fpu: Parser[NonEmptyList[Option[GmosNorthFpu]]] =
@@ -70,10 +69,10 @@ trait GmosNorthParsers extends GmosCommonParsers {
       "N and S 2.00 arcsec"  -> GmosNorthFpu.Ns5
     ).withContext("GMOS North FPU")
 
-  val grating: Parser[NonEmptyList[Option[GmosNorthGrating]]] =
-    manyOfOptionEnumerated[GmosNorthGrating]("Mirror").withContext("GMOS North grating")
+  val grating: Parser[Availability[NonEmptyList[Option[GmosNorthGrating]]]] =
+    manyOfObsoletableOptionEnumerated[GmosNorthGrating]("Mirror", Set("B600_G5303", "B600_G5307", "R150_G5306")).withContext("GMOS North grating")
 
-  val fileKey: Parser[FileKey.North] =
+  val fileKey: Parser[Availability[FileKey.North]] =
     (
       (grating           <* columnSep) ~
       (filter            <* columnSep) ~
@@ -84,14 +83,12 @@ trait GmosNorthParsers extends GmosCommonParsers {
       (order             <* columnSep) ~
       gain
     ).map { case (((((((grating, filter), fpu), xBin), yBin), range), order), gain) =>
-      FileKey(grating, filter, fpu, xBin, yBin, range, order, gain)
+      (grating, filter).mapN((g, f) => FileKey(g, f, fpu, xBin, yBin, range, order, gain))
     }
 
-  def fileEntry: Parser[FileEntry.North] =
+  def fileEntry: Parser[Availability[FileEntry.North]] =
     ((fileKey <* file.keyValueSep) ~ file.legacyValue).map { case (k, v) =>
-      FileEntry(k, v)
+      k.map(k => FileEntry(k, v))
     }
-
-}
 
 object gmosNorth extends GmosNorthParsers

--- a/modules/smartgcal/src/test/scala/lucuma/odb/smartgcal/FileReaderSuite.scala
+++ b/modules/smartgcal/src/test/scala/lucuma/odb/smartgcal/FileReaderSuite.scala
@@ -5,43 +5,50 @@ package lucuma.odb.smartgcal
 
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-import eu.timepit.refined.types.numeric.PosLong
-import fs2.Pipe
+import cats.parse.Parser
+import fs2.Stream
 import lucuma.odb.smartgcal.data.Gmos.FileEntry
+import lucuma.odb.smartgcal.parsers.Availability
 
-final class FileReaderSuite extends munit.FunSuite {
+final class FileReaderSuite extends munit.FunSuite:
 
   private def loadGmos[G, L, U](
-    filename: String,
-    pipe:     String => Pipe[IO, Byte, (PosLong, FileEntry[G, L, U])]
-  ): Unit = {
+    filename:    String,
+    entryParser: Parser[Availability[FileEntry[G, L, U]]]
+  ): Unit =
 
     val r  = s"smartgcal/$filename.csv"
     val is = IO(this.getClass.getClassLoader.getResourceAsStream(r))
     val s  = fs2.io.readInputStream[IO](is,8192)
 
-    val parsedEntryCount = s.through(pipe(r)).compile.count.unsafeRunSync()
+    val (obsolete, current) =
+       s.through(FileReader.entryLines)
+        .flatMap: (lineNumber, s) =>
+          entryParser.parseAll(s) match
+            case Left(e)  => Stream.raiseError[IO](new RuntimeException(s"$filename $lineNumber: $s"))
+            case Right(a) => Stream.emit(a)
+        .fold((0L, 0L)) { case ((o, c), a) =>
+          a.fold((o+1, c), _ => (o, c+1))
+        }
+        .compile
+        .onlyOrError
+        .unsafeRunSync()
+
     val rawLineCount     = s.through(FileReader.entryLines).compile.count.unsafeRunSync()
 
     // In reality, the test is just that the parsing doesn't fail.  Assuming
     // there are no parse errors the parsed entry count should be the same as
     // the number of entry lines.
-    assertEquals(parsedEntryCount, rawLineCount)
-  }
+    assertEquals((obsolete + current), rawLineCount)
 
-  test("GMOS-N_ARC") {
-    loadGmos("GMOS-N_ARC", FileReader.gmosNorth)
-  }
+  test("GMOS-N_ARC"):
+    loadGmos("GMOS-N_ARC", parsers.gmosNorth.fileEntry)
 
-  test("GMOS-N_FLAT") {
-    loadGmos("GMOS-N_FLAT", FileReader.gmosNorth)
-  }
+  test("GMOS-N_FLAT"):
+    loadGmos("GMOS-N_FLAT", parsers.gmosNorth.fileEntry)
 
-  test("GMOS-S_ARC") {
-    loadGmos("GMOS-S_ARC", FileReader.gmosSouth)
-  }
+  test("GMOS-S_ARC"):
+    loadGmos("GMOS-S_ARC", parsers.gmosSouth.fileEntry.map(Availability.Current.apply))
 
-  test("GMOS-S_FLAT") {
-    loadGmos("GMOS-S_FLAT", FileReader.gmosSouth)
-  }
-}
+  test("GMOS-S_FLAT"):
+    loadGmos("GMOS-S_FLAT", parsers.gmosSouth.fileEntry.map(Availability.Current.apply))

--- a/modules/smartgcal/src/test/scala/lucuma/odb/smartgcal/parsers/GmosNorthParsersSuite.scala
+++ b/modules/smartgcal/src/test/scala/lucuma/odb/smartgcal/parsers/GmosNorthParsersSuite.scala
@@ -52,7 +52,10 @@ final class GmosNorthParsersSuite extends munit.FunSuite {
       )
 
     assertEquals(
-      gmosNorth.fileKey.parseAll(definition).map(_.tableKeys),
+      gmosNorth.fileKey.parseAll(definition).map {
+        case Availability.Current(a) => a.tableKeys
+        case _                       => sys.error("Not expecting obsolete value here.")
+      },
       Right(expected)
     )
 
@@ -81,7 +84,10 @@ final class GmosNorthParsersSuite extends munit.FunSuite {
       )
 
     assertEquals(
-      gmosNorth.fileKey.parseAll(definition).map(_.tableKeys),
+      gmosNorth.fileKey.parseAll(definition).map {
+        case Availability.Current(a) => a.tableKeys
+        case _                       => sys.error("Not expecting obsolete value here")
+      },
       Right(expected)
     )
 


### PR DESCRIPTION
To get #1648 merged as quickly as possible, I ended up editing the GMOS smart gcal files to remove obsolete entries that would otherwise stop the parser.  In this PR I've restored the original Smart Gcal files that science provided and updated the parser to skip obsolete items in the lines that it reads.