### PR TITLE
WhereExecutionEvent Update

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -13546,8 +13546,8 @@ input WhereExecutionEvent {
   "Matches on the visit id"
   visitId: WhereEqVisitId
 
-  "Matches on observation id"
-  observationId: WhereOrderObservationId
+  "Matches on observation"
+  observation: WhereObservation
 
   "Matches on event reception time"
   received: WhereOrderTimestamp

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereExecutionEvent.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereExecutionEvent.scala
@@ -13,7 +13,6 @@ import lucuma.core.enums.SequenceCommand
 import lucuma.core.enums.SlewStage
 import lucuma.core.enums.StepStage
 import lucuma.core.model.ExecutionEvent
-import lucuma.core.model.Observation
 import lucuma.core.model.Visit
 import lucuma.core.model.sequence.Dataset
 import lucuma.core.model.sequence.Step
@@ -26,7 +25,7 @@ object WhereExecutionEvent {
   def binding(path: Path): Matcher[Predicate] = {
     val WhereExecutionEventIdBinding   = WhereOrder.binding[ExecutionEvent.Id](path / "id", ExecutionEventIdBinding)
     val WhereVisitIdBinding            = WhereEq.binding[Visit.Id](path / "visit" / "id", VisitIdBinding)
-    val WhereObservationIdBinding      = WhereOrder.binding[Observation.Id](path / "observation" / "id", ObservationIdBinding)
+    val WhereObservationBinding        = WhereObservation.binding(path / "observation")
     val WhereTimestampBinding          = WhereOrder.binding[Timestamp](path / "received", TimestampBinding)
     val WhereExecutionEventTypeBinding = WhereEq.binding(path / "eventType", enumeratedBinding[ExecutionEventType])
 
@@ -46,7 +45,7 @@ object WhereExecutionEvent {
         WhereExecutionEventBinding.Option("NOT", rNOT),
         WhereExecutionEventIdBinding.Option("id", rId),
         WhereVisitIdBinding.Option("visitId", rVisitId),
-        WhereObservationIdBinding.Option("observationId", rObservationId),
+        WhereObservationBinding.Option("observation", rObservation),
         WhereTimestampBinding.Option("received", rReceived),
         WhereExecutionEventTypeBinding.Option("eventType", rEventType),
         WhereSlewStageBinding.Option("slewStage", rSlewStage),
@@ -56,15 +55,15 @@ object WhereExecutionEvent {
         WhereDatasetIdBinding.Option("datasetId", rDatasetId),
         WhereDatasetStageBinding.Option("datasetStage", rDatasetStage)
 
-      ) => (rAND, rOR, rNOT, rId, rVisitId, rObservationId, rReceived, rEventType, rSlewStage, rSequenceCommand, rStepId, rStepStage, rDatasetId, rDatasetStage).parMapN {
-        (AND, OR, NOT, id, vid, oid, received, eventType, slewStage, sequenceCommand, stepId, stepStage, datasetId, datasetStage) =>
+      ) => (rAND, rOR, rNOT, rId, rVisitId, rObservation, rReceived, rEventType, rSlewStage, rSequenceCommand, rStepId, rStepStage, rDatasetId, rDatasetStage).parMapN {
+        (AND, OR, NOT, id, vid, observation, received, eventType, slewStage, sequenceCommand, stepId, stepStage, datasetId, datasetStage) =>
           and(List(
             AND.map(and),
             OR.map(or),
             NOT.map(Not(_)),
             id,
             vid,
-            oid,
+            observation,
             received,
             eventType,
             slewStage,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionEvents.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionEvents.scala
@@ -161,14 +161,14 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
     }
   }
 
-  test("query -> events (WHERE observationId)") {
+  test("query -> events (WHERE observation id)") {
     recordAll(pi, service, mode, offset = 300, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           events(
             WHERE: {
-              observationId: {
-                EQ: "${on.id}"
+              observation: {
+                id: { EQ: "${on.id}" }
               }
             }
           ) {
@@ -193,14 +193,14 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
     }
   }
 
-  test("query -> events (WHERE observationId + eventType SEQUENCE)") {
+  test("query -> events (WHERE observation id + eventType SEQUENCE)") {
     recordAll(pi, service, mode, offset = 400, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           events(
             WHERE: {
-              observationId: {
-                EQ: "${on.id}"
+              observation: {
+                id: { EQ: "${on.id}" }
               },
               eventType: {
                 EQ: SEQUENCE
@@ -229,14 +229,14 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
     }
   }
 
-  test("query -> events (WHERE observationId + eventType SLEW)") {
+  test("query -> events (WHERE observation id + eventType SLEW)") {
     recordAll(pi, service, mode, offset = 450, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           events(
             WHERE: {
-              observationId: {
-                EQ: "${on.id}"
+              observation: {
+                id: { EQ: "${on.id}" }
               },
               eventType: {
                 EQ: SLEW
@@ -265,7 +265,7 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
     }
   }
 
-  test("query -> events (WHERE observationId + received)") {
+  test("query -> events (WHERE observation id + received)") {
     recordAll(pi, service, mode, offset = 500).flatMap { on =>
       val start: Timestamp = on.allEvents.head.received
       val end: Timestamp   = on.allEvents.last.received
@@ -274,8 +274,8 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
         query {
           events(
             WHERE: {
-              observationId: {
-                EQ: "${on.id}"
+              observation: {
+                id: { EQ: "${on.id}" }
               },
               received: {
                 GT: "$start",
@@ -371,14 +371,14 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
     }
   }
 
-  test("query -> events (WHERE observationId + sequenceEvent command)") {
+  test("query -> events (WHERE observation id + sequenceEvent command)") {
     recordAll(pi, service, mode, offset = 800, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           events(
             WHERE: {
-              observationId: {
-                EQ: "${on.id}"
+              observation: {
+                id: { EQ: "${on.id}" }
               },
               sequenceCommand: {
                 EQ: START
@@ -407,7 +407,7 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
     }
   }
 
-  test("query -> events (WHERE observationId + stepEvent stepId)") {
+  test("query -> events (WHERE observation id + stepEvent stepId)") {
     recordAll(pi, service, mode, offset = 900, stepCount = 2).flatMap { on =>
       val sid = on.visits.head.atoms.head.steps.head.id
 
@@ -415,8 +415,8 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
         query {
           events(
             WHERE: {
-              observationId: {
-                EQ: "${on.id}"
+              observation: {
+                id: { EQ: "${on.id}" }
               },
               eventType: {
                 EQ: STEP
@@ -460,14 +460,14 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
     }
   }
 
-  test("query -> events (WHERE observationId + stepEvent stepStage)") {
+  test("query -> events (WHERE observation + stepEvent stepStage)") {
     recordAll(pi, service, mode, offset = 1000, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           events(
             WHERE: {
-              observationId: {
-                EQ: "${on.id}"
+              observation: {
+                id: { EQ: "${on.id}" }
               },
               stepStage: {
                 EQ: END_STEP
@@ -531,14 +531,14 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
     }
   }
 
-  test("query -> events (WHERE observationId + datasetStage)") {
+  test("query -> events (WHERE observation id + datasetStage)") {
     recordAll(pi, service, mode, offset = 1200, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           events(
             WHERE: {
-              observationId: {
-                EQ: "${on.id}"
+              observation: {
+                id: { EQ: "${on.id}" }
               },
               datasetStage: {
                 EQ: END_WRITE
@@ -567,14 +567,14 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
     }
   }
 
-  test("query -> events (WHERE observationId + slewEvent slewStage)") {
+  test("query -> events (WHERE observation id + slewEvent slewStage)") {
     recordAll(pi, service, mode, offset = 1300, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           events(
             WHERE: {
-              observationId: {
-                EQ: "${on.id}"
+              observation: {
+                id: { EQ: "${on.id}" }
               },
               slewStage: {
                 EQ: END_SLEW


### PR DESCRIPTION
A minor requested change to `WhereExecutionEvent`.  Instead of filtering on observation id, it instead allows filtering on any `WhereObservation` parameter.  This should permit the requested feature of getting all events for a particular program via:

```
query {
  events(
    WHERE: {
      observation: { program: { reference: { label: { EQ: " ... " } } } }
    }
  ) {
    matches { id }
  }
}
```