### PR TITLE
Update lucuma-core to remove Bhros FPU and some old instruments.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,11 +16,10 @@ val http4sJdkHttpClientVersion = "0.9.2"
 val jwtVersion                 = "5.0.0"
 val logbackVersion             = "1.5.17"
 val log4catsVersion            = "2.7.0"
-val lucumaCatalogVersion       = "0.50.2"
-val lucumaItcVersion           = "0.32.0"
-val lucumaCoreVersion          = "0.119.1"
+val lucumaItcVersion           = "0.32.1"
+val lucumaCoreVersion          = "0.120.0"
 val lucumaGraphQLRoutesVersion = "0.8.17"
-val lucumaSsoVersion           = "0.8.6"
+val lucumaSsoVersion           = "0.8.7"
 val munitVersion               = "0.7.29"  // check test output if you attempt to update this
 val munitCatsEffectVersion     = "1.0.7"   // check test output if you attempt to update this
 val munitDisciplineVersion     = "1.0.9"   // check test output if you attempt to update this
@@ -124,8 +123,8 @@ lazy val service = project
       "com.monovore"             %% "decline"                            % declineVersion,
       "io.laserdisc"             %% "fs2-aws-s3"                         % fs2AwsVersion,
       "org.typelevel"            %% "grackle-skunk"                      % grackleVersion,
-      "edu.gemini"               %% "lucuma-catalog"                     % lucumaCatalogVersion,
-      "edu.gemini"               %% "lucuma-ags"                         % lucumaCatalogVersion,
+      "edu.gemini"               %% "lucuma-catalog"                     % lucumaCoreVersion,
+      "edu.gemini"               %% "lucuma-ags"                         % lucumaCoreVersion,
       "edu.gemini"               %% "lucuma-graphql-routes"              % lucumaGraphQLRoutesVersion,
       "edu.gemini"               %% "lucuma-sso-backend-client"          % lucumaSsoVersion,
       "is.cir"                   %% "ciris"                              % cirisVersion,
@@ -151,7 +150,7 @@ lazy val service = project
       "org.scalameta"            %% "munit"                              % munitVersion               % Test,
       "org.scalameta"            %% "munit-scalacheck"                   % munitVersion               % Test,
       "org.typelevel"            %% "discipline-munit"                   % munitDisciplineVersion     % Test,
-      "edu.gemini"               %% "lucuma-catalog-testkit"             % lucumaCatalogVersion       % Test,
+      "edu.gemini"               %% "lucuma-catalog-testkit"             % lucumaCoreVersion          % Test,
       "edu.gemini"               %% "lucuma-core-testkit"                % lucumaCoreVersion          % Test,
       "org.typelevel"            %% "cats-time"                          % catsTimeVersion,
       "org.typelevel"            %% "log4cats-slf4j"                     % log4catsVersion,

--- a/modules/calibrations/src/main/scala/lucuma/odb/calibrations/Main.scala
+++ b/modules/calibrations/src/main/scala/lucuma/odb/calibrations/Main.scala
@@ -6,6 +6,7 @@ package lucuma.odb.calibrations
 import cats.*
 import cats.effect.*
 import cats.effect.std.Console
+import cats.effect.std.SecureRandom
 import cats.effect.std.Supervisor
 import cats.effect.std.UUIDGen
 import cats.effect.syntax.all.*
@@ -159,7 +160,7 @@ object CMain extends MainParams {
             }.compile.drain.start.void)
     } yield ()
 
-  def services[F[_]: Concurrent: Parallel: UUIDGen: Trace: Logger](
+  def services[F[_]: Concurrent: Parallel: UUIDGen: Trace: Logger: SecureRandom](
     user: Option[User],
     enums: Enums
   )(pool: Session[F]): F[Services[F]] =
@@ -181,7 +182,7 @@ object CMain extends MainParams {
    * Our main server, as a resource that starts up our server on acquire and shuts it all down
    * in cleanup, yielding an `ExitCode`. Users will `use` this resource and hold it forever.
    */
-  def server[F[_]: Async: Parallel: Logger: Trace: Console: Network]: Resource[F, ExitCode] =
+  def server[F[_]: Async: Parallel: Logger: Trace: Console: Network: SecureRandom]: Resource[F, ExitCode] =
     for {
       c           <- Resource.eval(Config.fromCiris.load[F])
       _           <- Resource.eval(banner[F](c))
@@ -194,7 +195,7 @@ object CMain extends MainParams {
     } yield ExitCode.Success
 
   /** Our logical entry point. */
-  def runF[F[_]:   Async: Parallel: Logger: Trace: Network: Console]: F[ExitCode] =
+  def runF[F[_]:   Async: Parallel: Logger: Trace: Network: Console: SecureRandom]: F[ExitCode] =
     server.use(_ => Concurrent[F].never[ExitCode])
 
 }

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7596,11 +7596,6 @@ GMOS South FPU
 """
 enum GmosSouthBuiltinFpu {
   """
-  GmosSouthBuiltinFpu Bhros
-  """
-  BHROS
-
-  """
   GmosSouthBuiltinFpu Ns1
   """
   NS1
@@ -8436,11 +8431,6 @@ enum Instrument {
   ACQ_CAM
 
   """
-  Instrument Bhros
-  """
-  BHROS
-
-  """
   Instrument Flamingos2
   """
   FLAMINGOS2
@@ -8476,34 +8466,9 @@ enum Instrument {
   GSAOI
 
   """
-  Instrument Michelle
-  """
-  MICHELLE
-
-  """
-  Instrument Nici
-  """
-  NICI
-
-  """
-  Instrument Nifs
-  """
-  NIFS
-
-  """
   Instrument Niri
   """
   NIRI
-
-  """
-  Instrument Phoenix
-  """
-  PHOENIX
-
-  """
-  Instrument Trecs
-  """
-  TRECS
 
   """
   Instrument Visitor

--- a/modules/service/src/main/resources/db/migration/V0974__remove_old_instruments_and_bhros_fpu.sql
+++ b/modules/service/src/main/resources/db/migration/V0974__remove_old_instruments_and_bhros_fpu.sql
@@ -1,0 +1,30 @@
+-- This migration removes old instruments and BHROS FPU
+
+DO LANGUAGE plpgsql $$DECLARE to_delete d_tag[];    
+BEGIN    
+  to_delete := array['Bhros', 'Michelle', 'Nici', 'Nifs', 'Phoenix', 'Trecs'];    
+
+  -- t_cfp_instrument has ON DELETE CASCADE
+  -- t_gmos_north_longslit and t_gmos_south_longslit are constrained to their instruments
+
+  UPDATE t_observation SET c_instrument = 'GmosNorth' WHERE c_instrument = any(to_delete);
+  
+  UPDATE t_program SET c_instrument = 'GmosNorth' WHERE c_instrument = any(to_delete);  
+
+  DELETE FROM t_spectroscopy_config_option WHERE c_instrument = any(to_delete);
+  DELETE FROM t_time_estimate WHERE c_instrument = any(to_delete);
+  DELETE FROM t_gcal WHERE c_instrument = any(to_delete);
+  DELETE FROM t_instrument WHERE c_tag = any(to_delete);    
+    
+END$$;
+
+DELETE FROM t_gmos_south_dynamic WHERE c_fpu_builtin = 'Bhros';
+
+UPDATE t_gmos_south_long_slit
+  SET c_fpu = 'Ns1',
+      c_initial_fpu = 'Ns1'
+  WHERE c_fpu = 'Bhros'
+    OR  c_initial_fpu = 'Bhros';
+
+DELETE FROm t_smart_gmos_south WHERE c_fpu = 'Bhros';
+DELETE FROM t_gmos_south_fpu WHERE c_tag = 'Bhros';

--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -8,6 +8,7 @@ import cats.data.Kleisli
 import cats.effect.*
 import cats.effect.std.AtomicCell
 import cats.effect.std.Console
+import cats.effect.std.SecureRandom
 import cats.implicits.*
 import com.comcast.ip4s.Port
 import com.monovore.decline.*
@@ -198,7 +199,7 @@ object FMain extends MainParams {
     }
 
   /** A resource that yields our HttpRoutes, wrapped in accessory middleware. */
-  def routesResource[F[_]: Async: Parallel: Trace: Logger: Network: Console](
+  def routesResource[F[_]: Async: Parallel: Trace: Logger: Network: Console: SecureRandom](
     config: Config
   ): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
     routesResource(
@@ -217,7 +218,7 @@ object FMain extends MainParams {
     )
 
   /** A resource that yields our HttpRoutes, wrapped in accessory middleware. */
-  def routesResource[F[_]: Async: Parallel: Trace: Logger: Network: Console](
+  def routesResource[F[_]: Async: Parallel: Trace: Logger: Network: Console: SecureRandom](
     databaseConfig:       Config.Database,
     awsConfig:            Config.Aws,
     emailConfig:          Config.Email,
@@ -309,7 +310,7 @@ object FMain extends MainParams {
    * Our main server, as a resource that starts up our server on acquire and shuts it all down
    * in cleanup, yielding an `ExitCode`. Users will `use` this resource and hold it forever.
    */
-  def server[F[_]: Async: Parallel: Logger: Console: Network](
+  def server[F[_]: Async: Parallel: Logger: Console: Network: SecureRandom](
     reset:         ResetDatabase,
     skipMigration: SkipMigration
   ): Resource[F, ExitCode] =
@@ -325,7 +326,7 @@ object FMain extends MainParams {
     } yield ExitCode.Success
 
   /** Our logical entry point. */
-  def runF[F[_]: Async: Parallel: Logger: Console: Network](
+  def runF[F[_]: Async: Parallel: Logger: Console: Network: SecureRandom](
     reset:         ResetDatabase,
     skipMigration: SkipMigration
   ): F[ExitCode] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/AttachmentRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/AttachmentRoutes.scala
@@ -5,6 +5,7 @@ package lucuma.odb.graphql
 
 import cats.Parallel
 import cats.effect.*
+import cats.effect.std.SecureRandom
 import cats.effect.std.UUIDGen
 import cats.implicits.*
 import eu.timepit.refined.types.string.NonEmptyString
@@ -31,7 +32,7 @@ object AttachmentRoutes {
   }
 
   // the normal constructor
-  def apply[F[_]: Async: Parallel: Trace](
+  def apply[F[_]: Async: Parallel: Trace: SecureRandom](
     pool:                  Resource[F, Session[F]],
     s3:                    S3FileService[F],
     ssoClient:             SsoClient[F, User],
@@ -45,7 +46,7 @@ object AttachmentRoutes {
     )
 
   // used by tests
-  def apply[F[_]: Async: Trace](
+  def apply[F[_]: Async: Trace: SecureRandom](
     service:     AttachmentFileService[F],
     ssoClient:   SsoClient[F, User],
     maxUploadMb: Int,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
@@ -6,6 +6,7 @@ package lucuma.odb.graphql
 import cats.Parallel
 import cats.data.OptionT
 import cats.effect.*
+import cats.effect.std.SecureRandom
 import cats.implicits.*
 import cats.kernel.Order
 import grackle.Operation
@@ -51,7 +52,7 @@ object GraphQLRoutes {
    * Construct a source of `HttpRoutes` tailored to the requesting user. Routes will be cached
    * based on the `Authorization` header and discarded when `ttl` expires.
    */
-  def apply[F[_]: Async: Parallel: Trace: Logger](
+  def apply[F[_]: Async: Parallel: Trace: Logger: SecureRandom](
     itcClient:    ItcClient[F],
     commitHash:   CommitHash,
     goaUsers:     Set[User.Id],

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -7,6 +7,7 @@ import _root_.skunk.AppliedFragment
 import _root_.skunk.Session
 import cats.Monoid
 import cats.Parallel
+import cats.effect.std.SecureRandom
 import cats.effect.std.Supervisor
 import cats.effect.{Unique as _, *}
 import cats.syntax.all.*
@@ -79,7 +80,7 @@ object OdbMapping {
   private implicit def monoidPartialFunction[A, B]: Monoid[PartialFunction[A, B]] =
     Monoid.instance(PartialFunction.empty, _ orElse _)
 
-  def apply[F[_]: Async: Parallel: Trace: Logger](
+  def apply[F[_]: Async: Parallel: Trace: Logger: SecureRandom](
     database:      Resource[F, Session[F]],
     monitor0:      SkunkMonitor[F],
     user0:         User,

--- a/modules/service/src/main/scala/lucuma/odb/service/AttachmentFileService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AttachmentFileService.scala
@@ -6,6 +6,7 @@ package lucuma.odb.service
 import cats.Applicative
 import cats.data.EitherT
 import cats.effect.Concurrent
+import cats.effect.std.SecureRandom
 import cats.effect.std.UUIDGen
 import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
@@ -144,7 +145,7 @@ object AttachmentFileService {
     if (fileSize <= 0) InvalidRequest("File cannot be empty").asLeft
     else ().asRight
 
-  def instantiate[F[_]: Concurrent: Trace: UUIDGen](
+  def instantiate[F[_]: Concurrent: Trace: SecureRandom: UUIDGen](
     s3FileSvc: S3FileService[F]
   )(using Services[F]): AttachmentFileService[F] = {
 

--- a/modules/service/src/main/scala/lucuma/odb/service/Services.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/Services.scala
@@ -8,6 +8,7 @@ import cats.Parallel
 import cats.effect.Concurrent
 import cats.effect.MonadCancelThrow
 import cats.effect.Resource
+import cats.effect.std.SecureRandom
 import cats.effect.std.UUIDGen
 import cats.syntax.all.*
 import grackle.Mapping
@@ -210,7 +211,7 @@ object Services:
    * lazily.
    */
   def forUser[F[_]](u: User, e: Enums, m: Option[Mapping[F]])(s: Session[F])(
-    using tf: Trace[F], uf: UUIDGen[F], cf: Concurrent[F], par: Parallel[F]
+    using tf: Trace[F], uf: UUIDGen[F], sr: SecureRandom[F], cf: Concurrent[F], par: Parallel[F]
   ): Services[F[_]] =
     new Services[F]:
       val user = u

--- a/modules/service/src/main/scala/lucuma/odb/syntax/instrument.scala
+++ b/modules/service/src/main/scala/lucuma/odb/syntax/instrument.scala
@@ -15,7 +15,6 @@ trait ToInstrumentOps {
     def site: Set[Site] =
       self match {
         case Instrument.AcqCam     => Set(Site.GN, Site.GS)
-        case Instrument.Bhros      => Set(Site.GS)
         case Instrument.Flamingos2 => Set(Site.GS)
         case Instrument.Ghost      => Set(Site.GS)
         case Instrument.GmosNorth  => Set(Site.GN)
@@ -24,12 +23,7 @@ trait ToInstrumentOps {
         case Instrument.Gpi        => Set(Site.GN)
         case Instrument.Gsaoi      => Set(Site.GS)
         case Instrument.Igrins2    => Set(Site.GN)
-        case Instrument.Michelle   => Set(Site.GN)
-        case Instrument.Nici       => Set(Site.GN)
-        case Instrument.Nifs       => Set(Site.GN)
         case Instrument.Niri       => Set(Site.GN)
-        case Instrument.Phoenix    => Set(Site.GN)
-        case Instrument.Trecs      => Set(Site.GS)
         case Instrument.Visitor    => Set(Site.GN, Site.GS)
         case Instrument.Scorpio    => Set(Site.GS)
         case Instrument.Alopeke    => Set(Site.GN)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -97,7 +97,7 @@ object OdbSuite:
 
   // a runtime that is constructed the same as global, but lets us see unhandled errors (above)
   val runtime: IORuntime =
-    val (compute, _) = IORuntime.createWorkStealingComputeThreadPool(reportFailure = reportFailure)
+    val (compute, _, _) = IORuntime.createWorkStealingComputeThreadPool(reportFailure = reportFailure)
     val (blocking, _) = IORuntime.createDefaultBlockingExecutionContext()
     val (scheduler, _) = IORuntime.createDefaultScheduler()
     IORuntime(compute, blocking, scheduler, () => (), IORuntimeConfig())

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/introspection.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/introspection.scala
@@ -115,5 +115,6 @@ class introspection extends OdbSuite:
           }
         }      
       """
-    ).onError: t =>
+    ).onError { case t =>
       fail("\n🐞🐞🐞\n🐞🐞🐞 Schema introspection failed!\n🐞🐞🐞\n", t)
+    }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/targetEdit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/targetEdit.scala
@@ -248,7 +248,7 @@ class targetEdit extends OdbSuite {
               .flatMap(pid => withServices(service) {services =>
                 services.session.transaction.use { xa =>
                   services.targetService.deleteOrphanCalibrationTargets(pid)(using xa)
-                }.onError(r => IO(r.printStackTrace()))
+                }.onError { case r => IO(r.printStackTrace()) }
               })
           ),
         expectedF = ref.get.map(i =>

--- a/modules/smartgcal/src/main/scala/lucuma/odb/smartgcal/parsers/gmosSouth.scala
+++ b/modules/smartgcal/src/main/scala/lucuma/odb/smartgcal/parsers/gmosSouth.scala
@@ -51,7 +51,6 @@ trait GmosSouthParsers extends GmosCommonParsers {
 
   val fpu: Parser[NonEmptyList[Option[GmosSouthFpu]]] =
     manyOfOption("None",
-      "bHROS"                -> GmosSouthFpu.Bhros,
       "N and S 0.50 arcsec"  -> GmosSouthFpu.Ns1,
       "N and S 0.75 arcsec"  -> GmosSouthFpu.Ns2,
       "N and S 1.00 arcsec"  -> GmosSouthFpu.Ns3,


### PR DESCRIPTION
I tested the migration against the dev, staging and production DBs. We shouldn't really have programs or observations with these instruments or the Bhros FPU, but you never know.

Cats effect 3.6.0 got pulled in and caused a bunch of errors. I don't know if there is a better way than threading `SecureRandom` through everywhere or not. I just followed the compilation errors.

Also, lucuma-catalog and lucuma-ags are folded into lucuma-core in this version.