### PR TITLE
SC-4973 part 2

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -3335,13 +3335,6 @@ input ObservationPropertiesInput {
   """
   observerNotes: NonEmptyString
 
-  """
-  Set to `true` to mark the observation as complete regardless of how many steps
-  may remain.  Set to `false` (the default) to allow all prescribed steps to
-  execute before considering the observation complete.
-  """
-  declaredComplete: Boolean
-
 }
 
 """
@@ -8987,12 +8980,6 @@ type Observation {
 
   workflow: ObservationWorkflow!
 
-  """
-  When true, a user has taken action to explicitly mark the observation complete
-  regardless of how many steps have been executed and which steps may remain.
-  """
-  declaredComplete: Boolean!
-
 }
 
 enum ExecutionState {
@@ -13643,11 +13630,6 @@ input WhereObservation {
   Matches on the site associated with the observation's instrument, if any.
   """
   site: WhereOptionEqSite
-
-  """
-  Matches on whether the observation has been marked explicitly complete.
-  """
-  declaredComplete: WhereBoolean
 
 }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
@@ -48,7 +48,6 @@ object ObservationPropertiesInput {
     group:               Option[Group.Id],
     groupIndex:          Option[NonNegShort],
     observerNotes:       Option[NonEmptyString],
-    declaredComplete:    Option[Boolean]
   ) extends AsterismInput
 
   object Create {
@@ -71,7 +70,6 @@ object ObservationPropertiesInput {
         group               = None,
         groupIndex          = None,
         observerNotes       = None,
-        declaredComplete    = false.some
       )
 
     val Binding: Matcher[Create] =
@@ -90,7 +88,6 @@ object ObservationPropertiesInput {
           GroupIdBinding.Option("groupId", rGroupId),
           NonNegShortBinding.Option("groupIndex", rGroupIndex),
           NonEmptyStringBinding.Option("observerNotes", rObserverNotes),
-          BooleanBinding.Option("declaredComplete", rComplete)
         ) =>
           (rSubtitle,
             rScienceBand,
@@ -105,7 +102,6 @@ object ObservationPropertiesInput {
             rGroupId,
             rGroupIndex,
             rObserverNotes,
-            rComplete
           ).parMapN(Create.apply)
       }
 
@@ -125,7 +121,6 @@ object ObservationPropertiesInput {
     group:               Nullable[Group.Id],
     groupIndex:          Option[NonNegShort],
     observerNotes:       Nullable[NonEmptyString],
-    declaredComplete:    Option[Boolean]
   ) extends AsterismInput
 
   object Edit {
@@ -145,7 +140,6 @@ object ObservationPropertiesInput {
         group =               Nullable.Absent,
         groupIndex =          None,
         observerNotes =       Nullable.Absent,
-        declaredComplete =    None
       )
 
     val Binding: Matcher[Edit] =
@@ -164,7 +158,6 @@ object ObservationPropertiesInput {
           GroupIdBinding.Nullable("groupId", rGroupId),
           NonNegShortBinding.NonNullable("groupIndex", rGroupIndex),
           NonEmptyStringBinding.Nullable("observerNotes", rObserverNotes),
-          BooleanBinding.Option("declaredComplete", rComplete)
         ) =>
           (rSubtitle,
             rScienceBand,
@@ -179,7 +172,6 @@ object ObservationPropertiesInput {
             rGroupId,
             rGroupIndex,
             rObserverNotes,
-            rComplete
           ).parMapN(apply)
       }
   }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
@@ -60,7 +60,6 @@ object WhereObservation {
     val ScienceBandBinding = WhereOptionOrder.binding(path / "scienceBand", enumeratedBinding[ScienceBand])
     val InstrumentBinding = WhereOptionEq.binding(path / "instrument", enumeratedBinding[Instrument])
     val SiteBinding = siteBinding(enumeratedBinding[Site])
-    val DeclaredCompleteBinding = WhereBoolean.binding(path / "declaredComplete", BooleanBinding)
 
     lazy val WhereObservationBinding = binding(path)
     ObjectFieldsBinding.rmap {
@@ -75,10 +74,9 @@ object WhereObservation {
         ScienceBandBinding.Option("scienceBand", rScienceBand),
         InstrumentBinding.Option("instrument", rInstrument),
         SiteBinding.Option("site", rSite),
-        DeclaredCompleteBinding.Option("declaredComplete", rComplete)
       ) =>
-        (rAND, rOR, rNOT, rId, rRef, rProgram, rSubtitle, rScienceBand, rInstrument, rSite, rComplete).parMapN {
-          (AND, OR, NOT, id, ref, program, subtitle, scienceBand, instrument, site, complete) =>
+        (rAND, rOR, rNOT, rId, rRef, rProgram, rSubtitle, rScienceBand, rInstrument, rSite).parMapN {
+          (AND, OR, NOT, id, ref, program, subtitle, scienceBand, instrument, site) =>
             and(List(
               AND.map(and),
               OR.map(or),
@@ -90,7 +88,6 @@ object WhereObservation {
               scienceBand,
               instrument,
               site,
-              complete
             ).flatten)
         }
     }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -86,7 +86,6 @@ trait ObservationMapping[F[_]]
       SqlObject("configuration"),
       EffectField("configurationRequests", configurationRequestsQueryHandler, List("id", "programId")),
       EffectField("workflow", workflowQueryHandler, List("id", "programId")),
-      SqlField("declaredComplete", ObservationView.DeclaredComplete)
     )
 
   lazy val ObservationElaborator: PartialFunction[(TypeRef, String, List[Binding]), Elab[Unit]] = {

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -259,6 +259,9 @@ object Generator {
           // Commit Hash
           md5.update(commitHash.hashBytes)
 
+          // Completion Declaration
+          md5.update(params.declaredComplete.hashBytes)
+
           Md5Hash.unsafeFromByteArray(md5.digest())
         }
 

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -247,8 +247,8 @@ object Generator {
         val hash: Md5Hash = {
           val md5 = MessageDigest.getInstance("MD5")
 
-          // Observing Mode
-          md5.update(params.observingMode.hashBytes)
+          // Generator Params
+          md5.update(params.hashBytes)
 
           // Integration Time
           List(acquisitionIntegrationTime, scienceIntegrationTime).foreach { ving =>
@@ -258,9 +258,6 @@ object Generator {
 
           // Commit Hash
           md5.update(commitHash.hashBytes)
-
-          // Completion Declaration
-          md5.update(params.declaredComplete.hashBytes)
 
           Md5Hash.unsafeFromByteArray(md5.digest())
         }

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -68,7 +68,6 @@ import lucuma.odb.graphql.mapping.AccessControl
 import lucuma.odb.util.Codecs.*
 import natchez.Trace
 import skunk.*
-import skunk.codec.boolean.bool
 import skunk.exception.PostgresErrorException
 import skunk.implicits.*
 
@@ -543,7 +542,6 @@ object ObservationService {
           SET.observingMode.flatMap(_.observingModeType),
           SET.observingMode.flatMap(_.observingModeType).map(_.instrument),
           SET.observerNotes,
-          SET.declaredComplete.getOrElse(false)
         )
       }
 
@@ -562,7 +560,6 @@ object ObservationService {
       modeType:            Option[ObservingModeType],
       instrument:          Option[Instrument],
       observerNotes:       Option[NonEmptyString],
-      declaredComplete:    Boolean
     ): AppliedFragment = {
 
       val insert: AppliedFragment = {
@@ -615,7 +612,6 @@ object ObservationService {
            modeType                                                                 ,
            instrument                                                               ,
            observerNotes                                                            ,
-           declaredComplete
         )
       }
 
@@ -661,7 +657,6 @@ object ObservationService {
       Option[ObservingModeType]        ,
       Option[Instrument]               ,
       Option[NonEmptyString]           ,
-      Boolean
     )] =
       sql"""
         INSERT INTO t_observation (
@@ -697,8 +692,7 @@ object ObservationService {
           c_spec_capability,
           c_observing_mode_type,
           c_instrument,
-          c_observer_notes,
-          c_declared_complete
+          c_observer_notes
         )
         SELECT
           $program_id,
@@ -733,8 +727,7 @@ object ObservationService {
           ${spectroscopy_capabilities.opt},
           ${observing_mode_type.opt},
           ${instrument.opt},
-          ${text_nonempty.opt},
-          $bool
+          ${text_nonempty.opt}
       """
 
     def selectObservingModes(
@@ -861,7 +854,6 @@ object ObservationService {
       val upSubtitle          = sql"c_subtitle = ${text_nonempty.opt}"
       val upScienceBand       = sql"c_science_band = ${science_band.opt}"
       val upObserverNotes     = sql"c_observer_notes = ${text_nonempty.opt}"
-      val upDeclaredComplete  = sql"c_declared_complete = $bool"
 
       val ups: List[AppliedFragment] =
         List(
@@ -869,7 +861,6 @@ object ObservationService {
           SET.subtitle.foldPresent(upSubtitle),
           SET.scienceBand.foldPresent(upScienceBand),
           SET.observerNotes.foldPresent(upObserverNotes),
-          SET.declaredComplete.map(upDeclaredComplete)
         ).flatten
 
       val posAngleConstraint: List[AppliedFragment] =

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -584,7 +584,9 @@ object ObservationWorkflowService {
           .value
 
       extension (wf: ObservationWorkflow) def isCompatibleWith(states: Set[ObservationWorkflowState]): Boolean =
-        (wf.state :: wf.validTransitions).forall(states.contains)
+        // An allowed transition from ongoing to completed [via declared completion] shouldn't prevent editing,
+        // even though editing will be disabled if the transition is taken.
+        (wf.state :: wf.validTransitions.filterNot(_ === ObservationWorkflowState.Completed)).forall(states.contains)
 
       override def filterState(
         oids: List[Observation.Id], 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -532,28 +532,28 @@ trait DatabaseOperations { this: OdbSuite =>
     )
 
 
-  def setDeclaredComplete(user: User, oid: Observation.Id, declaredComplete: Boolean = true): IO[Unit] =
-    query(
-      user,
-      s"""
-        mutation {
-          updateObservations(
-            input: {
-              SET: {
-                declaredComplete: $declaredComplete
-              }
-              WHERE: {
-                id: { EQ: "$oid" }
-              }
-            }
-          ) {
-            observations {
-              id
-            }
-          }
-        }
-      """
-    ).void
+  // def setDeclaredComplete(user: User, oid: Observation.Id, declaredComplete: Boolean = true): IO[Unit] =
+  //   query(
+  //     user,
+  //     s"""
+  //       mutation {
+  //         updateObservations(
+  //           input: {
+  //             SET: {
+  //               declaredComplete: $declaredComplete
+  //             }
+  //             WHERE: {
+  //               id: { EQ: "$oid" }
+  //             }
+  //           }
+  //         ) {
+  //           observations {
+  //             id
+  //           }
+  //         }
+  //       }
+  //     """
+  //   ).void
 
   def setScienceBandAs(user: User, oid: Observation.Id, band: Option[ScienceBand]): IO[Unit] =
     query(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4596.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4596.scala
@@ -207,7 +207,7 @@ class ShortCut_4596 extends OdbSuite
         oids = List(ongoing, undefined),
         expected = Ior.Both(
           List(
-            s"Observation $ongoing is ineligibile for this operation due to its workflow state (Ongoing with allowed transition to Inactive)."
+            s"Observation $ongoing is ineligibile for this operation due to its workflow state (Ongoing with allowed transition to Inactive/Completed)."
           ),
           json"""
           {
@@ -333,7 +333,7 @@ class ShortCut_4596 extends OdbSuite
     setup.flatMap: (oid, tid) =>
       tryUpdateAsterismsAs(pi, oid, tid,
         Ior.Both(
-          List(s"Observation $oid is ineligibile for this operation due to its workflow state (Ongoing with allowed transition to Inactive)."),
+          List(s"Observation $oid is ineligibile for this operation due to its workflow state (Ongoing with allowed transition to Inactive/Completed)."),
           json"""
             {
               "updateAsterisms": {
@@ -459,7 +459,7 @@ class ShortCut_4596 extends OdbSuite
             }
           """,
           expected = Ior.Left(List(
-            s"Observation $oid is ineligibile for this operation due to its workflow state (Ongoing with allowed transition to Inactive)."
+            s"Observation $oid is ineligibile for this operation due to its workflow state (Ongoing with allowed transition to Inactive/Completed)."
           ))
         )  
 
@@ -504,7 +504,7 @@ class ShortCut_4596 extends OdbSuite
           expected = 
             Ior.Both(
               List(
-                s"Observation $oid is ineligibile for this operation due to its workflow state (Ongoing with allowed transition to Inactive)."
+                s"Observation $oid is ineligibile for this operation due to its workflow state (Ongoing with allowed transition to Inactive/Completed)."
               ),
               json"""
                 {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation.scala
@@ -537,57 +537,6 @@ class createObservation extends OdbSuite {
     }
   }
 
-  test("[general] new observation without declaredComplete should be false"):
-    createProgramAs(pi).flatMap: pid =>
-      query(pi,
-        s"""
-          mutation {
-            createObservation(input: {
-              programId: ${pid.asJson}
-            }) {
-              observation {
-                declaredComplete
-              }
-            }
-          }
-          """
-        ).flatMap: js =>
-          val get = js.hcursor
-            .downField("createObservation")
-            .downField("observation")
-            .downField("declaredComplete")
-            .as[Boolean]
-            .leftMap(f => new RuntimeException(f.message))
-            .liftTo[IO]
-          assertIOBoolean(get.map(declaredComplete => !declaredComplete))
-
-  test("[general] new observation should respect declaredComplete"):
-    createProgramAs(pi).flatMap: pid =>
-      query(pi,
-        s"""
-          mutation {
-            createObservation(input: {
-              programId: ${pid.asJson}
-              SET: {
-                declaredComplete: true
-              }
-            }) {
-              observation {
-                declaredComplete
-              }
-            }
-          }
-          """
-        ).flatMap: js =>
-          val get = js.hcursor
-            .downField("createObservation")
-            .downField("observation")
-            .downField("declaredComplete")
-            .as[Boolean]
-            .leftMap(f => new RuntimeException(f.message))
-            .liftTo[IO]
-          assertIOBoolean(get)
-
   test("[general] created observation has no explicit base by default") {
     createProgramAs(pi).flatMap { pid =>
       query(pi,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
@@ -30,6 +30,7 @@ import lucuma.core.syntax.string.*
 import lucuma.core.syntax.timespan.*
 import lucuma.itc.IntegrationTime
 import lucuma.odb.data.Md5Hash
+import lucuma.core.enums.ObservationWorkflowState
 
 
 class executionDigest extends ExecutionTestSupport {
@@ -562,8 +563,16 @@ class executionDigest extends ExecutionTestSupport {
         p <- createProgram
         t <- createTargetWithProfileAs(pi, p)
         o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
-        _  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
-        _  <- setDeclaredComplete(pi, o, declaredComplete = true)
+        v  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+        a  <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Science)
+        s0 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthArc(0), ArcStep, telescopeConfig(0, 0, StepGuideState.Disabled), ObserveClass.NightCal)
+        _  <- addEndStepEvent(s0)
+        s1 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthFlat(0), FlatStep, telescopeConfig(0, 0, StepGuideState.Disabled), ObserveClass.NightCal)
+        _  <- addEndStepEvent(s1)
+        s2 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, telescopeConfig(0, 0, StepGuideState.Enabled), ObserveClass.Science)
+        _  <- addEndStepEvent(s2)
+        _  <- computeItcResultAs(pi, o)
+        _  <- setObservationWorkflowState(pi, o, ObservationWorkflowState.Completed)
       yield o
 
     setup.flatMap: oid =>
@@ -580,8 +589,16 @@ class executionDigest extends ExecutionTestSupport {
         p <- createProgram
         t <- createTargetWithProfileAs(pi, p)
         o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
-        _  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
-        _  <- setDeclaredComplete(pi, o, declaredComplete = true)
+        v  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+        a  <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Science)
+        s0 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthArc(0), ArcStep, telescopeConfig(0, 0, StepGuideState.Disabled), ObserveClass.NightCal)
+        _  <- addEndStepEvent(s0)
+        s1 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthFlat(0), FlatStep, telescopeConfig(0, 0, StepGuideState.Disabled), ObserveClass.NightCal)
+        _  <- addEndStepEvent(s1)
+        s2 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, telescopeConfig(0, 0, StepGuideState.Enabled), ObserveClass.Science)
+        _  <- addEndStepEvent(s2)
+        _  <- computeItcResultAs(pi, o)
+        _  <- setObservationWorkflowState(pi, o, ObservationWorkflowState.Completed)
       yield (p, o)
 
     setup.flatMap: (_, oid) =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
@@ -14,6 +14,7 @@ import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.ExecutionState
 import lucuma.core.enums.Instrument
+import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.SequenceType
 import lucuma.core.enums.StepGuideState
@@ -30,7 +31,6 @@ import lucuma.core.syntax.string.*
 import lucuma.core.syntax.timespan.*
 import lucuma.itc.IntegrationTime
 import lucuma.odb.data.Md5Hash
-import lucuma.core.enums.ObservationWorkflowState
 
 
 class executionDigest extends ExecutionTestSupport {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observation.scala
@@ -57,7 +57,6 @@ class observation extends OdbSuite {
                       centralWavelength: { nanometers: 500 }
                     }
                   }
-                  declaredComplete: false
                 }
               }
             ) {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observations.scala
@@ -431,18 +431,4 @@ class observations extends OdbSuite {
       res  <- observationsWhere(pi4, """instrument: { EQ: GMOS_NORTH }, site: { EQ: GS }""")
     yield assertEquals(res, Nil)
 
-  test("filter on declaredComplete"):
-    for
-      pid     <- createProgramAs(pi3)
-      oid1    <- createObservationAs(pi3, pid, ObservingModeType.GmosNorthLongSlit.some)
-      _       <- setDeclaredComplete(pi3, oid1, true)
-      oid2    <- createObservationAs(pi3, pid, ObservingModeType.GmosSouthLongSlit.some)
-      oid3    <- createObservationAs(pi3, pid)
-      _       <- setDeclaredComplete(pi3, oid3, true)
-      done    <- observationsWhere(pi3, s"""declaredComplete: { EQ: true },  program: { id: { EQ: "$pid" } } """)
-      notDone <- observationsWhere(pi3, s"""declaredComplete: { EQ: false }, program: { id: { EQ: "$pid" } } """)
-    yield
-      assertEquals(done, List(oid1, oid3))
-      assertEquals(notDone, List(oid2))
-
 }


### PR DESCRIPTION
This removes `declaredComplete` from the schema and folds it into workflow state. By setting an `Ongoing` observation to `Completed` the bit is set. A completed observation can also be set back to `Ongoing` if it was set to `Completed` in this way (but not if it's "naturally" complete in terms of its science requirements).

This took my small brain a long time to do because the execution digest cache wasn't being invalidated … not sure if I did this right. @swalker2m see the note below.