### PR TITLE
Store the full SignalToNoiseAt of itc results

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -8572,6 +8572,18 @@ type ItcResultSet {
   index:    NonNegInt!
 }
 
+"""Calculated signal to noise at a specific wavelength"""
+type SignalToNoiseAt {
+  """Single exposure signal to noise"""
+  single: SignalToNoise!
+
+  """Total exposure signal to noise"""
+  total: SignalToNoise!
+
+  """Wavelength sn was calculated at"""
+  wavelength: Wavelength!
+}
+
 """
 A single ITC call result.
 """
@@ -8579,9 +8591,7 @@ type ItcResult {
   targetId:      TargetId!
   exposureTime:  TimeSpan!
   exposureCount: NonNegInt!
-  # TODO This needs to include two values and a wavelength
-  # It is nullable as imaging doesn't return a signal to noise value yet
-  signalToNoise: SignalToNoise
+  signalToNoiseAt: SignalToNoiseAt
 }
 
 type LineFluxIntegrated {

--- a/modules/service/src/main/resources/db/migration/V0975__reset_itc.sql
+++ b/modules/service/src/main/resources/db/migration/V0975__reset_itc.sql
@@ -1,0 +1,3 @@
+-- The format of itc results changed, let's clean it up
+
+TRUNCATE TABLE t_itc_result;

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -10,12 +10,12 @@ import cats.syntax.traverse.*
 import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
-import lucuma.core.math.SignalToNoise
 import lucuma.core.math.Wavelength
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.model.User
+import lucuma.odb.json.wavelength.transport.given
 
 class itc extends OdbSuite with ObservingModeSetupOperations {
 
@@ -59,7 +59,13 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                   seconds
                 }
                 exposureCount
-                signalToNoise
+                signalToNoiseAt {
+                  wavelength {
+                    picometers
+                  }
+                  single
+                  total
+                }
               }
               all {
                 targetId
@@ -72,7 +78,13 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                   seconds
                 }
                 exposureCount
-                signalToNoise
+                signalToNoiseAt {
+                  wavelength {
+                    picometers
+                  }
+                  single
+                  total
+                }
               }
               all {
                 targetId
@@ -97,7 +109,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                   "seconds": 10.000000
                 },
                 "exposureCount": ${FakeItcResult.exposureCount.value},
-                "signalToNoise": ${fakeSignalToNoiseAt(Wavelength.fromIntNanometers(500).get).total.value.toBigDecimal}
+                "signalToNoiseAt": ${fakeSignalToNoiseAt(Wavelength.fromIntNanometers(500).get).asJson}
               },
               "all": [
                 {
@@ -112,7 +124,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                   "seconds": 10.000000
                 },
                 "exposureCount": ${FakeItcResult.exposureCount.value},
-                "signalToNoise": null
+                "signalToNoiseAt": null
               },
               "all": [
                 {


### PR DESCRIPTION
This turned out simpler than what I expected as we store the result as a blob