### PR TITLE
Changes to Average Parallactic Angle calculation and obs duration

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
@@ -196,9 +196,12 @@ object GuideService {
     def obsTime: Result[Timestamp] =
       optObsTime.toResult(generalError(s"Observation time not set for observation $id.").asProblem)
 
-    def validGuideStarName(generatorHash:Md5Hash, remainingTime: TimeSpan): Option[GuideStarName] =
+    def obsDuration: Result[TimeSpan] =
+      optObsDuration.toResult(generalError(s"Observation duration not set for observation $id.").asProblem)
+
+    def validGuideStarName(generatorHash:Md5Hash): Option[GuideStarName] =
       (guideStarName, guideStarHash).flatMapN { (name, hash) =>
-        val newHash = newGuideStarHash(generatorHash, remainingTime)
+        val newHash = newGuideStarHash(generatorHash)
         if (hash === newHash) guideStarName
         else none
        }
@@ -235,7 +238,7 @@ object GuideService {
       Md5Hash.unsafeFromByteArray(md5.digest())
     }
 
-    def newGuideStarHash(generatorHash:Md5Hash, duration: TimeSpan): Md5Hash = {
+    def newGuideStarHash(generatorHash:Md5Hash): Md5Hash = {
       val md5 = MessageDigest.getInstance("MD5")
 
       md5.update(generatorHash.toByteArray)
@@ -253,7 +256,7 @@ object GuideService {
       // changing time or duration doesn't necessarily invalidate the guide star, but
       // we're not tracking what the "original" values are, so we can't say for sure...
       md5.update(optObsTime.hashBytes)
-      md5.update(duration.hashBytes)
+      md5.update(optObsDuration.hashBytes)
 
       Md5Hash.unsafeFromByteArray(md5.digest())
     }
@@ -265,6 +268,7 @@ object GuideService {
     hash:   Md5Hash
   ) {
     val timeEstimate                         = digest.fullTimeEstimate.sum
+    val setupTime                            = digest.setup.full
     val offsets                              = NonEmptyList.fromFoldable(digest.science.offsets.union(digest.acquisition.offsets))
     val (site, agsParams, centralWavelength): (Site, AgsParams, Wavelength) = params.observingMode match
       case mode: gmos.longslit.Config.GmosNorth =>
@@ -272,6 +276,14 @@ object GuideService {
       case mode: gmos.longslit.Config.GmosSouth =>
         (Site.GS, AgsParams.GmosAgsParams(mode.fpu.asRight.some, PortDisposition.Side), mode.centralWavelength)
 
+    def getScienceStartTime(obsTime: Timestamp): Timestamp = obsTime +| setupTime
+    def getScienceDuration(obsDuration: TimeSpan, obsId: Observation.Id): Result[TimeSpan] =
+      if (obsDuration > timeEstimate)
+        generalError(s"Observation duration of ${obsDuration.format} exceeds the remaining time of ${timeEstimate.format} for observation $obsId.").asFailure
+      else
+        (obsDuration.subtract(setupTime))
+          .filter(_.nonZero)
+          .toResult(generalError(s"Observation duration of ${obsDuration.format} is less than the setup time of ${setupTime.format} for observation $obsId.").asProblem)
   }
 
   def instantiate[F[_]: Concurrent: Trace](
@@ -749,7 +761,9 @@ object GuideService {
         obsInfo: ObservationInfo,
         genInfo: GeneratorInfo,
         obsTime: Timestamp,
-        duration: TimeSpan
+        obsDuration: TimeSpan,
+        scienceTime: Timestamp,
+        scienceDuration: TimeSpan
       ): F[Result[GuideEnvironment]] =
         // If we got here, we either have the name but need to get all the details (they queried for more
         // than name), or the name wasn't set or wasn't valid and we need to find all the candidates and
@@ -759,7 +773,7 @@ object GuideService {
           baseTracking   = obsInfo.explicitBase.fold(ObjectTracking.fromAsterism(asterism))(ObjectTracking.constant)
           visitEnd      <- ResultT.fromResult(
                              obsTime
-                               .plusMicrosOption(duration.toMicroseconds)
+                               .plusMicrosOption(obsDuration.toMicroseconds)
                                .toResult(generalError("Visit end time out of range").asProblem)
                            )
           candidates    <- ResultT(
@@ -786,7 +800,7 @@ object GuideService {
                            )
           angles        <- ResultT.fromResult(
                              obsInfo.posAngleConstraint
-                              .anglesToTestAt(genInfo.site, baseTracking, obsTime.toInstant, duration.toDuration)
+                              .anglesToTestAt(genInfo.site, baseTracking, scienceTime.toInstant, scienceDuration.toDuration)
                               .toResult(generalError(s"No angles to test for guide target candidates for observation $oid.").asProblem)
                            )
           positions      = getPositions(angles, genInfo.offsets)
@@ -808,13 +822,15 @@ object GuideService {
       ): F[Result[GuideEnvironment]] =
         Trace[F].span("getGuideEnvironment"):
           (for {
-            obsInfo       <- ResultT(getObservationInfo(oid))
-            obsTime       <- ResultT.fromResult(obsInfo.obsTime)
-            asterism      <- ResultT(getAsterism(pid, oid))
-            genInfo       <- ResultT(getGeneratorInfo(pid, oid))
-            duration       = obsInfo.optObsDuration.getOrElse(genInfo.timeEstimate)
-            oGSName        = obsInfo.validGuideStarName(genInfo.hash, duration)
-            result        <- ResultT(lookupGuideStar(pid, oid, oGSName, obsInfo, genInfo, obsTime, duration))
+            obsInfo         <- ResultT(getObservationInfo(oid))
+            obsTime         <- ResultT.fromResult(obsInfo.obsTime)
+            obsDuration     <- ResultT.fromResult(obsInfo.obsDuration)
+            asterism        <- ResultT(getAsterism(pid, oid))
+            genInfo         <- ResultT(getGeneratorInfo(pid, oid))
+            scienceDuration <- ResultT.fromResult(genInfo.getScienceDuration(obsDuration, oid))
+            scienceStart     = genInfo.getScienceStartTime(obsTime)
+            oGSName          = obsInfo.validGuideStarName(genInfo.hash)
+            result          <- ResultT(lookupGuideStar(pid, oid, oGSName, obsInfo, genInfo, obsTime, obsDuration, scienceStart, scienceDuration))
           } yield result).value
 
       override def getGuideTargetName(pid: Program.Id, oid: Observation.Id)(
@@ -825,8 +841,7 @@ object GuideService {
           genInfo    <- ResultT.liftF(getGeneratorInfo(pid, oid)).map(_.toOption)
           oGSName    <- ResultT.pure(
                           genInfo.flatMap{ gi =>
-                            val duration = obsInfo.optObsDuration.getOrElse(gi.timeEstimate)
-                            obsInfo.validGuideStarName(gi.hash, duration)
+                            obsInfo.validGuideStarName(gi.hash)
                           }
                         )
         } yield oGSName.map(_.toNonEmptyString)).value
@@ -904,8 +919,7 @@ object GuideService {
                         GuideStarName.from(name.value).toOption.toResult(guideStarNameError(name.value).asProblem)
                       )
             genInfo  <- ResultT(getGeneratorInfo(obsInfo.programId, obsInfo.id))
-            duration  = obsInfo.optObsDuration.getOrElse(genInfo.timeEstimate)
-            hash      = obsInfo.newGuideStarHash(genInfo.hash, duration)
+            hash      = obsInfo.newGuideStarHash(genInfo.hash)
             result   <- ResultT(updateGuideTargetName(obsInfo.programId, obsInfo.id, gsn.some, hash.some))
           } yield result).value
         }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -1769,7 +1769,9 @@ trait DatabaseOperations { this: OdbSuite =>
     obsDuration: Option[TimeSpan]
   ): IO[Unit] = {
     val time = obsTime.fold("null")(ts => s"\"${ts.isoFormat}\"")
-    val duration = obsDuration.fold("null")(ts => s"{ microseconds: ${ts.toMicroseconds} }")
+    // microseconds can be bigger than max int. The schema is a Long but values outside of
+    // the Int range must be a string.
+    val duration = obsDuration.fold("null")(ts => s"{ microseconds: \"${ts.toMicroseconds}\" }")
     val q = s"""
       mutation {
         updateObservationsTimes(input: {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
@@ -16,6 +16,7 @@ import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.model.User
+import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import org.http4s.Request
 import org.http4s.Response
@@ -26,6 +27,15 @@ class guideEnvironment extends ExecutionTestSupport {
   val gaiaEmpty   = Timestamp.FromString.getOption("3000-01-30T04:00:00Z").get
   // for tests in which gaia should not get called
   val gaiaError   = Timestamp.FromString.getOption("4000-12-30T20:00:00Z").get
+
+  val setupTime = TimeSpan.fromMinutes(16).get
+  val fullTimeEstimate = TimeSpan.parse("PT36M1.8S").toOption.get
+  val durationTooShort = setupTime -| TimeSpan.fromMicroseconds(1).get
+  val durationTooLong = fullTimeEstimate +| TimeSpan.fromMicroseconds(1).get
+
+  // For tests in which the actual value of the duration is not validated because
+  // the execution digest cannot be calculated.
+  val durationNotValidated = TimeSpan.Zero
 
   val invalidTargetId = 1L
   val defaultTargetId = 3219118090462918016L
@@ -627,7 +637,7 @@ class guideEnvironment extends ExecutionTestSupport {
       for {
         p <- createProgramAs(pi)
         o <- createObservationAs(pi, p, List.empty)
-        _ <- setObservationTimeAndDuration(pi, o, gaiaError.some, none)
+        _ <- setObservationTimeAndDuration(pi, o, gaiaError.some, durationNotValidated.some)
       } yield o
     setup.flatMap { oid =>
       expect(
@@ -637,13 +647,76 @@ class guideEnvironment extends ExecutionTestSupport {
     }
   }
 
+  test("no observation time") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationAs(pi, p, List(t))
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideEnvironmentQuery(oid),
+        expected = List(s"Observation time not set for observation $oid.").asLeft)
+    }
+  }
+
+  test("no observation duration") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, gaiaError.some, none)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideEnvironmentQuery(oid),
+        expected = List(s"Observation duration not set for observation $oid.").asLeft)
+    }
+  }
+
+  test("observation duration too short") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, gaiaError.some, durationTooShort.some)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideEnvironmentQuery(oid),
+        expected = List(s"Observation duration of ${durationTooShort.format} is less than the setup time of ${setupTime.format} for observation $oid.").asLeft)
+    }
+  }
+
+  test("observation duration too long") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgramAs(pi)
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationAs(pi, p, List(t))
+        _ <- setObservationTimeAndDuration(pi, o, gaiaError.some, durationTooLong.some)
+      } yield o
+    setup.flatMap { oid =>
+      expect(
+        pi,
+        guideEnvironmentQuery(oid),
+        expected = List(s"Observation duration of ${durationTooLong.format} exceeds the remaining time of ${fullTimeEstimate.format} for observation $oid.").asLeft)
+    }
+  }
+
   test("no guide stars") {
     val setup: IO[Observation.Id] =
       for {
         p <- createProgramAs(pi)
         t <- createTargetWithProfileAs(pi, p)
         o <- createObservationAs(pi, p, List(t))
-        _ <- setObservationTimeAndDuration(pi, o, gaiaEmpty.some, none)
+        _ <- setObservationTimeAndDuration(pi, o, gaiaEmpty.some, fullTimeEstimate.some)
       } yield o
     setup.flatMap { oid =>
       expect(
@@ -659,7 +732,7 @@ class guideEnvironment extends ExecutionTestSupport {
         p <- createProgramAs(pi)
         t <- createTargetWithProfileAs(pi, p)
         o <- createObservationWithNoModeAs(pi, p, t)
-        _ <- setObservationTimeAndDuration(pi, o, gaiaError.some, none)
+        _ <- setObservationTimeAndDuration(pi, o, gaiaError.some, durationNotValidated.some)
       } yield o
     setup.flatMap { oid =>
       expect(
@@ -675,7 +748,7 @@ class guideEnvironment extends ExecutionTestSupport {
         p <- createProgramAs(pi)
         t <- createTargetWithProfileAs(pi, p)
         o <- createObservationAs(pi, p, List(t))
-        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
+        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, fullTimeEstimate.some)
         _ <- setGuideTargetName(pi, o, invalidTargetName.some)
       } yield o
     setup.flatMap { oid =>
@@ -692,7 +765,7 @@ class guideEnvironment extends ExecutionTestSupport {
         p <- createProgramAs(pi)
         t <- createTargetWithProfileAs(pi, p)
         o <- createObservationAs(pi, p, List(t))
-        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
+        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, fullTimeEstimate.some)
       } yield o
     setup.flatMap { oid =>
       expect(pi, guideEnvironmentQuery(oid), expected = defaultGuideEnvironmentResults)
@@ -705,7 +778,7 @@ class guideEnvironment extends ExecutionTestSupport {
         p <- createProgramAs(pi)
         t <- createTargetWithProfileAs(pi, p)
         o <- createObservationAs(pi, p, List(t))
-        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
+        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, fullTimeEstimate.some)
       } yield o
     setup.flatMap { oid =>
       expect(pi, guideEnvironmentQuery(oid), expected = defaultGuideEnvironmentResults)
@@ -718,7 +791,7 @@ class guideEnvironment extends ExecutionTestSupport {
         p <- createProgramAs(pi)
         t <- createTargetWithProfileAs(pi, p)
         o <- createObservationAs(pi, p, List(t))
-        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
+        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, fullTimeEstimate.some)
         _ <- setGuideTargetName(pi, o, defaultTargetName.some)
       } yield o
     setup.flatMap { oid =>
@@ -732,7 +805,7 @@ class guideEnvironment extends ExecutionTestSupport {
         p <- createProgramAs(pi)
         t <- createTargetWithProfileAs(pi, p)
         o <- createObservationAs(pi, p, List(t))
-        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, none)
+        _ <- setObservationTimeAndDuration(pi, o, gaiaSuccess.some, fullTimeEstimate.some)
         _ <- setGuideTargetName(pi, o, otherTargetName.some)
       } yield o
     setup.flatMap { oid =>

--- a/modules/service/src/test/scala/lucuma/odb/service/GuideServiceGuideStarHash.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/GuideServiceGuideStarHash.scala
@@ -45,11 +45,10 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       gs:            Option[GuideStarName],
       gsHash:        Option[Md5Hash],
       genHash:       Md5Hash,
-      visitDuration: TimeSpan
     ) =>
       val obsInfo1 = ObservationInfo(obsId1, pid, cs, pac, oc, ot, od, gs, gsHash)
       val obsInfo2 = ObservationInfo(obsId2, pid, cs, pac, oc, ot, od, gs, gsHash)
-      assertEquals(obsInfo1.newGuideStarHash(genHash, visitDuration), obsInfo2.newGuideStarHash(genHash, visitDuration))
+      assertEquals(obsInfo1.newGuideStarHash(genHash), obsInfo2.newGuideStarHash(genHash))
     }
   }
 
@@ -66,10 +65,9 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       gsHash:        Option[Md5Hash],
       genHash1:      Md5Hash,
       genHash2:      Md5Hash,
-      visitDuration: TimeSpan
     ) =>
-      val hash1 = ObservationInfo(obsId, pid, cs, pac, oc, ot, od, gs, gsHash).newGuideStarHash(genHash1, visitDuration)
-      val hash2 = ObservationInfo(obsId, pid, cs, pac, oc, ot, od, gs, gsHash).newGuideStarHash(genHash2, visitDuration)
+      val hash1 = ObservationInfo(obsId, pid, cs, pac, oc, ot, od, gs, gsHash).newGuideStarHash(genHash1)
+      val hash2 = ObservationInfo(obsId, pid, cs, pac, oc, ot, od, gs, gsHash).newGuideStarHash(genHash2)
 
       if (genHash1 === genHash2)
         assertEquals(hash1, hash2)
@@ -91,10 +89,9 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       gs:            Option[GuideStarName],
       gsHash:        Option[Md5Hash],
       genHash:       Md5Hash,
-      visitDuration: TimeSpan
     ) =>
-      val hash1 = ObservationInfo(obsId, pid, cs1, pac, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
-      val hash2 = ObservationInfo(obsId, pid, cs2, pac, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash1 = ObservationInfo(obsId, pid, cs1, pac, oc, ot, od, gs, gsHash).newGuideStarHash(genHash)
+      val hash2 = ObservationInfo(obsId, pid, cs2, pac, oc, ot, od, gs, gsHash).newGuideStarHash(genHash)
 
       if (cs1 === cs2)
         assertEquals(hash1, hash2)
@@ -116,13 +113,12 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       gs:            Option[GuideStarName],
       gsHash:        Option[Md5Hash],
       genHash:       Md5Hash,
-      visitDuration: TimeSpan
     ) =>
       val obsInfo1 = ObservationInfo(obsId, pid, cs, pac1, oc, ot, od, gs, gsHash)
       val obsInfo2 = ObservationInfo(obsId, pid, cs, pac2, oc, ot, od, gs, gsHash)
 
-      val hash1 = obsInfo1.newGuideStarHash(genHash, visitDuration)
-      val hash2 = obsInfo2.newGuideStarHash(genHash, visitDuration)
+      val hash1 = obsInfo1.newGuideStarHash(genHash)
+      val hash2 = obsInfo2.newGuideStarHash(genHash)
 
       if (pac1 === pac2)
         assertEquals(hash1, hash2)
@@ -144,10 +140,9 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       gs:            Option[GuideStarName],
       gsHash:        Option[Md5Hash],
       genHash:       Md5Hash,
-      visitDuration: TimeSpan
     ) =>
-      val hash1 = ObservationInfo(obsId, pid, cs, pac, oc1, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
-      val hash2 = ObservationInfo(obsId, pid, cs, pac, oc2, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash1 = ObservationInfo(obsId, pid, cs, pac, oc1, ot, od, gs, gsHash).newGuideStarHash(genHash)
+      val hash2 = ObservationInfo(obsId, pid, cs, pac, oc2, ot, od, gs, gsHash).newGuideStarHash(genHash)
 
       if (oc1 === oc2)
         assertEquals(hash1, hash2)
@@ -169,10 +164,9 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       gs:            Option[GuideStarName],
       gsHash:        Option[Md5Hash],
       genHash:       Md5Hash,
-      visitDuration: TimeSpan
     ) =>
-      val hash1 = ObservationInfo(obsId, pid, cs, pac, oc, ot1, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
-      val hash2 = ObservationInfo(obsId, pid, cs, pac, oc, ot2, od, gs, gsHash).newGuideStarHash(genHash, visitDuration)
+      val hash1 = ObservationInfo(obsId, pid, cs, pac, oc, ot1, od, gs, gsHash).newGuideStarHash(genHash)
+      val hash2 = ObservationInfo(obsId, pid, cs, pac, oc, ot2, od, gs, gsHash).newGuideStarHash(genHash)
 
       if (ot1 === ot2)
         assertEquals(hash1, hash2)
@@ -181,25 +175,24 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
     }
   }
 
-  test("hashes different for different durations") {
+  test("hashes different for different observation durations") {
     forAll { (
-      obsId:          Observation.Id,
+      obsId:         Observation.Id,
       pid:           Program.Id,
-      cs:             ConstraintSet,
-      pac:            PosAngleConstraint,
-      oc:             Option[Coordinates],
-      ot:             Option[Timestamp],
-      od:             Option[TimeSpan],
-      gs:             Option[GuideStarName],
-      gsHash:         Option[Md5Hash],
-      genHash:        Md5Hash,
-      visitDuration1: TimeSpan,
-      visitDuration2: TimeSpan
+      cs:            ConstraintSet,
+      pac:           PosAngleConstraint,
+      oc:            Option[Coordinates],
+      ot:            Option[Timestamp],
+      od1:           Option[TimeSpan],
+      od2:           Option[TimeSpan],
+      gs:            Option[GuideStarName],
+      gsHash:        Option[Md5Hash],
+      genHash:       Md5Hash,
     ) =>
-      val hash1 = ObservationInfo(obsId, pid, cs, pac, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration1)
-      val hash2 = ObservationInfo(obsId, pid, cs, pac, oc, ot, od, gs, gsHash).newGuideStarHash(genHash, visitDuration2)
+      val hash1 = ObservationInfo(obsId, pid, cs, pac, oc, ot, od1, gs, gsHash).newGuideStarHash(genHash)
+      val hash2 = ObservationInfo(obsId, pid, cs, pac, oc, ot, od2, gs, gsHash).newGuideStarHash(genHash)
 
-      if (visitDuration1 === visitDuration2)
+      if (od1 === od2)
         assertEquals(hash1, hash2)
       else
         assertNotEquals(hash1, hash2)
@@ -215,18 +208,16 @@ class GuideServiceGuideStarHash extends ScalaCheckSuite {
       pac:           PosAngleConstraint,
       oc:            Option[Coordinates],
       ot:            Option[Timestamp],
-      od1:           Option[TimeSpan],
-      od2:           Option[TimeSpan],
+      od:            Option[TimeSpan],
       gs1:           Option[GuideStarName],
       gs2:           Option[GuideStarName],
       gsHash1:       Option[Md5Hash],
       gsHash2:       Option[Md5Hash],
       genHash:       Md5Hash,
-      visitDuration: TimeSpan
     ) =>
-      val obsInfo1 = ObservationInfo(obsId, pid1, cs, pac, oc, ot, od1, gs1, gsHash1)
-      val obsInfo2 = ObservationInfo(obsId, pid2, cs, pac, oc, ot, od2, gs2, gsHash2)
-      assertEquals(obsInfo1.newGuideStarHash(genHash, visitDuration), obsInfo2.newGuideStarHash(genHash, visitDuration))
+      val obsInfo1 = ObservationInfo(obsId, pid1, cs, pac, oc, ot, od, gs1, gsHash1)
+      val obsInfo2 = ObservationInfo(obsId, pid2, cs, pac, oc, ot, od, gs2, gsHash2)
+      assertEquals(obsInfo1.newGuideStarHash(genHash), obsInfo2.newGuideStarHash(genHash))
     }
   }
   


### PR DESCRIPTION
For sc-5061 ([app.shortcut.com/lucuma/story/5061/average-parallactic-angle-calculation-should-only-include-science-portion](https://app.shortcut.com/lucuma/story/5061/average-parallactic-angle-calculation-should-only-include-science-portion)) this changes the average parallactic angle calculation to ignore the setup time and calculate with science time (obs time + setup time) and science duration (obs duration - setup time).

For [sc-5193] ([app.shortcut.com/lucuma/story/5193/do-not-automatically-recalculate-average-parallactic-angles](https://app.shortcut.com/lucuma/story/5193/do-not-automatically-recalculate-average-parallactic-angles), obs duration is now required and must be greater than the setup time and no greater than the estimated remaining time.