### PR TITLE
Enable Slew Events

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -71,8 +71,8 @@ type AddSequenceEventResult {
 
 "SlewEvent creation parameters."
 input AddSlewEventInput {
-  visitId:   VisitId!
-  slewStage: SlewStage!
+  observationId: ObservationId!
+  slewStage:     SlewStage!
 }
 
 "The result of adding a slew event."

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -12616,6 +12616,9 @@ type Visit {
   "Created by Observe at time."
   created: Timestamp!
 
+  "Site of the visit."
+  site: Site!
+
   "Time interval during which this visit executed."
   interval: TimestampInterval
 

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/VisitRecord.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/VisitRecord.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.sequence.data
 
 import lucuma.core.enums.Instrument
+import lucuma.core.enums.Site
 import lucuma.core.model.Observation
 import lucuma.core.model.Visit
 import lucuma.core.util.Timestamp
@@ -12,5 +13,7 @@ case class VisitRecord(
   visitId:       Visit.Id,
   observationId: Observation.Id,
   instrument:    Instrument,
-  created:       Timestamp
+  created:       Timestamp,
+  site:          Site,
+  chargeable:    Boolean
 )

--- a/modules/service/src/main/resources/db/migration/V0976__visit_chargeable.sql
+++ b/modules/service/src/main/resources/db/migration/V0976__visit_chargeable.sql
@@ -1,0 +1,21 @@
+-- Add a site and a chargeable boolean column.  A chargeable visit is one for
+-- which time may be charged.  Only one visit at a time can be charged, so there
+-- is only one current chargeable visit per site.
+ALTER TABLE t_visit
+  ADD COLUMN c_site       e_site,
+  ADD COLUMN c_chargeable boolean NOT NULL DEFAULT true;
+
+-- Set the site based on the instrument, of which we only have GMOS-N, GMOS-S,
+-- and part of Flamingos2 for now.
+UPDATE t_visit
+   SET c_site = 'gn'
+ WHERE c_instrument = 'GmosNorth';
+
+UPDATE t_visit
+   SET c_site = 'gs'
+ WHERE c_site IS NULL;
+
+ALTER TABLE t_visit
+  ALTER COLUMN c_site SET NOT NULL;
+
+CREATE INDEX i_visit_created ON t_visit (c_created);

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/AddSlewEventInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/AddSlewEventInput.scala
@@ -5,25 +5,21 @@ package lucuma.odb.graphql.input
 
 import cats.syntax.parallel.*
 import lucuma.core.enums.SlewStage
-import lucuma.core.model.Visit
+import lucuma.core.model.Observation
 import lucuma.odb.graphql.binding.*
 
 case class AddSlewEventInput(
-  visitId:   Visit.Id,
-  slewStage: SlewStage
+  observationId: Observation.Id,
+  slewStage:     SlewStage
 )
 
-object AddSlewEventInput {
+object AddSlewEventInput:
 
   val Binding: Matcher[AddSlewEventInput] =
-    ObjectFieldsBinding.rmap {
+    ObjectFieldsBinding.rmap:
       case List(
-        VisitIdBinding("visitId", rVisitId),
+        ObservationIdBinding("observationId", rObsId),
         SlewStageBinding("slewStage", rStage)
       ) =>
-        (rVisitId, rStage).parMapN { (vid, stg) =>
-          AddSlewEventInput(vid, stg)
-        }
-    }
-
-}
+        (rObsId, rStage).parMapN: (oid, stg) =>
+          AddSlewEventInput(oid, stg)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -505,7 +505,7 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
 
   private lazy val AddSlewEvent: MutationField =
     addEvent("addSlewEvent", AddSlewEventInput.Binding, Predicates.slewEvent) { input =>
-      executionEventService.insertSlewEvent(input.visitId, input.slewStage)
+      executionEventService.insertSlewEvent(input.observationId, input.slewStage)
     }
 
   private lazy val AddStepEvent: MutationField =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -490,27 +490,27 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
 
   private lazy val AddAtomEvent: MutationField =
     addEvent("addAtomEvent", AddAtomEventInput.Binding, Predicates.atomEvent) { input =>
-      executionEventService.insertAtomEvent(input.atomId, input.atomStage)
+      executionEventService.insertAtomEvent(input)
     }
 
   private lazy val AddDatasetEvent: MutationField =
     addEvent("addDatasetEvent", AddDatasetEventInput.Binding, Predicates.datasetEvent) { input =>
-      executionEventService.insertDatasetEvent(input.datasetId, input.datasetStage)
+      executionEventService.insertDatasetEvent(input)
     }
 
   private lazy val AddSequenceEvent: MutationField =
     addEvent("addSequenceEvent", AddSequenceEventInput.Binding, Predicates.sequenceEvent) { input =>
-      executionEventService.insertSequenceEvent(input.visitId, input.command)
+      executionEventService.insertSequenceEvent(input)
     }
 
   private lazy val AddSlewEvent: MutationField =
     addEvent("addSlewEvent", AddSlewEventInput.Binding, Predicates.slewEvent) { input =>
-      executionEventService.insertSlewEvent(input.observationId, input.slewStage)
+      executionEventService.insertSlewEvent(input)
     }
 
   private lazy val AddStepEvent: MutationField =
     addEvent("addStepEvent", AddStepEventInput.Binding, Predicates.stepEvent) { input =>
-      executionEventService.insertStepEvent(input.stepId, input.stepStage)
+      executionEventService.insertStepEvent(input)
     }
 
   private def recordAtom(
@@ -571,7 +571,7 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
       services.useTransactionally:
         requireServiceAccess:
           recordVisit(
-            visitService.insertGmosNorth(input.observationId, input.static),
+            visitService.recordGmosNorth(input),
             Predicates.visit.id,
             child
           )
@@ -581,7 +581,7 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
       services.useTransactionally:
         requireServiceAccess:
           recordVisit(
-            visitService.insertGmosSouth(input.observationId, input.static),
+            visitService.recordGmosSouth(input),
             Predicates.visit.id,
             child
           )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/VisitMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/VisitMapping.scala
@@ -43,6 +43,7 @@ trait VisitMapping[F[_]] extends VisitTable[F]
       SqlField("instrument",   VisitTable.Instrument, discriminator = true),
       SqlObject("observation", Join(VisitTable.ObservationId, ObservationView.Id)),
       SqlField("created",      VisitTable.Created),
+      SqlField("site",         VisitTable.Site),
       EffectField("interval", intervalHandler, List("id")),
       SqlObject("atomRecords"),
       SqlObject("datasets"),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/VisitTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/VisitTable.scala
@@ -7,27 +7,25 @@
  import lucuma.odb.util.Codecs.core_timestamp
  import lucuma.odb.util.Codecs.instrument
  import lucuma.odb.util.Codecs.observation_id
+ import lucuma.odb.util.Codecs.site
  import lucuma.odb.util.Codecs.time_span
  import lucuma.odb.util.Codecs.visit_id
+ import skunk.codec.boolean.bool
 
+ trait VisitTable[F[_]] extends BaseMapping[F]:
 
- trait VisitTable[F[_]] extends BaseMapping[F] {
-
-   object VisitTable extends TableDef("t_visit") {
+   object VisitTable extends TableDef("t_visit"):
      val Id: ColumnRef            = col("c_visit_id",       visit_id)
      val ObservationId: ColumnRef = col("c_observation_id", observation_id)
      val Instrument: ColumnRef    = col("c_instrument",     instrument)
      val Created: ColumnRef       = col("c_created",        core_timestamp)
+     val Site: ColumnRef          = col("c_site",           site)
+     val Chargeable: ColumnRef    = col("c_chargeable",     bool)
 
-     object Raw {
+     object Raw:
        val NonChargedTime = col("c_raw_non_charged_time", time_span)
        val ProgramTime    = col("c_raw_program_time",     time_span)
-     }
 
-     object Final {
+     object Final:
        val NonChargedTime = col("c_final_non_charged_time", time_span)
        val ProgramTime    = col("c_final_program_time",     time_span)
-     }
-   }
-
- }

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -264,7 +264,7 @@ object Generator {
 
         def checkCache(using NoTransaction[F]): EitherT[F, Error, Option[ExecutionDigest]] =
           EitherT.right(services.transactionally {
-            executionDigestService.selectOne(pid, oid, hash)
+            executionDigestService.selectOne(oid, hash)
           })
 
         def cache(digest: ExecutionDigest)(using NoTransaction[F]): EitherT[F, Error, Unit] =

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
@@ -28,6 +28,11 @@ import lucuma.core.util.Timestamp
 import lucuma.core.util.TimestampInterval
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
+import lucuma.odb.graphql.input.AddAtomEventInput
+import lucuma.odb.graphql.input.AddDatasetEventInput
+import lucuma.odb.graphql.input.AddSequenceEventInput
+import lucuma.odb.graphql.input.AddSlewEventInput
+import lucuma.odb.graphql.input.AddStepEventInput
 import lucuma.odb.util.Codecs.*
 import skunk.*
 import skunk.implicits.*
@@ -49,28 +54,23 @@ trait ExecutionEventService[F[_]] {
   )(using Transaction[F]): F[Option[TimestampInterval]]
 
   def insertAtomEvent(
-    atomId:    Atom.Id,
-    atomStage: AtomStage
+    input: AddAtomEventInput
   )(using Transaction[F], Services.ServiceAccess): F[Result[ExecutionEvent]]
 
   def insertDatasetEvent(
-    datasetId:    Dataset.Id,
-    datasetStage: DatasetStage
+    input: AddDatasetEventInput
   )(using Transaction[F], Services.ServiceAccess): F[Result[ExecutionEvent]]
 
   def insertSequenceEvent(
-    visitId: Visit.Id,
-    command: SequenceCommand
+    input: AddSequenceEventInput
   )(using Transaction[F], Services.ServiceAccess): F[Result[ExecutionEvent]]
 
   def insertSlewEvent(
-    observationId: Observation.Id,
-    slewStage:     SlewStage
+    input: AddSlewEventInput
   )(using Transaction[F], Services.ServiceAccess): F[Result[ExecutionEvent]]
 
   def insertStepEvent(
-    stepId:    Step.Id,
-    stepStage: StepStage
+    input: AddStepEventInput
   )(using Transaction[F], Services.ServiceAccess): F[Result[ExecutionEvent]]
 
 }
@@ -95,134 +95,120 @@ object ExecutionEventService {
       )(using Transaction[F]): F[Option[TimestampInterval]] =
         session.unique(Statements.SelectVisitRange)(visitId)
 
-      def insertAtomEvent(
-        atomId:    Atom.Id,
-        atomStage: AtomStage
-      )(using Transaction[F], Services.ServiceAccess): F[Result[ExecutionEvent]] = {
+      override def insertAtomEvent(
+        input: AddAtomEventInput
+      )(using Transaction[F], Services.ServiceAccess): F[Result[ExecutionEvent]] =
         def invalidAtom: OdbError.InvalidAtom =
-          OdbError.InvalidAtom(atomId, Some(s"Atom '$atomId' not found"))
+          OdbError.InvalidAtom(input.atomId, Some(s"Atom '${input.atomId}' not found"))
 
         val insert: F[Result[(Id, Timestamp, Observation.Id, Visit.Id)]] =
           session
-            .option(Statements.InsertAtomEvent)(atomId, atomStage)
+            .option(Statements.InsertAtomEvent)(input.atomId, input.atomStage)
             .map(_.toResult(invalidAtom.asProblem))
-            .recoverWith {
+            .recoverWith:
               case SqlState.ForeignKeyViolation(_) => invalidAtom.asFailureF
-            }
 
-        (for {
+        (for
           e <- ResultT(insert)
           (eid, time, oid, vid) = e
-          _ <- ResultT.liftF(services.sequenceService.setAtomExecutionState(atomId, atomStage))
-          _ <- ResultT.liftF(services.sequenceService.abandonOngoingAtomsExcept(oid, atomId))
+          _ <- ResultT.liftF(services.sequenceService.setAtomExecutionState(input.atomId, input.atomStage))
+          _ <- ResultT.liftF(services.sequenceService.abandonOngoingAtomsExcept(oid, input.atomId))
           _ <- ResultT.liftF(timeAccountingService.update(vid))
-        } yield AtomEvent(eid, time, oid, vid, atomId, atomStage)).value
-      }
+        yield AtomEvent(eid, time, oid, vid, input.atomId, input.atomStage)).value
 
       override def insertDatasetEvent(
-        datasetId:    Dataset.Id,
-        datasetStage: DatasetStage
-      )(using xa: Transaction[F], sa: Services.ServiceAccess): F[Result[ExecutionEvent]] = {
+        input: AddDatasetEventInput
+      )(using xa: Transaction[F], sa: Services.ServiceAccess): F[Result[ExecutionEvent]] =
 
         def invalidDataset: OdbError.InvalidDataset =
-          OdbError.InvalidDataset(datasetId, Some(s"Dataset '${datasetId.show}' not found"))
+          OdbError.InvalidDataset(input.datasetId, Some(s"Dataset '${input.datasetId.show}' not found"))
 
         val insertEvent: F[Result[(Id, Timestamp, Observation.Id, Visit.Id, Atom.Id, Step.Id)]] =
           session
-            .option(Statements.InsertDatasetEvent)(datasetId, datasetStage)
+            .option(Statements.InsertDatasetEvent)(input.datasetId, input.datasetStage)
             .map(_.toResult(invalidDataset.asProblem))
-            .recoverWith {
+            .recoverWith:
               case SqlState.ForeignKeyViolation(_) => invalidDataset.asFailureF
-            }
 
         // Best-effort to set the dataset time accordingly.  This can fail (leaving the timestamps
         // unchanged) if there is an end event but no start or if the end time comes before the
         // start.
-        def setDatasetTime(t: Timestamp): F[Unit] = {
+        def setDatasetTime(t: Timestamp): F[Unit] =
           def setWith(f: (Dataset.Id, Timestamp) => F[Unit]): F[Unit] =
-            for {
+            for
               s <- xa.savepoint
-              _ <- f(datasetId, t).recoverWith {
+              _ <- f(input.datasetId, t).recoverWith:
                 case SqlState.CheckViolation(_) => xa.rollback(s).void
-              }
-            } yield ()
+            yield ()
 
           // StartExpose signals the start of the dataset, EndWrite the end.
-          datasetStage match {
+          input.datasetStage match
             case DatasetStage.StartExpose => setWith(services.datasetService.setStartTime)
             case DatasetStage.EndWrite    => setWith(services.datasetService.setEndTime)
             case _                        => ().pure
-          }
-        }
 
-        (for {
+        (for
           e <- ResultT(insertEvent)
           (eid, time, oid, vid, aid, sid) = e
           _ <- ResultT.liftF(setDatasetTime(time))
           _ <- ResultT.liftF(timeAccountingService.update(vid))
-        } yield DatasetEvent(eid, time, oid, vid, aid, sid, datasetId, datasetStage)).value
-      }
+        yield DatasetEvent(eid, time, oid, vid, aid, sid, input.datasetId, input.datasetStage)).value
+
 
       override def insertSequenceEvent(
-        visitId: Visit.Id,
-        command: SequenceCommand
-      )(using Transaction[F], Services.ServiceAccess): F[Result[ExecutionEvent]] = {
+        input: AddSequenceEventInput
+      )(using Transaction[F], Services.ServiceAccess): F[Result[ExecutionEvent]] =
 
         def invalidVisit: OdbError.InvalidVisit =
-          OdbError.InvalidVisit(visitId, Some(s"Visit '$visitId' not found"))
+          OdbError.InvalidVisit(input.visitId, Some(s"Visit '${input.visitId}' not found"))
 
         val insert: F[Result[(Id, Timestamp, Observation.Id)]] =
           session
-            .option(Statements.InsertSequenceEvent)(visitId, command)
+            .option(Statements.InsertSequenceEvent)(input.visitId, input.command)
             .map(_.toResult(invalidVisit.asProblem))
-            .recoverWith {
+            .recoverWith:
               case SqlState.ForeignKeyViolation(_) => invalidVisit.asFailureF
-            }
 
-        (for {
+        (for
           e <- ResultT(insert)
           (eid, time, oid) = e
-          _ <- ResultT.liftF(services.sequenceService.abandonAtomsAndStepsForObservation(oid).whenA(command.isTerminal))
-          _ <- ResultT.liftF(timeAccountingService.update(visitId))
-        } yield SequenceEvent(eid, time, oid, visitId, command)).value
-      }
+          _ <- ResultT.liftF(services.sequenceService.abandonAtomsAndStepsForObservation(oid).whenA(input.command.isTerminal))
+          _ <- ResultT.liftF(timeAccountingService.update(input.visitId))
+        yield SequenceEvent(eid, time, oid, input.visitId, input.command)).value
+
 
       override def insertSlewEvent(
-        observationId: Observation.Id,
-        slewStage:     SlewStage
+        input: AddSlewEventInput
       )(using Transaction[F], Services.ServiceAccess): F[Result[ExecutionEvent]] =
         (for
-          v <- ResultT(visitService.lookupOrInsert(observationId))
-          e <- ResultT.liftF(session.unique(Statements.InsertSlewEvent)(v, slewStage))
+          v <- ResultT(visitService.lookupOrInsert(input.observationId))
+          e <- ResultT.liftF(session.unique(Statements.InsertSlewEvent)(v, input.slewStage))
           (eid, time) = e
           _ <- ResultT.liftF(timeAccountingService.update(v))
-        yield SlewEvent(eid, time, observationId, v, slewStage)).value
+        yield SlewEvent(eid, time, input.observationId, v, input.slewStage)).value
 
       override def insertStepEvent(
-        stepId:       Step.Id,
-        stepStage:    StepStage
-      )(using Transaction[F], Services.ServiceAccess): F[Result[ExecutionEvent]] = {
+        input: AddStepEventInput
+      )(using Transaction[F], Services.ServiceAccess): F[Result[ExecutionEvent]] =
 
         def invalidStep: OdbError.InvalidStep =
-          OdbError.InvalidStep(stepId, Some(s"Step '$stepId' not found"))
+          OdbError.InvalidStep(input.stepId, Some(s"Step '${input.stepId}' not found"))
 
         val insert: F[Result[(Id, Timestamp, Observation.Id, Visit.Id, Atom.Id)]] =
           session
-            .option(Statements.InsertStepEvent)(stepId, stepStage)
+            .option(Statements.InsertStepEvent)(input.stepId, input.stepStage)
             .map(_.toResult(invalidStep.asProblem))
-            .recoverWith {
+            .recoverWith:
               case SqlState.ForeignKeyViolation(_) => invalidStep.asFailureF
-            }
 
-        (for {
+        (for
           e <- ResultT(insert)
           (eid, time, oid, vid, aid) = e
           _ <- ResultT.liftF(services.sequenceService.setAtomExecutionState(aid, AtomStage.StartAtom))
-          _ <- ResultT.liftF(services.sequenceService.setStepExecutionState(stepId, stepStage, time))
-          _ <- ResultT.liftF(services.sequenceService.abandonOngoingStepsExcept(oid, aid, stepId))
+          _ <- ResultT.liftF(services.sequenceService.setStepExecutionState(input.stepId, input.stepStage, time))
+          _ <- ResultT.liftF(services.sequenceService.abandonOngoingStepsExcept(oid, aid, input.stepId))
           _ <- ResultT.liftF(timeAccountingService.update(vid))
-        } yield StepEvent(eid, time, oid, vid, aid, stepId, stepStage)).value
-      }
+        yield StepEvent(eid, time, oid, vid, aid, input.stepId, input.stepStage)).value
 
     }
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -503,7 +503,6 @@ object ObservationService {
               asterismService
                 .setAsterism(pid, NonEmptyList.of(newOid), oSET.fold(Nullable.Absent)(_.asterism))
                 .map(_.as(CloneIds(origOid, newOid)))
-
     }
 
   private object Statements {

--- a/modules/service/src/main/scala/lucuma/odb/service/Services.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/Services.scala
@@ -166,6 +166,9 @@ trait Services[F[_]]:
   /** The `TargetService`. */
   def targetService: TargetService[F]
 
+  /** The `TimeService`. */
+  def timeService: TimeService[F]
+
   /** The `TimingWindowService`. */
   def timingWindowService: TimingWindowService[F]
 
@@ -281,6 +284,7 @@ object Services:
       lazy val sequenceService = SequenceService.instantiate
       lazy val targetService = TargetService.instantiate
       lazy val timeAccountingService = TimeAccountingService.instantiate
+      lazy val timeService = TimeService.instantiate
       lazy val timingWindowService = TimingWindowService.instantiate
       lazy val visitService = VisitService.instantiate
 
@@ -333,6 +337,7 @@ object Services:
     def sequenceService[F[_]](using Services[F]): SequenceService[F] = summon[Services[F]].sequenceService
     def targetService[F[_]](using Services[F]): TargetService[F] = summon[Services[F]].targetService
     def timeAccountingService[F[_]](using Services[F]): TimeAccountingService[F] = summon[Services[F]].timeAccountingService
+    def timeService[F[_]](using Services[F]): TimeService[F] = summon[Services[F]].timeService
     def timingWindowService[F[_]](using Services[F]): TimingWindowService[F] = summon[Services[F]].timingWindowService
     def visitService[F[_]](using Services[F]): VisitService[F] = summon[Services[F]].visitService
     def itcService[F[_]](client: ItcClient[F])(using Services[F]): ItcService[F] = summon[Services[F]].itcService(client)

--- a/modules/service/src/main/scala/lucuma/odb/service/TimeService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TimeService.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service
+
+import cats.effect.Concurrent
+import cats.syntax.functor.*
+import lucuma.core.enums.Site
+import lucuma.core.model.ObservingNight
+import lucuma.core.util.Timestamp
+import skunk.*
+import skunk.codec.temporal.timestamptz
+import skunk.implicits.*
+
+import Services.Syntax.*
+
+/**
+ * A service for database-time related queries.
+ */
+trait TimeService[F[_]]:
+
+  /**
+   * The database time associated with the current transaction.
+   */
+  def transactionTime(using Transaction[F]): F[Timestamp]
+
+  /**
+   * The observing night associated with the site and transaction time.
+   */
+  def currentObservingNight(site: Site)(using Transaction[F]): F[ObservingNight]
+
+object TimeService:
+
+  def instantiate[F[_]: Concurrent](using Services[F]): TimeService[F] =
+    new TimeService[F]:
+
+      override def transactionTime(using Transaction[F]): F[Timestamp] =
+        session.unique(Statements.TransactionTime)
+
+      override def currentObservingNight(site: Site)(using Transaction[F]): F[ObservingNight] =
+        transactionTime.map(t => ObservingNight.fromSiteAndInstant(site, t.toInstant))
+
+  object Statements:
+
+    val TransactionTime: Query[Void, Timestamp] =
+      sql"""SELECT CURRENT_TIMESTAMP(6)"""
+        .query(timestamptz(6))
+        .map(t => Timestamp.unsafeFromInstantTruncated(t.toInstant))

--- a/modules/service/src/main/scala/lucuma/odb/service/VisitService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/VisitService.scala
@@ -11,8 +11,11 @@ import cats.syntax.all.*
 import fs2.Stream
 import grackle.Result
 import grackle.ResultT
+import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.Instrument
+import lucuma.core.enums.Site
 import lucuma.core.model.Observation
+import lucuma.core.model.ObservingNight
 import lucuma.core.model.Visit
 import lucuma.core.model.sequence.gmos.StaticConfig.GmosNorth
 import lucuma.core.model.sequence.gmos.StaticConfig.GmosSouth
@@ -20,13 +23,21 @@ import lucuma.core.util.Timestamp
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.sequence.data.VisitRecord
-import lucuma.odb.util.Codecs.*
+import lucuma.odb.syntax.instrument.*
+import lucuma.odb.util.Codecs.{site as _, *}
 import skunk.*
+import skunk.codec.boolean.bool
+import skunk.codec.numeric.int8
+import skunk.codec.temporal.timestamp
+import skunk.codec.temporal.timestamptz
 import skunk.implicits.*
+
+import java.time.LocalDateTime
+import java.time.ZoneOffset.UTC
 
 import Services.Syntax.*
 
-trait VisitService[F[_]] {
+trait VisitService[F[_]]:
 
   def select(
     visitId: Visit.Id
@@ -35,6 +46,10 @@ trait VisitService[F[_]] {
   def selectAll(
     observationId: Observation.Id
   ): Stream[F, VisitRecord]
+
+  def lookupOrInsert(
+    observationId: Observation.Id
+  )(using Transaction[F], Services.ServiceAccess): F[Result[Visit.Id]]
 
   def insertGmosNorth(
     observationId: Observation.Id,
@@ -46,64 +61,155 @@ trait VisitService[F[_]] {
     static:        GmosSouth
   )(using Transaction[F], Services.ServiceAccess): F[Result[Visit.Id]]
 
-}
 
-object VisitService {
+object VisitService:
+
+  case class ObsDescription(
+    instrument:      Instrument,
+    calibrationRole: Option[CalibrationRole]
+  ):
+    // TODO: need to make instrument and site 1:1
+    def site: Site =
+      instrument.site.head
+
+    // Determine whether an observation is chargeable.  I'd originally planned
+    // to do this by generating the sequence and dropping atoms until the first
+    // one with a chargeable obsclass was found (if ever).  That's a more
+    // general way that wouldn't need to be updated as code changes, but this is
+    // far cheaper and is correct at least for now.
+    def isChargeable: Boolean =
+      calibrationRole match
+        case None                                     |
+             Some(CalibrationRole.Photometric)        |
+             Some(CalibrationRole.SpectroPhotometric) |
+             Some(CalibrationRole.Telluric)            => true
+        case Some(CalibrationRole.Twilight)            => false
 
   def instantiate[F[_]: Concurrent](using Services[F]): VisitService[F] =
-    new VisitService[F] {
+    new VisitService[F]:
 
       override def select(
         visitId: Visit.Id
       ): F[Option[VisitRecord]] =
         session.option(Statements.SelectVisit)(visitId)
 
-      def selectAll(
+      override def selectAll(
         observationId: Observation.Id
       ): Stream[F, VisitRecord] =
         session.stream(VisitService.Statements.SelectAllVisit)(observationId, 1024)
 
-      private def insert(
+      private def obsDescription(
+        observationId: Observation.Id
+      ): ResultT[F, ObsDescription] =
+        ResultT:
+          session.option(Statements.SelectObsDescription)(observationId).map: od =>
+            Result.fromOption(od, OdbError.InvalidObservation(observationId, s"Observation '$observationId' not found.".some).asProblem)
+
+      override def lookupOrInsert(
+        observationId: Observation.Id
+      )(using Transaction[F], Services.ServiceAccess): F[Result[Visit.Id]] =
+
+        // Application transaction advisory lock on visit creation. The idea is
+        // to prevent two callers (Observe and Navigate) from doing a lookup
+        // simultaneously and coming to the conclusion to each create a new
+        // visit.
+        val lockCreation: ResultT[F, Unit] =
+          ResultT.liftF:
+            session.unique(Statements.LockCreation)(Statements.VisitCreationLockId)
+
+        def lookupVisit(desc:  ObsDescription, night: ObservingNight): ResultT[F, Option[Visit.Id]] =
+          ResultT.liftF:
+            if desc.isChargeable then
+              session
+                .option(Statements.SelectChargeableVisit)(night)
+                .map: o =>
+                  o.collect:
+                    case vr if vr.observationId === observationId => vr.visitId
+            else
+              session
+                .option(Statements.SelectLastVisit)(night, observationId)
+                .map(_.map(_.visitId))
+
+        def insertNewVisit(desc: ObsDescription): ResultT[F, Visit.Id] =
+           ResultT.liftF:
+             session.unique(Statements.InsertVisit)(observationId, desc)
+
+        (for
+          d  <- obsDescription(observationId)
+          n  <- ResultT.liftF(session.unique(Statements.selectObservingNight(d.site)))
+          _  <- lockCreation
+          v  <- lookupVisit(d, n)
+          vʹ <- v.fold(insertNewVisit(d))(ResultT.pure)
+        yield vʹ).value
+
+      private def insertStaticConfig[A](
         observationId: Observation.Id,
+        static:        A,
         instrument:    Instrument,
-        insertStatic:  Option[Visit.Id] => F[Long]
-      )(using Services.ServiceAccess): F[Result[Visit.Id]] = {
+        lookupStatic:  Visit.Id                              => F[Option[A]],
+        insertStatic:  (Observation.Id, Option[Visit.Id], A) => F[Long]
+      )(using Transaction[F], Services.ServiceAccess): F[Result[Visit.Id]] =
 
-        val insertVisit: F[Result[Visit.Id]] =
-          session
-            .unique(Statements.InsertVisit)(observationId, instrument)
-            .map(Result.success)
-            .recover:
-              case SqlState.ForeignKeyViolation(_) =>
-                OdbError.InvalidObservation(observationId, Some(s"Observation '$observationId' not found or is not a ${instrument.longName} observation")).asFailure
- 
-        val rt = for 
-          v <- ResultT(insertVisit)
-          _ <- ResultT.liftF(insertStatic(v.some).void)
-        yield v
+        val insertNewVisit: ResultT[F, Visit.Id] =
+          for
+            d <- obsDescription(observationId)
+            v <- ResultT.liftF(session.unique(Statements.InsertVisit)(observationId, d))
+          yield v
 
-        rt.value
+        def insertStaticForVisit(v: Visit.Id): ResultT[F, Unit] =
+          ResultT.liftF(insertStatic(observationId, v.some, static)).void
 
-      }
+        val update = (for
+          v0 <- ResultT(lookupOrInsert(observationId))
+          os <- ResultT.liftF(lookupStatic(v0))
+          v1 <- os.fold(insertStaticForVisit(v0).as(v0)): s =>
+                  insertNewVisit.flatMap: v =>
+                    insertStaticForVisit(v).as(v)
+        yield v1).value
+
+        update
+          .recover:
+            case SqlState.ForeignKeyViolation(_) =>
+              OdbError.InvalidObservation(observationId, Some(s"Observation '$observationId' not found or is not a ${instrument.longName} observation")).asFailure
 
       override def insertGmosNorth(
         observationId: Observation.Id,
         static:        GmosNorth
       )(using Transaction[F], Services.ServiceAccess): F[Result[Visit.Id]] =
-        insert(observationId, Instrument.GmosNorth, gmosSequenceService.insertGmosNorthStatic(observationId, _, static))
+        insertStaticConfig(
+          observationId,
+          static,
+          Instrument.GmosNorth,
+          gmosSequenceService.selectGmosNorthStatic,
+          gmosSequenceService.insertGmosNorthStatic
+        )
 
       override def insertGmosSouth(
         observationId: Observation.Id,
         static:        GmosSouth
       )(using Transaction[F], Services.ServiceAccess): F[Result[Visit.Id]] =
-        insert(observationId, Instrument.GmosSouth, gmosSequenceService.insertGmosSouthStatic(observationId, _, static))
+        insertStaticConfig(
+          observationId,
+          static,
+          Instrument.GmosSouth,
+          gmosSequenceService.selectGmosSouthStatic,
+          gmosSequenceService.insertGmosSouthStatic
+        )
 
-    }
+  object Statements:
 
-  object Statements {
+    private val obs_description: Codec[ObsDescription] =
+      (instrument *: calibration_role.opt).to[ObsDescription]
 
     private val visit_record: Codec[VisitRecord] =
-      (visit_id *: observation_id *: instrument *: core_timestamp).to[VisitRecord]
+      (visit_id *: observation_id *: instrument *: core_timestamp *: lucuma.odb.util.Codecs.site *: bool).to[VisitRecord]
+
+    val VisitCreationLockId = 100l
+
+    val LockCreation: Query[Long, Unit] =
+      sql"""
+        SELECT pg_advisory_xact_lock($int8)
+      """.query(void)
 
     val SelectVisit: Query[Visit.Id, VisitRecord] =
       sql"""
@@ -111,7 +217,9 @@ object VisitService {
           c_visit_id,
           c_observation_id,
           c_instrument,
-          c_created
+          c_created,
+          c_site,
+          c_chargeable
         FROM t_visit
         WHERE c_visit_id = $visit_id
       """.query(visit_record)
@@ -122,23 +230,92 @@ object VisitService {
           c_visit_id,
           c_observation_id,
           c_instrument,
-          c_created
+          c_created,
+          c_site,
+          c_chargeable
         FROM t_visit
         WHERE c_observation_id = $observation_id
       """.query(visit_record)
 
-    val InsertVisit: Query[(Observation.Id, Instrument), Visit.Id] =
+    def selectObservingNight(site: Site): Query[Void, ObservingNight] =
+      sql"""SELECT NOW()"""
+        .query(timestamptz)
+        .map(t => ObservingNight.fromSiteAndInstant(site, t.toInstant))
+
+    val SelectChargeableVisit: Query[ObservingNight, VisitRecord] =
+      sql"""
+        SELECT
+          c_visit_id,
+          c_observation_id,
+          c_instrument,
+          c_created,
+          c_site,
+          c_chargeable
+         FROM t_visit
+        WHERE c_chargeable = true
+          AND c_created >= $timestamp
+          AND c_created  < $timestamp
+          AND c_site = ${lucuma.odb.util.Codecs.site}
+        ORDER BY c_created DESC LIMIT 1;
+      """
+        .query(visit_record)
+        .contramap: n =>
+          (
+            LocalDateTime.ofInstant(n.start, UTC),
+            LocalDateTime.ofInstant(n.end,   UTC),
+            n.site
+          )
+
+    val SelectLastVisit: Query[(ObservingNight, Observation.Id), VisitRecord] =
+      sql"""
+        SELECT
+          c_visit_id,
+          c_observation_id,
+          c_instrument,
+          c_created,
+          c_site,
+          c_chargeable
+         FROM t_visit
+        WHERE c_created >= $timestamp
+          AND c_created  < $timestamp
+          AND c_observtation_id = $observation_id
+        ORDER BY c_created DESC LIMIT 1;
+      """
+        .query(visit_record)
+        .contramap: (n, o) =>
+          (
+            LocalDateTime.ofInstant(n.start, UTC),
+            LocalDateTime.ofInstant(n.end,   UTC),
+            o
+          )
+
+    val SelectObsDescription: Query[Observation.Id, ObsDescription] =
+      sql"""
+        SELECT c_instrument,
+               c_calibration_role
+          FROM t_observation
+         WHERE c_observation_id=$observation_id
+      """.query(obs_description)
+
+    val InsertVisit: Query[(Observation.Id, ObsDescription), Visit.Id] =
       sql"""
         INSERT INTO t_visit (
           c_observation_id,
-          c_instrument
+          c_instrument,
+          c_site,
+          c_chargeable
         )
         SELECT
           $observation_id,
-          $instrument
+          $instrument,
+          ${lucuma.odb.util.Codecs.site},
+          $bool
         RETURNING
           c_visit_id
-      """.query(visit_id)
-
-  }
-}
+      """.query(visit_id).contramap: (oid, od) =>
+        (
+          oid,
+          od.instrument,
+          od.site,
+          od.isChargeable
+        )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -1198,19 +1198,19 @@ trait DatabaseOperations { this: OdbSuite =>
 
   def addSlewEventAs(
     user: User,
-    vid:  Visit.Id,
+    oid:  Observation.Id,
     stg:  SlewStage
   ): IO[SlewEvent] = {
     val q = s"""
       mutation {
         addSlewEvent(input: {
-          visitId: "$vid",
+          observationId: "$oid",
           slewStage: ${stg.tag.toUpperCase}
         }) {
           event {
             id
             received
-            observation { id }
+            visit { id }
           }
         }
       }
@@ -1221,8 +1221,8 @@ trait DatabaseOperations { this: OdbSuite =>
       val e = for {
         i <- c.downField("id").as[ExecutionEvent.Id]
         r <- c.downField("received").as[Timestamp]
-        o <- c.downFields("observation", "id").as[Observation.Id]
-      } yield SlewEvent(i, r, o, vid, stg)
+        v <- c.downFields("visit", "id").as[Visit.Id]
+      } yield SlewEvent(i, r, oid, v, stg)
       e.fold(f => throw new RuntimeException(f.message), identity)
     }
   }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordVisit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordVisit.scala
@@ -13,7 +13,7 @@ import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.odb.data.OdbError
 
-class recordVisit extends OdbSuite {
+class recordVisit extends OdbSuite:
 
   val service: User = TestUsers.service(nextId)
 
@@ -25,15 +25,15 @@ class recordVisit extends OdbSuite {
     query:    Observation.Id => String,
     expected: Either[Observation.Id => String, Json]
   ): IO[Unit] =
-    for {
+    for
       pid <- createProgramAs(user)
       oid <- createObservationAs(user, pid, mode.some)
       _   <- expectSuccessOrOdbError(user, query(oid), expected.leftMap: f =>
         case OdbError.InvalidObservation(_, Some(d)) if d === f(oid) => ()
       ) 
-    } yield ()
+    yield ()
 
-  test("recordGmosNorthVisit") {
+  test("recordGmosNorthVisit"):
 
     recordVisitTest(
       ObservingModeType.GmosNorthLongSlit,
@@ -75,9 +75,7 @@ class recordVisit extends OdbSuite {
       """.asRight
     )
 
-  }
-
-  test("recordGmosSouthVisit") {
+  test("recordGmosSouthVisit"):
 
     recordVisitTest(
       ObservingModeType.GmosSouthLongSlit,
@@ -115,9 +113,7 @@ class recordVisit extends OdbSuite {
       """.asRight
     )
 
-  }
-
-  test("record visit cross site") {
+  test("record visit cross site"):
 
     recordVisitTest(
       ObservingModeType.GmosNorthLongSlit,
@@ -142,6 +138,3 @@ class recordVisit extends OdbSuite {
       """,
       ((oid: Observation.Id) => s"Observation '$oid' not found or is not a GMOS South observation").asLeft
     )
-
-  }
-}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAtomRecords.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAtomRecords.scala
@@ -44,7 +44,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
     } yield (oid, aid)
 
   test("observation -> execution -> atomRecords") {
-    recordAll(pi, serviceUser, mode, offset = 0, visitCount = 2, atomCount = 2).flatMap { on =>
+    recordAll(pi, serviceUser, mode, offset = 0, atomCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -59,7 +59,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
         }
       """
 
-      val matches = on.visits.flatMap(_.atoms).map { a =>
+      val matches = on.visit.atoms.map { a =>
         Json.obj("id" -> a.id.asJson)
       }
 
@@ -80,7 +80,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
   }
 
   test("observation -> execution -> atomRecords -> interval") {
-    recordAll(pi, serviceUser, mode, offset = 50, visitCount = 2, stepCount = 2).flatMap { on =>
+    recordAll(pi, serviceUser, mode, offset = 50, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -99,7 +99,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
         }
       """
 
-      val matches = on.visits.flatMap(_.atoms).map { atom =>
+      val matches = on.visit.atoms.map { atom =>
         val inv = for {
           s <- atom.allEvents.headOption.map(_.received)
           e <- atom.allEvents.lastOption.map(_.received)
@@ -135,7 +135,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
   }
 
   test("observation -> execution -> atomRecords -> steps") {
-    recordAll(pi, serviceUser, mode, offset = 100, visitCount = 2, stepCount = 2).flatMap { on =>
+    recordAll(pi, serviceUser, mode, offset = 100, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -154,7 +154,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
         }
       """
 
-      val matches = on.visits.flatMap(_.atoms).map { a =>
+      val matches = on.visit.atoms.map { a =>
         Json.obj(
           "steps" -> Json.obj(
             "matches" -> a.steps.map(s => Json.obj("id" -> s.id.asJson)).asJson
@@ -179,7 +179,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
   }
 
   test("observation -> execution -> atomRecords -> steps -> interval") {
-    recordAll(pi, serviceUser, mode, offset = 150, visitCount = 2, stepCount = 2).flatMap { on =>
+    recordAll(pi, serviceUser, mode, offset = 150, stepCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -202,7 +202,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
         }
       """
 
-      val matches = on.visits.flatMap(_.atoms).map { atom =>
+      val matches = on.visit.atoms.map { atom =>
         val stepMatches = atom.steps.map { step =>
           val inv = for {
             s <- step.allEvents.headOption.map(_.received)
@@ -269,7 +269,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
         }
       """
 
-      val matches = on.visits.flatMap(_.atoms).map { a =>
+      val matches = on.visit.atoms.map { a =>
         Json.obj(
           "steps" -> Json.obj(
             "matches" -> a.steps.map { s =>
@@ -325,7 +325,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
         }
       """
 
-      val matches = on.visits.flatMap(_.atoms).map { a =>
+      val matches = on.visit.atoms.map { a =>
         Json.obj(
           "steps" -> Json.obj(
             "matches" -> a.steps.map { s =>
@@ -381,7 +381,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
         }
       """
 
-      val matches = on.visits.flatMap(_.atoms).map { a =>
+      val matches = on.visit.atoms.map { a =>
         Json.obj(
           "steps" -> Json.obj(
             "matches" ->

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDatasets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDatasets.scala
@@ -23,7 +23,7 @@ class executionDatasets extends OdbSuite with ExecutionQuerySetupOperations {
   val validUsers = List(pi, pi2, service).toList
 
   test("observation -> execution -> datasets") {
-    recordAll(pi, service, mode, offset = 0, visitCount = 2, atomCount = 2, stepCount = 3, datasetCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 0, atomCount = 2, stepCount = 3, datasetCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -76,7 +76,7 @@ class executionDatasets extends OdbSuite with ExecutionQuerySetupOperations {
         }
       """
 
-      val List(s0, s1) = on.visits.head.atoms.head.steps
+      val List(s0, s1) = on.visit.atoms.head.steps
       val matches      = (s0.datasets ++ s1.datasets).map { d =>
         Json.obj("events" -> Json.obj("matches" -> d.allEvents.map(e => Json.obj("id" -> e.id.asJson)).asJson))
       }
@@ -134,7 +134,7 @@ class executionDatasets extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("observation -> execution -> datasets -> visit") {
-    recordAll(pi, service, mode, offset = 300, visitCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 300).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -151,8 +151,6 @@ class executionDatasets extends OdbSuite with ExecutionQuerySetupOperations {
         }
       """
 
-      val List(v0, v1) = on.visits
-
       val e = json"""
       {
         "observation": {
@@ -161,12 +159,7 @@ class executionDatasets extends OdbSuite with ExecutionQuerySetupOperations {
               "matches": [
                 {
                   "visit": {
-                    "id": ${v0.id}
-                  }
-                },
-                {
-                  "visit": {
-                    "id": ${v1.id}
+                    "id": ${on.visit.id}
                   }
                 }
               ]

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
@@ -491,7 +491,7 @@ class executionDigest extends ExecutionTestSupport {
           for {
             _ <- services.executionDigestService.insertOrUpdate(p, o, Md5Hash.Zero, ExecutionDigest.Zero)(using xa)
             _ <- services.executionEventService.insertStepEvent(s, StepStage.EndStep)(using xa, ().asInstanceOf) // shhh
-            d <- services.executionDigestService.selectOne(p, o, Md5Hash.Zero)(using xa)
+            d <- services.executionDigestService.selectOne(o, Md5Hash.Zero)(using xa)
           } yield d.isEmpty
         }
       }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
@@ -31,6 +31,7 @@ import lucuma.core.syntax.string.*
 import lucuma.core.syntax.timespan.*
 import lucuma.itc.IntegrationTime
 import lucuma.odb.data.Md5Hash
+import lucuma.odb.graphql.input.AddStepEventInput
 
 
 class executionDigest extends ExecutionTestSupport {
@@ -490,7 +491,7 @@ class executionDigest extends ExecutionTestSupport {
         services.session.transaction.use { xa =>
           for {
             _ <- services.executionDigestService.insertOrUpdate(p, o, Md5Hash.Zero, ExecutionDigest.Zero)(using xa)
-            _ <- services.executionEventService.insertStepEvent(s, StepStage.EndStep)(using xa, ().asInstanceOf) // shhh
+            _ <- services.executionEventService.insertStepEvent(AddStepEventInput(s, StepStage.EndStep))(using xa, ().asInstanceOf) // shhh
             d <- services.executionDigestService.selectOne(o, Md5Hash.Zero)(using xa)
           } yield d.isEmpty
         }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionEvents.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionEvents.scala
@@ -42,21 +42,20 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
     mode:    ObservingModeType,
     setup:   Setup,
     user:    User,
-    oid:     Observation.Id,
-    visit:   Int
+    oid:     Observation.Id
   ): IO[VisitNode] =
     for {
       vid <- recordVisitAs(user, mode.instrument, oid)
-      e0  <- addSlewEventAs(user, vid, SlewStage.StartSlew)
-      e1  <- addSlewEventAs(user, vid, SlewStage.EndSlew)
+      e0  <- addSlewEventAs(user, oid, SlewStage.StartSlew)
+      e1  <- addSlewEventAs(user, oid, SlewStage.EndSlew)
       e2  <- addSequenceEventAs(user, vid, SequenceCommand.Start)
-      as  <- (0 until setup.atomCount).toList.traverse { a => recordAtom(mode, setup, user, vid, visit, a) }
+      as  <- (0 until setup.atomCount).toList.traverse { a => recordAtom(mode, setup, user, vid, a) }
       e3  <- addSequenceEventAs(user, vid, SequenceCommand.Stop)
     } yield VisitNode(vid, as, List(e0, e1, e2, e3))
 
 
   test("observation -> execution -> events") {
-    recordAll(pi, service, mode, offset = 0, visitCount = 2, atomCount = 2, stepCount = 3, datasetCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 0, atomCount = 2, stepCount = 3, datasetCount = 2).flatMap { on =>
       val q = s"""
         query {
           observation(observationId: "${on.id}") {
@@ -115,7 +114,7 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
         Json.obj(
           "id" -> e.id.asJson,
           "observation" -> Json.obj("id" -> on.id.asJson),
-          "visit" -> Json.obj("id" -> on.visits.head.id.asJson)
+          "visit" -> Json.obj("id" -> on.visit.id.asJson)
         )
       }
 
@@ -306,13 +305,13 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
   }
 
   test("query -> events (WHERE visitId)") {
-    recordAll(pi, service, mode, offset = 600, visitCount = 2).flatMap { on =>
+    recordAll(pi, service, mode, offset = 600).flatMap { on =>
       val q = s"""
         query {
           events(
             WHERE: {
               visitId: {
-                EQ: "${on.visits.head.id}"
+                EQ: "${on.visit.id}"
               }
             }
           ) {
@@ -324,7 +323,7 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
       """
 
       val events: List[Json] =
-         on.visits.head.allEvents.map(e => Json.obj("id" -> e.id.asJson))
+         on.visit.allEvents.map(e => Json.obj("id" -> e.id.asJson))
 
       val e = json"""
       {
@@ -409,7 +408,7 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
 
   test("query -> events (WHERE observation id + stepEvent stepId)") {
     recordAll(pi, service, mode, offset = 900, stepCount = 2).flatMap { on =>
-      val sid = on.visits.head.atoms.head.steps.head.id
+      val sid = on.visit.atoms.head.steps.head.id
 
       val q = s"""
         query {
@@ -498,7 +497,7 @@ class executionEvents extends OdbSuite with ExecutionQuerySetupOperations {
 
   test("query -> events (WHERE datasetId)") {
     recordAll(pi, service, mode, offset = 1100, stepCount = 2).flatMap { on =>
-      val dids = on.visits.head.atoms.head.steps.head.allDatasets
+      val dids = on.visit.atoms.head.steps.head.allDatasets
       val q = s"""
         query {
           events(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionStepRecords.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionStepRecords.scala
@@ -156,7 +156,7 @@ class executionStepRecords extends OdbSuite with ExecutionQuerySetupOperations {
       """
 
     def expected(on: ObservationNode): Either[List[String], Json] = {
-      val events = on.visits.head.atoms.head.steps.head.allEvents
+      val events = on.visit.atoms.head.steps.head.allEvents
       val start  = events.head.received
       val end    = events.last.received
       json"""

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/executionEventAdded.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/executionEventAdded.scala
@@ -77,7 +77,7 @@ class executionEventAdded extends OdbSuite with SubscriptionUtils:
           }
         """,
         mutations = Right(
-          addSlewEventAs(service, vid, SlewStage.StartSlew)
+          addSlewEventAs(service, oid, SlewStage.StartSlew)
         ),
         expected = List(
           eventJson(pid, oid, vid, ExecutionEventType.Slew)
@@ -98,8 +98,8 @@ class executionEventAdded extends OdbSuite with SubscriptionUtils:
         mutations = Right(
           recordAtomAs(service, mode.instrument, vid).flatMap: aid =>
             recordStepAs(service, mode.instrument, aid).flatMap: sid =>
-              addSlewEventAs(service, vid, SlewStage.StartSlew)       >>
-              addSlewEventAs(service, vid, SlewStage.EndSlew)         >>
+              addSlewEventAs(service, oid, SlewStage.StartSlew)       >>
+              addSlewEventAs(service, oid, SlewStage.EndSlew)         >>
               addSequenceEventAs(service, vid, SequenceCommand.Start) >>
               addAtomEventAs(service, aid, AtomStage.StartAtom)       >>
               addStepEventAs(service, sid, StepStage.StartStep)
@@ -121,8 +121,8 @@ class executionEventAdded extends OdbSuite with SubscriptionUtils:
         mutations = Right(
           recordAtomAs(service, mode.instrument, vid).flatMap: aid =>
             recordStepAs(service, mode.instrument, aid).flatMap: sid =>
-              addSlewEventAs(service, vid, SlewStage.StartSlew)       >>
-              addSlewEventAs(service, vid, SlewStage.EndSlew)         >>
+              addSlewEventAs(service, oid, SlewStage.StartSlew)       >>
+              addSlewEventAs(service, oid, SlewStage.EndSlew)         >>
               addSequenceEventAs(service, vid, SequenceCommand.Start) >>
               addAtomEventAs(service, aid, AtomStage.StartAtom)       >>
               addStepEventAs(service, sid, StepStage.StartStep)
@@ -149,8 +149,8 @@ class executionEventAdded extends OdbSuite with SubscriptionUtils:
           recordAtomAs(service, mode.instrument, vid).flatMap: aid =>
             recordStepAs(service, mode.instrument, aid).flatMap: sid =>
               recordDatasetAs(service, sid, "N20250103S0001.fits").flatMap: did =>
-                addSlewEventAs(service, vid, SlewStage.StartSlew)         >>
-                addSlewEventAs(service, vid, SlewStage.EndSlew)           >>
+                addSlewEventAs(service, oid, SlewStage.StartSlew)         >>
+                addSlewEventAs(service, oid, SlewStage.EndSlew)           >>
                 addSequenceEventAs(service, vid, SequenceCommand.Start)   >>
                 addAtomEventAs(service, aid, AtomStage.StartAtom)         >>
                 addStepEventAs(service, sid, StepStage.StartStep)         >>
@@ -179,8 +179,8 @@ class executionEventAdded extends OdbSuite with SubscriptionUtils:
           recordAtomAs(service, mode.instrument, vid).flatMap: aid =>
             recordStepAs(service, mode.instrument, aid).flatMap: sid =>
               recordDatasetAs(service, sid, "N20250103S0002.fits").flatMap: did =>
-                addSlewEventAs(service, vid, SlewStage.StartSlew)         >>
-                addSlewEventAs(service, vid, SlewStage.EndSlew)           >>
+                addSlewEventAs(service, oid, SlewStage.StartSlew)         >>
+                addSlewEventAs(service, oid, SlewStage.EndSlew)           >>
                 addSequenceEventAs(service, vid, SequenceCommand.Start)   >>
                 addAtomEventAs(service, aid, AtomStage.StartAtom)         >>
                 addStepEventAs(service, sid, StepStage.StartStep)         >>


### PR DESCRIPTION
Slew events will be sent by Navigate, while all other execution events (sequence, step, dataset) are sent by Observe.  All events, regardless of source, are associated with a "visit".  The visit is a time accounting concept and a hopefully intuitive notion of a session spent observing some part of an observation.

The issue tackled by this PR is to allow Navigate to send slew events without knowing with which visit they will be associated. Accordingly the API is adjusted such that the `AddSlewEventInput` now takes an `ObservationId` instead of a `VisitId`.

In the implementation, when a slew event arrives we find the current "chargeable" visit.  Only one "chargeable" visit is active at a time per site because we cannot double charge time.  A visit is chargeable if time spent doing it will be charged against the program.  If there is already a chargeable visit for the same observation, we use that visit.  If not we create a new "preliminary" visit and it becomes the chargeable visit.  It is preliminary because it will be missing its static instrument configuration.

Observe continues recording visits explicitly.  If the observation is chargeable, we'll first try to find an existing chargeable visit.  If there is one, and it is for this observation, and it is preliminary, we just add the static configuration.  Otherwise we make a new visit as usual.

Notes
* Please know that I'm sorry about all of this and will gladly accept alternative suggestions.
* The most import updates are in `VisitService`.  Some chaff was generated as I meandered through various options
* A followup PR will address adding an "overlap" discount similar to what we have in `ocs` such that when a chargeable visit begins time spent on any already ongoing chargeable visit is free.