### PR TITLE
Filter zero exposure time

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -1193,7 +1193,7 @@ input ExposureTimeModeInput {
 Time And Count exposure time mode parameters
 """
 input TimeAndCountExposureTimeModeInput {
-  "Exposure time."
+  "Exposure time, which must be greater than zero."
   time: TimeSpanInput!
 
   "Exposure count."

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Acquisition.scala
@@ -286,10 +286,11 @@ object Acquisition:
 
       case _                              =>
         time
-          .bimap(
-            m => s"GMOS Long Slit acquisition requires a valid target: ${m.format}",
-            t => AcquisitionState.Init(lastReset, IndexTracker.Zero, atomBuilder, stepComp.compute(acqFilters, fpu, t.exposureTime, λ))
-          )
+          .leftMap: m =>
+             s"GMOS Long Slit acquisition requires a valid target: ${m.format}"
+          .filterOrElse(_.exposureTime.toNonNegMicroseconds.value > 0, s"GMOS Long Slit acquisition requires a positive exposure time.")
+          .map: t =>
+             AcquisitionState.Init(lastReset, IndexTracker.Zero, atomBuilder, stepComp.compute(acqFilters, fpu, t.exposureTime, λ))
 
   def gmosNorth(
     estimator: TimeEstimateCalculator[StaticConfig.GmosNorth, GmosNorth],

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Science.scala
@@ -737,7 +737,10 @@ object Science:
     ): F[Either[String, SequenceGenerator[D]]] =
 
       def extractTime: Either[String, IntegrationTime] =
-        time.leftMap(m => s"GMOS Long Slit requires a valid target: ${m.format}")
+        time
+          .leftMap: m =>
+             s"GMOS Long Slit requires a valid target: ${m.format}"
+          .filterOrElse(_.exposureTime.toNonNegMicroseconds.value > 0, s"GMOS Long Slit science requires a positive exposure time.")
 
       // Adjust the config and integration time according to the calibration role.
       val configAndTime = calRole match

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/timeAndCountExposureTimeMode.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/timeAndCountExposureTimeMode.scala
@@ -294,3 +294,66 @@ class timeAndCountExposureTimeMode extends ExecutionTestSupport:
           }
         """.asRight
       )
+
+  test("cannot generate time and count sequence with 0 second exposure time"):
+    for
+      p <- createProgram
+      t <- createTargetWithProfileAs(pi, p)
+      _ <- expect(
+        user  = pi,
+        query = s"""
+        mutation {
+         createObservation(input: {
+             programId: ${p.asJson},
+             SET: {
+               constraintSet: {
+                 cloudExtinction: POINT_ONE,
+                 imageQuality: ONE_POINT_ZERO,
+                 skyBackground: DARKEST
+               },
+               targetEnvironment: {
+                 asterism: ${List(t).asJson}
+               },
+               scienceRequirements: {
+                 mode: SPECTROSCOPY,
+                 spectroscopy: {
+                   wavelength: {
+                     nanometers: 500
+                   },
+                   resolution: 100,
+                   exposureTimeMode: {
+                     timeAndCount: {
+                       time: { minutes: 0 },
+                       count: 3,
+                       at: { nanometers: 500 }
+                     }
+                   },
+                   wavelengthCoverage: {
+                     nanometers: 20
+                   },
+                   focalPlane: SINGLE_SLIT,
+                   focalPlaneAngle: {
+                     microarcseconds: 0
+                   }
+                 }
+               },
+               observingMode: {
+                 gmosNorthLongSlit: {
+                   grating: R831_G5302,
+                   fpu: LONG_SLIT_1_00,
+                   centralWavelength: {
+                     nanometers: 500
+                   }
+                 }
+               }
+             }
+           }) {
+             observation { id }
+           }
+         }
+        """,
+        expected = List(
+          "Argument 'input.SET.scienceRequirements.spectroscopy.exposureTimeMode.timeAndCount' is invalid: Exposure `time` parameter must be positive."
+        ).asLeft
+      )
+    yield ()


### PR DESCRIPTION
This PR just rejects `TimeAndCount` exposure time mode when the exposure time is zero.  It is correct that biases have a zero exposure time, but they will not be specified via a `TimeAndCount` exposure time mode science requirement.

Down inside the GMOS generators, another check is made in order to fail more gracefully than "divide by zero".