### PR TITLE
Use timestamp of a custom SED as part of the itc validation hash

### DIFF
--- a/modules/sequence/src/test/scala/lucuma/odb/sequence/data/arb/ArbGeneratorParams.scala
+++ b/modules/sequence/src/test/scala/lucuma/odb/sequence/data/arb/ArbGeneratorParams.scala
@@ -40,7 +40,7 @@ trait ArbGeneratorParams:
       im <- arbitrary[ImagingParameters]
       sm <- arbitrary[SpectroscopyParameters]
       s  <- Gen.choose(1, 4)
-      t  <- Gen.listOfN(s, arbitrary[(Target.Id, TargetInput)]).map(NonEmptyList.fromListUnsafe)
+      t  <- Gen.listOfN(s, arbitrary[(Target.Id, TargetInput, Option[Timestamp])]).map(NonEmptyList.fromListUnsafe)
     yield ItcInput(im.copy(mode = mo), sm.copy(mode = mo), t)
 
   val genGmosNorthLongSlit: Gen[GeneratorParams] =


### PR DESCRIPTION
For custom seds, the attachment id is stored in the json blob of the source profile. The source profile is part of the validation hash for the itc calls, so if the attachment id changes, the itc is requeried. However, the user can also upload a new file for that attachment and the id does not change. In this case we still need to requery the itc. The best way I could figure to get around this was to include the timestamp for the attachment in the hash, because that will change if a new file is uploaded.

If someone has a better idea, let me know. :)
