### PR TITLE
Remove guide environment check for too long of observation duration

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
@@ -278,10 +278,11 @@ object GuideService {
 
     def getScienceStartTime(obsTime: Timestamp): Timestamp = obsTime +| setupTime
     def getScienceDuration(obsDuration: TimeSpan, obsId: Observation.Id): Result[TimeSpan] =
-      if (obsDuration > timeEstimate)
-        generalError(s"Observation duration of ${obsDuration.format} exceeds the remaining time of ${timeEstimate.format} for observation $obsId.").asFailure
-      else
-        (obsDuration.subtract(setupTime))
+      // Temporarily(?) disable check for too long of a duration for sc-5322
+      // if (obsDuration > timeEstimate)
+      //   generalError(s"Observation duration of ${obsDuration.format} exceeds the remaining time of ${timeEstimate.format} for observation $obsId.").asFailure
+      // else
+      obsDuration.subtract(setupTime)
           .filter(_.nonZero)
           .toResult(generalError(s"Observation duration of ${obsDuration.format} is less than the setup time of ${setupTime.format} for observation $obsId.").asProblem)
   }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
@@ -694,21 +694,22 @@ class guideEnvironment extends ExecutionTestSupport {
     }
   }
 
-  test("observation duration too long") {
-    val setup: IO[Observation.Id] =
-      for {
-        p <- createProgramAs(pi)
-        t <- createTargetWithProfileAs(pi, p)
-        o <- createObservationAs(pi, p, List(t))
-        _ <- setObservationTimeAndDuration(pi, o, gaiaError.some, durationTooLong.some)
-      } yield o
-    setup.flatMap { oid =>
-      expect(
-        pi,
-        guideEnvironmentQuery(oid),
-        expected = List(s"Observation duration of ${durationTooLong.format} exceeds the remaining time of ${fullTimeEstimate.format} for observation $oid.").asLeft)
-    }
-  }
+  // Temporarily(?) disable check for too long of a duration for sc-5322
+  // test("observation duration too long") {
+  //   val setup: IO[Observation.Id] =
+  //     for {
+  //       p <- createProgramAs(pi)
+  //       t <- createTargetWithProfileAs(pi, p)
+  //       o <- createObservationAs(pi, p, List(t))
+  //       _ <- setObservationTimeAndDuration(pi, o, gaiaError.some, durationTooLong.some)
+  //     } yield o
+  //   setup.flatMap { oid =>
+  //     expect(
+  //       pi,
+  //       guideEnvironmentQuery(oid),
+  //       expected = List(s"Observation duration of ${durationTooLong.format} exceeds the remaining time of ${fullTimeEstimate.format} for observation $oid.").asLeft)
+  //   }
+  // }
 
   test("no guide stars") {
     val setup: IO[Observation.Id] =


### PR DESCRIPTION
This should allow observe to run observations, but we need to discuss what the behavior of the odb and observe should be.

See the story for more information: https://app.shortcut.com/lucuma/story/5322/observe-crashes-running-sequence