### PR TITLE
Revert "Merge pull request #1702 from gemini-hlsw/ember-server"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ val flywayVersion              = "9.20.0"
 val fs2AwsVersion              = "6.2.0"
 val fs2Version                 = "3.11.0"
 val grackleVersion             = "0.23.0"
+val http4sBlazeVersion         = "0.23.17"
 val http4sEmberVersion         = "0.23.30"
 val http4sJdkHttpClientVersion = "0.9.2"
 val jwtVersion                 = "5.0.0"
@@ -157,8 +158,8 @@ lazy val service = project
       "is.cir"                   %% "ciris-refined"                      % cirisVersion,
       "org.flywaydb"              % "flyway-core"                        % flywayVersion,
       "org.http4s"               %% "http4s-jdk-http-client"             % http4sJdkHttpClientVersion,
+      "org.http4s"               %% "http4s-blaze-server"                % http4sBlazeVersion,
       "org.http4s"               %% "http4s-ember-client"                % http4sEmberVersion,
-      "org.http4s"               %% "http4s-ember-server"                % http4sEmberVersion,
       "org.postgresql"            % "postgresql"                         % postgresVersion,
       "org.tpolecat"             %% "natchez-honeycomb"                  % natchezVersion,
       "org.tpolecat"             %% "natchez-http4s"                     % natchezHttp4sVersion,

--- a/modules/service/src/main/resources/logback.xml
+++ b/modules/service/src/main/resources/logback.xml
@@ -5,6 +5,11 @@
     </encoder>
   </appender>
 
+  <!-- Suppress reporting of https://github.com/http4s/http4s/issues/2835 -->
+  <logger name="org.http4s.blaze" level="OFF" />
+  <logger name="org.http4s.blazecore.IdleTimeoutStage" level="OFF" />
+  <logger name="org.http4s.blazecore.websocket.Http4sWSStage" level="OFF" />
+
   <logger name="lucuma-odb" level="INFO" />
   <logger name="lucuma-odb-container" level="DEBUG" />
   <logger name="lucuma-odb-test" level="ERROR" />

--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -11,7 +11,6 @@ import cats.effect.std.Console
 import cats.effect.std.SecureRandom
 import cats.implicits.*
 import com.comcast.ip4s.Port
-import com.comcast.ip4s.host
 import com.monovore.decline.*
 import com.monovore.decline.effect.CommandIOApp
 import fs2.io.net.Network
@@ -39,8 +38,8 @@ import natchez.http4s.implicits.*
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.output.MigrateResult
 import org.http4s.*
+import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.client.Client
-import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.implicits.*
 import org.http4s.server.*
 import org.http4s.server.websocket.WebSocketBuilder2
@@ -179,15 +178,15 @@ object FMain extends MainParams {
           .onFinalize(cell.updateAndGet(_ + 1).flatMap(n => Logger[F].debug(s"released session (should be $n remaining)")))
 
   /** A resource that yields a running HTTP server. */
-  def serverResource[F[_]: Async: Network](
+  def serverResource[F[_]: Async](
     port: Port,
     app:  WebSocketBuilder2[F] => HttpApp[F]
   ): Resource[F, Server] =
-    EmberServerBuilder.default[F]
-      .withPort(port)
-      .withHost(host"0.0.0.0")
+    BlazeServerBuilder
+      .apply[F]
+      .bindHttp(port.value, "0.0.0.0")
       .withHttpWebSocketApp(app)
-      .build
+      .resource
 
   /** A resource that yields a Natchez tracing entry point. */
   def entryPointResource[F[_]: Sync](config: Config): Resource[F, EntryPoint[F]] =
@@ -334,3 +333,4 @@ object FMain extends MainParams {
     server(reset, skipMigration).use(_ => Concurrent[F].never[ExitCode])
 
 }
+

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -20,7 +20,6 @@ import clue.http4s.Http4sWebSocketBackend
 import clue.http4s.Http4sWebSocketClient
 import clue.model.GraphQLErrors
 import clue.websocket.WebSocketClient
-import com.comcast.ip4s.port
 import com.dimafeng.testcontainers.GenericContainer
 import com.dimafeng.testcontainers.PostgreSQLContainer
 import com.dimafeng.testcontainers.munit.TestContainerForAll
@@ -68,8 +67,8 @@ import lucuma.refined.*
 import munit.CatsEffectSuite
 import munit.internal.console.AnsiColors
 import natchez.Trace.Implicits.noop
+import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.client.Client
-import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.headers.Authorization
 import org.http4s.jdkhttpclient.JdkHttpClient
 import org.http4s.jdkhttpclient.JdkWSClient
@@ -360,12 +359,10 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
   protected def server: Resource[IO, Server] =
     for {
       a <- httpApp
-      s <- EmberServerBuilder
-             .default[IO]
-             .withPort(port"0")
+      s <- BlazeServerBuilder[IO]
              .withHttpWebSocketApp(a)
-             .withShutdownTimeout(Duration.Zero)
-             .build
+             .bindAny()
+             .resource
     } yield s
 
   protected def session: Resource[IO, Session[IO]] =


### PR DESCRIPTION
> This reverts commit e988c28b46ba19ad9265821e8b5dcf7f0bb7c2ad, reversing changes made to 445a69412ef2b4d86c8b3e28c6f84db1f3961d66.

The database is logging a ton of these:

```
2025-04-07T21:23:45.417143+00:00 app[web.2]: [[1;31mERROR[0;39m] [36morg.http4s.ember.server.EmberServerBuilderCompanionPlatform[0;39m - WebSocket connection terminated with exception 
2025-04-07T21:23:45.417155+00:00 app[web.2]: java.util.concurrent.TimeoutException: 60 seconds
2025-04-07T21:23:45.417155+00:00 app[web.2]: 	at cats.effect.IO.timeout$$anonfun$2$$anonfun$1(IO.scala:822)
2025-04-07T21:23:45.417155+00:00 app[web.2]: 	at cats.effect.IOFiber.runLoop(IOFiber.scala:427)
2025-04-07T21:23:45.417157+00:00 app[web.2]: 	at cats.effect.IOFiber.asyncContinueSuccessfulR(IOFiber.scala:1403)
2025-04-07T21:23:45.417158+00:00 app[web.2]: 	at cats.effect.IOFiber.run(IOFiber.scala:123)
2025-04-07T21:23:45.417158+00:00 app[web.2]: 	at cats.effect.unsafe.WorkerThread.run(WorkerThread.scala:851)
```

It mentions `EmberServerBuilder` though it isn't at all clear that that is the actual problem.  Should we try to revert the switch to Ember and see what happens?