### PR TITLE
Shortcut 3202: `null` value compare bug

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -320,7 +320,7 @@ object CalibrationsService extends CalibrationObservations {
           .map { o => (o.id, props.get(o.data)) }
           .collect { case (oid, Some(props)) if props.band.isDefined || props.wavelengthAt.isDefined => (oid, props) }
           .traverse { (oid, props) =>
-            val bandFragment = props.band.map(sql"c_science_band <> $science_band")
+            val bandFragment = props.band.map(sql"c_science_band IS DISTINCT FROM $science_band")
             val waveFragment = props.wavelengthAt.map(sql"c_spec_signal_to_noise_at <> $wavelength_pm")
             val needsUpdate  = List(bandFragment, waveFragment).flatten.intercalate(void" OR ")
 


### PR DESCRIPTION
The science band for specphots is not being assigned as expected because I foolishly used `<>` to compare a possibly `null` value.

N.B., I don't see test cases for calibrations, so I monkey tested it.