### PR TITLE
more access control

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/EmailWebhookRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/EmailWebhookRoutes.scala
@@ -13,6 +13,7 @@ import lucuma.core.util.Timestamp
 import lucuma.odb.Config
 import lucuma.odb.data.EmailId
 import lucuma.odb.service.EmailWebhookService
+import lucuma.odb.service.Services
 import org.http4s.*
 import org.http4s.circe.CirceEntityCodec.*
 import org.http4s.dsl.Http4sDsl
@@ -21,7 +22,6 @@ import scodec.bits.ByteVector
 
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
-import lucuma.odb.service.Services
 
 object EmailWebhookRoutes {
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/EmailWebhookRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/EmailWebhookRoutes.scala
@@ -21,6 +21,7 @@ import scodec.bits.ByteVector
 
 import javax.crypto.Mac
 import javax.crypto.spec.SecretKeySpec
+import lucuma.odb.service.Services
 
 object EmailWebhookRoutes {
 
@@ -95,7 +96,8 @@ object EmailWebhookRoutes {
     import dsl.*
 
     def updateStatus(data: EventData): F[Unit] =
-      webhookService.updateStatus(data.messageId, data.emailStatus, data.timestamp)
+      Services.asSuperUser:
+        webhookService.updateStatus(data.messageId, data.emailStatus, data.timestamp)
 
     def validateSignature(event: WebhookEvent): F[Unit] =
       if (event.signature.isValid(emailConfig.webhookSigningKey)) Async[F].unit

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
@@ -16,6 +16,7 @@ import grackle.ResultT
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.model.Access
 import lucuma.core.model.Observation
+import lucuma.core.model.ObservationWorkflow
 import lucuma.core.model.Program
 import lucuma.core.model.ProgramNote
 import lucuma.core.model.ProgramReference
@@ -44,6 +45,7 @@ import lucuma.odb.graphql.input.ProgramReferencePropertiesInput
 import lucuma.odb.graphql.input.ResetAcquisitionInput
 import lucuma.odb.graphql.input.SetAllocationsInput
 import lucuma.odb.graphql.input.SetGuideTargetNameInput
+import lucuma.odb.graphql.input.SetObservationWorkflowStateInput
 import lucuma.odb.graphql.input.SetProgramReferenceInput
 import lucuma.odb.graphql.input.TargetPropertiesInput
 import lucuma.odb.graphql.input.UpdateAsterismsInput
@@ -215,6 +217,20 @@ trait AccessControl[F[_]] extends Predicates[F] {
               .compile
               .toList
               .map(Result.success)
+
+  /** Verify that `oid` is writable. */
+  private def verifyWritable(
+    oid: Observation.Id
+  )(using Services[F], NoTransaction[F]): F[Result[Unit]] =
+    selectForObservationCloneImpl(
+      includeDeleted = None,
+      WHERE = Some(Predicates.observation.id.eql(oid)),
+      includeCalibrations = false
+    ).map: res =>
+      res.flatMap:
+        case List(`oid`) => Result.unit
+        case Nil         => OdbError.NotAuthorized(user.id).asFailure
+        case _           => Result.internalError("Unpossible: selectForObservationCloneImpl returned multiple ids, or the wrong id")
 
   /**
    * Select and return the ids of programs that are editable by the current user and meet
@@ -652,6 +668,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
            Services.asSuperUser:
              AccessControl.unchecked(input.SET, nids, program_note_id)
         })
+
   def selectForUpdate(
     input: CloneTargetInput
   )(using Services[F], NoTransaction[F]): F[Result[CheckedWithId[CloneTargetInput, Program.Id]]] =
@@ -700,5 +717,16 @@ trait AccessControl[F[_]] extends Predicates[F] {
             Services.asSuperUser:
               AccessControl.unchecked(CloneTargetInput(tid, input.SET, NonEmptyList.fromList(oids)), pid, program_id)
       .value
+
+
+  def selectForUpdate(input: SetObservationWorkflowStateInput)(using Services[F], NoTransaction[F]): F[Result[CheckedWithId[(ObservationWorkflow, ObservationWorkflowState), Observation.Id]]] =
+    verifyWritable(input.observationId) >>
+    Services.asSuperUser:
+      observationWorkflowService.getWorkflows(List(input.observationId), commitHash, itcClient, timeEstimateCalculator)
+        .map: res =>
+          res.map(_(input.observationId)).flatMap: w =>
+            if w.state === input.state || w.validTransitions.contains(input.state)
+            then Result(AccessControl.unchecked((w, input.state), input.observationId, observation_id))
+            else Result.failure(OdbError.InvalidWorkflowTransition(w.state, input.state).asProblem)
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
@@ -449,17 +449,18 @@ trait AccessControl[F[_]] extends Predicates[F] {
 
     // Compute our ObservationPropertiesInput.Create and set/verify the science band
     def props(pid: Program.Id): F[Result[ObservationPropertiesInput.Create]] =
-      val props = input.SET.getOrElse(ObservationPropertiesInput.Create.Default)
-      props.scienceBand match
-        case None =>
-          allocationService
-            .selectScienceBands(pid)
-            .map(_.toList)
-            .map:
-              case List(b) => Result(props.copy(scienceBand = Some(b)))
-              case _       => Result(props)
-        case Some(band) =>
-          allocationService.validateBand(band, List(pid)).map(_.as(props))
+      Services.asSuperUser:
+        val props = input.SET.getOrElse(ObservationPropertiesInput.Create.Default)
+        props.scienceBand match
+          case None =>
+            allocationService
+              .selectScienceBands(pid)
+              .map(_.toList)
+              .map:
+                case List(b) => Result(props.copy(scienceBand = Some(b)))
+                case _       => Result(props)
+          case Some(band) =>
+            allocationService.validateBand(band, List(pid)).map(_.as(props))
 
     // Put it together
     ResultT(resolvePidWritable(input.programId, input.proposalReference, input.programReference))

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
@@ -426,21 +426,22 @@ trait AccessControl[F[_]] extends Predicates[F] {
     includeCalibrations: Boolean
   )(using Services[F],
           NoTransaction[F]
-  ): F[Result[AccessControl.CheckedWithId[SetGuideTargetNameInput, Observation.Id]]]  =
-    observationService.resolveOid(input.observationId, input.observationRef).flatMap: r =>
-      r.flatTraverse: oid =>
-        selectForObservationUpdateImpl(
-          None,
-          List(oid),
-          includeCalibrations,
-          if user.role.access <= Access.Pi 
-            then ObservationWorkflowState.preExecutionSet
-            else ObservationWorkflowState.allButComplete
-        ).map: r =>
-          r.flatMap:
-            case Nil => Result(AccessControl.Checked.Empty)
-            case List(x) => Services.asSuperUser(Result(AccessControl.unchecked(input, x, observation_id)))
-            case _ => Result.internalError("Unpossible: got more than one oid back")
+  ): F[Result[AccessControl.CheckedWithId[SetGuideTargetNameInput, Observation.Id]]] =
+    Services.asSuperUser:
+      observationService.resolveOid(input.observationId, input.observationRef).flatMap: r =>
+        r.flatTraverse: oid =>
+          selectForObservationUpdateImpl(
+            None,
+            List(oid),
+            includeCalibrations,
+            if user.role.access <= Access.Pi 
+              then ObservationWorkflowState.preExecutionSet
+              else ObservationWorkflowState.allButComplete
+          ).map: r =>
+            r.flatMap:
+              case Nil => Result(AccessControl.Checked.Empty)
+              case List(x) => Services.asSuperUser(Result(AccessControl.unchecked(input, x, observation_id)))
+              case _ => Result.internalError("Unpossible: got more than one oid back")
 
   // Resolve to a Program.Id if the corresponding program is writable by the user.
   def resolvePidWritable(
@@ -509,19 +510,20 @@ trait AccessControl[F[_]] extends Predicates[F] {
   )(using Services[F]): F[Result[AccessControl.CheckedWithId[Option[ObservationPropertiesInput.Edit], Observation.Id]]] = {
 
     val ensureWritable: F[Result[Option[Observation.Id]]] =
-      observationService
-        .resolveOid(input.observationId, input.observationRef)
-        .flatMap: r =>
-          r.flatTraverse: oid =>
-            selectForObservationCloneImpl(
-              includeDeleted = None,
-              WHERE = Some(Predicates.observation.id.eql(oid)),
-              includeCalibrations = false
-            ).map: res =>
-              res.flatMap:
-                case List(oid) => Result(Some(oid))
-                case Nil       => Result(None)
-                case _         => Result.internalError("Unpossible: selectForObservationCloneImpl returned multiple ids")
+      Services.asSuperUser:
+        observationService
+          .resolveOid(input.observationId, input.observationRef)
+          .flatMap: r =>
+            r.flatTraverse: oid =>
+              selectForObservationCloneImpl(
+                includeDeleted = None,
+                WHERE = Some(Predicates.observation.id.eql(oid)),
+                includeCalibrations = false
+              ).map: res =>
+                res.flatMap:
+                  case List(oid) => Result(Some(oid))
+                  case Nil       => Result(None)
+                  case _         => Result.internalError("Unpossible: selectForObservationCloneImpl returned multiple ids")
 
     ensureWritable.nestMap:
       case None      => AccessControl.Checked.Empty
@@ -535,11 +537,11 @@ trait AccessControl[F[_]] extends Predicates[F] {
     input: ResetAcquisitionInput,
   )(using Services[F]): F[Result[AccessControl.CheckedWithId[Unit, Observation.Id]]] =
      requireStaffAccess:
-       observationService
-         .resolveOid(input.observationId, input.observationRef)
-         .nestMap: oid =>
-           Services.asSuperUser:
-             AccessControl.unchecked((), oid, observation_id)
+      Services.asSuperUser:
+        observationService
+          .resolveOid(input.observationId, input.observationRef)
+          .nestMap: oid =>
+            AccessControl.unchecked((), oid, observation_id)
 
   def selectForUpdate(
     input: CreateProgramNoteInput

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConfigurationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConfigurationMapping.scala
@@ -85,11 +85,12 @@ trait ConfigurationMapping[F[_]]
             Result(None).pure[F]
           case Some(refTime) =>
             services.use { implicit s =>
-              s.guideService(httpClient, itcClient, commitHash, timeEstimateCalculator)
-                .getObjectTracking(pid, oid)
-                .map:
-                  case Failure(problems) => Warning(problems, None) // turn failure into a warning
-                  case other => other.map(_.at(refTime.toInstant).map(_.value))
+              Services.asSuperUser:
+                s.guideService(httpClient, itcClient, commitHash, timeEstimateCalculator)
+                  .getObjectTracking(pid, oid)
+                  .map:
+                    case Failure(problems) => Warning(problems, None) // turn failure into a warning
+                    case other => other.map(_.at(refTime.toInstant).map(_.value))
             }
 
       private def queryContext(queries: List[(Query, Cursor)]): Result[List[(Program.Id, Observation.Id, Option[Timestamp])]] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
@@ -179,7 +179,8 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
     val calculate: (Program.Id, Observation.Id, Unit) => F[Result[Json]] =
       (_, oid, _) => {
         services.useTransactionally {
-          timeAccountingService.selectObservation(oid).map(_.asJson.success)
+          Services.asSuperUser:
+            timeAccountingService.selectObservation(oid).map(_.asJson.success)
         }
       }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -643,7 +643,9 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
   private lazy val SetObservationWorkflowState =
     MutationField.encodable("setObservationWorkflowState", SetObservationWorkflowStateInput.Binding): input =>
       services.useNonTransactionally:
-        observationWorkflowService.setWorkflowState(input.observationId, input.state, commitHash, itcClient, timeEstimateCalculator)
+        selectForUpdate(input).flatMap: res =>
+          res.flatTraverse: checked =>
+            observationWorkflowService.setWorkflowState(checked, commitHash, itcClient, timeEstimateCalculator)
 
   private lazy val SetProgramReference =
     MutationField("setProgramReference", SetProgramReferenceInput.Binding): (input, child) =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -60,6 +60,7 @@ import lucuma.odb.logic.TimeEstimateCalculatorImplementation
 import lucuma.odb.sequence.util.CommitHash
 import lucuma.odb.service.NoTransaction
 import lucuma.odb.service.Services
+import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.service.Services.Syntax.*
 import org.http4s.client.Client
 import org.tpolecat.typename.TypeName
@@ -776,7 +777,7 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
               }
             }
 
-      def setAsterisms(m: Map[Program.Id, List[Observation.Id]])(using Services[F], Transaction[F]): ResultT[F, Unit] =
+      def setAsterisms(m: Map[Program.Id, List[Observation.Id]])(using Services[F], Transaction[F], SuperUserAccess): ResultT[F, Unit] =
         ResultT:
           // The "obvious" implementation with `traverse` doesn't work here because
           // ResultT isn't a Monad and thus doesn't short-circuit. Doing an explicit
@@ -796,8 +797,9 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
                 updateObservations(edit)
                   .flatMap: 
                     case (map, query) =>
-                      setAsterisms(map)
-                        .as(query)
+                      Services.asSuperUser:
+                        setAsterisms(map)
+                          .as(query)
                   .value
                   .flatTap: q =>
                     transaction.rollback.unlessA(q.hasValue)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
@@ -237,7 +237,8 @@ trait ProgramMapping[F[_]]
   private val timeChargeHandler: EffectHandler[F] =
     keyValueEffectHandler[Program.Id, List[BandedTime]]("id") { pid =>
       services.useTransactionally {
-        timeAccountingService.selectProgram(pid)
+        Services.asSuperUser:
+          timeAccountingService.selectProgram(pid)
       }
     }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
@@ -124,9 +124,10 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
     val calculate: (Program.Id, Observation.Id, Timestamp) => F[Result[Option[Coordinates]]] =
       (pid, oid, obsTime) =>
         services.use { implicit s =>
-          s.guideService(httpClient, itcClient, commitHash, timeEstimateCalculator)
-            .getObjectTracking(pid, oid)
-            .map(_.map(_.at(obsTime.toInstant).map(_.value)))
+          Services.asSuperUser:
+            s.guideService(httpClient, itcClient, commitHash, timeEstimateCalculator)
+              .getObjectTracking(pid, oid)
+              .map(_.map(_.at(obsTime.toInstant).map(_.value)))
         }
 
     effectHandler(readEnv, calculate)
@@ -138,8 +139,9 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
     val calculate: (Program.Id, Observation.Id, Timestamp) => F[Result[List[GuideService.GuideEnvironment]]] =
       (pid, oid, obsTime) =>
         services.use { implicit s =>
-          s.guideService(httpClient, itcClient, commitHash, timeEstimateCalculator)
-            .getGuideEnvironments(pid, oid, obsTime)
+          Services.asSuperUser:
+            s.guideService(httpClient, itcClient, commitHash, timeEstimateCalculator)
+              .getGuideEnvironments(pid, oid, obsTime)
         }
 
     effectHandler(readEnv, calculate)
@@ -151,8 +153,9 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
     val calculate: (Program.Id, Observation.Id, Unit) => F[Result[GuideService.GuideEnvironment]] =
       (pid, oid, _) =>
         services.use { implicit s =>
-          s.guideService(httpClient, itcClient, commitHash, timeEstimateCalculator)
-            .getGuideEnvironment(pid, oid)
+          Services.asSuperUser:
+            s.guideService(httpClient, itcClient, commitHash, timeEstimateCalculator)
+              .getGuideEnvironment(pid, oid)
         }
 
     effectHandler(readEnv, calculate)
@@ -170,8 +173,9 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
     val calculate: (Program.Id, Observation.Id, TimestampInterval) => F[Result[List[GuideService.AvailabilityPeriod]]] =
       (pid, oid, period) =>
         services.use { implicit s =>
-          s.guideService(httpClient, itcClient, commitHash, timeEstimateCalculator)
-            .getGuideAvailability(pid, oid, period)
+          Services.asSuperUser:
+            s.guideService(httpClient, itcClient, commitHash, timeEstimateCalculator)
+              .getGuideAvailability(pid, oid, period)
         }
 
     effectHandler(readEnv, calculate)
@@ -183,8 +187,9 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
     val calculate: (Program.Id, Observation.Id, Unit) => F[Result[Option[NonEmptyString]]] =
       (pid, oid, _) =>
         services.use { implicit s =>
-          s.guideService(httpClient, itcClient, commitHash, timeEstimateCalculator)
-            .getGuideTargetName(pid, oid)
+          Services.asSuperUser:
+            s.guideService(httpClient, itcClient, commitHash, timeEstimateCalculator)
+              .getGuideTargetName(pid, oid)
         }
 
     effectHandler(readEnv, calculate)

--- a/modules/service/src/main/scala/lucuma/odb/service/AllocationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AllocationService.scala
@@ -16,12 +16,12 @@ import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.graphql.input.AllocationInput
 import lucuma.odb.graphql.mapping.AccessControl
+import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
 import skunk.*
 import skunk.implicits.*
 
 import Services.Syntax.*
-import lucuma.odb.service.Services.SuperUserAccess
 
 trait AllocationService[F[_]] {
 

--- a/modules/service/src/main/scala/lucuma/odb/service/AllocationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AllocationService.scala
@@ -21,6 +21,7 @@ import skunk.*
 import skunk.implicits.*
 
 import Services.Syntax.*
+import lucuma.odb.service.Services.SuperUserAccess
 
 trait AllocationService[F[_]] {
 
@@ -28,7 +29,7 @@ trait AllocationService[F[_]] {
    * Selects the science bands for which time has been allocated, if any, for
    * the given program.
    */
-  def selectScienceBands(pid: Program.Id): F[Set[ScienceBand]]
+  def selectScienceBands(pid: Program.Id)(using SuperUserAccess): F[Set[ScienceBand]]
 
   def setAllocations(input: AccessControl.CheckedWithId[List[AllocationInput], Program.Id])(using Transaction[F]): F[Result[Unit]]
 
@@ -36,7 +37,7 @@ trait AllocationService[F[_]] {
    * Validates that the given `band` may be assigned to observations in the
    * programs referenced by `pids`.
    */
-  def validateBand(band: ScienceBand, pids: List[Program.Id]): F[Result[Unit]]
+  def validateBand(band: ScienceBand, pids: List[Program.Id])(using SuperUserAccess): F[Result[Unit]]
 }
 
 object AllocationService {
@@ -44,10 +45,10 @@ object AllocationService {
   def instantiate[F[_]: MonadCancelThrow](using Services[F]): AllocationService[F] =
     new AllocationService[F] {
 
-      def selectScienceBands(pid: Program.Id): F[Set[ScienceBand]] =
+      def selectScienceBands(pid: Program.Id)(using SuperUserAccess): F[Set[ScienceBand]] =
         session.execute(Statements.SelectScienceBands)(pid).map(_.toSet)
 
-      def validateBand(band: ScienceBand, pids: List[Program.Id]): F[Result[Unit]] =
+      def validateBand(band: ScienceBand, pids: List[Program.Id])(using SuperUserAccess): F[Result[Unit]] =
         NonEmptyList.fromList(pids).fold(Result.unit.pure[F]) { nelPids =>
           session.execute(Statements.validPidsForBand(nelPids))((band, nelPids)).map { validPids =>
             (pids.toSet &~ validPids.toSet).toList match {

--- a/modules/service/src/main/scala/lucuma/odb/service/AttachmentFileService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AttachmentFileService.scala
@@ -18,6 +18,7 @@ import lucuma.core.model.GuestUser
 import lucuma.core.model.Program
 import lucuma.core.model.User
 import lucuma.core.util.NewType
+import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
 import natchez.Trace
 import skunk.*
@@ -289,7 +290,7 @@ object AttachmentFileService {
           .map(_.fold(().asRight)(_ => InvalidRequest(duplicateTypeMsg(attachmentType)).asLeft))
       else ().asRight.pure
 
-    def filePath(programId: Program.Id, remoteId: UUID, fileName: NonEmptyString): NonEmptyString =
+    def filePath(programId: Program.Id, remoteId: UUID, fileName: NonEmptyString)(using SuperUserAccess): NonEmptyString =
       s3FileSvc.filePath(programId, remoteId, fileName)
 
     new AttachmentFileService[F] {
@@ -302,7 +303,7 @@ object AttachmentFileService {
           path <- services.transactionallyEitherT {
                       getAttachmentInfoAndCheckAccess(user, attachmentId).map(_._2)
                   }
-          res  <- s3FileSvc.verifyAndGet(path).right
+          res  <- Services.asSuperUser(s3FileSvc.verifyAndGet(path)).right
         } yield res).value
           .recoverWith { case e: AttachmentException =>
             e.asLeft.pure
@@ -327,7 +328,7 @@ object AttachmentFileService {
                             checkForDuplicateName(programId, fn, none).asEitherT
                         }
               uuid   <- UUIDGen[F].randomUUID.right
-              path    = filePath(programId, uuid, fn.value)
+              path    = Services.asSuperUser(filePath(programId, uuid, fn.value))
             } yield (fn, path)
           ).value
           .flatTap {
@@ -341,7 +342,7 @@ object AttachmentFileService {
           }.asEitherT
           .flatMap((fn, path) =>
             for {
-              size   <- s3FileSvc.upload(path, data).right
+              size   <- Services.asSuperUser(s3FileSvc.upload(path, data)).right
               _      <- checkForEmptyFile(size).liftF
               result <- insertAttachmentInDB(programId,
                                              attachmentType,
@@ -372,7 +373,7 @@ object AttachmentFileService {
                 } yield (pid, oldPath)
               }
             uuid           <- UUIDGen[F].randomUUID.right
-            newPath         = filePath(pid, uuid, fn.value)
+            newPath         = Services.asSuperUser(filePath(pid, uuid, fn.value))
           } yield (fn, pid, oldPath, newPath)
         ).value
         .flatTap {
@@ -382,7 +383,7 @@ object AttachmentFileService {
         }.asEitherT
         .flatMap((fn, pid, oldPath, newPath) =>
           for {
-            size    <- s3FileSvc.upload(newPath, data).right
+            size    <- Services.asSuperUser(s3FileSvc.upload(newPath, data)).right
             _       <- checkForEmptyFile(size).liftF
             _       <- updateAttachmentInDB(pid,
                                             attachmentId,
@@ -391,7 +392,7 @@ object AttachmentFileService {
                                             size,
                                             newPath
                         ).asEitherT
-            _       <- s3FileSvc.delete(oldPath).right
+            _       <- Services.asSuperUser(s3FileSvc.delete(oldPath)).right
           } yield ()
         )
         .value
@@ -410,7 +411,7 @@ object AttachmentFileService {
           res  <-
             // We'll trap errors from the remote delete because, although not ideal, we don't
             // care so much if an orphan file is left on S3. The error will have been put in the trace.
-            s3FileSvc.delete(path).handleError { case _ => () }.right
+            Services.asSuperUser(s3FileSvc.delete(path)).handleError { case _ => () }.right
         } yield res).value
 
       def getPresignedUrl(user: User, attachmentId: Attachment.Id)(using
@@ -420,7 +421,7 @@ object AttachmentFileService {
           path <- services.transactionallyEitherT {
                       getAttachmentInfoAndCheckAccess(user, attachmentId).map(_._2)
                   }
-          res  <- s3FileSvc.presignedUrl(path).right
+          res  <- Services.asSuperUser(s3FileSvc.presignedUrl(path)).right
         } yield res).value
 
     }

--- a/modules/service/src/main/scala/lucuma/odb/service/AttachmentMetadataService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AttachmentMetadataService.scala
@@ -19,6 +19,7 @@ import skunk.codec.all.*
 import skunk.implicits.*
 
 import Services.Syntax.*
+import lucuma.odb.service.Services.SuperUserAccess
 
 trait AttachmentMetadataService [F[_]] {
 
@@ -26,7 +27,7 @@ trait AttachmentMetadataService [F[_]] {
     input: AccessControl.Checked[AttachmentPropertiesInput.Edit]
   )(using Transaction[F]): F[Result[List[Attachment.Id]]]
 
-  def getUpdatedAt(aids: NonEmptyList[Attachment.Id])(using NoTransaction[F]): F[Map[Attachment.Id, Timestamp]]
+  def getUpdatedAt(aids: NonEmptyList[Attachment.Id])(using NoTransaction[F], SuperUserAccess): F[Map[Attachment.Id, Timestamp]]
 }
 
 object AttachmentMetadataService {
@@ -45,7 +46,7 @@ object AttachmentMetadataService {
           }.map(Result.success)
 
       // Called by other services, no access validation is performed.
-      def getUpdatedAt(aids: NonEmptyList[Attachment.Id])(using NoTransaction[F]): F[Map[Attachment.Id, Timestamp]] =
+      def getUpdatedAt(aids: NonEmptyList[Attachment.Id])(using NoTransaction[F], SuperUserAccess): F[Map[Attachment.Id, Timestamp]] =
         val uniqueIds = aids.distinct
         session.execute(Statements.getUpdatedAt(uniqueIds))(uniqueIds.toList).map(_.toMap)
     }

--- a/modules/service/src/main/scala/lucuma/odb/service/AttachmentMetadataService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AttachmentMetadataService.scala
@@ -12,6 +12,7 @@ import lucuma.core.util.Timestamp
 import lucuma.odb.data.Nullable
 import lucuma.odb.graphql.input.AttachmentPropertiesInput
 import lucuma.odb.graphql.mapping.AccessControl
+import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
 import natchez.Trace
 import skunk.*
@@ -19,7 +20,6 @@ import skunk.codec.all.*
 import skunk.implicits.*
 
 import Services.Syntax.*
-import lucuma.odb.service.Services.SuperUserAccess
 
 trait AttachmentMetadataService [F[_]] {
 

--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -406,7 +406,8 @@ object CalibrationsService extends CalibrationObservations {
           o    <- session.execute(Statements.selectCalibrationTimeAndConf)(oid).map(_.headOption)
           // Find the original target
           otgs <- o.map(_._1).map { oid =>
-                    asterismService.getAsterism(pid, oid).map(_.map(_._1))
+                    Services.asSuperUser:
+                      asterismService.getAsterism(pid, oid).map(_.map(_._1))
                   }.getOrElse(List.empty.pure[F])
           // Select a new target
           tgts <- o match {

--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -299,7 +299,7 @@ object CalibrationsService extends CalibrationObservations {
       private def removeUnnecessaryCalibrations(
         scienceConfigs: List[CalibrationConfigSubset],
         calibrations:   List[(Observation.Id, CalibrationConfigSubset)]
-      )(using Transaction[F]): F[List[Observation.Id]] = {
+      )(using Transaction[F], ServiceAccess): F[List[Observation.Id]] = {
         val oids = NonEmptyList.fromList(
           calibrations
             .collect { case (oid, c) if !scienceConfigs.exists(_ === c) => oid }

--- a/modules/service/src/main/scala/lucuma/odb/service/EmailService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/EmailService.scala
@@ -26,6 +26,7 @@ import skunk.Transaction
 import skunk.implicits.*
 
 import Services.Syntax.*
+import lucuma.odb.service.Services.SuperUserAccess
 
 trait EmailService[F[_]] {
   def send(
@@ -35,7 +36,7 @@ trait EmailService[F[_]] {
     subject: NonEmptyString,
     textMessage: NonEmptyString,
     htmlMessage: Option[NonEmptyString]
-  )(using Transaction[F]): F[Result[EmailId]]
+  )(using Transaction[F], SuperUserAccess): F[Result[EmailId]]
 }
 
 object EmailService {
@@ -57,7 +58,7 @@ object EmailService {
         subject: NonEmptyString,
         textMessage: NonEmptyString,
         htmlMessage: Option[NonEmptyString]
-      )(using Transaction[F]): F[Result[EmailId]] = {
+      )(using Transaction[F], SuperUserAccess): F[Result[EmailId]] = {
 
         def insertEmail(emailId: EmailId): F[Result[Unit]] = {
           val af = Statements.insertEmail(emailId, programId, from, to, subject, textMessage, htmlMessage)

--- a/modules/service/src/main/scala/lucuma/odb/service/EmailService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/EmailService.scala
@@ -16,6 +16,7 @@ import lucuma.odb.Config
 import lucuma.odb.data.EmailId
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
+import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
 import org.http4s.*
 import org.http4s.circe.CirceEntityCodec.*
@@ -26,7 +27,6 @@ import skunk.Transaction
 import skunk.implicits.*
 
 import Services.Syntax.*
-import lucuma.odb.service.Services.SuperUserAccess
 
 trait EmailService[F[_]] {
   def send(

--- a/modules/service/src/main/scala/lucuma/odb/service/EmailWebhookService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/EmailWebhookService.scala
@@ -12,16 +12,17 @@ import lucuma.odb.util.Codecs.*
 import skunk.AppliedFragment
 import skunk.Session
 import skunk.implicits.*
+import lucuma.odb.service.Services.SuperUserAccess
 
 trait EmailWebhookService[F[Unit]] {
   
-  def updateStatus(emailId: EmailId, status: EmailStatus, timestamp: Timestamp): F[Unit]
+  def updateStatus(emailId: EmailId, status: EmailStatus, timestamp: Timestamp)(using SuperUserAccess): F[Unit]
 }
 
 object EmailWebhookService:
   def fromSession[F[_]: MonadCancelThrow](session: Session[F]): EmailWebhookService[F] = 
     new EmailWebhookService[F]:
-      override def updateStatus(emailId: EmailId, status: EmailStatus, timestamp: Timestamp): F[Unit] =
+      override def updateStatus(emailId: EmailId, status: EmailStatus, timestamp: Timestamp)(using SuperUserAccess): F[Unit] =
         val af = Statements.updateStatus(emailId, status, timestamp)
     
         session.prepareR(af.fragment.command)

--- a/modules/service/src/main/scala/lucuma/odb/service/EmailWebhookService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/EmailWebhookService.scala
@@ -8,11 +8,11 @@ import cats.syntax.all.*
 import lucuma.core.enums.EmailStatus
 import lucuma.core.util.Timestamp
 import lucuma.odb.data.EmailId
+import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
 import skunk.AppliedFragment
 import skunk.Session
 import skunk.implicits.*
-import lucuma.odb.service.Services.SuperUserAccess
 
 trait EmailWebhookService[F[Unit]] {
   

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -163,7 +163,7 @@ object GeneratorParamsService {
         for
           paramsRows <- params
           oms         = paramsRows.collect { case ParamsRow(oid, _, _, _, Some(om), _, _, _, _, _, _, _) => (oid, om) }.distinct
-          m          <- observingModeServices.selectObservingMode(oms)
+          m          <- Services.asSuperUser(observingModeServices.selectObservingMode(oms))
         yield
           NonEmptyList.fromList(paramsRows).fold(Map.empty): paramsRowsNel =>
             ObsParams.fromParamsRows(paramsRowsNel).map: (obsId, obsParams) =>

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -207,7 +207,7 @@ object GeneratorParamsService {
       private def addCustomSedTimestamps(params: List[ParamsRow]): F[List[ParamsRow]] =
         NonEmptyList.fromList(params.map(p => p.sourceProfile.flatMap(customSedIdOptional.getOption)).flattenOption)
           .fold(params.pure)(attIds =>
-            attachmentMetadataService.getUpdatedAt(attIds).map(map =>
+            Services.asSuperUser(attachmentMetadataService.getUpdatedAt(attIds)).map(map =>
               params.map(p =>  
                 val aid = p.sourceProfile.flatMap(customSedIdOptional.getOption)
                 aid.fold(p)(id => p.copy(customSedTimestamp = map.get(id)))

--- a/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
@@ -67,6 +67,7 @@ import lucuma.odb.sequence.gmos
 import lucuma.odb.sequence.syntax.hash.*
 import lucuma.odb.sequence.util.CommitHash
 import lucuma.odb.sequence.util.HashBytes
+import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
 import natchez.Trace
 import org.http4s.Header
@@ -90,19 +91,19 @@ trait GuideService[F[_]] {
   import GuideService.GuideEnvironment
 
   def getObjectTracking(pid: Program.Id, oid: Observation.Id)(using
-    NoTransaction[F]
+    NoTransaction[F], SuperUserAccess
   ): F[Result[ObjectTracking]]
 
   def getGuideEnvironments(pid: Program.Id, oid: Observation.Id, obsTime: Timestamp)(using
-    NoTransaction[F]
+    NoTransaction[F], SuperUserAccess
   ): F[Result[List[GuideEnvironment]]]
 
   def getGuideEnvironment(pid: Program.Id, oid: Observation.Id)(using
-    NoTransaction[F]
+    NoTransaction[F], SuperUserAccess
   ): F[Result[GuideEnvironment]]
 
   def getGuideAvailability(pid: Program.Id, oid: Observation.Id, period: TimestampInterval)(using
-    NoTransaction[F]
+    NoTransaction[F], SuperUserAccess
   ): F[Result[List[AvailabilityPeriod]]]
 
   // def setGuideTargetName(input: SetGuideTargetNameInput)(
@@ -113,7 +114,7 @@ trait GuideService[F[_]] {
   )(using NoTransaction[F]): F[Result[Observation.Id]]
 
   def getGuideTargetName(pid: Program.Id, oid: Observation.Id)(using
-    NoTransaction[F]
+    NoTransaction[F], SuperUserAccess
   ): F[Result[Option[NonEmptyString]]]
 }
 
@@ -296,7 +297,7 @@ object GuideService {
     new GuideService[F] {
 
       def getAsterism(pid: Program.Id, oid: Observation.Id)(using
-        NoTransaction[F]
+        NoTransaction[F], SuperUserAccess
       ): F[Result[NonEmptyList[Target]]] =
         asterismService
           .getAsterism(pid, oid)
@@ -610,7 +611,7 @@ object GuideService {
         genInfo:         GeneratorInfo,
         currentAvail:    ContiguousTimestampMap[List[Angle]],
         newHash:         Md5Hash
-      ): F[Result[ContiguousTimestampMap[List[Angle]]]] =
+      )(using SuperUserAccess): F[Result[ContiguousTimestampMap[List[Angle]]]] =
         (for {
           asterism     <- ResultT(getAsterism(pid, obsInfo.id))
           tracking      = ObjectTracking.fromAsterism(asterism)
@@ -747,7 +748,7 @@ object GuideService {
         name.toGaiaSourceId.toResult(generalError(s"Invalid guide star name `$name`").asProblem)
 
       override def getObjectTracking(pid: Program.Id, oid: Observation.Id)(using
-        NoTransaction[F]
+        NoTransaction[F], SuperUserAccess
       ): F[Result[ObjectTracking]] =
         (for {
           obsInfo       <- ResultT(getObservationInfo(oid))
@@ -765,7 +766,7 @@ object GuideService {
         obsDuration: TimeSpan,
         scienceTime: Timestamp,
         scienceDuration: TimeSpan
-      ): F[Result[GuideEnvironment]] =
+      )(using SuperUserAccess): F[Result[GuideEnvironment]] =
         // If we got here, we either have the name but need to get all the details (they queried for more
         // than name), or the name wasn't set or wasn't valid and we need to find all the candidates and
         // select the best.
@@ -819,7 +820,7 @@ object GuideService {
         } yield env).value
 
       override def getGuideEnvironment(pid: Program.Id, oid: Observation.Id)(
-        using NoTransaction[F]
+        using NoTransaction[F], SuperUserAccess
       ): F[Result[GuideEnvironment]] =
         Trace[F].span("getGuideEnvironment"):
           (for {
@@ -835,7 +836,7 @@ object GuideService {
           } yield result).value
 
       override def getGuideTargetName(pid: Program.Id, oid: Observation.Id)(
-        using NoTransaction[F]
+        using NoTransaction[F], SuperUserAccess
       ): F[Result[Option[NonEmptyString]]] =
         (for {
           obsInfo    <- ResultT(getObservationInfo(oid))
@@ -849,7 +850,7 @@ object GuideService {
 
       // TODO: This can go away when Navigate is ready.
       override def getGuideEnvironments(pid: Program.Id, oid: Observation.Id, obsTime: Timestamp)(
-        using NoTransaction[F]
+        using NoTransaction[F], SuperUserAccess
       ): F[Result[List[GuideEnvironment]]] =
         (for {
           obsInfo       <- ResultT(getObservationInfo(oid))
@@ -887,7 +888,7 @@ object GuideService {
         } yield usable.toGuideEnvironments.toList).value
 
       override def getGuideAvailability(pid: Program.Id, oid: Observation.Id, period: TimestampInterval)(
-        using NoTransaction[F]
+        using NoTransaction[F], SuperUserAccess
       ): F[Result[List[AvailabilityPeriod]]] =
         Trace[F].span("getGuideAvailability"):
           (for {

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -66,6 +66,7 @@ import lucuma.odb.graphql.input.SpectroscopyScienceRequirementsInput
 import lucuma.odb.graphql.input.TargetEnvironmentInput
 import lucuma.odb.graphql.input.TimingWindowInput
 import lucuma.odb.graphql.mapping.AccessControl
+import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
 import natchez.Trace
 import skunk.*
@@ -213,7 +214,7 @@ object ObservationService {
       private def setTimingWindows(
         oids:          List[Observation.Id],
         timingWindows: Option[List[TimingWindowInput]],
-      )(using Transaction[F]): F[Result[Unit]] =
+      )(using Transaction[F], SuperUserAccess): F[Result[Unit]] =
         timingWindows
           .traverse(timingWindowService.createFunction)
           .map { optF =>
@@ -224,7 +225,7 @@ object ObservationService {
       private def createObservationImpl(
         programId: Program.Id,
         SET:       ObservationPropertiesInput.Create
-      )(using Transaction[F]): F[Result[Observation.Id]] =
+      )(using Transaction[F], SuperUserAccess): F[Result[Observation.Id]] =
         Trace[F].span("createObservation") {
           session.execute(sql"set constraints all deferred".command) >>
           session.prepareR(GroupService.Statements.OpenHole).use(_.unique(programId, SET.group, SET.groupIndex)).flatMap { ix =>
@@ -242,7 +243,7 @@ object ObservationService {
 
                 }
               }.flatTap { rOid =>
-                rOid.flatTraverse { oid => setTimingWindows(List(oid), SET.timingWindows) }
+                rOid.flatTraverse { oid => Services.asSuperUser(setTimingWindows(List(oid), SET.timingWindows)) }
               }.flatMap { rOid =>
                 SET.attachments.fold(rOid.pure[F]) { aids =>
                   rOid.flatTraverse { oid =>
@@ -297,7 +298,7 @@ object ObservationService {
         input.foldWithId(
           OdbError.InvalidArgument().asFailureF // typically handled by caller
         ): (SET, pid) =>
-          ResultT(createObservationImpl(pid, SET))
+          ResultT(Services.asSuperUser(createObservationImpl(pid, SET)))
             .flatMap: oid =>
               SET
                 .asterism
@@ -407,7 +408,7 @@ object ObservationService {
                 u  = g.values.reduceOption(_ ++ _).flatMap(NonEmptyList.fromList)  // ungrouped: NonEmptyList[Observation.Id]
                 _ <- validateBand(g.keys.toList)
                 _ <- ResultT(u.map(u => updateObservingModes(SET.observingMode, u)).getOrElse(Result.unit.pure[F]))
-                _ <- ResultT(setTimingWindows(u.foldMap(_.toList), SET.timingWindows.foldPresent(_.orEmpty)))
+                _ <- ResultT(Services.asSuperUser(setTimingWindows(u.foldMap(_.toList), SET.timingWindows.foldPresent(_.orEmpty))))
                 _ <- ResultT(g.toList.traverse { case (pid, oids) =>
                       obsAttachmentAssignmentService.setAssignments(pid, oids, SET.attachments)
                     }.map(_.sequence))
@@ -475,10 +476,11 @@ object ObservationService {
               case Some(oid2) =>
 
                 val cloneRelatedItems =
-                  asterismService.cloneAsterism(observationId, oid2) >>
-                  observingMode.traverse(observingModeServices.cloneFunction(_)(observationId, oid2)) >>
-                  timingWindowService.cloneTimingWindows(observationId, oid2) >>
-                  obsAttachmentAssignmentService.cloneAssignments(observationId, oid2)
+                  Services.asSuperUser:
+                    asterismService.cloneAsterism(observationId, oid2) >>
+                    observingMode.traverse(observingModeServices.cloneFunction(_)(observationId, oid2)) >>
+                    timingWindowService.cloneTimingWindows(observationId, oid2) >>
+                    obsAttachmentAssignmentService.cloneAssignments(observationId, oid2)
 
                 val doUpdate =
                   SET match

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -300,7 +300,9 @@ object ObservationService {
               SET
                 .asterism
                 .traverse: a =>
-                  ResultT(asterismService.insertAsterism(pid, NonEmptyList.one(oid), a))
+                  ResultT:
+                    Services.asSuperUser:
+                      asterismService.insertAsterism(pid, NonEmptyList.one(oid), a)
                 .as(oid)
             .value
             .flatTap: r =>
@@ -506,9 +508,10 @@ object ObservationService {
         input.foldWithId(OdbError.InvalidArgument().asFailureF): (oSET, origOid) =>
           cloneObservationImpl(origOid, oSET).flatMap: res =>
             res.flatTraverse: (pid, newOid) =>
-              asterismService
-                .setAsterism(pid, NonEmptyList.of(newOid), oSET.fold(Nullable.Absent)(_.asterism))
-                .map(_.as(CloneIds(origOid, newOid)))
+              Services.asSuperUser:
+                asterismService
+                  .setAsterism(pid, NonEmptyList.of(newOid), oSET.fold(Nullable.Absent)(_.asterism))
+                  .map(_.as(CloneIds(origOid, newOid)))
 
       override def resetAcquisition(
         input: AccessControl.CheckedWithId[Unit, Observation.Id]

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -391,7 +391,10 @@ object ObservationService {
         Trace[F].span("updateObservation") {
           update.fold(Result(Map.empty).pure[F]): (SET, which) =>
             def validateBand(pids: => List[Program.Id]): ResultT[F, Unit] =
-              SET.scienceBand.toOption.fold(ResultT.unit)(band => ResultT(allocationService.validateBand(band, pids)))
+              SET.scienceBand.toOption.fold(ResultT.unit): band => 
+                ResultT:
+                  Services.asSuperUser:
+                    allocationService.validateBand(band, pids)
 
             val updates: ResultT[F, Map[Program.Id, List[Observation.Id]]] =
               for {

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -66,6 +66,7 @@ import lucuma.odb.graphql.input.SpectroscopyScienceRequirementsInput
 import lucuma.odb.graphql.input.TargetEnvironmentInput
 import lucuma.odb.graphql.input.TimingWindowInput
 import lucuma.odb.graphql.mapping.AccessControl
+import lucuma.odb.service.Services.ServiceAccess
 import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
 import natchez.Trace
@@ -83,15 +84,11 @@ sealed trait ObservationService[F[_]] {
   def resolveOid(
     oid: Option[Observation.Id],
     ref: Option[ObservationReference]
-  ): F[Result[Observation.Id]]
+  )(using SuperUserAccess): F[Result[Observation.Id]]
 
   def createObservation(
     input: AccessControl.CheckedWithId[ObservationPropertiesInput.Create, Program.Id]
   )(using Transaction[F]): F[Result[Observation.Id]]
-
-  def selectObservingModes(
-    which: List[Observation.Id]
-  )(using Transaction[F]): F[Map[Option[ObservingModeType], List[Observation.Id]]]
 
   def updateObservations(
     update: AccessControl.Checked[ObservationPropertiesInput.Edit]
@@ -107,7 +104,7 @@ sealed trait ObservationService[F[_]] {
 
   def deleteCalibrationObservations(
     oids: NonEmptyList[Observation.Id]
-  )(using Transaction[F]): F[Result[Unit]]
+  )(using Transaction[F], ServiceAccess): F[Result[Unit]]
 
   def resetAcquisition(
     input: AccessControl.CheckedWithId[Unit, Observation.Id]
@@ -208,7 +205,7 @@ object ObservationService {
       override def resolveOid(
         oid: Option[Observation.Id],
         ref: Option[ObservationReference]
-      ): F[Result[Observation.Id]] =
+      )(using SuperUserAccess): F[Result[Observation.Id]] =
         resolver.resolve(oid, ref)
 
       private def setTimingWindows(
@@ -263,7 +260,7 @@ object ObservationService {
       // It assumes the imple case where the observation has no extra timing windows or attachments
       def deleteCalibrationObservations(
         oids: NonEmptyList[Observation.Id]
-      )(using Transaction[F]): F[Result[Unit]] = {
+      )(using Transaction[F], ServiceAccess): F[Result[Unit]] = {
         val existenceOff = ObservationPropertiesInput.Edit.Empty.copy(
           existence = Existence.Deleted.some,
           group     = Nullable.Null
@@ -309,7 +306,7 @@ object ObservationService {
             .flatTap: r =>
               transaction.rollback.unlessA(r.hasValue)
 
-      override def selectObservingModes(
+      def selectObservingModes(
         which: List[Observation.Id]
       )(using Transaction[F]): F[Map[Option[ObservingModeType], List[Observation.Id]]] =
         NonEmptyList

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -336,7 +336,7 @@ object ObservationService {
       private def updateObservingModes(
         nEdit: Nullable[ObservingModeInput.Edit],
         oids:  NonEmptyList[Observation.Id],
-      )(using Transaction[F]): F[Result[Unit]] =
+      )(using Transaction[F], SuperUserAccess): F[Result[Unit]] =
 
         nEdit.toOptionOption.fold(Result.unit.pure[F]) { oEdit =>
           for {
@@ -407,7 +407,7 @@ object ObservationService {
                 g  = r.groupMap(_._1)(_._2)                                        // grouped:   Map[Program.Id, List[Observation.Id]]
                 u  = g.values.reduceOption(_ ++ _).flatMap(NonEmptyList.fromList)  // ungrouped: NonEmptyList[Observation.Id]
                 _ <- validateBand(g.keys.toList)
-                _ <- ResultT(u.map(u => updateObservingModes(SET.observingMode, u)).getOrElse(Result.unit.pure[F]))
+                _ <- ResultT(u.map(u => Services.asSuperUser(updateObservingModes(SET.observingMode, u))).getOrElse(Result.unit.pure[F]))
                 _ <- ResultT(Services.asSuperUser(setTimingWindows(u.foldMap(_.toList), SET.timingWindows.foldPresent(_.orEmpty))))
                 _ <- ResultT(g.toList.traverse { case (pid, oids) =>
                       obsAttachmentAssignmentService.setAssignments(pid, oids, SET.attachments)

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -39,6 +39,7 @@ import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.data.Tag
 import lucuma.odb.graphql.enums.Enums
+import lucuma.odb.graphql.mapping.AccessControl
 import lucuma.odb.logic.TimeEstimateCalculatorImplementation
 import lucuma.odb.sequence.data.GeneratorParams
 import lucuma.odb.sequence.data.MissingParamSet
@@ -80,8 +81,7 @@ sealed trait ObservationWorkflowService[F[_]] {
   )(using NoTransaction[F], SuperUserAccess): F[Result[Map[Observation.Id, ObservationWorkflow]]]
 
   def setWorkflowState(
-    oid: Observation.Id,
-    state: ObservationWorkflowState,
+    input: AccessControl.CheckedWithId[(ObservationWorkflow, ObservationWorkflowState), Observation.Id],
     commitHash: CommitHash,
     itcClient: ItcClient[F],
     ptc: TimeEstimateCalculatorImplementation.ForInstrumentMode
@@ -551,18 +551,14 @@ object ObservationWorkflowService {
           .flatMap(getWorkflows(_, commitHash, itcClient, ptc))
 
       override def setWorkflowState(
-        oid: Observation.Id,
-        state: ObservationWorkflowState,
+        input: AccessControl.CheckedWithId[(ObservationWorkflow, ObservationWorkflowState), Observation.Id],
         commitHash: CommitHash,
         itcClient: ItcClient[F],
         ptc: TimeEstimateCalculatorImplementation.ForInstrumentMode
       )(using NoTransaction[F]): F[Result[ObservationWorkflow]] =
-        ResultT(Services.asSuperUser(getWorkflows(List(oid), commitHash, itcClient, ptc)))
-          .map(_(oid))
-          .flatMap: w =>
+        input.foldWithId(OdbError.InvalidArgument().asFailureF): 
+          case ((w, state), oid) =>
             if w.state === state then ResultT.success(w)
-            else if !w.validTransitions.contains(state)
-            then ResultT.failure(OdbError.InvalidWorkflowTransition(w.state, state).asProblem)
             else ResultT: 
               // If we're transitioning to or from a UserState, just update that column
               if w.state.isUserState || state.isUserState then

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservingModeServices.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservingModeServices.scala
@@ -13,6 +13,7 @@ import lucuma.core.model.Observation
 import lucuma.core.model.SourceProfile
 import lucuma.odb.graphql.input.ObservingModeInput
 import lucuma.odb.sequence.ObservingMode
+import lucuma.odb.service.Services.SuperUserAccess
 import skunk.Transaction
 
 import Services.Syntax.*
@@ -21,27 +22,27 @@ sealed trait ObservingModeServices[F[_]] {
 
   def selectObservingMode(
     which: List[(Observation.Id, ObservingModeType)]
-  )(using Transaction[F]): F[Map[Observation.Id, SourceProfile => ObservingMode]]
+  )(using Transaction[F], SuperUserAccess): F[Map[Observation.Id, SourceProfile => ObservingMode]]
 
   def createFunction(
     input: ObservingModeInput.Create
-  ): Result[(List[Observation.Id], Transaction[F]) => F[Unit]]
+  )(using SuperUserAccess): Result[(List[Observation.Id], Transaction[F]) => F[Unit]]
 
   def deleteFunction(
     mode: ObservingModeType
-  ): (List[Observation.Id], Transaction[F]) => F[Unit]
+  )(using SuperUserAccess): (List[Observation.Id], Transaction[F]) => F[Unit]
 
   def updateFunction(
     input: ObservingModeInput.Edit
-  ): Result[(List[Observation.Id], Transaction[F]) => F[Unit]]
+  )(using SuperUserAccess): Result[(List[Observation.Id], Transaction[F]) => F[Unit]]
 
   def createViaUpdateFunction(
     input: ObservingModeInput.Edit
-  ): Result[(List[Observation.Id], Transaction[F]) => F[Unit]]
+  )(using SuperUserAccess): Result[(List[Observation.Id], Transaction[F]) => F[Unit]]
 
   def cloneFunction(
     mode: ObservingModeType
-  ): (Observation.Id, Observation.Id) => F[Unit]
+  )(using SuperUserAccess): (Observation.Id, Observation.Id) => F[Unit]
 
 }
 
@@ -52,7 +53,7 @@ object ObservingModeServices {
 
       override def selectObservingMode(
         which: List[(Observation.Id, ObservingModeType)]
-      )(using Transaction[F]): F[Map[Observation.Id, SourceProfile => ObservingMode]] = {
+      )(using Transaction[F], SuperUserAccess): F[Map[Observation.Id, SourceProfile => ObservingMode]] = {
         import ObservingModeType.*
 
         which.groupMap(_._2)(_._1).toList.traverse {
@@ -72,7 +73,7 @@ object ObservingModeServices {
 
       override def createFunction(
         input: ObservingModeInput.Create
-      ): Result[(List[Observation.Id], Transaction[F]) => F[Unit]] =
+      )(using SuperUserAccess): Result[(List[Observation.Id], Transaction[F]) => F[Unit]] =
         List(
           input.gmosNorthLongSlit.map(gmosLongSlitService.insertNorth),
           input.gmosSouthLongSlit.map(gmosLongSlitService.insertSouth)
@@ -84,7 +85,7 @@ object ObservingModeServices {
 
       override def deleteFunction(
         mode: ObservingModeType
-      ): (List[Observation.Id], Transaction[F]) => F[Unit] =
+      )(using SuperUserAccess): (List[Observation.Id], Transaction[F]) => F[Unit] =
         mode match {
           case ObservingModeType.GmosNorthLongSlit  => gmosLongSlitService.deleteNorth
           case ObservingModeType.GmosSouthLongSlit  => gmosLongSlitService.deleteSouth
@@ -93,7 +94,7 @@ object ObservingModeServices {
 
       override def updateFunction(
         input: ObservingModeInput.Edit
-      ): Result[(List[Observation.Id], Transaction[F]) => F[Unit]] =
+      )(using SuperUserAccess): Result[(List[Observation.Id], Transaction[F]) => F[Unit]] =
         List(
           input.gmosNorthLongSlit.map(gmosLongSlitService.updateNorth),
           input.gmosSouthLongSlit.map(gmosLongSlitService.updateSouth)
@@ -105,7 +106,7 @@ object ObservingModeServices {
 
       override def createViaUpdateFunction(
         input: ObservingModeInput.Edit
-      ): Result[(List[Observation.Id], Transaction[F]) => F[Unit]] =
+      )(using SuperUserAccess): Result[(List[Observation.Id], Transaction[F]) => F[Unit]] =
         List(
           input.gmosNorthLongSlit.map(m => m.toCreate.map(gmosLongSlitService.insertNorth)),
           input.gmosSouthLongSlit.map(m => m.toCreate.map(gmosLongSlitService.insertSouth))
@@ -117,7 +118,7 @@ object ObservingModeServices {
 
       override def cloneFunction(
         mode: ObservingModeType
-      ): (Observation.Id, Observation.Id) => F[Unit] =
+      )(using SuperUserAccess): (Observation.Id, Observation.Id) => F[Unit] =
         mode match {
           case ObservingModeType.GmosNorthLongSlit  => gmosLongSlitService.cloneNorth
           case ObservingModeType.GmosSouthLongSlit  => gmosLongSlitService.cloneSouth

--- a/modules/service/src/main/scala/lucuma/odb/service/PartnerSplitsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/PartnerSplitsService.scala
@@ -9,6 +9,7 @@ import cats.syntax.all.*
 import lucuma.core.enums.Partner
 import lucuma.core.model.IntPercent
 import lucuma.core.model.Program
+import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
 import natchez.Trace
 import skunk.*
@@ -18,9 +19,9 @@ import Services.Syntax.*
 
 private[service] trait PartnerSplitsService[F[_]] {
 
-    def insertSplits(splits: Map[Partner, IntPercent], pid: Program.Id)(using Transaction[F]): F[Unit]
+    def insertSplits(splits: Map[Partner, IntPercent], pid: Program.Id)(using Transaction[F], SuperUserAccess): F[Unit]
 
-    def updateSplits(splits: Map[Partner, IntPercent], pid: Program.Id)(using Transaction[F]): F[Unit]
+    def updateSplits(splits: Map[Partner, IntPercent], pid: Program.Id)(using Transaction[F], SuperUserAccess): F[Unit]
 
 }
 
@@ -33,12 +34,12 @@ object PartnerSplitsService {
   def instantiate[F[_]: Concurrent: Trace](using Services[F]): PartnerSplitsService[F] =
     new PartnerSplitsService[F] {
 
-      def insertSplits(splits: Map[Partner, IntPercent], pid: Program.Id)(using Transaction[F]): F[Unit] =
+      def insertSplits(splits: Map[Partner, IntPercent], pid: Program.Id)(using Transaction[F], SuperUserAccess): F[Unit] =
         NonEmptyList.fromList(splits.toList).traverse_ { lst =>
           session.prepareR(Statements.insertSplits(lst)).use(_.execute(pid, lst)).void
         }
 
-      def updateSplits(splits: Map[Partner, IntPercent], pid: Program.Id)(using Transaction[F]): F[Unit] =
+      def updateSplits(splits: Map[Partner, IntPercent], pid: Program.Id)(using Transaction[F], SuperUserAccess): F[Unit] =
         for {
           _ <- deleteSplits(pid)
           _ <- insertSplits(splits, pid)

--- a/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
@@ -300,7 +300,8 @@ object ProposalService {
 
         val insertSplits: ResultT[F, Unit] =
           ResultT.liftF(
-            partnerSplitsService.insertSplits(input.SET.typeʹ.partnerSplits, input.programId)
+            Services.asSuperUser:
+              partnerSplitsService.insertSplits(input.SET.typeʹ.partnerSplits, input.programId)
           )
 
         (for {
@@ -352,7 +353,8 @@ object ProposalService {
 
         def updateSplits(pid: Program.Id, set: ProposalPropertiesInput.Edit): ResultT[F, Unit] =
           ResultT.liftF(Nullable.orAbsent(set.typeʹ).flatMap(_.partnerSplits).foldPresent( splits =>
-            partnerSplitsService.updateSplits(splits.getOrElse(Map.empty), pid)
+            Services.asSuperUser:
+              partnerSplitsService.updateSplits(splits.getOrElse(Map.empty), pid)
           ).sequence.void)
 
         (for {

--- a/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
@@ -51,14 +51,6 @@ import Services.Syntax.*
 
 trait SequenceService[F[_]] {
 
-  // def selectGmosNorthStepRecords(
-  //   observationId: Observation.Id
-  // ): Stream[F, StepRecord[GmosNorth]]
-
-  // def selectGmosSouthStepRecords(
-  //   observationId: Observation.Id
-  // ): Stream[F, StepRecord[GmosSouth]]
-
   def abandonAtomsAndStepsForObservation(
     observationId: Observation.Id
   )(using Transaction[F], Services.ServiceAccess): F[Unit]
@@ -147,16 +139,6 @@ object SequenceService {
 
   def instantiate[F[_]: Concurrent: UUIDGen](using Services[F]): SequenceService[F] =
     new SequenceService[F] {
-
-      // override def selectGmosNorthStepRecords(
-      //   observationId: Observation.Id
-      // ): Stream[F, StepRecord[GmosNorth]] =
-      //   gmosSequenceService.selectGmosNorthStepRecords(observationId)
-
-      // override def selectGmosSouthStepRecords(
-      //   observationId: Observation.Id
-      // ): Stream[F, StepRecord[GmosSouth]] =
-      //   gmosSequenceService.selectGmosSouthStepRecords(observationId)
 
       /**
        * We'll need to estimate the cost of executing the next step.  For that

--- a/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
@@ -16,7 +16,6 @@ import cats.syntax.foldable.*
 import cats.syntax.functor.*
 import cats.syntax.option.*
 import cats.syntax.traverse.*
-import fs2.Stream
 import grackle.Result
 import lucuma.core.enums.AtomStage
 import lucuma.core.enums.Instrument
@@ -52,13 +51,13 @@ import Services.Syntax.*
 
 trait SequenceService[F[_]] {
 
-  def selectGmosNorthStepRecords(
-    observationId: Observation.Id
-  ): Stream[F, StepRecord[GmosNorth]]
+  // def selectGmosNorthStepRecords(
+  //   observationId: Observation.Id
+  // ): Stream[F, StepRecord[GmosNorth]]
 
-  def selectGmosSouthStepRecords(
-    observationId: Observation.Id
-  ): Stream[F, StepRecord[GmosSouth]]
+  // def selectGmosSouthStepRecords(
+  //   observationId: Observation.Id
+  // ): Stream[F, StepRecord[GmosSouth]]
 
   def abandonAtomsAndStepsForObservation(
     observationId: Observation.Id
@@ -78,7 +77,7 @@ trait SequenceService[F[_]] {
     stepId: Step.Id,
     stage:  StepStage,
     time:   Timestamp
-  )(using Transaction[F]): F[Unit]
+  )(using Transaction[F], Services.ServiceAccess): F[Unit]
 
   def abandonOngoingStepsExcept(
     observationId: Observation.Id,
@@ -149,15 +148,15 @@ object SequenceService {
   def instantiate[F[_]: Concurrent: UUIDGen](using Services[F]): SequenceService[F] =
     new SequenceService[F] {
 
-      override def selectGmosNorthStepRecords(
-        observationId: Observation.Id
-      ): Stream[F, StepRecord[GmosNorth]] =
-        gmosSequenceService.selectGmosNorthStepRecords(observationId)
+      // override def selectGmosNorthStepRecords(
+      //   observationId: Observation.Id
+      // ): Stream[F, StepRecord[GmosNorth]] =
+      //   gmosSequenceService.selectGmosNorthStepRecords(observationId)
 
-      override def selectGmosSouthStepRecords(
-        observationId: Observation.Id
-      ): Stream[F, StepRecord[GmosSouth]] =
-        gmosSequenceService.selectGmosSouthStepRecords(observationId)
+      // override def selectGmosSouthStepRecords(
+      //   observationId: Observation.Id
+      // ): Stream[F, StepRecord[GmosSouth]] =
+      //   gmosSequenceService.selectGmosSouthStepRecords(observationId)
 
       /**
        * We'll need to estimate the cost of executing the next step.  For that
@@ -237,7 +236,7 @@ object SequenceService {
         stepId: Step.Id,
         stage:  StepStage,
         time:   Timestamp
-      )(using Transaction[F]): F[Unit] = {
+      )(using Transaction[F], Services.ServiceAccess): F[Unit] = {
         val state = stage match {
           case StepStage.EndStep => StepExecutionState.Completed
           case StepStage.Abort   => StepExecutionState.Aborted

--- a/modules/service/src/main/scala/lucuma/odb/service/Services.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/Services.scala
@@ -206,6 +206,9 @@ object Services:
   opaque type ServiceAccess   <: AdminAccess = Unit
   opaque type SuperUserAccess <: ServiceAccess = Unit
 
+  // You're always at least a guest
+  given GuestAccess = ()
+
   def asSuperUser[A](f: SuperUserAccess ?=> A): A =
     f(using ())
 

--- a/modules/service/src/main/scala/lucuma/odb/service/SmartGcalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SmartGcalService.scala
@@ -32,6 +32,8 @@ import lucuma.core.model.sequence.f2.F2DynamicConfig as Flamingos2
 import lucuma.core.model.sequence.gmos.DynamicConfig.GmosNorth
 import lucuma.core.model.sequence.gmos.DynamicConfig.GmosSouth
 import lucuma.core.util.TimeSpan
+import lucuma.odb.service.Services.GuestAccess
+import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.smartgcal.data.Flamingos2.TableKey as Flamingos2SearchKey
 import lucuma.odb.smartgcal.data.Flamingos2.TableRow as Flamingos2TableRow
 import lucuma.odb.smartgcal.data.Gmos.SearchKey.North as GmosNorthSearchKey
@@ -63,7 +65,7 @@ trait SmartGcalService[F[_]] {
   def selectGmosNorth(
     gn:  GmosNorthSearchKey,
     sgt: SmartGcalType
-  ): F[List[(GmosNorth => GmosNorth, Gcal)]]
+  )(using GuestAccess): F[List[(GmosNorth => GmosNorth, Gcal)]]
 
   /**
    * Selects calibration information corresponding to the given search key and
@@ -79,7 +81,7 @@ trait SmartGcalService[F[_]] {
   def selectGmosSouth(
     gn:  GmosSouthSearchKey,
     sgt: SmartGcalType
-  ): F[List[(GmosSouth => GmosSouth, Gcal)]]
+  )(using GuestAccess): F[List[(GmosSouth => GmosSouth, Gcal)]]
 
   /**
    * Selects calibration information corresponding to the given search key and
@@ -95,24 +97,24 @@ trait SmartGcalService[F[_]] {
   def selectFlamingos2(
     f2:  Flamingos2SearchKey,
     sgt: SmartGcalType
-  ): F[List[(Flamingos2 => Flamingos2, Gcal)]]
+  )(using GuestAccess): F[List[(Flamingos2 => Flamingos2, Gcal)]]
 
   // N.B. Insertion is done by a flyway migration and not via this method.  The
   // insert here is intended for initializing a database for testing.
   def insertGmosNorth(
     id:  Int,
     row: GmosNorthTableRow
-  ): F[Unit]
+  )(using SuperUserAccess): F[Unit]
 
   def insertGmosSouth(
     id:  Int,
     row: GmosSouthTableRow
-  ): F[Unit]
+  )(using SuperUserAccess): F[Unit]
 
   def insertFlamingos2(
     id:  Int,
     row: Flamingos2TableRow
-  ): F[Unit]
+  )(using SuperUserAccess): F[Unit]
 }
 
 object SmartGcalService {
@@ -123,7 +125,7 @@ object SmartGcalService {
       override def selectGmosNorth(
         gn:  GmosNorthSearchKey,
         sgt: SmartGcalType
-      ): F[List[(GmosNorth => GmosNorth, Gcal)]] =
+      )(using GuestAccess): F[List[(GmosNorth => GmosNorth, Gcal)]] =
         selectGcal(Statements.selectGmosNorth(gn, sgt)) { exposureTime =>
           GmosNorth.exposure.replace(exposureTime)
         }
@@ -131,7 +133,7 @@ object SmartGcalService {
       override def selectGmosSouth(
         gs:  GmosSouthSearchKey,
         sgt: SmartGcalType
-      ): F[List[(GmosSouth => GmosSouth, Gcal)]] =
+      )(using GuestAccess): F[List[(GmosSouth => GmosSouth, Gcal)]] =
         selectGcal(Statements.selectGmosSouth(gs, sgt)) { exposureTime =>
           GmosSouth.exposure.replace(exposureTime)
         }
@@ -153,7 +155,7 @@ object SmartGcalService {
       def selectFlamingos2(
         f2:  Flamingos2SearchKey,
         sgt: SmartGcalType
-      ): F[List[(Flamingos2 => Flamingos2, Gcal)]] =
+      )(using GuestAccess): F[List[(Flamingos2 => Flamingos2, Gcal)]] =
         selectGcal(Statements.selectF2(f2, sgt)) { exposureTime =>
           Flamingos2.exposure.replace(exposureTime)
         }
@@ -161,7 +163,7 @@ object SmartGcalService {
       override def insertGmosNorth(
         id:  Int,
         row: GmosNorthTableRow
-      ): F[Unit] =
+      )(using SuperUserAccess): F[Unit] =
 
         val insertInstRow =
           session.executeCommand(
@@ -194,7 +196,7 @@ object SmartGcalService {
       override def insertGmosSouth(
         id:  Int,
         row: GmosSouthTableRow
-      ): F[Unit] =
+      )(using SuperUserAccess): F[Unit] =
 
         val insertInstRow =
           session.executeCommand(
@@ -227,7 +229,7 @@ object SmartGcalService {
       def insertFlamingos2(
         id:  Int,
         row: Flamingos2TableRow
-      ): F[Unit] =
+      )(using SuperUserAccess): F[Unit] =
         val insertGcalRow  =
           session.executeCommand(
             Statements.InsertGcal(

--- a/modules/service/src/main/scala/lucuma/odb/service/TimeAccountingService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TimeAccountingService.scala
@@ -37,6 +37,7 @@ import skunk.implicits.*
 import java.time.Duration
 
 import Services.Syntax.*
+import lucuma.odb.service.Services.SuperUserAccess
 
 
 trait TimeAccountingService[F[_]] {
@@ -46,7 +47,7 @@ trait TimeAccountingService[F[_]] {
    */
   def update(
     visitId: Visit.Id
-  )(using Transaction[F]): F[Unit]
+  )(using Transaction[F], Services.ServiceAccess): F[Unit]
 
   /**
    * Adds a manual time charge correction.
@@ -61,14 +62,14 @@ trait TimeAccountingService[F[_]] {
    */
   def selectObservation(
     observationId: Observation.Id
-  )(using Transaction[F]): F[Option[CategorizedTime]]
+  )(using Transaction[F], SuperUserAccess): F[Option[CategorizedTime]]
 
   /**
    * Sums the final time accounting result for all observations of a program.
    */
   def selectProgram(
     programId: Program.Id
-  )(using Transaction[F]): F[List[BandedTime]]
+  )(using Transaction[F], SuperUserAccess): F[List[BandedTime]]
 }
 
 object TimeAccountingService {
@@ -128,7 +129,7 @@ object TimeAccountingService {
 
       override def update(
         visitId: Visit.Id
-      )(using Transaction[F]): F[Unit] =
+      )(using Transaction[F], Services.ServiceAccess): F[Unit] =
         Update(visitId).run
 
       case class Update(visitId: Visit.Id)(using Transaction[F]) {
@@ -257,13 +258,13 @@ object TimeAccountingService {
 
       def selectObservation(
         observationId: Observation.Id
-      )(using Transaction[F]): F[Option[CategorizedTime]] =
+      )(using Transaction[F], SuperUserAccess): F[Option[CategorizedTime]] =
         session
           .option(SelectObservation)(observationId)
 
       def selectProgram(
         programId: Program.Id
-      )(using Transaction[F]): F[List[BandedTime]] =
+      )(using Transaction[F], SuperUserAccess): F[List[BandedTime]] =
         session
           .execute(SelectProgram)(programId)
 

--- a/modules/service/src/main/scala/lucuma/odb/service/TimeAccountingService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TimeAccountingService.scala
@@ -27,6 +27,7 @@ import lucuma.core.util.Timestamp
 import lucuma.core.util.TimestampInterval
 import lucuma.odb.data.TimeCharge
 import lucuma.odb.graphql.input.TimeChargeCorrectionInput
+import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
 import skunk.*
 import skunk.codec.numeric.int8
@@ -37,7 +38,6 @@ import skunk.implicits.*
 import java.time.Duration
 
 import Services.Syntax.*
-import lucuma.odb.service.Services.SuperUserAccess
 
 
 trait TimeAccountingService[F[_]] {

--- a/modules/service/src/main/scala/lucuma/odb/service/TimeService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TimeService.scala
@@ -8,6 +8,7 @@ import cats.syntax.functor.*
 import lucuma.core.enums.Site
 import lucuma.core.model.ObservingNight
 import lucuma.core.util.Timestamp
+import lucuma.odb.service.Services.GuestAccess
 import skunk.*
 import skunk.codec.temporal.timestamptz
 import skunk.implicits.*
@@ -22,22 +23,22 @@ trait TimeService[F[_]]:
   /**
    * The database time associated with the current transaction.
    */
-  def transactionTime(using Transaction[F]): F[Timestamp]
+  def transactionTime(using Transaction[F], GuestAccess): F[Timestamp]
 
   /**
    * The observing night associated with the site and transaction time.
    */
-  def currentObservingNight(site: Site)(using Transaction[F]): F[ObservingNight]
+  def currentObservingNight(site: Site)(using Transaction[F], GuestAccess): F[ObservingNight]
 
 object TimeService:
 
   def instantiate[F[_]: Concurrent](using Services[F]): TimeService[F] =
     new TimeService[F]:
 
-      override def transactionTime(using Transaction[F]): F[Timestamp] =
+      override def transactionTime(using Transaction[F], GuestAccess): F[Timestamp] =
         session.unique(Statements.TransactionTime)
 
-      override def currentObservingNight(site: Site)(using Transaction[F]): F[ObservingNight] =
+      override def currentObservingNight(site: Site)(using Transaction[F], GuestAccess): F[ObservingNight] =
         transactionTime.map(t => ObservingNight.fromSiteAndInstant(site, t.toInstant))
 
   object Statements:

--- a/modules/service/src/main/scala/lucuma/odb/service/TimingWindowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TimingWindowService.scala
@@ -8,6 +8,7 @@ import cats.syntax.all.*
 import grackle.Result
 import lucuma.core.model.Observation
 import lucuma.odb.graphql.input.TimingWindowInput
+import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
 import skunk.AppliedFragment
 import skunk.Transaction
@@ -19,12 +20,12 @@ import Services.Syntax.*
 trait TimingWindowService[F[_]] {
   def createFunction(
     timingWindows: List[TimingWindowInput]
-  ): Result[(List[Observation.Id], Transaction[F]) => F[Unit]]
+  )(using SuperUserAccess): Result[(List[Observation.Id], Transaction[F]) => F[Unit]]
 
   def cloneTimingWindows(
     originalId: Observation.Id,
     newId: Observation.Id,
-  )(using Transaction[F]): F[Unit]
+  )(using Transaction[F], SuperUserAccess): F[Unit]
 }
 
 object TimingWindowService:
@@ -37,7 +38,7 @@ object TimingWindowService:
 
       override def createFunction(
         timingWindows: List[TimingWindowInput]
-      ): Result[(List[Observation.Id], Transaction[F]) => F[Unit]] =
+      )(using SuperUserAccess): Result[(List[Observation.Id], Transaction[F]) => F[Unit]] =
         Result( (obsIds, _) =>
           exec(Statements.deleteObservationsTimingWindows(obsIds)) >>
             Statements.createObservationsTimingWindows(obsIds, timingWindows).fold(().pure[F])(exec)
@@ -46,7 +47,7 @@ object TimingWindowService:
       def cloneTimingWindows(
         originalId: Observation.Id,
         newId: Observation.Id,
-      )(using Transaction[F]): F[Unit] =
+      )(using Transaction[F], SuperUserAccess): F[Unit] =
         exec(Statements.clone(originalId, newId))
     }
 

--- a/modules/service/src/main/scala/lucuma/odb/service/UserInvitationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/UserInvitationService.scala
@@ -79,8 +79,9 @@ object UserInvitationService:
         )
 
         // A different message could be sent for html clients
-        emailService(emailConfig, httpClient)
-          .send(pid, emailConfig.invitationFrom, input.recipientEmail, subject, textMessage, none)
+        Services.asSuperUser:
+          emailService(emailConfig, httpClient)
+            .send(pid, emailConfig.invitationFrom, input.recipientEmail, subject, textMessage, none)
       }
 
       def updateEmailId(invitationId: UserInvitation.Id, emailId: EmailId): F[Result[Unit]] =

--- a/modules/service/src/main/scala/lucuma/odb/service/VisitService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/VisitService.scala
@@ -41,11 +41,11 @@ trait VisitService[F[_]]:
 
   def select(
     visitId: Visit.Id
-  ): F[Option[VisitRecord]]
+  )(using Services.ServiceAccess): F[Option[VisitRecord]]
 
   def selectAll(
     observationId: Observation.Id
-  ): Stream[F, VisitRecord]
+  )(using Services.ServiceAccess): Stream[F, VisitRecord]
 
   def lookupOrInsert(
     observationId: Observation.Id
@@ -88,12 +88,12 @@ object VisitService:
 
       override def select(
         visitId: Visit.Id
-      ): F[Option[VisitRecord]] =
+      )(using Services.ServiceAccess): F[Option[VisitRecord]] =
         session.option(Statements.SelectVisit)(visitId)
 
       override def selectAll(
         observationId: Observation.Id
-      ): Stream[F, VisitRecord] =
+      )(using Services.ServiceAccess): Stream[F, VisitRecord] =
         session.stream(VisitService.Statements.SelectAllVisit)(observationId, 1024)
 
       private def obsDescription(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
@@ -171,7 +171,8 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
       val services = Services.forUser(pi /* doesn't matter*/, e, None)(s)
       services.transactionally {
         tableRows.zipWithIndex.traverse_ { (r, i) =>
-          services.smartGcalService.insertGmosNorth(i, r)
+          Services.asSuperUser:
+            services.smartGcalService.insertGmosNorth(i, r)
         }
       }
     }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/smartgcal.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/smartgcal.scala
@@ -180,7 +180,8 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
           expTimeSec: Int              = 1,
           count:      Int              = 1
         ): IO[Unit] =
-          defineGmos(id, stepOrder, disperser, low, high, expTimeSec, count)(row, services.smartGcalService.insertGmosNorth)
+          Services.asSuperUser:
+            defineGmos(id, stepOrder, disperser, low, high, expTimeSec, count)(row, services.smartGcalService.insertGmosNorth)
 
         def defineGmosS(
           id:         Int,
@@ -192,7 +193,8 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
           expTimeSec: Int              = 1,
           count:      Int              = 1
         ): IO[Unit] =
-          defineGmos(id, stepOrder, disperser, low, high, expTimeSec, count)(row, services.smartGcalService.insertGmosSouth)
+          Services.asSuperUser:
+            defineGmos(id, stepOrder, disperser, low, high, expTimeSec, count)(row, services.smartGcalService.insertGmosSouth)
 
         def defineGmos[G, L, U](
           id:         Int,
@@ -243,7 +245,8 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
               _ <- Flamingos2.TableRow.stepCount       := PosInt.unsafeFrom(count)
             } yield ()
 
-          services.smartGcalService.insertFlamingos2(id, update.runS(tableRow).value)
+          Services.asSuperUser:
+            services.smartGcalService.insertFlamingos2(id, update.runS(tableRow).value)
         }
 
         for {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/timeAccounting.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/timeAccounting.scala
@@ -496,7 +496,7 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       v <- recordVisit(pi, service, mode, visitTime, 1, 1, 1, 100)
       es = events.map { (c, t) => SequenceEvent(EventId, t, v.oid, v.vid, c) }
       _ <- insertEvents(v.pid, es)
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
       _ <- expect(pi, invoiceQuery(v.oid), invoiceExected(invoice, Nil))
     } yield ()
 
@@ -527,7 +527,7 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       v <- recordVisit(pi, service, mode, visitTime, 1, 1, 1, 200)
       es = events.map { (c, t) => SequenceEvent(EventId, t, v.oid, v.vid, c) }
       _ <- insertEvents(v.pid, es)
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
       _ <- expect(pi, invoiceQuery(v.oid), invoiceExected(invoice, Nil))
     } yield ()
 
@@ -553,7 +553,7 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       v <- recordVisit(pi, service, mode, visitTime, 1, 0, 0, 250)
       es = events.map { (c, t) => SequenceEvent(EventId, t, v.oid, v.vid, c) }
       _ <- insertEvents(v.pid, es)
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
       _ <- expect(pi, invoiceQuery(v.oid), invoiceExected(invoice, Nil))
     } yield ()
 
@@ -606,7 +606,7 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       es = events(v)
       _ <- insertEvents(v.pid, es)
       _ <- updateDatasets(staff, DatasetQaState.Fail, v.atoms.last.steps.head.dids)
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
       _ <- expect(pi, invoiceQuery(v.oid), invoiceExected(invoice(v), Nil))
     } yield ()
 
@@ -631,7 +631,7 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       v <- recordVisit(pi, service, mode, visitTime, 1, 1, 1, index)
       es = events.map { (c, t) => SequenceEvent(EventId, t, v.oid, v.vid, c) }
       _ <- insertEvents(v.pid, es)
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
       _ <- corrections.traverse_ { c => addTimeChargeCorrection(staff, v.vid, c) }
       _ <- expect(pi, invoiceQuery(v.oid), invoiceExected(invoice, corrections))
     } yield ()
@@ -777,7 +777,7 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       v <- recordVisit(pi, service, mode, visitTime, 1, 1, 1, 1200)
       es = events.map { (c, t) => SequenceEvent(EventId, t, v.oid, v.vid, c) }
       _ <- insertEvents(v.pid, es)
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
       _ <- expect(pi, observationQuery(v.oid), observationExpectedCharge(expected))
     } yield ()
 
@@ -802,12 +802,12 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       oid = v0.oid
       es0 = events0.map { (c, t) => SequenceEvent(EventId, t, oid, v0.vid, c) }
       _ <- insertEvents(pid, es0)
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
 
       v1 <- recordVisitForObs(pid, oid, service, mode, t20, 1, 1, 1, 1301)
       es1 = events1.map { (c, t) => SequenceEvent(EventId, t, oid, v1.vid, c) }
       _ <- insertEvents(pid, es1)
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
 
       _ <- expect(pi, observationQuery(oid), observationExpectedCharge(expected))
     } yield ()
@@ -841,12 +841,12 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       oid = v0.oid
       es0 = events0.map { (c, t) => SequenceEvent(EventId, t, oid, v0.vid, c) }
       _ <- insertEvents(es0)
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
 
       v1 <- recordVisitForObs(pid, oid, service, mode, t2, 1, 1, 1, 1401)
       es1 = events1.map { (c, t) => SequenceEvent(EventId, t, oid, v1.vid, c) }
       _ <- insertEvents(es1)
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
       _ <- addTimeChargeCorrection(staff, v1.vid, correction)
 
       _ <- expect(pi, observationQuery(oid), observationExpectedCharge(expected))
@@ -901,7 +901,7 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       v <- recordVisit(pi, service, mode, visitTime, 1, 1, 1, 1500)
       es = events.map { (c, t) => SequenceEvent(EventId, t, v.oid, v.vid, c) }
       _ <- insertEvents(v.pid, es)
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v.vid)(using xa) } }
       _ <- expect(pi, programQuery(v.pid), programExpectedCharge(expected))
     } yield ()
   }
@@ -926,14 +926,14 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       oid0 = v0.oid
       es0  = events0.map { (c, t) => SequenceEvent(EventId, t, oid0, v0.vid, c) }
       _   <- insertEvents(pid, es0)
-      _   <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
+      _   <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
 
       // Obs1
       oid1 <- createObservationAs(pi, pid, mode.some)
       v1   <- recordVisitForObs(pid, oid1, service, mode, t20, 1, 1, 1, 1601)
       es1   = events1.map { (c, t) => SequenceEvent(EventId, t, oid1, v1.vid, c) }
       _    <- insertEvents(pid, es1)
-      _    <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
+      _    <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
 
       _ <- expect(pi, programQuery(pid), programExpectedCharge(expected))
     } yield ()
@@ -964,7 +964,7 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
 
       es0  = events0.map { (c, t) => SequenceEvent(EventId, t, oid0, v0.vid, c) }
       _   <- insertEvents(pid, es0)
-      _   <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
+      _   <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
 
       // Obs1
       oid1 <- createObservationAs(pi, pid, mode.some)
@@ -972,7 +972,7 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       v1   <- recordVisitForObs(pid, oid1, service, mode, t20, 1, 1, 1, 1701)
       es1   = events1.map { (c, t) => SequenceEvent(EventId, t, oid1, v1.vid, c) }
       _    <- insertEvents(pid, es1)
-      _    <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
+      _    <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
 
       _ <- expect(pi, programQuery(pid), programExpectedCharge(expected))
     } yield ()
@@ -1011,7 +1011,7 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
 
       es0  = events0.map { (c, t) => SequenceEvent(EventId, t, oid0, v0.vid, c) }
       _   <- insertEvents(pid, es0)
-      _   <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
+      _   <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
 
       // Obs1
       oid1 <- createObservationAs(pi, pid, mode.some)
@@ -1019,7 +1019,7 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       v1   <- recordVisitForObs(pid, oid1, service, mode, t20, 1, 1, 1, 1801)
       es1   = events1.map { (c, t) => SequenceEvent(EventId, t, oid1, v1.vid, c) }
       _    <- insertEvents(pid, es1)
-      _    <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
+      _    <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
 
       _ <- expect(pi, programQuery(pid), programExpectedCharge(expected))
     } yield ()
@@ -1069,8 +1069,8 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       e1  = events1.map { (c, t) => SequenceEvent(EventId, t, v1.oid, v1.vid, c) }
       _  <- insertEvents(v1.pid, e1)
 
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
 
       _ <- expect(pi, invoiceQuery(v0.oid), invoiceExected(invoice0(v1.oid), Nil))
       _ <- expect(pi, invoiceQuery(v1.oid), invoiceExected(invoice1, Nil))
@@ -1141,9 +1141,9 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       e2  = events2.map { (c, t) => SequenceEvent(EventId, t, v2.oid, v2.vid, c) }
       _  <- insertEvents(v2.pid, e2)
 
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v2.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v2.vid)(using xa) } }
 
       _ <- expect(pi, invoiceQuery(v0.oid), invoiceExected(invoice0(v1.oid), Nil))
       _ <- expect(pi, invoiceQuery(v1.oid), invoiceExected(invoice1(v2.oid), Nil))
@@ -1208,8 +1208,8 @@ class timeAccounting extends OdbSuite with DatabaseOperations { this: OdbSuite =
       e1  = events1.map { (c, t) => SequenceEvent(EventId, t, v1.oid, v1.vid, c) }
       _  <- insertEvents(v1.pid, e1)
 
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
-      _ <- withServices(pi) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v0.vid)(using xa) } }
+      _ <- withServices(service) { s => s.session.transaction use { xa => s.timeAccountingService.update(v1.vid)(using xa) } }
 
       _ <- expect(pi, invoiceQuery(v0.oid), invoiceExected(invoice0(v1.oid), Nil))
       _ <- expect(pi, invoiceQuery(v1.oid), invoiceExected(invoice1, Nil))

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEdit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEdit.scala
@@ -441,9 +441,9 @@ class observationEdit extends OdbSuite with SubscriptionUtils {
   }
 
   test("triggers for deleting a calibration observation") {
-    import Group1.pi
+    import Group1.{ pi, service }
     def deleteCalibrationObservation(oid: Observation.Id) =
-      withServices(pi) { services =>
+      withServices(service) { services =>
         services.session.transaction.use { xa =>
           services.observationService.deleteCalibrationObservations(NonEmptyList.one(oid))(using xa)
         }


### PR DESCRIPTION
This adds a few `Checked` implementations for service methods, but also marks a lot of service methods as requiring `SuperUserAccess`. The idea is:

- Service methods all need an access control indication in their types (either a `Checked` parameter or an `XxxAccess` token).
- Service methods that are invoked directly by GraphQL mutations generally need a `Checked` parameter.
- Service methods that are invoked only by other services can be marked as requiring `SuperUserAccess`, indicating to the caller that no further access control checks are going to happen.
- Service methods that are invoked in read mappings (i.e., their results are serialized back as JSON) are also marked as requiring `SuperUserAccess`; access control is provided here via predicates added during query elaboration.

Sorry for the length, it's mostly mechanical.