### PR TITLE
Update F2 spectroscopy modes

### DIFF
--- a/modules/phase0/src/main/resources/phase0/Phase0_Instrument_Matrix - Spectroscopy.tsv
+++ b/modules/phase0/src/main/resources/phase0/Phase0_Instrument_Matrix - Spectroscopy.tsv
@@ -62,13 +62,13 @@ GMOS-N	R831 1.0" CaT	singleslit,multislit	1.0"	1.000	330	R831	CaT	0.78	0.933	0.8
 GMOS-N	R831 1.5" CaT	singleslit,multislit	1.5"	1.500	330	R831	CaT	0.78	0.933	0.86	0.153	1465	no		n
 GMOS-N	R831 2.0" CaT	singleslit,multislit	2.0"	2.000	330	R831	CaT	0.78	0.933	0.86	0.153	1099	no		n
 GMOS-N	R831 5.0" CaT	singleslit,multislit	5.0"	5.000	330	R831	CaT	0.78	0.933	0.86	0.153	440	no		n
-GMOS-N	B480 0.25"	singleslit,multislit	0.25"	0.250	330	B480	none	0.36	0.72	0.422	0.39	3040	no		n
-GMOS-N	B480 0.50"	singleslit,multislit	0.50"	0.500	330	B480	none	0.36	0.72	0.422	0.39	1520	no		n
-GMOS-N	B480 0.75"	singleslit,multislit	0.75"	0.750	330	B480	none	0.36	0.72	0.422	0.39	1013	no		n
-GMOS-N	B480 1.0"	singleslit,multislit	1.0"	1.000	330	B480	none	0.36	0.72	0.422	0.39	760	no		n
-GMOS-N	B480 1.5"	singleslit,multislit	1.5"	1.500	330	B480	none	0.36	0.72	0.422	0.39	507	no		n
-GMOS-N	B480 2.0"	singleslit,multislit	2.0"	2.000	330	B480	none	0.36	0.72	0.422	0.39	380	no		n
-GMOS-N	B480 5.0"	singleslit,multislit	5.0"	5.000	330	B480	none	0.36	0.72	0.422	0.39	152	no		n
+GMOS-N	B480 0.25"	singleslit,multislit	0.25"	0.250	330	B480	none	0.36	0.72	0.422	0.36	3040	no		n
+GMOS-N	B480 0.50"	singleslit,multislit	0.50"	0.500	330	B480	none	0.36	0.72	0.422	0.36	1520	no		n
+GMOS-N	B480 0.75"	singleslit,multislit	0.75"	0.750	330	B480	none	0.36	0.72	0.422	0.36	1013	no		n
+GMOS-N	B480 1.0"	singleslit,multislit	1.0"	1.000	330	B480	none	0.36	0.72	0.422	0.36	760	no		n
+GMOS-N	B480 1.5"	singleslit,multislit	1.5"	1.500	330	B480	none	0.36	0.72	0.422	0.36	507	no		n
+GMOS-N	B480 2.0"	singleslit,multislit	2.0"	2.000	330	B480	none	0.36	0.72	0.422	0.36	380	no		n
+GMOS-N	B480 5.0"	singleslit,multislit	5.0"	5.000	330	B480	none	0.36	0.72	0.422	0.36	152	no		n
 GMOS-N	B480 0.25" GG455	singleslit,multislit	0.25"	0.250	330	B480	GG455	0.46	0.92	0.422	0.39	3040	no		n
 GMOS-N	B480 0.50" GG455	singleslit,multislit	0.50"	0.500	330	B480	GG455	0.46	0.92	0.422	0.39	1520	no		n
 GMOS-N	B480 0.75" GG455	singleslit,multislit	0.75"	0.750	330	B480	GG455	0.46	0.92	0.422	0.39	1013	no		n
@@ -90,20 +90,20 @@ GMOS-N	B480 1.0" RG610	singleslit,multislit	1.0"	1.000	330	B480	RG610	0.61	1.03	
 GMOS-N	B480 1.5" RG610	singleslit,multislit	1.5"	1.500	330	B480	RG610	0.61	1.03	0.422	0.39	507	no		n
 GMOS-N	B480 2.0" RG610	singleslit,multislit	2.0"	2.000	330	B480	RG610	0.61	1.03	0.422	0.39	380	no		n
 GMOS-N	B480 5.0" RG610	singleslit,multislit	5.0"	5.000	330	B480	RG610	0.61	1.03	0.422	0.39	152	no		n
-GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	none	0.36	0.72	0.764	0.472	3836	no		n
-GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	none	0.36	0.72	0.764	0.472	1918	no		n
-GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	none	0.36	0.72	0.764	0.472	1279	no		n
-GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	none	0.36	0.72	0.764	0.472	959	no		n
-GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	none	0.36	0.72	0.764	0.472	639	no		n
-GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	none	0.36	0.72	0.764	0.472	480	no		n
-GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	none	0.36	0.72	0.764	0.472	192	no		n
-GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	GG455	0.46	0.92	0.764	0.472	3836	no		n
-GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	GG455	0.46	0.92	0.764	0.472	1918	no		n
-GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	GG455	0.46	0.92	0.764	0.472	1279	no		n
-GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	GG455	0.46	0.92	0.764	0.472	959	no		n
-GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	GG455	0.46	0.92	0.764	0.472	639	no		n
-GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	GG455	0.46	0.92	0.764	0.472	480	no		n
-GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	GG455	0.46	0.92	0.764	0.472	192	no		n
+GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	none	0.36	0.72	0.764	0.36	3836	no		n
+GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	none	0.36	0.72	0.764	0.36	1918	no		n
+GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	none	0.36	0.72	0.764	0.36	1279	no		n
+GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	none	0.36	0.72	0.764	0.36	959	no		n
+GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	none	0.36	0.72	0.764	0.36	639	no		n
+GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	none	0.36	0.72	0.764	0.36	480	no		n
+GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	none	0.36	0.72	0.764	0.36	192	no		n
+GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	GG455	0.46	0.92	0.764	0.46	3836	no		n
+GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	GG455	0.46	0.92	0.764	0.46	1918	no		n
+GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	GG455	0.46	0.92	0.764	0.46	1279	no		n
+GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	GG455	0.46	0.92	0.764	0.46	959	no		n
+GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	GG455	0.46	0.92	0.764	0.46	639	no		n
+GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	GG455	0.46	0.92	0.764	0.46	480	no		n
+GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	GG455	0.46	0.92	0.764	0.46	192	no		n
 GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	OG515	0.52	1.03	0.764	0.472	3836	no		n
 GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	OG515	0.52	1.03	0.764	0.472	1918	no		n
 GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	OG515	0.52	1.03	0.764	0.472	1279	no		n
@@ -111,13 +111,13 @@ GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	OG515	0.52	1.03	0.764	
 GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	OG515	0.52	1.03	0.764	0.472	639	no		n
 GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	OG515	0.52	1.03	0.764	0.472	480	no		n
 GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	OG515	0.52	1.03	0.764	0.472	192	no		n
-GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	RG610	0.61	1.03	0.764	0.472	3836	no		n
-GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	RG610	0.61	1.03	0.764	0.472	1918	no		n
-GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	RG610	0.61	1.03	0.764	0.472	1279	no		n
-GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	RG610	0.61	1.03	0.764	0.472	959	no		n
-GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	RG610	0.61	1.03	0.764	0.472	639	no		n
-GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	RG610	0.61	1.03	0.764	0.472	480	no		n
-GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	RG610	0.61	1.03	0.764	0.472	192	no		n
+GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	RG610	0.61	1.03	0.764	0.42	3836	no		n
+GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	RG610	0.61	1.03	0.764	0.42	1918	no		n
+GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	RG610	0.61	1.03	0.764	0.42	1279	no		n
+GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	RG610	0.61	1.03	0.764	0.42	959	no		n
+GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	RG610	0.61	1.03	0.764	0.42	639	no		n
+GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	RG610	0.61	1.03	0.764	0.42	480	no		n
+GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	RG610	0.61	1.03	0.764	0.42	192	no		n
 GMOS-N	R400 0.25"	singleslit,multislit	0.25"	0.250	330	R400	CaT	0.78	0.933	0.86	0.153	3836	no		n
 GMOS-N	R400 0.50"	singleslit,multislit	0.50"	0.500	330	R400	CaT	0.78	0.933	0.86	0.153	1918	no		n
 GMOS-N	R400 0.75"	singleslit,multislit	0.75"	0.750	330	R400	CaT	0.78	0.933	0.86	0.153	1279	no		n
@@ -125,41 +125,41 @@ GMOS-N	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	CaT	0.78	0.933	0.86	0.
 GMOS-N	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	CaT	0.78	0.933	0.86	0.153	639	no		n
 GMOS-N	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	CaT	0.78	0.933	0.86	0.153	480	no		n
 GMOS-N	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	CaT	0.78	0.933	0.86	0.153	192	no		n
-GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	none	0.36	0.72	0.717	1.219	1262	no		n
-GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	none	0.36	0.72	0.717	1.219	631	no		n
-GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	none	0.36	0.72	0.717	1.219	421	no		n
-GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	none	0.36	0.72	0.717	1.219	316	no		n
-GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	none	0.36	0.72	0.717	1.219	210	no		n
-GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	none	0.36	0.72	0.717	1.219	158	no		n
-GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	none	0.36	0.72	0.717	1.219	63	no		n
-GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	GG455	0.46	0.92	0.717	1.219	1262	no		n
-GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	GG455	0.46	0.92	0.717	1.219	631	no		n
-GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	GG455	0.46	0.92	0.717	1.219	421	no		n
-GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	GG455	0.46	0.92	0.717	1.219	316	no		n
-GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	GG455	0.46	0.92	0.717	1.219	210	no		n
-GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	GG455	0.46	0.92	0.717	1.219	158	no		n
-GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	GG455	0.46	0.92	0.717	1.219	63	no		n
-GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	OG515	0.52	1.03	0.717	1.219	1262	no		n
-GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	OG515	0.52	1.03	0.717	1.219	631	no		n
-GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	OG515	0.52	1.03	0.717	1.219	421	no		n
-GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	OG515	0.52	1.03	0.717	1.219	316	no		n
-GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	OG515	0.52	1.03	0.717	1.219	210	no		n
-GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	OG515	0.52	1.03	0.717	1.219	158	no		n
-GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	OG515	0.52	1.03	0.717	1.219	63	no		n
-GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	RG610	0.61	1.03	0.717	1.219	1262	no		n
-GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	RG610	0.61	1.03	0.717	1.219	631	no		n
-GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	RG610	0.61	1.03	0.717	1.219	421	no		n
-GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	RG610	0.61	1.03	0.717	1.219	316	no		n
-GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	RG610	0.61	1.03	0.717	1.219	210	no		n
-GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	RG610	0.61	1.03	0.717	1.219	158	no		n
-GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	RG610	0.61	1.03	0.717	1.219	63	no		n
-GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	CaT	0.78	0.933	0.86	1.219	1262	no		n
-GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	CaT	0.78	0.933	0.86	1.219	631	no		n
-GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	CaT	0.78	0.933	0.86	1.219	421	no		n
-GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	CaT	0.78	0.933	0.86	1.219	316	no		n
-GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	CaT	0.78	0.933	0.86	1.219	210	no		n
-GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	CaT	0.78	0.933	0.86	1.219	158	no		n
-GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	CaT	0.78	0.933	0.86	1.219	63	no		n
+GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	none	0.36	0.72	0.717	0.36	1262	no		n
+GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	none	0.36	0.72	0.717	0.36	631	no		n
+GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	none	0.36	0.72	0.717	0.36	421	no		n
+GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	none	0.36	0.72	0.717	0.36	316	no		n
+GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	none	0.36	0.72	0.717	0.36	210	no		n
+GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	none	0.36	0.72	0.717	0.36	158	no		n
+GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	none	0.36	0.72	0.717	0.36	63	no		n
+GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	GG455	0.46	0.92	0.717	0.46	1262	no		n
+GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	GG455	0.46	0.92	0.717	0.46	631	no		n
+GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	GG455	0.46	0.92	0.717	0.46	421	no		n
+GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	GG455	0.46	0.92	0.717	0.46	316	no		n
+GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	GG455	0.46	0.92	0.717	0.46	210	no		n
+GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	GG455	0.46	0.92	0.717	0.46	158	no		n
+GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	GG455	0.46	0.92	0.717	0.46	63	no		n
+GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	OG515	0.52	1.03	0.717	0.51	1262	no		n
+GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	OG515	0.52	1.03	0.717	0.51	631	no		n
+GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	OG515	0.52	1.03	0.717	0.51	421	no		n
+GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	OG515	0.52	1.03	0.717	0.51	316	no		n
+GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	OG515	0.52	1.03	0.717	0.51	210	no		n
+GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	OG515	0.52	1.03	0.717	0.51	158	no		n
+GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	OG515	0.52	1.03	0.717	0.51	63	no		n
+GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	RG610	0.61	1.03	0.717	0.42	1262	no		n
+GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	RG610	0.61	1.03	0.717	0.42	631	no		n
+GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	RG610	0.61	1.03	0.717	0.42	421	no		n
+GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	RG610	0.61	1.03	0.717	0.42	316	no		n
+GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	RG610	0.61	1.03	0.717	0.42	210	no		n
+GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	RG610	0.61	1.03	0.717	0.42	158	no		n
+GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	RG610	0.61	1.03	0.717	0.42	63	no		n
+GMOS-N	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	CaT	0.78	0.933	0.86	0.153	1262	no		n
+GMOS-N	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	CaT	0.78	0.933	0.86	0.153	631	no		n
+GMOS-N	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	CaT	0.78	0.933	0.86	0.153	421	no		n
+GMOS-N	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	CaT	0.78	0.933	0.86	0.153	316	no		n
+GMOS-N	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	CaT	0.78	0.933	0.86	0.153	210	no		n
+GMOS-N	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	CaT	0.78	0.933	0.86	0.153	158	no		n
+GMOS-N	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	CaT	0.78	0.933	0.86	0.153	63	no		n
 GMOS-N	B480 IFU1	ifu	IFU-R	3	5	B480	none	0.36	1.03	0.461	0.317	2500	no		n
 GMOS-N	B480 IFU2	ifu	IFU-2	5	7	B480	g	0.398	0.552	0.461	0.154	2500	no		n
 GMOS-S	B1200 0.25"	singleslit,multislit	0.25"	0.250	330	B1200	none	0.36	0.72	0.463	0.159	7488	no		s
@@ -295,13 +295,13 @@ GMOS-S	R400 1.0"	singleslit,multislit	1.0"	1.000	330	R400	none	0.36	0.72	0.764	0
 GMOS-S	R400 1.5"	singleslit,multislit	1.5"	1.500	330	R400	none	0.36	0.72	0.764	0.462	639	no		s
 GMOS-S	R400 2.0"	singleslit,multislit	2.0"	2.000	330	R400	none	0.36	0.72	0.764	0.462	480	no		s
 GMOS-S	R400 5.0"	singleslit,multislit	5.0"	5.000	330	R400	none	0.36	0.72	0.764	0.462	192	no		s
-GMOS-S	R400 0.25"  GG455	singleslit,multislit	0.25"	0.250	330	R400	GG455	0.46	0.92	0.764	0.462	3836	no		s
-GMOS-S	R400 0.50"  GG455	singleslit,multislit	0.50"	0.500	330	R400	GG455	0.46	0.92	0.764	0.462	1918	no		s
-GMOS-S	R400 0.75"  GG455	singleslit,multislit	0.75"	0.750	330	R400	GG455	0.46	0.92	0.764	0.462	1279	no		s
-GMOS-S	R400 1.0"  GG455	singleslit,multislit	1.0"	1.000	330	R400	GG455	0.46	0.92	0.764	0.462	959	no		s
-GMOS-S	R400 1.5"  GG455	singleslit,multislit	1.5"	1.500	330	R400	GG455	0.46	0.92	0.764	0.462	639	no		s
-GMOS-S	R400 2.0"  GG455	singleslit,multislit	2.0"	2.000	330	R400	GG455	0.46	0.92	0.764	0.462	480	no		s
-GMOS-S	R400 5.0"  GG455	singleslit,multislit	5.0"	5.000	330	R400	GG455	0.46	0.92	0.764	0.462	192	no		s
+GMOS-S	R400 0.25"  GG455	singleslit,multislit	0.25"	0.250	330	R400	GG455	0.46	0.92	0.764	0.46	3836	no		s
+GMOS-S	R400 0.50"  GG455	singleslit,multislit	0.50"	0.500	330	R400	GG455	0.46	0.92	0.764	0.46	1918	no		s
+GMOS-S	R400 0.75"  GG455	singleslit,multislit	0.75"	0.750	330	R400	GG455	0.46	0.92	0.764	0.46	1279	no		s
+GMOS-S	R400 1.0"  GG455	singleslit,multislit	1.0"	1.000	330	R400	GG455	0.46	0.92	0.764	0.46	959	no		s
+GMOS-S	R400 1.5"  GG455	singleslit,multislit	1.5"	1.500	330	R400	GG455	0.46	0.92	0.764	0.46	639	no		s
+GMOS-S	R400 2.0"  GG455	singleslit,multislit	2.0"	2.000	330	R400	GG455	0.46	0.92	0.764	0.46	480	no		s
+GMOS-S	R400 5.0"  GG455	singleslit,multislit	5.0"	5.000	330	R400	GG455	0.46	0.92	0.764	0.46	192	no		s
 GMOS-S	R400 0.25" OG515	singleslit,multislit	0.25"	0.250	330	R400	OG515	0.52	1.03	0.764	0.462	3836	no		s
 GMOS-S	R400 0.50" OG515	singleslit,multislit	0.50"	0.500	330	R400	OG515	0.52	1.03	0.764	0.462	1918	no		s
 GMOS-S	R400 0.75" OG515	singleslit,multislit	0.75"	0.750	330	R400	OG515	0.52	1.03	0.764	0.462	1279	no		s
@@ -309,20 +309,20 @@ GMOS-S	R400 1.0" OG515	singleslit,multislit	1.0"	1.000	330	R400	OG515	0.52	1.03	
 GMOS-S	R400 1.5" OG515	singleslit,multislit	1.5"	1.500	330	R400	OG515	0.52	1.03	0.764	0.462	639	no		s
 GMOS-S	R400 2.0" OG515	singleslit,multislit	2.0"	2.000	330	R400	OG515	0.52	1.03	0.764	0.462	480	no		s
 GMOS-S	R400 5.0" OG515	singleslit,multislit	5.0"	5.000	330	R400	OG515	0.52	1.03	0.764	0.462	192	no		s
-GMOS-S	R400 0.25" RG610	singleslit,multislit	0.25"	0.250	330	R400	RG610	0.61	1.03	0.764	0.462	3836	no		s
-GMOS-S	R400 0.50" RG610	singleslit,multislit	0.50"	0.500	330	R400	RG610	0.61	1.03	0.764	0.462	1918	no		s
-GMOS-S	R400 0.75" RG610	singleslit,multislit	0.75"	0.750	330	R400	RG610	0.61	1.03	0.764	0.462	1279	no		s
-GMOS-S	R400 1.0" RG610	singleslit,multislit	1.0"	1.000	330	R400	RG610	0.61	1.03	0.764	0.462	959	no		s
-GMOS-S	R400 1.5" RG610	singleslit,multislit	1.5"	1.500	330	R400	RG610	0.61	1.03	0.764	0.462	639	no		s
-GMOS-S	R400 2.0" RG610	singleslit,multislit	2.0"	2.000	330	R400	RG610	0.61	1.03	0.764	0.462	480	no		s
-GMOS-S	R400 5.0" RG610	singleslit,multislit	5.0"	5.000	330	R400	RG610	0.61	1.03	0.764	0.462	192	no		s
-GMOS-S	R400 0.25" RG780	singleslit,multislit	0.25"	0.250	330	R400	RG780	0.78	1.03	0.764	0.462	3836	no		s
-GMOS-S	R400 0.50" RG780	singleslit,multislit	0.50"	0.500	330	R400	RG780	0.78	1.03	0.764	0.462	1918	no		s
-GMOS-S	R400 0.75" RG780	singleslit,multislit	0.75"	0.750	330	R400	RG780	0.78	1.03	0.764	0.462	1279	no		s
-GMOS-S	R400 1.0" RG780	singleslit,multislit	1.0"	1.000	330	R400	RG780	0.78	1.03	0.764	0.462	959	no		s
-GMOS-S	R400 1.5" RG780	singleslit,multislit	1.5"	1.500	330	R400	RG780	0.78	1.03	0.764	0.462	639	no		s
-GMOS-S	R400 2.0" RG780	singleslit,multislit	2.0"	2.000	330	R400	RG780	0.78	1.03	0.764	0.462	480	no		s
-GMOS-S	R400 5.0" RG780	singleslit,multislit	5.0"	5.000	330	R400	RG780	0.78	1.03	0.764	0.462	192	no		s
+GMOS-S	R400 0.25" RG610	singleslit,multislit	0.25"	0.250	330	R400	RG610	0.61	1.03	0.764	0.42	3836	no		s
+GMOS-S	R400 0.50" RG610	singleslit,multislit	0.50"	0.500	330	R400	RG610	0.61	1.03	0.764	0.42	1918	no		s
+GMOS-S	R400 0.75" RG610	singleslit,multislit	0.75"	0.750	330	R400	RG610	0.61	1.03	0.764	0.42	1279	no		s
+GMOS-S	R400 1.0" RG610	singleslit,multislit	1.0"	1.000	330	R400	RG610	0.61	1.03	0.764	0.42	959	no		s
+GMOS-S	R400 1.5" RG610	singleslit,multislit	1.5"	1.500	330	R400	RG610	0.61	1.03	0.764	0.42	639	no		s
+GMOS-S	R400 2.0" RG610	singleslit,multislit	2.0"	2.000	330	R400	RG610	0.61	1.03	0.764	0.42	480	no		s
+GMOS-S	R400 5.0" RG610	singleslit,multislit	5.0"	5.000	330	R400	RG610	0.61	1.03	0.764	0.42	192	no		s
+GMOS-S	R400 0.25" RG780	singleslit,multislit	0.25"	0.250	330	R400	RG780	0.78	1.03	0.764	0.25	3836	no		s
+GMOS-S	R400 0.50" RG780	singleslit,multislit	0.50"	0.500	330	R400	RG780	0.78	1.03	0.764	0.25	1918	no		s
+GMOS-S	R400 0.75" RG780	singleslit,multislit	0.75"	0.750	330	R400	RG780	0.78	1.03	0.764	0.25	1279	no		s
+GMOS-S	R400 1.0" RG780	singleslit,multislit	1.0"	1.000	330	R400	RG780	0.78	1.03	0.764	0.25	959	no		s
+GMOS-S	R400 1.5" RG780	singleslit,multislit	1.5"	1.500	330	R400	RG780	0.78	1.03	0.764	0.25	639	no		s
+GMOS-S	R400 2.0" RG780	singleslit,multislit	2.0"	2.000	330	R400	RG780	0.78	1.03	0.764	0.25	480	no		s
+GMOS-S	R400 5.0" RG780	singleslit,multislit	5.0"	5.000	330	R400	RG780	0.78	1.03	0.764	0.25	192	no		s
 GMOS-S	R400 0.25" CaT	singleslit,multislit	0.25"	0.250	330	R400	CaT	0.78	0.933	0.86	0.153	3836	no		s
 GMOS-S	R400 0.50" CaT	singleslit,multislit	0.50"	0.500	330	R400	CaT	0.78	0.933	0.86	0.153	1918	no		s
 GMOS-S	R400 0.75" CaT	singleslit,multislit	0.75"	0.750	330	R400	CaT	0.78	0.933	0.86	0.153	1279	no		s
@@ -330,41 +330,41 @@ GMOS-S	R400 1.0" CaT	singleslit,multislit	1.0"	1.000	330	R400	CaT	0.78	0.933	0.8
 GMOS-S	R400 1.5" CaT	singleslit,multislit	1.5"	1.500	330	R400	CaT	0.78	0.933	0.86	0.153	639	no		s
 GMOS-S	R400 2.0" CaT	singleslit,multislit	2.0"	2.000	330	R400	CaT	0.78	0.933	0.86	0.153	480	no		s
 GMOS-S	R400 5.0" CaT	singleslit,multislit	5.0"	5.000	330	R400	CaT	0.78	0.933	0.86	0.153	192	no		s
-GMOS-S	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	none	0.36	0.72	0.717	1.19	1262	no		s
-GMOS-S	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	none	0.36	0.72	0.717	1.19	631	no		s
-GMOS-S	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	none	0.36	0.72	0.717	1.19	421	no		s
-GMOS-S	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	none	0.36	0.72	0.717	1.19	316	no		s
-GMOS-S	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	none	0.36	0.72	0.717	1.19	210	no		s
-GMOS-S	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	none	0.36	0.72	0.717	1.19	158	no		s
-GMOS-S	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	none	0.36	0.72	0.717	1.19	63	no		s
-GMOS-S	R150 0.25"  GG455	singleslit,multislit	0.25"	0.250	330	R150	GG455	0.46	0.92	0.717	1.19	1262	no		s
-GMOS-S	R150 0.50"  GG455	singleslit,multislit	0.50"	0.500	330	R150	GG455	0.46	0.92	0.717	1.19	631	no		s
-GMOS-S	R150 0.75"  GG455	singleslit,multislit	0.75"	0.750	330	R150	GG455	0.46	0.92	0.717	1.19	421	no		s
-GMOS-S	R150 1.0"  GG455	singleslit,multislit	1.0"	1.000	330	R150	GG455	0.46	0.92	0.717	1.19	316	no		s
-GMOS-S	R150 1.5"  GG455	singleslit,multislit	1.5"	1.500	330	R150	GG455	0.46	0.92	0.717	1.19	210	no		s
-GMOS-S	R150 2.0"  GG455	singleslit,multislit	2.0"	2.000	330	R150	GG455	0.46	0.92	0.717	1.19	158	no		s
-GMOS-S	R150 5.0"  GG455	singleslit,multislit	5.0"	5.000	330	R150	GG455	0.46	0.92	0.717	1.19	63	no		s
-GMOS-S	R150 0.25" OG515	singleslit,multislit	0.25"	0.250	330	R150	OG515	0.52	1.03	0.717	1.19	1262	no		s
-GMOS-S	R150 0.50" OG515	singleslit,multislit	0.50"	0.500	330	R150	OG515	0.52	1.03	0.717	1.19	631	no		s
-GMOS-S	R150 0.75" OG515	singleslit,multislit	0.75"	0.750	330	R150	OG515	0.52	1.03	0.717	1.19	421	no		s
-GMOS-S	R150 1.0" OG515	singleslit,multislit	1.0"	1.000	330	R150	OG515	0.52	1.03	0.717	1.19	316	no		s
-GMOS-S	R150 1.5" OG515	singleslit,multislit	1.5"	1.500	330	R150	OG515	0.52	1.03	0.717	1.19	210	no		s
-GMOS-S	R150 2.0" OG515	singleslit,multislit	2.0"	2.000	330	R150	OG515	0.52	1.03	0.717	1.19	158	no		s
-GMOS-S	R150 5.0" OG515	singleslit,multislit	5.0"	5.000	330	R150	OG515	0.52	1.03	0.717	1.19	63	no		s
-GMOS-S	R150 0.25" RG610	singleslit,multislit	0.25"	0.250	330	R150	RG610	0.61	1.03	0.717	1.19	1262	no		s
-GMOS-S	R150 0.50" RG610	singleslit,multislit	0.50"	0.500	330	R150	RG610	0.61	1.03	0.717	1.19	631	no		s
-GMOS-S	R150 0.75" RG610	singleslit,multislit	0.75"	0.750	330	R150	RG610	0.61	1.03	0.717	1.19	421	no		s
-GMOS-S	R150 1.0" RG610	singleslit,multislit	1.0"	1.000	330	R150	RG610	0.61	1.03	0.717	1.19	316	no		s
-GMOS-S	R150 1.5" RG610	singleslit,multislit	1.5"	1.500	330	R150	RG610	0.61	1.03	0.717	1.19	210	no		s
-GMOS-S	R150 2.0" RG610	singleslit,multislit	2.0"	2.000	330	R150	RG610	0.61	1.03	0.717	1.19	158	no		s
-GMOS-S	R150 5.0" RG610	singleslit,multislit	5.0"	5.000	330	R150	RG610	0.61	1.03	0.717	1.19	63	no		s
-GMOS-S	R150 0.25" RG780	singleslit,multislit	0.25"	0.250	330	R150	RG780	0.78	1.03	0.717	1.19	1262	no		s
-GMOS-S	R150 0.50" RG780	singleslit,multislit	0.50"	0.500	330	R150	RG780	0.78	1.03	0.717	1.19	631	no		s
-GMOS-S	R150 0.75" RG780	singleslit,multislit	0.75"	0.750	330	R150	RG780	0.78	1.03	0.717	1.19	421	no		s
-GMOS-S	R150 1.0" RG780	singleslit,multislit	1.0"	1.000	330	R150	RG780	0.78	1.03	0.717	1.19	316	no		s
-GMOS-S	R150 1.5" RG780	singleslit,multislit	1.5"	1.500	330	R150	RG780	0.78	1.03	0.717	1.19	210	no		s
-GMOS-S	R150 2.0" RG780	singleslit,multislit	2.0"	2.000	330	R150	RG780	0.78	1.03	0.717	1.19	158	no		s
-GMOS-S	R150 5.0" RG780	singleslit,multislit	5.0"	5.000	330	R150	RG780	0.78	1.03	0.717	1.19	63	no		s
+GMOS-S	R150 0.25"	singleslit,multislit	0.25"	0.250	330	R150	none	0.36	0.72	0.717	0.36	1262	no		s
+GMOS-S	R150 0.50"	singleslit,multislit	0.50"	0.500	330	R150	none	0.36	0.72	0.717	0.36	631	no		s
+GMOS-S	R150 0.75"	singleslit,multislit	0.75"	0.750	330	R150	none	0.36	0.72	0.717	0.36	421	no		s
+GMOS-S	R150 1.0"	singleslit,multislit	1.0"	1.000	330	R150	none	0.36	0.72	0.717	0.36	316	no		s
+GMOS-S	R150 1.5"	singleslit,multislit	1.5"	1.500	330	R150	none	0.36	0.72	0.717	0.36	210	no		s
+GMOS-S	R150 2.0"	singleslit,multislit	2.0"	2.000	330	R150	none	0.36	0.72	0.717	0.36	158	no		s
+GMOS-S	R150 5.0"	singleslit,multislit	5.0"	5.000	330	R150	none	0.36	0.72	0.717	0.36	63	no		s
+GMOS-S	R150 0.25"  GG455	singleslit,multislit	0.25"	0.250	330	R150	GG455	0.46	0.92	0.717	0.46	1262	no		s
+GMOS-S	R150 0.50"  GG455	singleslit,multislit	0.50"	0.500	330	R150	GG455	0.46	0.92	0.717	0.46	631	no		s
+GMOS-S	R150 0.75"  GG455	singleslit,multislit	0.75"	0.750	330	R150	GG455	0.46	0.92	0.717	0.46	421	no		s
+GMOS-S	R150 1.0"  GG455	singleslit,multislit	1.0"	1.000	330	R150	GG455	0.46	0.92	0.717	0.46	316	no		s
+GMOS-S	R150 1.5"  GG455	singleslit,multislit	1.5"	1.500	330	R150	GG455	0.46	0.92	0.717	0.46	210	no		s
+GMOS-S	R150 2.0"  GG455	singleslit,multislit	2.0"	2.000	330	R150	GG455	0.46	0.92	0.717	0.46	158	no		s
+GMOS-S	R150 5.0"  GG455	singleslit,multislit	5.0"	5.000	330	R150	GG455	0.46	0.92	0.717	0.46	63	no		s
+GMOS-S	R150 0.25" OG515	singleslit,multislit	0.25"	0.250	330	R150	OG515	0.52	1.03	0.717	0.51	1262	no		s
+GMOS-S	R150 0.50" OG515	singleslit,multislit	0.50"	0.500	330	R150	OG515	0.52	1.03	0.717	0.51	631	no		s
+GMOS-S	R150 0.75" OG515	singleslit,multislit	0.75"	0.750	330	R150	OG515	0.52	1.03	0.717	0.51	421	no		s
+GMOS-S	R150 1.0" OG515	singleslit,multislit	1.0"	1.000	330	R150	OG515	0.52	1.03	0.717	0.51	316	no		s
+GMOS-S	R150 1.5" OG515	singleslit,multislit	1.5"	1.500	330	R150	OG515	0.52	1.03	0.717	0.51	210	no		s
+GMOS-S	R150 2.0" OG515	singleslit,multislit	2.0"	2.000	330	R150	OG515	0.52	1.03	0.717	0.51	158	no		s
+GMOS-S	R150 5.0" OG515	singleslit,multislit	5.0"	5.000	330	R150	OG515	0.52	1.03	0.717	0.51	63	no		s
+GMOS-S	R150 0.25" RG610	singleslit,multislit	0.25"	0.250	330	R150	RG610	0.61	1.03	0.717	0.42	1262	no		s
+GMOS-S	R150 0.50" RG610	singleslit,multislit	0.50"	0.500	330	R150	RG610	0.61	1.03	0.717	0.42	631	no		s
+GMOS-S	R150 0.75" RG610	singleslit,multislit	0.75"	0.750	330	R150	RG610	0.61	1.03	0.717	0.42	421	no		s
+GMOS-S	R150 1.0" RG610	singleslit,multislit	1.0"	1.000	330	R150	RG610	0.61	1.03	0.717	0.42	316	no		s
+GMOS-S	R150 1.5" RG610	singleslit,multislit	1.5"	1.500	330	R150	RG610	0.61	1.03	0.717	0.42	210	no		s
+GMOS-S	R150 2.0" RG610	singleslit,multislit	2.0"	2.000	330	R150	RG610	0.61	1.03	0.717	0.42	158	no		s
+GMOS-S	R150 5.0" RG610	singleslit,multislit	5.0"	5.000	330	R150	RG610	0.61	1.03	0.717	0.42	63	no		s
+GMOS-S	R150 0.25" RG780	singleslit,multislit	0.25"	0.250	330	R150	RG780	0.78	1.03	0.717	0.25	1262	no		s
+GMOS-S	R150 0.50" RG780	singleslit,multislit	0.50"	0.500	330	R150	RG780	0.78	1.03	0.717	0.25	631	no		s
+GMOS-S	R150 0.75" RG780	singleslit,multislit	0.75"	0.750	330	R150	RG780	0.78	1.03	0.717	0.25	421	no		s
+GMOS-S	R150 1.0" RG780	singleslit,multislit	1.0"	1.000	330	R150	RG780	0.78	1.03	0.717	0.25	316	no		s
+GMOS-S	R150 1.5" RG780	singleslit,multislit	1.5"	1.500	330	R150	RG780	0.78	1.03	0.717	0.25	210	no		s
+GMOS-S	R150 2.0" RG780	singleslit,multislit	2.0"	2.000	330	R150	RG780	0.78	1.03	0.717	0.25	158	no		s
+GMOS-S	R150 5.0" RG780	singleslit,multislit	5.0"	5.000	330	R150	RG780	0.78	1.03	0.717	0.25	63	no		s
 GMOS-S	R150 0.25" CaT	singleslit,multislit	0.25"	0.250	330	R150	CaT	0.78	0.933	0.86	0.153	1262	no		s
 GMOS-S	R150 0.50" CaT	singleslit,multislit	0.50"	0.500	330	R150	CaT	0.78	0.933	0.86	0.153	631	no		s
 GMOS-S	R150 0.75" CaT	singleslit,multislit	0.75"	0.750	330	R150	CaT	0.78	0.933	0.86	0.153	421	no		s
@@ -379,41 +379,60 @@ GMOS-S	B600 IFU2 NS	ifu	IFU-NS-2	5	7	B600	g	0.398	0.552	0.461	0.154	2723	no	Nod&
 GMOS-S	R150 NS1.0 GG455	singleslit,multislit	NS1.0"	1.000	330	R150	GG455	0.46	1.03	0.717	0.57	316	no	Nod&Shuffle	s
 GMOS-S	R150 NS1.0 OG515	singleslit,multislit	NS1.0"	1.000	330	R150	OG515	0.52	1.03	0.717	0.51	316	no	Nod&Shuffle	s
 GMOS-S	R831 NS1.0 CaT	singleslit,multislit	NS1.0"	1.000	330	R831	CaT	0.78	0.933	0.757	0.23	2198	no	Nod&Shuffle	s
-Flamingos2	R3K + J + 0.36"	singleslit,multislit	Long Slit 2px	0.360	263	R3000	J	1.175	1.333	1.254	0.158	2800	no		s
-Flamingos2	R3K + H + 0.36"	singleslit,multislit	Long Slit 2px	0.360	263	R3000	H	1.486	1.775	1.6305	0.289	2800	no		s
-Flamingos2	R3K + Ks + 0.36"	singleslit,multislit	Long Slit 2px	0.360	263	R3000	K-short	1.991	2.32	2.1555	0.329	2900	no		s
-Flamingos2	R3K + Kb + 0.36"	singleslit,multislit	Long Slit 2px	0.360	263	R3000	K-blue	1.934	2.177	2.0555	0.243	2900	no		s
-Flamingos2	R3K + Kr + 0.36"	singleslit,multislit	Long Slit 2px	0.360	263	R3000	K-red	2.181	2.446	2.3135	0.265	2900	no		s
-Flamingos2	JH 0.36"	singleslit,multislit	Long Slit 2px	0.360	263	R1200JH	JH	0.97	1.805	1.3875	0.835	900	no		s
-Flamingos2	HK 0.36"	singleslit,multislit	Long Slit 2px	0.360	263	R1200HK	HK	1.261	2.551	1.906	1.29	900	no		s
-Flamingos2	R3K + J + 0.36"	singleslit,multislit	Long Slit 3px	0.540	263	R3000	J	1.175	1.333	1.254	0.158	1867	no		s
-Flamingos2	R3K + H + 0.36"	singleslit,multislit	Long Slit 3px	0.540	263	R3000	H	1.486	1.775	1.6305	0.289	1867	no		s
-Flamingos2	R3K + Ks + 0.36"	singleslit,multislit	Long Slit 3px	0.540	263	R3000	K-short	1.991	2.32	2.1555	0.329	1933	no		s
-Flamingos2	R3K + Kb + 0.36"	singleslit,multislit	Long Slit 3px	0.540	263	R3000	K-blue	1.934	2.177	2.0555	0.243	1933	no		s
-Flamingos2	R3K + Kr + 0.36"	singleslit,multislit	Long Slit 3px	0.540	263	R3000	K-red	2.181	2.446	2.3135	0.265	1933	no		s
-Flamingos2	JH 0.36"	singleslit,multislit	Long Slit 3px	0.540	263	R1200JH	JH	0.97	1.805	1.3875	0.835	600	no		s
-Flamingos2	HK 0.36"	singleslit,multislit	Long Slit 3px	0.540	263	R1200HK	HK	1.261	2.551	1.906	1.29	600	no		s
-Flamingos2	R3K + J + 0.36"	singleslit,multislit	Long Slit 4px	0.720	263	R3000	J	1.175	1.333	1.254	0.158	1400	no		s
-Flamingos2	R3K + H + 0.36"	singleslit,multislit	Long Slit 4px	0.720	263	R3000	H	1.486	1.775	1.6305	0.289	1400	no		s
-Flamingos2	R3K + Ks + 0.36"	singleslit,multislit	Long Slit 4px	0.720	263	R3000	K-short	1.991	2.32	2.1555	0.329	1450	no		s
-Flamingos2	R3K + Kb + 0.36"	singleslit,multislit	Long Slit 4px	0.720	263	R3000	K-blue	1.934	2.177	2.0555	0.243	1450	no		s
-Flamingos2	R3K + Kr + 0.36"	singleslit,multislit	Long Slit 4px	0.720	263	R3000	K-red	2.181	2.446	2.3135	0.265	1450	no		s
-Flamingos2	JH 0.36"	singleslit,multislit	Long Slit 4px	0.720	263	R1200JH	JH	0.97	1.805	1.3875	0.835	450	no		s
-Flamingos2	HK 0.36"	singleslit,multislit	Long Slit 4px	0.720	263	R1200HK	HK	1.261	2.551	1.906	1.29	450	no		s
-Flamingos2	R3K + J + 0.36"	singleslit,multislit	Long Slit 6px	1.080	263	R3000	J	1.175	1.333	1.254	0.158	933	no		s
-Flamingos2	R3K + H + 0.36"	singleslit,multislit	Long Slit 6px	1.080	263	R3000	H	1.486	1.775	1.6305	0.289	933	no		s
-Flamingos2	R3K + Ks + 0.36"	singleslit,multislit	Long Slit 6px	1.080	263	R3000	K-short	1.991	2.32	2.1555	0.329	967	no		s
-Flamingos2	R3K + Kb + 0.36"	singleslit,multislit	Long Slit 6px	1.080	263	R3000	K-blue	1.934	2.177	2.0555	0.243	967	no		s
-Flamingos2	R3K + Kr + 0.36"	singleslit,multislit	Long Slit 6px	1.080	263	R3000	K-red	2.181	2.446	2.3135	0.265	967	no		s
-Flamingos2	JH 0.36"	singleslit,multislit	Long Slit 6px	1.080	263	R1200JH	JH	0.97	1.805	1.3875	0.835	300	no		s
-Flamingos2	HK 0.36"	singleslit,multislit	Long Slit 6px	1.080	263	R1200HK	HK	1.261	2.551	1.906	1.29	300	no		s
-Flamingos2	R3K + J + 0.36"	singleslit,multislit	Long Slit 8px	1.440	263	R3000	J	1.175	1.333	1.254	0.158	700	no		s
-Flamingos2	R3K + H + 0.36"	singleslit,multislit	Long Slit 8px	1.440	263	R3000	H	1.486	1.775	1.6305	0.289	700	no		s
-Flamingos2	R3K + Ks + 0.36"	singleslit,multislit	Long Slit 8px	1.440	263	R3000	K-short	1.991	2.32	2.1555	0.329	725	no		s
-Flamingos2	R3K + Kb + 0.36"	singleslit,multislit	Long Slit 8px	1.440	263	R3000	K-blue	1.934	2.177	2.0555	0.243	725	no		s
-Flamingos2	R3K + Kr + 0.36"	singleslit,multislit	Long Slit 8px	1.440	263	R3000	K-red	2.181	2.446	2.3135	0.265	725	no		s
-Flamingos2	JH 0.36"	singleslit,multislit	Long Slit 8px	1.440	263	R1200JH	JH	0.97	1.805	1.3875	0.835	225	no		s
-Flamingos2	HK 0.36"	singleslit,multislit	Long Slit 8px	1.440	263	R1200HK	HK	1.261	2.551	1.906	1.29	225	no		s
+FLAMINGOS2	R3K + Jlow + 0.18"	singleslit,multislit	1 pixel	0.18	263	R3000	J-low	1.048	1.192	1.12	0.144	3500	no		s
+FLAMINGOS2	R3K + J + 0.18"	singleslit,multislit	1 pixel	0.18	263	R3000	J	1.175	1.333	1.254	0.158	3500	no		s
+FLAMINGOS2	R3K + H + 0.18"	singleslit,multislit	1 pixel	0.18	263	R3000	H	1.486	1.775	1.6305	0.289	3600	no		s
+FLAMINGOS2	R3K + Ks + 0.18"	singleslit,multislit	1 pixel	0.18	263	R3000	K-short	1.991	2.32	2.1555	0.329	3600	no		s
+FLAMINGOS2	R3K + Kb + 0.18"	singleslit,multislit	1 pixel	0.18	263	R3000	K-blue	1.934	2.177	2.0555	0.243	3600	no		s
+FLAMINGOS2	R3K + Kr + 0.18"	singleslit,multislit	1 pixel	0.18	263	R3000	K-red	2.181	2.446	2.3135	0.265	3600	no		s
+FLAMINGOS2	R3K + Kl + 0.18"	singleslit,multislit	1 pixel	0.18	263	R3000	K-long	1.9	2.483	2.1915	0.583	3600	no		s
+FLAMINGOS2	JH 0.18"	singleslit,multislit	1 pixel	0.18	263	R1200JH	JH	0.97	1.805	1.3875	0.835	1300	no		s
+FLAMINGOS2	HK 0.18"	singleslit,multislit	1 pixel	0.18	263	R1200HK	HK	1.261	2.551	1.906	1.29	1300	no		s
+FLAMINGOS2	R3K + Jlow + 0.36"	singleslit,multislit	2pixel	0.36	263	R3000	J-low	1.048	1.192	1.12	0.144	2700	no		s
+FLAMINGOS2	R3K + J + 0.36"	singleslit,multislit	2pixel	0.36	263	R3000	J	1.175	1.333	1.254	0.158	2800	no		s
+FLAMINGOS2	R3K + H + 0.36"	singleslit,multislit	2pixel	0.36	263	R3000	H	1.486	1.775	1.6305	0.289	2800	no		s
+FLAMINGOS2	R3K + Ks + 0.36"	singleslit,multislit	2pixel	0.36	263	R3000	K-short	1.991	2.32	2.1555	0.329	2900	no		s
+FLAMINGOS2	R3K + Kb + 0.36"	singleslit,multislit	2pixel	0.36	263	R3000	K-blue	1.934	2.177	2.0555	0.243	2900	no		s
+FLAMINGOS2	R3K + Kr + 0.36"	singleslit,multislit	2pixel	0.36	263	R3000	K-red	2.181	2.446	2.3135	0.265	2900	no		s
+FLAMINGOS2	R3K + Kl + 0.36"	singleslit,multislit	2pixel	0.36	263	R3000	K-long	1.9	2.483	2.1915	0.583	2900	no		s
+FLAMINGOS2	JH + 0.36"	singleslit,multislit	2pixel	0.36	263	R1200JH	JH	0.97	1.805	1.3875	0.835	900	no		s
+FLAMINGOS2	HK + 0.36"	singleslit,multislit	2pixel	0.36	263	R1200HK	HK	1.261	2.551	1.906	1.29	900	no		s
+FLAMINGOS2	R3K + Jlow + 0.54"	singleslit,multislit	3pixel	0.54	263	R3000	J-low	1.048	1.192	1.12	0.144	1800	no		s
+FLAMINGOS2	R3K + J + 0.54"	singleslit,multislit	3pixel	0.54	263	R3000	J	1.175	1.333	1.254	0.158	1867	no		s
+FLAMINGOS2	R3K + H + 0.54"	singleslit,multislit	3pixel	0.54	263	R3000	H	1.486	1.775	1.6305	0.289	1867	no		s
+FLAMINGOS2	R3K + Ks + 0.54"	singleslit,multislit	3pixel	0.54	263	R3000	K-short	1.991	2.32	2.1555	0.329	1933	no		s
+FLAMINGOS2	R3K + Kb + 0.54"	singleslit,multislit	3pixel	0.54	263	R3000	K-blue	1.934	2.177	2.0555	0.243	1933	no		s
+FLAMINGOS2	R3K + Kr + 0.54"	singleslit,multislit	3pixel	0.54	263	R3000	K-red	2.181	2.446	2.3135	0.265	1933	no		s
+FLAMINGOS2	R3K + Kl + 0.54"	singleslit,multislit	3pixel	0.54	263	R3000	K-long	1.9	2.483	2.1915	0.583	1933	no		s
+FLAMINGOS2	JH + 0.54"	singleslit,multislit	3pixel	0.54	263	R1200JH	JH	0.97	1.805	1.3875	0.835	600	no		s
+FLAMINGOS2	HK + 0.54"	singleslit,multislit	3pixel	0.54	263	R1200HK	HK	1.261	2.551	1.906	1.29	600	no		s
+FLAMINGOS2	R3K + Jlow + 0.72"	singleslit,multislit	4pixel	0.72	263	R3000	J-low	1.048	1.192	1.12	0.144	1350	no		s
+FLAMINGOS2	R3K + J + 0.72"	singleslit,multislit	4pixel	0.72	263	R3000	J	1.175	1.333	1.254	0.158	1400	no		s
+FLAMINGOS2	R3K + H + 0.72"	singleslit,multislit	4pixel	0.72	263	R3000	H	1.486	1.775	1.6305	0.289	1400	no		s
+FLAMINGOS2	R3K + Ks + 0.72"	singleslit,multislit	4pixel	0.72	263	R3000	K-short	1.991	2.32	2.1555	0.329	1450	no		s
+FLAMINGOS2	R3K + Kb + 0.72"	singleslit,multislit	4pixel	0.72	263	R3000	K-blue	1.934	2.177	2.0555	0.243	1450	no		s
+FLAMINGOS2	R3K + Kr + 0.72"	singleslit,multislit	4pixel	0.72	263	R3000	K-red	2.181	2.446	2.3135	0.265	1450	no		s
+FLAMINGOS2	R3K + Kl + 0.72"	singleslit,multislit	4pixel	0.72	263	R3000	K-long	1.9	2.483	2.1915	0.583	1450	no		s
+FLAMINGOS2	JH + 0.72"	singleslit,multislit	4pixel	0.72	263	R1200JH	JH	0.97	1.805	1.3875	0.835	450	no		s
+FLAMINGOS2	HK + 0.72"	singleslit,multislit	4pixel	0.72	263	R1200HK	HK	1.261	2.551	1.906	1.29	450	no		s
+FLAMINGOS2	R3K + Jlow + 1.08"	singleslit,multislit	6pixel	1.08	263	R3000	J-low	1.048	1.192	1.12	0.144	900	no		s
+FLAMINGOS2	R3K + J + 1.08"	singleslit,multislit	6pixel	1.08	263	R3000	J	1.175	1.333	1.254	0.158	933	no		s
+FLAMINGOS2	R3K + H + 1.08"	singleslit,multislit	6pixel	1.08	263	R3000	H	1.486	1.775	1.6305	0.289	933	no		s
+FLAMINGOS2	R3K + Ks + 1.08"	singleslit,multislit	6pixel	1.08	263	R3000	K-short	1.991	2.32	2.1555	0.329	967	no		s
+FLAMINGOS2	R3K + Kb + 1.08"	singleslit,multislit	6pixel	1.08	263	R3000	K-blue	1.934	2.177	2.0555	0.243	967	no		s
+FLAMINGOS2	R3K + Kr + 1.08"	singleslit,multislit	6pixel	1.08	263	R3000	K-red	2.181	2.446	2.3135	0.265	967	no		s
+FLAMINGOS2	R3K + Kl + 1.08"	singleslit,multislit	6pixel	1.08	263	R3000	K-long	1.9	2.483	2.1915	0.583	967	no		s
+FLAMINGOS2	JH + 1.08"	singleslit,multislit	6pixel	1.08	263	R1200JH	JH	0.97	1.805	1.3875	0.835	300	no		s
+FLAMINGOS2	HK + 1.08"	singleslit,multislit	6pixel	1.08	263	R1200HK	HK	1.261	2.551	1.906	1.29	300	no		s
+FLAMINGOS2	R3K + Jlow + 1.44"	singleslit,multislit	8pixel	1.44	263	R3000	J-low	1.048	1.192	1.12	0.144	675	no		s
+FLAMINGOS2	R3K + J + 1.44"	singleslit,multislit	8pixel	1.44	263	R3000	J	1.175	1.333	1.254	0.158	700	no		s
+FLAMINGOS2	R3K + H + 1.44	singleslit,multislit	8pixel	1.44	263	R3000	H	1.486	1.775	1.6305	0.289	700	no		s
+FLAMINGOS2	R3K + Ks + 1.44"	singleslit,multislit	8pixel	1.44	263	R3000	K-short	1.991	2.32	2.1555	0.329	725	no		s
+FLAMINGOS2	R3K + Kb + 1.44"	singleslit,multislit	8pixel	1.44	263	R3000	K-blue	1.934	2.177	2.0555	0.243	725	no		s
+FLAMINGOS2	R3K + Kr + 1.44"	singleslit,multislit	8pixel	1.44	263	R3000	K-red	2.181	2.446	2.3135	0.265	725	no		s
+FLAMINGOS2	R3K + Kl + 1.44"	singleslit,multislit	8pixel	1.44	263	R3000	K-long	1.9	2.483	2.1915	0.583	725	no		s
+FLAMINGOS2	JH + 1.44"	singleslit,multislit	8pixel	1.44	263	R1200JH	JH	0.97	1.805	1.3875	0.835	225	no		s
+FLAMINGOS2	HK + 1.44"	singleslit,multislit	8pixel	1.44	263	R1200HK	HK	1.261	2.551	1.906	1.29	225	no		s
 GPI-2	Y	ifu	Coronagraph	0.156	2.8	Prism	Y	0.95	1.14	1.045	0.19	35	yes	coronagraph	s
 GPI-2	J	ifu	Coronagraph	0.184	2.8	Prism	J	1.12	1.35	1.235	0.23	36	yes	coronagraph	s
 GPI-2	H	ifu	Coronagraph	0.246	2.8	Prism	H	1.5	1.8	1.65	0.30	46	yes	coronagraph	s


### PR DESCRIPTION
I got a ping that the modes list had a bunch of new F2 modes
However, there are also changes to some existing modes
Would this break existing observations?