### PR TITLE
Shortcut 5608: instrument reference name migration bug

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -9040,6 +9040,11 @@ enum Instrument {
   GSAOI
 
   """
+  Instrument Igrins2
+  """
+  IGRINS2
+
+  """
   Instrument Niri
   """
   NIRI

--- a/modules/service/src/main/resources/db/migration/V0990__instrument_reference_name.sql
+++ b/modules/service/src/main/resources/db/migration/V0990__instrument_reference_name.sql
@@ -1,0 +1,77 @@
+-- A function to get the instrument string to use in a program reference given
+-- a particular instrument.
+
+CREATE OR REPLACE FUNCTION instrument_reference_name(
+  instrument d_tag
+)
+RETURNS text AS $$
+DECLARE
+  name text;
+BEGIN
+  name := CASE
+    WHEN instrument = 'AcqCam'     THEN 'ACQCAM'
+    WHEN instrument = 'Alopeke'    THEN 'ALOPEKE'
+    WHEN instrument = 'Flamingos2' THEN 'F2'
+    WHEN instrument = 'Ghost'      THEN 'GHOST'
+    WHEN instrument = 'GmosNorth'  THEN 'GMOSN'
+    WHEN instrument = 'GmosSouth'  THEN 'GMOSS'
+    WHEN instrument = 'Gnirs'      THEN 'GNIRS'
+    WHEN instrument = 'Gpi'        THEN 'GPI'
+    WHEN instrument = 'Gsaoi'      THEN 'GSAOI'
+    WHEN instrument = 'Igrins2'    THEN 'IGRINS2'
+    WHEN instrument = 'Niri'       THEN 'NIRI'
+    WHEN instrument = 'Scorpio'    THEN 'SCORPIO'
+    WHEN instrument = 'Visitor'    THEN 'VISITOR'
+    WHEN instrument = 'Zorro'      THEN 'ZORRO'
+  END;
+
+  IF name IS NULL THEN
+    RAISE EXCEPTION 'Unknown instrument: %', instrument::text
+      USING HINT = 'Please update instrument_reference_name function';
+  END IF;
+
+  RETURN name;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Update functions that previously looked up this value from t_instrument to
+-- instead use this function.
+
+CREATE OR REPLACE FUNCTION format_semester_instrument_reference(ptype e_program_type, semester d_semester, index int4, instrument d_tag)
+RETURNS text AS $$
+DECLARE
+  abbr text;
+  inst text;
+BEGIN
+    abbr := public.program_type_abbr(ptype);
+    inst := public.instrument_reference_name(instrument);
+    RETURN CONCAT('G-', semester, '-', abbr, '-', inst, '-', LPAD(index::text, 2, '0'));
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION format_lib_or_xpl_reference(ptype e_program_type, instrument d_tag, description text)
+RETURNS text AS $$
+DECLARE
+  abbr text;
+  inst text;
+  prefix text;
+BEGIN
+    abbr   := public.program_type_abbr(ptype);
+    inst   := public.instrument_reference_name(instrument);
+    prefix := CONCAT('G-', abbr, '-', inst);
+
+    RETURN  CASE
+      WHEN ptype = 'library' THEN CONCAT(prefix, '-', description)
+      ELSE prefix
+    END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- We no longer maintain the reference in the instrument table.
+ALTER TABLE t_instrument
+  DROP COLUMN c_reference_name;
+
+-- We were missing IGrins2 in the instrument table!
+INSERT INTO t_instrument VALUES (
+  'Igrins2', 'IGRINS2', 'IGRINS2'
+);

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/reference.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/reference.scala
@@ -11,6 +11,7 @@ import io.circe.Decoder
 import io.circe.Json
 import io.circe.literal.*
 import lucuma.core.enums.CallForProposalsType
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.model.CallForProposals
 import lucuma.core.model.Observation
@@ -22,6 +23,7 @@ import lucuma.core.model.Semester
 import lucuma.core.model.User
 import lucuma.core.model.sequence.Dataset
 import lucuma.core.model.sequence.DatasetReference
+import lucuma.core.syntax.string.*
 
 
 class reference extends OdbSuite {
@@ -1216,5 +1218,12 @@ class reference extends OdbSuite {
       ref <- setProgramReference(staff, pid, """science: { semester: "2025B", scienceSubtype: POOR_WEATHER }""")
     } yield assertEquals(ref, "G-2025B-0002-P".programReference.some)
   }
+
+  test("there is a reference name in instrument_reference_name function for every instrument"):
+    Instrument.values.toList.traverse: inst =>
+      for
+        pid <- createProgramAs(pi)
+        ref <- setProgramReference(staff, pid, s"""engineering: { semester: "2025B", instrument: ${inst.tag.toScreamingSnakeCase} }""")
+      yield assert(ref.exists(_.label.startsWith(s"G-2025B-ENG-${inst.referenceName}-")))
 
 }


### PR DESCRIPTION
Some program reference types include a version of the instrument name in the reference label.  For example, `G-2025B-ENG-GMOSN-01` is for `GmosNorth` engineering.  Note that the reference name is not always identical to the instrument tag itself (`GMOSN` vs `GmosNorth` in this case).

To find the string to use for an instrument, we would consult the `t_instrument.c_reference_name` column.  This worked fine except during a database upgrade when the `t_program` generated program reference column would be executed to calculate the reference.

```
c_program_reference  | text | generated always as (format_program_reference(c_program_type, c_semester, c_semester_index, c_proposal_status, c_science_subtype, c_instrument, c_library_desc)) stored
```

In this case the program table was populated before the instrument table and a `NULL` instrument reference name was computed by the format function. A solution is to call a function to do the reference name lookup instead of reading it from `t_instrument`.