### PR TITLE
Shortcut 4365: F2 placeholder sequence

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -6737,6 +6737,12 @@ type ExecutionConfig {
   instrument: Instrument!
 
   """
+  Flamingos 2 execution config.  This will be null unless the `instrument` is
+  `FLAMINGOS2`.
+  """
+  flamingos2: Flamingos2ExecutionConfig
+
+  """
   GMOS North execution config.  This will be null unless the `instrument` is
   `GMOS_NORTH`.
   """

--- a/modules/schema/src/main/scala/lucuma/odb/json/flamingos2.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/flamingos2.scala
@@ -89,7 +89,7 @@ trait Flamingos2Codec:
         d <- c.downField("disperser").as[Option[Flamingos2Disperser]]
         f <- c.downField("filter").as[Flamingos2Filter]
         r <- c.downField("readMode").as[Flamingos2ReadMode]
-        l <- c.downField("lyot").as[Flamingos2LyotWheel]
+        l <- c.downField("lyotWheel").as[Flamingos2LyotWheel]
         u <- c.downField("mask").as[Flamingos2FpuMask]
         m <- c.downField("readoutMode").as[Option[Flamingos2ReadoutMode]]
         s <- c.downField("reads").as[Option[Flamingos2Reads]]
@@ -102,7 +102,7 @@ trait Flamingos2Codec:
         "disperser"   -> a.disperser.asJson,
         "filter"      -> a.filter.asJson,
         "readMode"    -> a.readMode.asJson,
-        "lyot"        -> a.lyot.asJson,
+        "lyotWheel"   -> a.lyot.asJson,
         "mask"        -> a.fpu.asJson,
         "readoutMode" -> a.readoutMode.asJson,
         "reads"       -> a.reads.asJson

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/Flamingos2InitialDynamicConfig.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/Flamingos2InitialDynamicConfig.scala
@@ -5,8 +5,8 @@ package lucuma.odb.sequence.flamingos2
 
 import cats.syntax.option.*
 import lucuma.core.enums.Flamingos2Filter.H
-import lucuma.core.enums.Flamingos2ReadMode.Bright
 import lucuma.core.enums.Flamingos2LyotWheel.F16
+import lucuma.core.enums.Flamingos2ReadMode.Bright
 import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig
 import lucuma.core.model.sequence.flamingos2.Flamingos2FpuMask.Imaging
 import lucuma.core.util.TimeSpan

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/Flamingos2InitialDynamicConfig.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/Flamingos2InitialDynamicConfig.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence.flamingos2
+
+import cats.syntax.option.*
+import lucuma.core.enums.Flamingos2Filter.H
+import lucuma.core.enums.Flamingos2ReadMode.Bright
+import lucuma.core.enums.Flamingos2LyotWheel.F16
+import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig
+import lucuma.core.model.sequence.flamingos2.Flamingos2FpuMask.Imaging
+import lucuma.core.util.TimeSpan
+
+trait Flamingos2InitialDynamicConfig:
+
+  /**
+   * Starting point, default dynamic configuration for Flamingos 2.  This will
+   * serve as the initial state in state computations that produce sequence
+   * steps.
+   */
+  val initialConfig: Flamingos2DynamicConfig =
+    Flamingos2DynamicConfig(
+      exposure    = TimeSpan.Min,
+      disperser   = none,
+      filter      = H,
+      readMode    = Bright,
+      lyot        = F16,
+      fpu         = Imaging,
+      readoutMode = none,
+      reads       = none
+    )

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Acquisition.scala
@@ -42,7 +42,9 @@ import lucuma.odb.sequence.util.IndexTracker
 
 import java.util.UUID
 
-
+/**
+ * Flamingos 2 long slit acquisition.
+ */
 object Acquisition:
 
   case class Steps(

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Acquisition.scala
@@ -1,0 +1,194 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence
+package flamingos2
+package longslit
+
+import cats.Eq
+import cats.data.NonEmptyList
+import cats.data.State
+import cats.syntax.either.*
+import cats.syntax.option.*
+import cats.syntax.order.*
+import eu.timepit.refined.*
+import eu.timepit.refined.types.string.NonEmptyString
+import fs2.Pure
+import fs2.Stream
+import lucuma.core.enums.Flamingos2Disperser
+import lucuma.core.enums.Flamingos2Filter
+import lucuma.core.enums.Flamingos2Fpu
+import lucuma.core.enums.Flamingos2LyotWheel
+import lucuma.core.enums.Flamingos2ReadoutMode
+import lucuma.core.enums.Flamingos2Reads
+import lucuma.core.enums.ObserveClass
+import lucuma.core.enums.SequenceType
+import lucuma.core.math.syntax.int.*
+import lucuma.core.model.Observation
+import lucuma.core.model.sequence.Atom
+import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig as F2
+import lucuma.core.model.sequence.flamingos2.Flamingos2FpuMask
+import lucuma.core.model.sequence.flamingos2.Flamingos2StaticConfig
+import lucuma.core.optics.syntax.lens.*
+import lucuma.core.syntax.timespan.*
+import lucuma.core.util.TimeSpan
+import lucuma.core.util.Timestamp
+import lucuma.itc.IntegrationTime
+import lucuma.odb.data.OdbError
+import lucuma.odb.sequence.data.ProtoStep
+import lucuma.odb.sequence.data.StepRecord
+import lucuma.odb.sequence.util.AtomBuilder
+import lucuma.odb.sequence.util.IndexTracker
+
+import java.util.UUID
+
+
+object Acquisition:
+
+  case class Steps(
+    image: ProtoStep[F2],
+    p10:   ProtoStep[F2],
+    slit:  ProtoStep[F2]
+  ):
+    val initialAtom: NonEmptyList[ProtoStep[F2]] =
+      NonEmptyList.of(image, p10, slit.withBreakpoint)
+
+    val repeatingAtom: NonEmptyList[ProtoStep[F2]] =
+      NonEmptyList.of(slit)
+
+  private object StepComputer extends SequenceState[F2] with Flamingos2InitialDynamicConfig:
+    def compute(
+      builtin:      Flamingos2Fpu,
+      exposureTime: TimeSpan
+    ): Steps =
+      eval:
+        for
+          _  <- F2.exposure    := exposureTime
+          _  <- F2.disperser   := none[Flamingos2Disperser]
+          _  <- F2.filter      := Flamingos2Filter.H
+          _  <- F2.readMode    := exposureTime.readMode
+          _  <- F2.lyot        := Flamingos2LyotWheel.F16
+          _  <- F2.fpu         := Flamingos2FpuMask.Imaging
+          _  <- F2.readoutMode := none[Flamingos2ReadoutMode]
+          _  <- F2.reads       := none[Flamingos2Reads]
+          s0 <- scienceStep(0.arcsec, 0.arcsec, ObserveClass.Acquisition)
+
+          _  <- F2.exposure    := 10.secondTimeSpan  // Fixed
+          _  <- F2.fpu         := Flamingos2FpuMask.Builtin(builtin)
+          s1 <- scienceStep(10.arcsec, 0.arcsec, ObserveClass.Acquisition)
+
+          s2 <- scienceStep(0.arcsec, 0.arcsec, ObserveClass.Acquisition)
+        yield Steps(s0, s1, s2)
+
+  private sealed trait AcquisitionState extends SequenceGenerator[F2]:
+
+    def builder: AtomBuilder[F2]
+    def steps: Steps
+    def recordCompleted(step: StepRecord[F2]): AcquisitionState
+    def calcState: TimeEstimateCalculator.Last[F2]
+    def tracker: IndexTracker
+
+    def updateTracker(calcState: TimeEstimateCalculator.Last[F2], tracker: IndexTracker): AcquisitionState
+
+    override def recordStep(step: StepRecord[F2])(using Eq[F2]): SequenceGenerator[F2] =
+      if step.isScienceSequence then this
+      else
+        val a = updateTracker(calcState.next(step.protoStep), tracker.record(step))
+        if step.successfullyCompleted then a.recordCompleted(step) else a
+
+  private object AcquisitionState:
+
+    def initialAcq(
+      builder: AtomBuilder[F2],
+      steps:   NonEmptyList[ProtoStep[F2]],
+      aix:     Int,
+      six:     Int
+    ): State[TimeEstimateCalculator.Last[F2], Atom[F2]] =
+      builder.build(NonEmptyString.unapply("Initial Acquisition"), aix, six, steps)
+
+    def fineAdjustments(
+      builder: AtomBuilder[F2],
+      slit:    ProtoStep[F2],
+      aix:     Int
+    ): State[TimeEstimateCalculator.Last[F2], Atom[F2]] =
+      builder.build(NonEmptyString.unapply("Fine Adjustments"), aix, 1, NonEmptyList.one(slit))
+
+    def gen(
+      builder:   AtomBuilder[F2],
+      init:      Option[NonEmptyList[ProtoStep[F2]]],
+      slit:      ProtoStep[F2],
+      calcState: TimeEstimateCalculator.Last[F2],
+      track:     IndexTracker
+    ): Stream[Pure, Atom[F2]] =
+      (for
+        a0 <- init.fold(fineAdjustments(builder, slit, track.atomCount)): nel =>
+                initialAcq(builder, nel, track.atomCount, track.stepCount)
+        a1 <- fineAdjustments(builder, slit, track.atomCount+1)
+      yield Stream(a0, a1)).runA(calcState).value
+
+    case class Init(lastReset: Option[Timestamp], tracker: IndexTracker, builder: AtomBuilder[F2], steps: Steps) extends SequenceGenerator[F2]:
+      override def generate(ignore: Timestamp): Stream[Pure, Atom[F2]] =
+        gen(builder, steps.initialAtom.some, steps.slit, TimeEstimateCalculator.Last.empty[F2], tracker)
+
+      override def recordStep(step: StepRecord[F2])(using Eq[F2]): SequenceGenerator[F2] =
+        if step.isScienceSequence then this
+        else if lastReset.exists(_ > step.created) then copy(tracker = tracker.record(step))
+        else ExpectImage(TimeEstimateCalculator.Last.empty[F2], tracker, builder, steps).recordStep(step)
+
+    case class ExpectImage(calcState: TimeEstimateCalculator.Last[F2], tracker: IndexTracker, builder: AtomBuilder[F2], steps: Steps) extends AcquisitionState:
+      override def generate(ignore: Timestamp): Stream[Pure, Atom[F2]] =
+        gen(builder, steps.initialAtom.some, steps.slit, calcState, tracker)
+
+      override def updateTracker(calcState: TimeEstimateCalculator.Last[F2], tracker: IndexTracker): AcquisitionState =
+        copy(calcState = calcState, tracker = tracker)
+
+      override def recordCompleted(step: StepRecord[F2]): AcquisitionState =
+        if steps.image.matches(step) then ExpectP10(calcState, tracker, builder, steps)
+        else this
+
+    case class ExpectP10(calcState: TimeEstimateCalculator.Last[F2], tracker: IndexTracker, builder: AtomBuilder[F2], steps: Steps) extends AcquisitionState:
+      override def generate(ignore: Timestamp): Stream[Pure, Atom[F2]] =
+        gen(builder, NonEmptyList.of(steps.p10, steps.slit.withBreakpoint).some, steps.slit, calcState, tracker)
+
+      override def updateTracker(calcState: TimeEstimateCalculator.Last[F2], tracker: IndexTracker): AcquisitionState =
+        copy(calcState = calcState, tracker = tracker)
+
+      override def recordCompleted(step: StepRecord[F2]): AcquisitionState =
+        if steps.p10.matches(step) then ExpectSlit(calcState, tracker, builder, steps, initialAtom = true)
+        else this
+
+    case class ExpectSlit(calcState: TimeEstimateCalculator.Last[F2], tracker: IndexTracker, builder: AtomBuilder[F2], steps: Steps, initialAtom: Boolean) extends AcquisitionState:
+
+      override def generate(ignore: Timestamp): Stream[Pure, Atom[F2]] =
+        gen(builder, Option.when(initialAtom)(NonEmptyList.one(steps.slit.withBreakpoint)), steps.slit, calcState, tracker)
+
+      override def updateTracker(calcState: TimeEstimateCalculator.Last[F2], tracker: IndexTracker): AcquisitionState =
+        copy(calcState = calcState, tracker = tracker)
+
+      override def recordCompleted(step: StepRecord[F2]): AcquisitionState =
+        if steps.slit.matches(step) then ExpectSlit(calcState, tracker, builder, steps, initialAtom = false)
+        else this
+
+  def instantiate(
+    observationId: Observation.Id,
+    estimator:     TimeEstimateCalculator[Flamingos2StaticConfig, F2],
+    static:        Flamingos2StaticConfig,
+    namespace:     UUID,
+    config:        Config,
+    time:          Either[OdbError, IntegrationTime],
+    lastReset:     Option[Timestamp]
+  ): Either[OdbError, SequenceGenerator[F2]] =
+    time
+      .filterOrElse(_.exposureTime.toNonNegMicroseconds.value > 0, OdbError.SequenceUnavailable(observationId, s"Could not generate a sequence for $observationId: Flamingos 2 Long Slit requires a positive exposure time.".some))
+      .map: t =>
+        AcquisitionState.Init(
+          lastReset,
+          IndexTracker.Zero,
+          AtomBuilder.instantiate(
+            estimator,
+            static,
+            namespace,
+            SequenceType.Acquisition
+          ),
+          StepComputer.compute(config.fpu, t.exposureTime)
+        )

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Acquisition.scala
@@ -20,7 +20,6 @@ import lucuma.core.enums.Flamingos2Filter
 import lucuma.core.enums.Flamingos2Fpu
 import lucuma.core.enums.Flamingos2LyotWheel
 import lucuma.core.enums.Flamingos2ReadoutMode
-import lucuma.core.enums.Flamingos2Reads
 import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.SequenceType
 import lucuma.core.math.syntax.int.*
@@ -71,8 +70,8 @@ object Acquisition:
           _  <- F2.readMode    := exposureTime.readMode
           _  <- F2.lyot        := Flamingos2LyotWheel.F16
           _  <- F2.fpu         := Flamingos2FpuMask.Imaging
-          _  <- F2.readoutMode := none[Flamingos2ReadoutMode]
-          _  <- F2.reads       := none[Flamingos2Reads]
+          _  <- F2.readoutMode := Flamingos2ReadoutMode.Science.some
+          _  <- F2.reads       := exposureTime.readMode.readCount.some
           s0 <- scienceStep(0.arcsec, 0.arcsec, ObserveClass.Acquisition)
 
           _  <- F2.exposure    := 10.secondTimeSpan  // Fixed

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/LongSlit.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/LongSlit.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence
+package flamingos2.longslit
+
+import cats.Monad
+import cats.data.EitherT
+import lucuma.core.enums.CalibrationRole
+import lucuma.core.enums.MosPreImaging
+import lucuma.core.model.Observation
+import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig as F2Dynamic
+import lucuma.core.model.sequence.flamingos2.Flamingos2StaticConfig as F2Static
+import lucuma.core.util.Timestamp
+import lucuma.itc.IntegrationTime
+import lucuma.odb.data.OdbError
+
+import java.util.UUID
+
+object LongSlit:
+
+  val Static: F2Static =
+    F2Static(
+      mosPreImaging          = MosPreImaging.IsNotMosPreImaging,
+      useElectronicOffseting = false
+    )
+
+  def instantiate[F[_]: Monad](
+    observationId:  Observation.Id,
+    estimator:      TimeEstimateCalculator[F2Static, F2Dynamic],
+    namespace:      UUID,
+    expander:       SmartGcalExpander[F, F2Dynamic],
+    config:         Config,
+    acquisitionItc: Either[OdbError, IntegrationTime],
+    scienceItc:     Either[OdbError, IntegrationTime],
+    calRole:        Option[CalibrationRole],
+    lastAcqReset:   Option[Timestamp]
+  ): F[Either[OdbError, ExecutionConfigGenerator[F2Static, F2Dynamic]]] =
+    (for
+       a <- EitherT.fromEither(Acquisition.instantiate(observationId, estimator, Static, namespace, config, acquisitionItc, lastAcqReset))
+       s <- EitherT(Science.instantiate(observationId, estimator, Static, namespace, expander, config, scienceItc))
+    yield ExecutionConfigGenerator(Static, a, s)).value

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Science.scala
@@ -1,0 +1,134 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence
+package flamingos2
+package longslit
+
+import cats.Eq
+import cats.data.NonEmptyList
+import cats.syntax.either.*
+import cats.syntax.option.*
+import eu.timepit.refined.*
+import eu.timepit.refined.types.string.NonEmptyString
+import fs2.Pure
+import fs2.Stream
+import lucuma.core.enums.Flamingos2LyotWheel
+import lucuma.core.enums.ObserveClass
+import lucuma.core.enums.SequenceType
+import lucuma.core.enums.StepGuideState.Disabled
+import lucuma.core.math.syntax.int.*
+import lucuma.core.model.Observation
+import lucuma.core.model.sequence.Atom
+import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig as F2
+import lucuma.core.model.sequence.flamingos2.Flamingos2FpuMask
+import lucuma.core.model.sequence.flamingos2.Flamingos2StaticConfig
+import lucuma.core.optics.syntax.lens.*
+import lucuma.core.util.TimeSpan
+import lucuma.core.util.Timestamp
+import lucuma.itc.IntegrationTime
+import lucuma.odb.data.OdbError
+import lucuma.odb.sequence.data.ProtoStep
+import lucuma.odb.sequence.data.StepRecord
+import lucuma.odb.sequence.util.AtomBuilder
+import lucuma.odb.sequence.util.IndexTracker
+
+import java.util.UUID
+
+/**
+ * Flamingos 2 long slit science sequence generation.
+ */
+object Science:
+
+  case class Steps(
+    a:    ProtoStep[F2],
+    b:    ProtoStep[F2],
+    flat: ProtoStep[F2],
+    arc:  ProtoStep[F2]
+  ):
+    val nominalSequence: NonEmptyList[ProtoStep[F2]] =
+      NonEmptyList.of(a, b, b, a, flat, arc)
+
+  object Steps extends SequenceState[F2] with Flamingos2InitialDynamicConfig:
+
+    def compute(
+      config: Config,
+      time:   IntegrationTime
+    ): Steps =
+      eval:
+        for
+          _ <- F2.exposure    := time.exposureTime
+          _ <- F2.disperser   := config.disperser.some
+          _ <- F2.filter      := config.filter
+          _ <- F2.readMode    := time.exposureTime.readMode
+          _ <- F2.lyot        := Flamingos2LyotWheel.F16
+          _ <- F2.fpu         := Flamingos2FpuMask.builtin(config.fpu)
+          _ <- F2.readoutMode := config.readoutMode.some
+          _ <- F2.reads       := config.explicitReads.getOrElse(time.exposureTime.readMode.readCount).some
+          a <- scienceStep(0.arcsec, -15.arcsec, ObserveClass.Science)
+          b <- scienceStep(0.arcsec,  15.arcsec, ObserveClass.Science)
+          f <- flatStep(a.telescopeConfig.copy(guiding = Disabled), ObserveClass.NightCal)
+          r <- arcStep(a.telescopeConfig.copy(guiding = Disabled), ObserveClass.NightCal)
+        yield Steps(a, b, f, r)
+
+  case class ScienceState(
+    steps:     Steps,
+    builder:   AtomBuilder[F2],
+    calcState: TimeEstimateCalculator.Last[F2],
+    tracker:   IndexTracker,
+    completed: Map[ProtoStep[F2], Int]
+  ) extends SequenceGenerator[F2]:
+
+    def generate(when: Timestamp): Stream[Pure, Atom[F2]] =
+      val ps = NonEmptyList.fromList(
+        Stream
+          .emits(steps.nominalSequence.toList)
+          .mapAccumulate(completed): (m, s) =>
+            val count = m.getOrElse(s, 0)
+            if count <= 0 then (m, s.some)
+            else (m.updatedWith(s)(_.map(_ - 1)), none)
+          .flatMap: (_, o) =>
+            Stream.emits(o.toList)
+          .compile
+          .toList
+        )
+
+      ps.fold(Stream.empty): ss =>
+        val f2    = steps.a._1
+        val name  = s"${f2.fpu.builtinFpu.fold("image")(_.shortName)}, ${f2.filter.shortName}, ${f2.disperser.fold("none")(_.shortName)}"
+        val state = builder.build(NonEmptyString.unapply(name), tracker.atomCount, tracker.stepCount, ss)
+        Stream.emit(state.runA(calcState).value)
+
+    def recordStep(step: StepRecord[F2])(using Eq[F2]): SequenceGenerator[F2] =
+      if step.isAcquisitionSequence then this
+      else copy(
+        calcState = calcState.next(step.protoStep),
+        tracker   = tracker.record(step),
+        completed = if step.successfullyCompleted
+                    then completed.updatedWith(step.protoStep)(n => (n.getOrElse(0) + 1).some)
+                    else completed
+      )
+
+  def instantiate(
+    observationId: Observation.Id,
+    estimator:     TimeEstimateCalculator[Flamingos2StaticConfig, F2],
+    static:        Flamingos2StaticConfig,
+    namespace:     UUID,
+    config:        Config,
+    time:          Either[OdbError, IntegrationTime]
+  ): Either[OdbError, SequenceGenerator[F2]] =
+    time
+      .filterOrElse(_.exposureTime.toNonNegMicroseconds.value > 0, OdbError.SequenceUnavailable(observationId, s"Could not generate a sequence for $observationId: Flamingos 2 Long Slit requires a positive exposure time.".some))
+      .map: t =>
+        ScienceState(
+          Steps.compute(config, t),
+          AtomBuilder.instantiate(
+            estimator,
+            static,
+            namespace,
+            SequenceType.Science
+          ),
+          TimeEstimateCalculator.Last.empty[F2],
+          IndexTracker.Zero,
+          Map.empty
+        )

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/package.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/package.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence
+
+import cats.syntax.order.*
+import lucuma.core.enums.Flamingos2ReadMode
+import lucuma.core.syntax.timespan.*
+import lucuma.core.util.TimeSpan
+
+package object flamingos2:
+
+  val FaintExposureFloor: TimeSpan  = 85.secondTimeSpan
+  val MediumExposureFloor: TimeSpan = 21.secondTimeSpan
+
+  extension (t: TimeSpan)
+    def readMode: Flamingos2ReadMode =
+      if t >= FaintExposureFloor then Flamingos2ReadMode.Faint
+      else if t >= MediumExposureFloor then Flamingos2ReadMode.Medium
+      else Flamingos2ReadMode.Bright

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/AtomBuilder.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/AtomBuilder.scala
@@ -18,7 +18,7 @@ import java.util.UUID
 
 /**
  * AtomBuilder encapsulates the complicated task of creating Atom from a list
- * of proto-steps.  This requires calculating the atom an step ids from indices
+ * of proto-steps.  This requires calculating the atom and step ids from indices
  * and estimating the step cost.
  */
 trait AtomBuilder[D]:

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -354,7 +354,13 @@ object Generator {
         role:   Option[CalibrationRole],
         when:   Option[Timestamp]
       ): EitherT[F, OdbError, (ProtoFlamingos2, ExecutionState)] =
-        EitherT.leftT(Error.sequenceUnavailable(ctx.oid, s"F2 longslit not implemented ($ctx, $config, $role, $when)"))
+        import lucuma.odb.sequence.flamingos2.longslit.LongSlit
+        val gen = LongSlit.instantiate(ctx.oid, calculator.flamingos2, ctx.namespace, exp.flamingos2, config, ctx.acquisitionIntegrationTime, ctx.scienceIntegrationTime, role, ctx.params.acqResetTime)
+        val srs = services.flamingos2SequenceService.selectStepRecords(ctx.oid)
+        for
+          g <- EitherT(gen)
+          p <- protoExecutionConfig(ctx, g, srs, when)
+        yield p
 
       private def gmosNorthLongSlit(
         ctx:    Context,
@@ -364,10 +370,10 @@ object Generator {
       ): EitherT[F, OdbError, (ProtoGmosNorth, ExecutionState)] =
         val gen = LongSlit.gmosNorth(ctx.oid, calculator.gmosNorth, ctx.namespace, exp.gmosNorth, config, ctx.acquisitionIntegrationTime, ctx.scienceIntegrationTime, role, ctx.params.acqResetTime)
         val srs = services.gmosSequenceService.selectGmosNorthStepRecords(ctx.oid)
-        for {
+        for
           g <- EitherT(gen)
           p <- protoExecutionConfig(ctx, g, srs, when)
-        } yield p
+        yield p
 
       private def gmosSouthLongSlit(
         ctx:    Context,
@@ -377,10 +383,10 @@ object Generator {
       ): EitherT[F, OdbError, (ProtoGmosSouth, ExecutionState)] =
         val gen = LongSlit.gmosSouth(ctx.oid, calculator.gmosSouth, ctx.namespace, exp.gmosSouth, config, ctx.acquisitionIntegrationTime, ctx.scienceIntegrationTime, role, ctx.params.acqResetTime)
         val srs = services.gmosSequenceService.selectGmosSouthStepRecords(ctx.oid)
-        for {
+        for
           g <- EitherT(gen)
           p <- protoExecutionConfig(ctx, g, srs, when)
-        } yield p
+        yield p
 
       private def calcDigestFromContext(
         ctx:  Context,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -246,6 +246,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
       override def spectroscopy(input: SpectroscopyInput, useCache: Boolean): IO[ClientCalculationResult] = {
         val signal = lucuma.core.math.Wavelength.fromIntNanometers(666).get
         val wavelength = input.mode match
+          case lucuma.itc.client.InstrumentMode.Flamingos2Spectroscopy(d, _, _)         => d.wavelength
           case lucuma.itc.client.InstrumentMode.GmosNorthSpectroscopy(w, _, _, _, _, _) => w
           case lucuma.itc.client.InstrumentMode.GmosSouthSpectroscopy(w, _, _, _, _, _) => w
           case _                                                                        => signal

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
@@ -19,6 +19,25 @@ trait ObservingModeSetupOperations extends DatabaseOperations { this: OdbSuite =
   private def formatExplicitOffsetsInput(arcsecs: List[Int]): String =
     arcsecs.map(a => s"{ arcseconds: $a }").mkString("explicitSpatialOffsets: [", ", ", "]")
 
+  def createFlamingos2LongSlitObservationAs(
+    user:         User,
+    pid:          Program.Id,
+    tids:         List[Target.Id],
+    offsetArcsec: Option[List[Int]] = None
+  ): IO[Observation.Id] =
+    createObservationWithModeAs(
+      user,
+      pid,
+      tids,
+      s"""
+        flamingos2LongSlit: {
+          disperser: R1200_JH
+          filter: JH
+          fpu: LONG_SLIT_1
+        }
+      """
+    )
+
   def createGmosNorthLongSlitObservationAs(
     user:         User,
     pid:          Program.Id,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqFlamingos2.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqFlamingos2.scala
@@ -1,0 +1,533 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.query
+
+import cats.effect.IO
+import cats.syntax.either.*
+import io.circe.Json
+import io.circe.literal.*
+import lucuma.core.enums.Breakpoint
+import lucuma.core.enums.StepGuideState
+import lucuma.core.model.Observation
+import lucuma.core.model.sequence.TelescopeConfig
+
+class executionAcqFlamingos2 extends ExecutionTestSupport {
+
+  def acqTelescopeConfig(p: Int): TelescopeConfig =
+    telescopeConfig(p, 0, StepGuideState.Enabled)
+
+  val InitialAcquisition: Json =
+    json"""
+      {
+        "observation": {
+          "execution": {
+            "config": {
+              "flamingos2": {
+                "acquisition": {
+                  "nextAtom": {
+                    "description": "Initial Acquisition",
+                    "observeClass": "ACQUISITION",
+                    "steps": [
+                      ${flamingos2ExpectedAcq(0,  0)},
+                      ${flamingos2ExpectedAcq(1, 10)},
+                      ${flamingos2ExpectedAcq(2,  0, Breakpoint.Enabled)}
+                    ]
+                  },
+                  "possibleFuture": [
+                    {
+                      "description": "Fine Adjustments",
+                      "observeClass": "ACQUISITION",
+                      "steps": [
+                        ${flamingos2ExpectedAcq(2, 0)}
+                      ]
+                    }
+                  ],
+                  "hasMore": false
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+  val FineAdjustments: Json =
+    json"""
+      {
+        "observation": {
+          "execution": {
+            "config": {
+              "flamingos2": {
+                "acquisition": {
+                  "nextAtom": {
+                    "description": "Fine Adjustments",
+                    "observeClass": "ACQUISITION",
+                    "steps": [
+                      ${flamingos2ExpectedAcq(2, 0, Breakpoint.Disabled)}
+                    ]
+                  },
+                  "possibleFuture": [
+                    {
+                      "description": "Fine Adjustments",
+                      "observeClass": "ACQUISITION",
+                      "steps": [
+                        ${flamingos2ExpectedAcq(2, 0, Breakpoint.Disabled)}
+                      ]
+                    }
+                  ],
+                  "hasMore": false
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+  test("initial generation") {
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createFlamingos2LongSlitObservationAs(pi, p, List(t))
+      } yield o
+
+    setup.flatMap { oid =>
+      expect(
+        user  = pi,
+        query =
+          s"""
+             query {
+               observation(observationId: "$oid") {
+                 ${flamingos2AcquisitionQuery(None)}
+               }
+             }
+           """,
+        expected = InitialAcquisition.asRight
+      )
+    }
+  }
+/*
+  test("execute first step only, reset"):
+    val setup: IO[Observation.Id] =
+      for
+        p  <- createProgram
+        t  <- createTargetWithProfileAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        v  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        // Record the first atom and one of its steps
+        a  <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s0 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthAcq(0), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s0)
+        _  <- resetAcquisitionAs(serviceUser, o)
+      yield o
+
+    setup.flatMap: oid =>
+      expect(
+        user  = pi,
+        query =
+          s"""
+             query {
+               observation(observationId: "$oid") {
+                 ${excutionConfigQuery("gmosNorth", "acquisition", GmosAtomQuery, None)}
+               }
+             }
+           """,
+        expected = InitialAcquisition.asRight
+      )
+
+  test("execute first atom - repeat of last acq step") {
+    val setup: IO[Observation.Id] =
+      for {
+        p  <- createProgram
+        t  <- createTargetWithProfileAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        v  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        // Record the first atom with 3 steps
+        a  <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s0 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthAcq(0), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s0)
+        s1 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthAcq(1), StepConfig.Science, acqTelescopeConfig(10), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s1)
+        s2 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthAcq(2), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s2)
+
+        // Now the last acquisition step should be generated as the nextAtom
+      } yield o
+
+    setup.flatMap { oid =>
+      expect(
+        user  = pi,
+        query =
+          s"""
+             query {
+               observation(observationId: "$oid") {
+                 ${excutionConfigQuery("gmosNorth", "acquisition", GmosAtomQuery, None)}
+               }
+             }
+           """,
+        expected = FineAdjustments.asRight
+      )
+    }
+  }
+
+  test("execute first step only") {
+    val setup: IO[Observation.Id] =
+      for {
+        p  <- createProgram
+        t  <- createTargetWithProfileAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        v  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        // Record the first atom and one of its steps
+        a  <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s0 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthAcq(0), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s0)
+
+      } yield o
+
+    setup.flatMap { oid =>
+      expect(
+        user  = pi,
+        query =
+          s"""
+             query {
+               observation(observationId: "$oid") {
+                 ${excutionConfigQuery("gmosNorth", "acquisition", GmosAtomQuery, None)}
+               }
+             }
+           """,
+        expected =
+          json"""
+            {
+              "observation": {
+                "execution": {
+                  "config": {
+                    "gmosNorth": {
+                      "acquisition": {
+                        "nextAtom": {
+                          "description": "Initial Acquisition",
+                          "observeClass": "ACQUISITION",
+                          "steps": [
+                            ${gmosNorthExpectedAcq(1, 10)},
+                            ${gmosNorthExpectedAcq(2,  0, Breakpoint.Enabled)}
+                          ]
+                        },
+                        "possibleFuture": [
+                          {
+                            "description": "Fine Adjustments",
+                            "observeClass": "ACQUISITION",
+                            "steps": [
+                              ${gmosNorthExpectedAcq(2, 0, Breakpoint.Disabled)}
+                            ]
+                          }
+                        ],
+                        "hasMore": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          """.asRight
+      )
+    }
+  }
+
+  test("execute first and second atoms - 2nd repeat of last acq step") {
+    val setup: IO[Observation.Id] =
+      for {
+        p  <- createProgram
+        t  <- createTargetWithProfileAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        v  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        // First atom with 3 steps.
+        a0 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s0 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(0), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s0)
+        s1 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(1), StepConfig.Science, acqTelescopeConfig(10), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s1)
+        s2 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(2), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s2)
+
+        // Second atom with just the last acq step
+        a1 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s3 <- recordStepAs(serviceUser, a1, Instrument.GmosNorth, gmosNorthAcq(2), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s3)
+
+        // Now we should expect to generate (again) the last acq step
+      } yield o
+
+    setup.flatMap { oid =>
+      expect(
+        user  = pi,
+        query =
+          s"""
+             query {
+               observation(observationId: "$oid") {
+                 ${excutionConfigQuery("gmosNorth", "acquisition", GmosAtomQuery, None)}
+               }
+             }
+           """,
+        expected = FineAdjustments.asRight
+      )
+    }
+  }
+
+  test("execute acquisition, switch to science, back to acquisition") {
+    val setup: IO[Observation.Id] =
+      for {
+        p  <- createProgram
+        t  <- createTargetWithProfileAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        v  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        // Acquisition Sequence
+        a0 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s0 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(0), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s0)
+        s1 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(1), StepConfig.Science, acqTelescopeConfig(10), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s1)
+        s2 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(2), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s2)
+        a1 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s3 <- recordStepAs(serviceUser, a1, Instrument.GmosNorth, gmosNorthAcq(2), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s3)
+
+        // Do a science step
+        a2 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Science)
+        s4 <- recordStepAs(serviceUser, a2, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Science)
+        _  <- addEndStepEvent(s4)
+
+        // Reset acquisition to take it from the top.
+        _  <- resetAcquisitionAs(serviceUser, o)
+      } yield o
+
+    setup.flatMap { oid =>
+      expect(
+        user  = pi,
+        query =
+          s"""
+             query {
+               observation(observationId: "$oid") {
+                 ${excutionConfigQuery("gmosNorth", "acquisition", GmosAtomQuery, None)}
+               }
+             }
+           """,
+        expected = InitialAcquisition.asRight
+      )
+    }
+  }
+
+  test("execute acquisition, make a new visit, back to acquisition") {
+    val setup: IO[Observation.Id] =
+      for {
+        p  <- createProgram
+        t  <- createTargetWithProfileAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        v0 <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        // Acquisition Sequence
+        a0 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v0, SequenceType.Acquisition)
+        s0 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(0), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s0)
+        s1 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(1), StepConfig.Science, acqTelescopeConfig(10), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s1)
+        s2 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(2), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s2)
+        a1 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v0, SequenceType.Acquisition)
+        s3 <- recordStepAs(serviceUser, a1, Instrument.GmosNorth, gmosNorthAcq(2), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s3)
+
+        // Record a new visit, but don't execute anything
+        _  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        // Reset acquisition
+        _  <- resetAcquisitionAs(serviceUser, o)
+      } yield o
+
+    setup.flatMap { oid =>
+      expect(
+        user  = pi,
+        query =
+          s"""
+             query {
+               observation(observationId: "$oid") {
+                 ${excutionConfigQuery("gmosNorth", "acquisition", GmosAtomQuery, None)}
+               }
+             }
+           """,
+        expected = InitialAcquisition.asRight
+      )
+    }
+  }
+
+  test("execute first step, second step, fail second step only") {
+    val setup: IO[Observation.Id] =
+      for {
+        p  <- createProgram
+        t  <- createTargetWithProfileAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        v  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        // Record the first atom and two of its steps
+        a  <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s0 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthAcq(0), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s0)
+        s1 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthAcq(1), StepConfig.Science, acqTelescopeConfig(10), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s1)
+
+        // Fail the second step
+        d  <- recordDatasetAs(serviceUser, s1, "N20240905S1000.fits")
+        _  <- setQaState(d, DatasetQaState.Usable)
+
+        // We'll have to repeat the second step (index 1)
+      } yield o
+
+    setup.flatMap { oid =>
+      expect(
+        user  = pi,
+        query =
+          s"""
+             query {
+               observation(observationId: "$oid") {
+                 ${excutionConfigQuery("gmosNorth", "acquisition", GmosAtomQuery, None)}
+               }
+             }
+           """,
+        expected =
+          json"""
+            {
+              "observation": {
+                "execution": {
+                  "config": {
+                    "gmosNorth": {
+                      "acquisition": {
+                        "nextAtom": {
+                          "description": "Initial Acquisition",
+                          "observeClass": "ACQUISITION",
+                          "steps": [
+                            ${gmosNorthExpectedAcq(1, 10)},
+                            ${gmosNorthExpectedAcq(2,  0, Breakpoint.Enabled)}
+                          ]
+                        },
+                        "possibleFuture": [
+                          {
+                            "description": "Fine Adjustments",
+                            "observeClass": "ACQUISITION",
+                            "steps": [
+                              ${gmosNorthExpectedAcq(2, 0)}
+                            ]
+                          }
+                        ],
+                        "hasMore": false
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          """.asRight
+      )
+    }
+  }
+
+  def firstScienceStepId(p: Program.Id, o: Observation.Id): IO[Step.Id] =
+    import lucuma.odb.testsyntax.execution.*
+    generateOrFail(p, o, 5.some).map(_.gmosNorthScience.nextAtom.steps.head.id)
+
+  test("science step ids do not change while executing acquisition"):
+    val execAcq: IO[Set[Step.Id]] =
+      for
+        p  <- createProgram
+        t  <- createTargetWithProfileAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        v  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        x0 <- firstScienceStepId(p, o)
+
+        // First atom with 3 steps.
+        a0 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s0 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(0), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s0)
+
+        x1 <- firstScienceStepId(p, o)
+
+        s1 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(1), StepConfig.Science, acqTelescopeConfig(10), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s1)
+
+        x1 <- firstScienceStepId(p, o)
+
+        s2 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(2), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s2)
+
+        x2 <- firstScienceStepId(p, o)
+
+        // Second atom with just the last acq step
+        a1 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s3 <- recordStepAs(serviceUser, a1, Instrument.GmosNorth, gmosNorthAcq(2), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s3)
+
+        x3 <- firstScienceStepId(p, o)
+      yield Set(x0, x1, x2, x3)
+
+    assertIO(execAcq.map(_.size), 1)
+
+  def nextAtomStepIds(p: Program.Id, o: Observation.Id): IO[NonEmptyList[Step.Id]] =
+    import lucuma.odb.testsyntax.execution.*
+    generateOrFail(p, o, 5.some).map(_.gmosNorthAcquisition.nextAtom.steps.map(_.id))
+
+  test("nextAtom step ids don't change while executing"):
+    val execAcq: IO[List[NonEmptyList[Step.Id]]] =
+      for
+        p  <- createProgram
+        t  <- createTargetWithProfileAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        v  <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
+
+        x0 <- nextAtomStepIds(p, o)
+
+        // First atom with 3 steps.
+        a0 <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Acquisition)
+        s0 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(0), StepConfig.Science, acqTelescopeConfig(0), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s0)
+
+        x1 <- nextAtomStepIds(p, o)
+
+        s1 <- recordStepAs(serviceUser, a0, Instrument.GmosNorth, gmosNorthAcq(1), StepConfig.Science, acqTelescopeConfig(10), ObserveClass.Acquisition)
+        _  <- addEndStepEvent(s1)
+
+        x2 <- nextAtomStepIds(p, o)
+      yield List(x0, x1, x2)
+
+    execAcq.map: ids =>
+      ids.zip(ids.tail).foreach: (before, after) =>
+        assertEquals(before.tail, after.toList, s"before: $before, after: $after")
+
+  test("reset can only be done by staff or better"):
+    for
+      p <- createProgram
+      t <- createTargetWithProfileAs(pi, p)
+      o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      _ <- expect(
+        user  = pi,
+        query = s"""
+          mutation {
+            resetAcquisition(input: {
+              observationId: "$o"
+            }) {
+              observation { id }
+            }
+          }
+        """,
+        expected = List(
+          s"User ${pi.id} is not authorized to perform this operation."
+        ).asLeft
+      )
+    yield ()
+*/
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGmosNorth.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGmosNorth.scala
@@ -23,7 +23,7 @@ import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.TelescopeConfig
 import lucuma.odb.json.all.transport.given
 
-class executionAcq extends ExecutionTestSupport {
+class executionAcqGmosNorth extends ExecutionTestSupport {
 
   def acqTelescopeConfig(p: Int): TelescopeConfig =
     telescopeConfig(p, 0, StepGuideState.Enabled)


### PR DESCRIPTION
This PR is a snapshot of progress on developing F2 placeholder sequences.  It adds something basic for acquisition and science, but both need testing.  (`Acquisition` is closer to a complete version than `Science`.) I'd like to stop and offer this now though because:

* I need to refactor `ExecutionTestSupport` to split F2 and GMOS and that will generate a lot of noise
* I'd like to make some adjustments to `Flamingos2DynamicConfig` before we go much further

I think those should be done in separate PRs before completing sequence testing.