### PR TITLE
Shortcut 4365: split `ExecutionTestSupport`

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/timeAndCountExposureTimeMode.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/timeAndCountExposureTimeMode.scala
@@ -11,9 +11,9 @@ import io.circe.syntax.*
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Target
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 
-class timeAndCountExposureTimeMode extends ExecutionTestSupport:
+class timeAndCountExposureTimeMode extends ExecutionTestSupportForGmos:
 
   def createGmosNorthLongSlitObservation(
     p: Program.Id,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/1023.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/1023.scala
@@ -8,9 +8,9 @@ import cats.effect.IO
 import cats.syntax.either.*
 import io.circe.literal.*
 import lucuma.core.model.Observation
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 
-class GitHub_1023 extends ExecutionTestSupport {
+class GitHub_1023 extends ExecutionTestSupportForGmos {
 
   test("one inline fragment") {
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/2772.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/2772.scala
@@ -15,10 +15,10 @@ import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.core.syntax.timespan.*
 import lucuma.itc.IntegrationTime
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 import lucuma.odb.graphql.query.ObservingModeSetupOperations
 
-class ShortCut_2772 extends ExecutionTestSupport {
+class ShortCut_2772 extends ExecutionTestSupportForGmos {
 
   // specify 2 exposures per atom (30 min x 2 fills a 1 hour block)
   override def fakeItcSpectroscopyResult: IntegrationTime =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/2887.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/2887.scala
@@ -13,10 +13,10 @@ import io.circe.literal.*
 import lucuma.core.model.Observation
 import lucuma.core.syntax.timespan.*
 import lucuma.itc.IntegrationTime
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 import lucuma.odb.logic.Generator.SequenceAtomLimit
 
-class ShortCut_2887 extends ExecutionTestSupport {
+class ShortCut_2887 extends ExecutionTestSupportForGmos {
 
   lazy val atomCount: Ref[IO, Int] =
     Ref.unsafe(0)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/3219.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/3219.scala
@@ -11,9 +11,9 @@ import eu.timepit.refined.types.numeric.NonNegInt
 import lucuma.core.model.sequence.Atom
 import lucuma.core.syntax.timespan.*
 import lucuma.itc.IntegrationTime
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 
-class ShortCut_3219 extends ExecutionTestSupport {
+class ShortCut_3219 extends ExecutionTestSupportForGmos {
 
   import lucuma.odb.testsyntax.execution.*
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/3660.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/3660.scala
@@ -8,7 +8,7 @@ import cats.effect.IO
 import cats.syntax.option.*
 import lucuma.core.model.Observation
 import lucuma.odb.data.OdbError
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 import munit.IgnoreSuite
 
 /**
@@ -19,7 +19,7 @@ import munit.IgnoreSuite
  * returned.
  */
 @IgnoreSuite
-class ShortCut_3660 extends ExecutionTestSupport {
+class ShortCut_3660 extends ExecutionTestSupportForGmos {
 
   test("cannot generate, missing mode + failed itc query") {
     val setup: IO[Observation.Id] =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4596.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4596.scala
@@ -28,13 +28,13 @@ import lucuma.core.syntax.timespan.*
 import lucuma.core.util.TimeSpan
 import lucuma.itc.IntegrationTime
 import lucuma.odb.graphql.mutation.UpdateConstraintSetOps
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 import lucuma.odb.graphql.query.ObservingModeSetupOperations
 import lucuma.odb.json.all.transport.given
 
 //https://app.shortcut.com/lucuma/story/4596/api-should-prevent-editing-of-observations-for-which-execution-has-started
 class ShortCut_4596 extends OdbSuite 
-  with ExecutionTestSupport 
+  with ExecutionTestSupportForGmos
   with ObservingModeSetupOperations 
   with UpdateConstraintSetOps {
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5017.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5017.scala
@@ -26,10 +26,10 @@ import lucuma.core.model.sequence.TelescopeConfig
 import lucuma.core.syntax.timespan.*
 import lucuma.core.util.TimeSpan
 import lucuma.itc.IntegrationTime
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 import lucuma.odb.json.all.transport.given
 
-class ShortCut_5017 extends ExecutionTestSupport:
+class ShortCut_5017 extends ExecutionTestSupportForGmos:
 
   def gcalTelescopeConfig(q: Int): TelescopeConfig =
     telescopeConfig(0, q, StepGuideState.Disabled)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5098.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5098.scala
@@ -6,9 +6,9 @@ package issue.shortcut
 
 import lucuma.core.model.Target
 import lucuma.odb.data.OdbError
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 
-class ShortCut_5098 extends ExecutionTestSupport:
+class ShortCut_5098 extends ExecutionTestSupportForGmos:
 
   def removeSED(t: Target.Id) = query(pi,
     s"""

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5331.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5331.scala
@@ -11,9 +11,9 @@ import grackle.Value
 import io.circe.literal.*
 import lucuma.core.model.Observation
 import lucuma.odb.graphql.binding.LongBinding
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 
-class ShortCut_5331 extends ExecutionTestSupport:
+class ShortCut_5331 extends ExecutionTestSupportForGmos:
   // Works up to 2147 seconds
   val secs: Long = 2148000000L
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setGuideTargetName.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setGuideTargetName.scala
@@ -18,7 +18,7 @@ import lucuma.core.model.User
 import lucuma.core.util.Timestamp
 import lucuma.odb.data.OdbError
 
-class setGuideTargetName extends query.ExecutionTestSupport {
+class setGuideTargetName extends query.ExecutionTestSupportForGmos {
   val targetName1: String = GuideStarName.gaiaSourceId.reverseGet(1L).value.value
 
   val Now: Timestamp = Timestamp.FromString.getOption("2024-08-25T00:00:00Z").get

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setObservationWorkflowState.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setObservationWorkflowState.scala
@@ -20,12 +20,12 @@ import lucuma.core.syntax.timespan.*
 import lucuma.core.util.TimeSpan
 import lucuma.itc.IntegrationTime
 import lucuma.odb.data.OdbError
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 import lucuma.odb.graphql.query.ObservingModeSetupOperations
 import lucuma.odb.json.all.transport.given
 
 class setObservationWorkflowState
-  extends ExecutionTestSupport
+  extends ExecutionTestSupportForGmos
      with ObservingModeSetupOperations
      with UpdateConstraintSetOps {
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
@@ -4,47 +4,16 @@
 package lucuma.odb.graphql
 package query
 
-import cats.data.NonEmptySet
 import cats.effect.Clock
 import cats.effect.IO
 import cats.syntax.all.*
-import eu.timepit.refined.types.numeric.PosInt
-import eu.timepit.refined.types.numeric.PosLong
 import io.circe.Json
 import io.circe.literal.*
-import io.circe.syntax.*
-import lucuma.core.enums.Breakpoint
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.DatasetQaState
 import lucuma.core.enums.DatasetStage
-import lucuma.core.enums.Flamingos2Decker
-import lucuma.core.enums.Flamingos2Disperser
-import lucuma.core.enums.Flamingos2Filter
-import lucuma.core.enums.Flamingos2Fpu
-import lucuma.core.enums.Flamingos2LyotWheel
-import lucuma.core.enums.Flamingos2ReadMode
-import lucuma.core.enums.Flamingos2ReadoutMode
-import lucuma.core.enums.Flamingos2Reads
-import lucuma.core.enums.GcalArc
-import lucuma.core.enums.GcalBaselineType
-import lucuma.core.enums.GcalContinuum
-import lucuma.core.enums.GcalDiffuser
-import lucuma.core.enums.GcalFilter
-import lucuma.core.enums.GcalShutter
-import lucuma.core.enums.GmosAmpCount
-import lucuma.core.enums.GmosAmpGain
-import lucuma.core.enums.GmosAmpReadMode
-import lucuma.core.enums.GmosDtax
-import lucuma.core.enums.GmosGratingOrder
-import lucuma.core.enums.GmosNorthFilter
-import lucuma.core.enums.GmosNorthFpu
-import lucuma.core.enums.GmosNorthGrating
-import lucuma.core.enums.GmosRoi
-import lucuma.core.enums.GmosXBinning
-import lucuma.core.enums.GmosYBinning
 import lucuma.core.enums.StepGuideState
 import lucuma.core.math.Angle
-import lucuma.core.math.BoundedInterval
 import lucuma.core.math.Offset
 import lucuma.core.math.Wavelength
 import lucuma.core.math.WavelengthDither
@@ -55,17 +24,8 @@ import lucuma.core.model.User
 import lucuma.core.model.sequence.Dataset
 import lucuma.core.model.sequence.InstrumentExecutionConfig
 import lucuma.core.model.sequence.Step
-import lucuma.core.model.sequence.StepConfig
-import lucuma.core.model.sequence.StepConfig.Gcal
 import lucuma.core.model.sequence.TelescopeConfig
-import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig
-import lucuma.core.model.sequence.flamingos2.Flamingos2FpuMask
-import lucuma.core.model.sequence.gmos.DynamicConfig.GmosNorth
-import lucuma.core.model.sequence.gmos.GmosCcdMode
-import lucuma.core.model.sequence.gmos.GmosFpuMask
-import lucuma.core.model.sequence.gmos.GmosGratingConfig
 import lucuma.core.syntax.string.*
-import lucuma.core.syntax.timespan.*
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import lucuma.odb.data.OdbError
@@ -74,12 +34,7 @@ import lucuma.odb.logic.Generator
 import lucuma.odb.logic.TimeEstimateCalculatorImplementation
 import lucuma.odb.sequence.util.CommitHash
 import lucuma.odb.service.Services
-import lucuma.odb.smartgcal.data.Flamingos2
-import lucuma.odb.smartgcal.data.Gmos
-import lucuma.odb.smartgcal.data.SmartGcalValue
-import lucuma.odb.smartgcal.data.SmartGcalValue.LegacyInstrumentConfig
 import natchez.Trace.Implicits.noop
-import skunk.Session
 
 trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
 
@@ -96,145 +51,6 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
 
   val createProgram: IO[Program.Id] =
     createProgramAs(pi, "Sequence Testing")
-
-  val f2_key_JH1: Flamingos2.TableKey =
-    Flamingos2.TableKey(
-      Flamingos2Disperser.R1200JH.some,
-      Flamingos2Filter.JH,
-      Flamingos2Fpu.LongSlit1.some
-    )
-
-  val f2_flat_JH1 =
-    SmartGcalValue(
-      Gcal(
-        Gcal.Lamp.fromContinuum(GcalContinuum.IrGreyBodyHigh),
-        GcalFilter.Nd20,
-        GcalDiffuser.Ir,
-        GcalShutter.Open
-      ),
-      GcalBaselineType.Night,
-      PosInt.unsafeFrom(1),
-      LegacyInstrumentConfig(
-        TimeSpan.unsafeFromMicroseconds(15_000_000L)
-      )
-    )
-
-  val f2_arc_JH1 =
-    SmartGcalValue(
-      Gcal(
-        Gcal.Lamp.fromArcs(NonEmptySet.one(GcalArc.ArArc)),
-        GcalFilter.Nir,
-        GcalDiffuser.Ir,
-        GcalShutter.Closed
-      ),
-      GcalBaselineType.Night,
-      PosInt.unsafeFrom(1),
-      LegacyInstrumentConfig(
-        TimeSpan.unsafeFromMicroseconds(32_000_000L)
-      )
-    )
-
-  val gn_key_0_50: Gmos.TableKey[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu] =
-    Gmos.TableKey(
-      Gmos.GratingConfigKey(
-        GmosNorthGrating.R831_G5302,
-        GmosGratingOrder.One,
-        BoundedInterval.unsafeOpenUpper(Wavelength.Min, Wavelength.Max)
-      ).some,
-      GmosNorthFilter.RPrime.some,
-      GmosNorthFpu.LongSlit_0_50.some,
-      GmosXBinning.One,
-      GmosYBinning.Two,
-      GmosAmpGain.Low
-    )
-
-  // NB: 2x4, no filter
-  val gn_key_1_00: Gmos.TableKey[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu] =
-    Gmos.TableKey(
-      Gmos.GratingConfigKey(
-        GmosNorthGrating.R831_G5302,
-        GmosGratingOrder.One,
-        BoundedInterval.unsafeOpenUpper(Wavelength.Min, Wavelength.Max)
-      ).some,
-      none,
-      GmosNorthFpu.LongSlit_1_00.some,
-      GmosXBinning.Two,
-      GmosYBinning.Four,
-      GmosAmpGain.Low
-    )
-
-  val gn_key_5_00: Gmos.TableKey[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu] =
-    Gmos.TableKey(
-      Gmos.GratingConfigKey(
-        GmosNorthGrating.R831_G5302,
-        GmosGratingOrder.One,
-        BoundedInterval.unsafeOpenUpper(Wavelength.Min, Wavelength.Max)
-      ).some,
-      GmosNorthFilter.RPrime.some,
-      GmosNorthFpu.LongSlit_5_00.some,
-      GmosXBinning.One,
-      GmosYBinning.Two,
-      GmosAmpGain.Low
-    )
-
-  val gn_flat =
-    SmartGcalValue(
-      Gcal(
-        Gcal.Lamp.fromContinuum(GcalContinuum.QuartzHalogen5W),
-        GcalFilter.Gmos,
-        GcalDiffuser.Ir,
-        GcalShutter.Open
-      ),
-      GcalBaselineType.Night,
-      PosInt.unsafeFrom(1),
-      LegacyInstrumentConfig(
-        TimeSpan.unsafeFromMicroseconds(1_000_000L)
-      )
-    )
-
-  val gn_arc =
-    SmartGcalValue(
-      Gcal(
-        Gcal.Lamp.fromArcs(NonEmptySet.one(GcalArc.CuArArc)),
-        GcalFilter.None,
-        GcalDiffuser.Visible,
-        GcalShutter.Closed
-      ),
-      GcalBaselineType.Day,
-      PosInt.unsafeFrom(1),
-      LegacyInstrumentConfig(
-        TimeSpan.unsafeFromMicroseconds(1_000_000L)
-      )
-    )
-
-  override def dbInitialization: Option[Session[IO] => IO[Unit]] = Some { s =>
-    val flamingos2TableRows: List[Flamingos2.TableRow] =
-      List(
-        Flamingos2.TableRow(PosLong.unsafeFrom(1), f2_key_JH1, f2_flat_JH1),
-        Flamingos2.TableRow(PosLong.unsafeFrom(1), f2_key_JH1, f2_arc_JH1)
-      )
-
-    val gmosNorthTableRows: List[Gmos.TableRow.North] =
-      List(
-        Gmos.TableRow(PosLong.unsafeFrom(1), gn_key_0_50, gn_flat),
-        Gmos.TableRow(PosLong.unsafeFrom(1), gn_key_0_50, gn_arc),
-        Gmos.TableRow(PosLong.unsafeFrom(1), gn_key_1_00, gn_flat),
-        Gmos.TableRow(PosLong.unsafeFrom(1), gn_key_1_00, gn_arc),
-        Gmos.TableRow(PosLong.unsafeFrom(1), gn_key_5_00, gn_flat),
-        Gmos.TableRow(PosLong.unsafeFrom(1), gn_key_5_00, gn_arc)
-      )
-
-    Enums.load(s).flatMap: e =>
-      val services = Services.forUser(pi /* doesn't matter*/, e, None)(s)
-      services.transactionally:
-        (
-          flamingos2TableRows.zipWithIndex.traverse_ : (r, i) =>
-            services.smartGcalService.insertFlamingos2(i, r)
-        ) *> (
-          gmosNorthTableRows.zipWithIndex.traverse_ : (r, i) =>
-            services.smartGcalService.insertGmosNorth(i, r)
-        )
-  }
 
   def calibrationProgram(role: CalibrationRole): IO[Program.Id] =
     query(
@@ -296,80 +112,6 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
   def twilightTargets: IO[List[Target.Id]] =
     calibrationTargets(CalibrationRole.Twilight)
 
-  val Flamingos2AtomQuery: String =
-    s"""
-      description
-      observeClass
-      steps {
-        instrumentConfig {
-          exposure { seconds }
-          disperser
-          filter
-          readMode
-          lyotWheel
-          fpu { builtin }
-          decker
-          readoutMode
-          reads
-        }
-        stepConfig {
-          stepType
-          ... on Gcal {
-            continuum
-            arcs
-          }
-        }
-        telescopeConfig {
-          offset {
-            p { arcseconds }
-            q { arcseconds }
-          }
-          guiding
-        }
-        observeClass
-        breakpoint
-      }
-    """
-
-  val GmosAtomQuery: String =
-    s"""
-      description
-      observeClass
-      steps {
-        instrumentConfig {
-          exposure { seconds }
-          readout {
-            xBin
-            yBin
-          }
-          roi
-          gratingConfig {
-            grating
-            wavelength { nanometers }
-          }
-          filter
-          fpu { builtin }
-          centralWavelength { nanometers }
-        }
-        stepConfig {
-          stepType
-          ... on Gcal {
-            continuum
-            arcs
-          }
-        }
-        telescopeConfig {
-          offset {
-            p { arcseconds }
-            q { arcseconds }
-          }
-          guiding
-        }
-        observeClass
-        breakpoint
-      }
-    """
-
   def excutionConfigQuery(inst: String, sequenceType: String, atomQuery: String, futureLimit: Option[Int]): String =
     s"""
       execution {
@@ -389,18 +131,6 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
       }
     """
 
-  def flamingos2AcquisitionQuery(futureLimit: Option[Int]): String =
-    excutionConfigQuery("flamingos2", "acquisition", Flamingos2AtomQuery, futureLimit)
-
-  def flamingos2ScienceQuery(futureLimit: Option[Int]): String =
-    excutionConfigQuery("flamingos2", "science", Flamingos2AtomQuery, futureLimit)
-
-  def gmosNorthAcquisitionQuery(futureLimit: Option[Int]): String =
-    excutionConfigQuery("gmosNorth", "acquisition", GmosAtomQuery, futureLimit)
-
-  def gmosNorthScienceQuery(futureLimit: Option[Int]): String =
-    excutionConfigQuery("gmosNorth", "science", GmosAtomQuery, futureLimit)
-
   val ObsWavelength: Wavelength =
     Wavelength.decimalNanometers.unsafeGet(BigDecimal("500.0"))
 
@@ -408,100 +138,6 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
     ObsWavelength.unsafeOffset(
       WavelengthDither.decimalNanometers.unsafeGet(BigDecimal(ditherNm))
     )
-
-  val Flamingos2Science: Flamingos2DynamicConfig =
-    Flamingos2DynamicConfig(
-      fakeItcSpectroscopyResult.exposureTime,
-      Flamingos2Disperser.R1200JH.some,
-      Flamingos2Filter.JH,
-      Flamingos2ReadMode.Bright,
-      Flamingos2LyotWheel.F16,
-      Flamingos2FpuMask.Builtin(Flamingos2Fpu.LongSlit1),
-      Flamingos2Decker.LongSlit,
-      Flamingos2ReadoutMode.Science,
-      Flamingos2ReadMode.Bright.readCount
-    )
-
-  def gmosNorthScience(ditherNm: Int): GmosNorth =
-    GmosNorth(
-      fakeItcSpectroscopyResult.exposureTime,
-      GmosCcdMode(GmosXBinning.One, GmosYBinning.Two, GmosAmpCount.Twelve, GmosAmpGain.Low, GmosAmpReadMode.Slow),
-      GmosDtax.Zero,
-      GmosRoi.FullFrame,
-      GmosGratingConfig.North(GmosNorthGrating.R831_G5302, GmosGratingOrder.One, obsWavelengthAt(ditherNm)).some,
-      GmosNorthFilter.RPrime.some,
-      GmosFpuMask.Builtin(GmosNorthFpu.LongSlit_0_50).some
-    )
-
-  def gmosNorthArc(ditherNm: Int): GmosNorth =
-    gmosNorthScience(ditherNm).copy(exposure = gn_arc.instrumentConfig.exposureTime)
-
-  def gmosNorthFlat(ditherNm: Int): GmosNorth =
-    gmosNorthScience(ditherNm).copy(exposure = gn_flat.instrumentConfig.exposureTime)
-
-  val Flamingos2Acq0: Flamingos2DynamicConfig =
-    Flamingos2Science.copy(
-      exposure  = fakeItcImagingResult.exposureTime,
-      disperser = none,
-      filter    = Flamingos2Filter.H,
-      fpu       = Flamingos2FpuMask.Imaging,
-      decker    = Flamingos2Decker.Imaging
-    )
-
-  val Flamingos2Acq1: Flamingos2DynamicConfig =
-    Flamingos2Acq0.copy(
-      exposure  = 10.secondTimeSpan,
-      fpu       = Flamingos2FpuMask.Builtin(Flamingos2Fpu.LongSlit1),
-      decker    = Flamingos2Decker.LongSlit
-    )
-
-  val Flamingos2Acq2: Flamingos2DynamicConfig =
-    Flamingos2Acq1.copy(
-      exposure = fakeItcImagingResult.exposureTime
-    )
-
-  def flamingos2Acq(step: Int): Flamingos2DynamicConfig =
-    step match
-      case 0 => Flamingos2Acq0
-      case 1 => Flamingos2Acq1
-      case 2 => Flamingos2Acq2
-      case _ => sys.error("Only 3 steps in a Flamingos 2 Acq")
-
-  val GmosNorthAcq0: GmosNorth =
-    gmosNorthScience(0).copy(
-      exposure      = fakeItcImagingResult.exposureTime,
-      readout       = GmosCcdMode(GmosXBinning.Two, GmosYBinning.Two, GmosAmpCount.Twelve, GmosAmpGain.Low, GmosAmpReadMode.Fast),
-      roi           = GmosRoi.Ccd2,
-      gratingConfig = none,
-      filter        = GmosNorthFilter.GPrime.some,
-      fpu           = none
-    )
-
-  val GmosNorthAcq1: GmosNorth =
-    GmosNorthAcq0.copy(
-      exposure = GmosNorthAcq0.exposure *| 2,
-      readout  = GmosCcdMode(GmosXBinning.One, GmosYBinning.One, GmosAmpCount.Twelve, GmosAmpGain.Low, GmosAmpReadMode.Fast),
-      roi      = GmosRoi.CentralStamp,
-      fpu      = gmosNorthScience(0).fpu
-    )
-
-  val GmosNorthAcq2: GmosNorth =
-    GmosNorthAcq1.copy(
-      exposure = GmosNorthAcq0.exposure *| 3
-    )
-
-  def gmosNorthAcq(step: Int): GmosNorth =
-    step match
-      case 0 => GmosNorthAcq0
-      case 1 => GmosNorthAcq1
-      case 2 => GmosNorthAcq2
-      case _ => sys.error("Only 3 steps in a GMOS North Acq")
-
-  val FlatStep: StepConfig.Gcal =
-    StepConfig.Gcal(Gcal.Lamp.fromContinuum(GcalContinuum.QuartzHalogen5W), GcalFilter.Gmos, GcalDiffuser.Ir, GcalShutter.Open)
-
-  val ArcStep: StepConfig.Gcal  =
-    StepConfig.Gcal(Gcal.Lamp.fromArcs(NonEmptySet.one(GcalArc.CuArArc)), GcalFilter.None, GcalDiffuser.Visible, GcalShutter.Closed)
 
   def telescopeConfig(p: Int, q: Int, g: StepGuideState): TelescopeConfig =
     TelescopeConfig(
@@ -525,133 +161,6 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
         "guiding": ${t.guiding}
       }
     """
-
-  protected def flamingos2ExpectedInstrumentConfig(f2: Flamingos2DynamicConfig): Json =
-    json"""
-      {
-        "exposure": { "seconds": ${f2.exposure.toSeconds} },
-        "disperser": ${f2.disperser.fold(Json.Null)(_.asJson)},
-        "filter": ${f2.filter},
-        "readMode": ${f2.readMode},
-        "lyotWheel": ${f2.lyotWheel},
-        "fpu": ${
-          f2.fpu match
-            case Flamingos2FpuMask.Imaging      => Json.Null
-            case Flamingos2FpuMask.Builtin(f)   => json"""{ "builtin": $f }"""
-            case Flamingos2FpuMask.Custom(f, w) => json"""{ "filename": ${f.value}, "slitWidth": $w }"""
-        },
-        "decker": ${f2.decker},
-        "readoutMode": ${f2.readoutMode},
-        "reads": ${f2.reads}
-      }
-    """
-
-  protected def flamingos2ExpectedAcq(step: Int, p: Int, breakpoint: Breakpoint = Breakpoint.Disabled): Json =
-    json"""
-      {
-        "instrumentConfig" : ${flamingos2ExpectedInstrumentConfig(flamingos2Acq(step))},
-        "stepConfig" : { "stepType":  "SCIENCE" },
-        "telescopeConfig": ${expectedTelescopeConfig(p, 0, StepGuideState.Enabled)},
-        "observeClass" : "ACQUISITION",
-        "breakpoint": ${breakpoint.tag.toScreamingSnakeCase.asJson}
-      }
-    """
-
-  protected def gmosNorthExpectedInstrumentConfig(gn: GmosNorth): Json =
-    json"""
-      {
-        "exposure": { "seconds": ${gn.exposure.toSeconds} },
-        "readout": {
-          "xBin": ${gn.readout.xBin},
-          "yBin": ${gn.readout.yBin}
-        },
-        "roi": ${gn.roi},
-        "gratingConfig": ${gn.gratingConfig.fold(Json.Null) { gc =>
-          json"""
-            {
-              "grating": ${gc.grating},
-              "wavelength": {
-                "nanometers": ${gc.wavelength.toNanometers.value.value}
-              }
-            }
-          """
-        }},
-        "filter": ${gn.filter},
-        "fpu": ${gn.fpu.fold(Json.Null) { fpu =>
-          json"""{ "builtin": ${fpu.builtin.map(_.value)} }"""
-        }},
-        "centralWavelength": ${gn.centralWavelength.fold(Json.Null) { cw =>
-          json"""
-            {
-              "nanometers": ${cw.toNanometers.value.value}
-            }
-          """
-        }}
-      }
-    """
-
-  protected def gmosNorthExpectedArc(ditherNm: Int, p: Int, q: Int): Json =
-    json"""
-      {
-        "instrumentConfig" : ${gmosNorthExpectedInstrumentConfig(gmosNorthArc(ditherNm))},
-        "stepConfig" : {
-          "stepType": "GCAL",
-          "continuum" : null,
-          "arcs" : ${gn_arc.gcalConfig.lamp.arcs.map(_.toList) }
-        },
-        "telescopeConfig": ${expectedTelescopeConfig(p, q, StepGuideState.Disabled)},
-        "observeClass" : "NIGHT_CAL",
-        "breakpoint": "DISABLED"
-      }
-    """
-
-  protected def gmosNorthExpectedFlat(ditherNm: Int, p: Int, q: Int): Json =
-    json"""
-      {
-        "instrumentConfig" : ${gmosNorthExpectedInstrumentConfig(gmosNorthFlat(ditherNm))},
-        "stepConfig" : {
-          "stepType": "GCAL",
-          "continuum" : ${gn_flat.gcalConfig.lamp.continuum},
-          "arcs" : []
-        },
-        "telescopeConfig": ${expectedTelescopeConfig(p, q, StepGuideState.Disabled)},
-        "observeClass" : "NIGHT_CAL",
-        "breakpoint": "DISABLED"
-      }
-    """
-
-  protected def gmosNorthExpectedScience(ditherNm: Int, p: Int, q: Int): Json =
-    json"""
-      {
-        "instrumentConfig" : ${gmosNorthExpectedInstrumentConfig(gmosNorthScience(ditherNm))},
-        "stepConfig" : { "stepType": "SCIENCE" },
-        "telescopeConfig": ${expectedTelescopeConfig(p, q, StepGuideState.Enabled)},
-        "observeClass" : "SCIENCE",
-        "breakpoint": "DISABLED"
-      }
-    """
-
-  protected def gmosNorthExpectedAcq(step: Int, p: Int, breakpoint: Breakpoint = Breakpoint.Disabled): Json =
-    json"""
-      {
-        "instrumentConfig" : ${gmosNorthExpectedInstrumentConfig(gmosNorthAcq(step))},
-        "stepConfig" : { "stepType":  "SCIENCE" },
-        "telescopeConfig": ${expectedTelescopeConfig(p, 0, StepGuideState.Enabled)},
-        "observeClass" : "ACQUISITION",
-        "breakpoint": ${breakpoint.tag.toScreamingSnakeCase.asJson}
-      }
-    """
-
-  protected def gmosNorthExpectedScienceAtom(ditherNm: Int, p: Int, q: Int, exposures: Int): Json =
-    val steps = List(
-      gmosNorthExpectedArc(ditherNm, p, q), gmosNorthExpectedFlat(ditherNm, p, q)
-    ) ++ List.fill(exposures)(gmosNorthExpectedScience(ditherNm, p, q))
-
-    Json.obj(
-      "description" -> s"$ditherNm.000 nm, $q.000000″".asJson,
-      "observeClass" -> "SCIENCE".asJson,
-      "steps" -> steps.asJson
-    )
 
   def addEndStepEvent(sid: Step.Id): IO[Unit] = {
     val q = s"""

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForFlamingos2.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForFlamingos2.scala
@@ -1,0 +1,215 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.query
+
+import cats.data.NonEmptySet
+import cats.effect.IO
+import cats.syntax.all.*
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.numeric.PosLong
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.enums.Breakpoint
+import lucuma.core.enums.Flamingos2Decker
+import lucuma.core.enums.Flamingos2Disperser
+import lucuma.core.enums.Flamingos2Filter
+import lucuma.core.enums.Flamingos2Fpu
+import lucuma.core.enums.Flamingos2LyotWheel
+import lucuma.core.enums.Flamingos2ReadMode
+import lucuma.core.enums.Flamingos2ReadoutMode
+import lucuma.core.enums.Flamingos2Reads
+import lucuma.core.enums.GcalArc
+import lucuma.core.enums.GcalBaselineType
+import lucuma.core.enums.GcalContinuum
+import lucuma.core.enums.GcalDiffuser
+import lucuma.core.enums.GcalFilter
+import lucuma.core.enums.GcalShutter
+import lucuma.core.enums.StepGuideState
+import lucuma.core.model.sequence.StepConfig
+import lucuma.core.model.sequence.StepConfig.Gcal
+import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig
+import lucuma.core.model.sequence.flamingos2.Flamingos2FpuMask
+import lucuma.core.syntax.string.*
+import lucuma.core.syntax.timespan.*
+import lucuma.core.util.TimeSpan
+import lucuma.odb.graphql.enums.Enums
+import lucuma.odb.service.Services
+import lucuma.odb.smartgcal.data.Flamingos2
+import lucuma.odb.smartgcal.data.SmartGcalValue
+import lucuma.odb.smartgcal.data.SmartGcalValue.LegacyInstrumentConfig
+import natchez.Trace.Implicits.noop
+import skunk.Session
+
+trait ExecutionTestSupportForFlamingos2 extends ExecutionTestSupport:
+
+  val f2_key_JH1: Flamingos2.TableKey =
+    Flamingos2.TableKey(
+      Flamingos2Disperser.R1200JH.some,
+      Flamingos2Filter.JH,
+      Flamingos2Fpu.LongSlit1.some
+    )
+
+  val f2_flat_JH1 =
+    SmartGcalValue(
+      Gcal(
+        Gcal.Lamp.fromContinuum(GcalContinuum.IrGreyBodyHigh),
+        GcalFilter.Nd20,
+        GcalDiffuser.Ir,
+        GcalShutter.Open
+      ),
+      GcalBaselineType.Night,
+      PosInt.unsafeFrom(1),
+      LegacyInstrumentConfig(
+        TimeSpan.unsafeFromMicroseconds(15_000_000L)
+      )
+    )
+
+  val f2_arc_JH1 =
+    SmartGcalValue(
+      Gcal(
+        Gcal.Lamp.fromArcs(NonEmptySet.one(GcalArc.ArArc)),
+        GcalFilter.Nir,
+        GcalDiffuser.Ir,
+        GcalShutter.Closed
+      ),
+      GcalBaselineType.Night,
+      PosInt.unsafeFrom(1),
+      LegacyInstrumentConfig(
+        TimeSpan.unsafeFromMicroseconds(32_000_000L)
+      )
+    )
+
+  override def dbInitialization: Option[Session[IO] => IO[Unit]] = Some { s =>
+    val rows: List[Flamingos2.TableRow] =
+      List(
+        Flamingos2.TableRow(PosLong.unsafeFrom(1), f2_key_JH1, f2_flat_JH1),
+        Flamingos2.TableRow(PosLong.unsafeFrom(1), f2_key_JH1, f2_arc_JH1)
+      )
+
+    Enums.load(s).flatMap: e =>
+      val services = Services.forUser(pi /* doesn't matter*/, e, None)(s)
+      services.transactionally:
+        rows.zipWithIndex.traverse_ : (r, i) =>
+          services.smartGcalService.insertFlamingos2(i, r)
+  }
+
+  val Flamingos2AtomQuery: String =
+    s"""
+      description
+      observeClass
+      steps {
+        instrumentConfig {
+          exposure { seconds }
+          disperser
+          filter
+          readMode
+          lyotWheel
+          fpu { builtin }
+          decker
+          readoutMode
+          reads
+        }
+        stepConfig {
+          stepType
+          ... on Gcal {
+            continuum
+            arcs
+          }
+        }
+        telescopeConfig {
+          offset {
+            p { arcseconds }
+            q { arcseconds }
+          }
+          guiding
+        }
+        observeClass
+        breakpoint
+      }
+    """
+
+  def flamingos2AcquisitionQuery(futureLimit: Option[Int]): String =
+    excutionConfigQuery("flamingos2", "acquisition", Flamingos2AtomQuery, futureLimit)
+
+  def flamingos2ScienceQuery(futureLimit: Option[Int]): String =
+    excutionConfigQuery("flamingos2", "science", Flamingos2AtomQuery, futureLimit)
+
+  val Flamingos2Science: Flamingos2DynamicConfig =
+    Flamingos2DynamicConfig(
+      fakeItcSpectroscopyResult.exposureTime,
+      Flamingos2Disperser.R1200JH.some,
+      Flamingos2Filter.JH,
+      Flamingos2ReadMode.Bright,
+      Flamingos2LyotWheel.F16,
+      Flamingos2FpuMask.Builtin(Flamingos2Fpu.LongSlit1),
+      Flamingos2Decker.LongSlit,
+      Flamingos2ReadoutMode.Science,
+      Flamingos2ReadMode.Bright.readCount
+    )
+
+  val Flamingos2Acq0: Flamingos2DynamicConfig =
+    Flamingos2Science.copy(
+      exposure  = fakeItcImagingResult.exposureTime,
+      disperser = none,
+      filter    = Flamingos2Filter.H,
+      fpu       = Flamingos2FpuMask.Imaging,
+      decker    = Flamingos2Decker.Imaging
+    )
+
+  val Flamingos2Acq1: Flamingos2DynamicConfig =
+    Flamingos2Acq0.copy(
+      exposure  = 10.secondTimeSpan,
+      fpu       = Flamingos2FpuMask.Builtin(Flamingos2Fpu.LongSlit1),
+      decker    = Flamingos2Decker.LongSlit
+    )
+
+  val Flamingos2Acq2: Flamingos2DynamicConfig =
+    Flamingos2Acq1.copy(
+      exposure = fakeItcImagingResult.exposureTime
+    )
+
+  def flamingos2Acq(step: Int): Flamingos2DynamicConfig =
+    step match
+      case 0 => Flamingos2Acq0
+      case 1 => Flamingos2Acq1
+      case 2 => Flamingos2Acq2
+      case _ => sys.error("Only 3 steps in a Flamingos 2 Acq")
+
+  val Flamingos2FlatStep: StepConfig.Gcal =
+    StepConfig.Gcal(Gcal.Lamp.fromContinuum(GcalContinuum.QuartzHalogen5W), GcalFilter.Nd20, GcalDiffuser.Ir, GcalShutter.Open)
+
+  val Flamingos2ArcStep: StepConfig.Gcal  =
+    StepConfig.Gcal(Gcal.Lamp.fromArcs(NonEmptySet.one(GcalArc.CuArArc)), GcalFilter.None, GcalDiffuser.Visible, GcalShutter.Closed)
+
+  protected def flamingos2ExpectedInstrumentConfig(f2: Flamingos2DynamicConfig): Json =
+    json"""
+      {
+        "exposure": { "seconds": ${f2.exposure.toSeconds} },
+        "disperser": ${f2.disperser.fold(Json.Null)(_.asJson)},
+        "filter": ${f2.filter},
+        "readMode": ${f2.readMode},
+        "lyotWheel": ${f2.lyotWheel},
+        "fpu": ${
+          f2.fpu match
+            case Flamingos2FpuMask.Imaging      => Json.Null
+            case Flamingos2FpuMask.Builtin(f)   => json"""{ "builtin": $f }"""
+            case Flamingos2FpuMask.Custom(f, w) => json"""{ "filename": ${f.value}, "slitWidth": $w }"""
+        },
+        "decker": ${f2.decker},
+        "readoutMode": ${f2.readoutMode},
+        "reads": ${f2.reads}
+      }
+    """
+
+  protected def flamingos2ExpectedAcq(step: Int, p: Int, breakpoint: Breakpoint = Breakpoint.Disabled): Json =
+    json"""
+      {
+        "instrumentConfig" : ${flamingos2ExpectedInstrumentConfig(flamingos2Acq(step))},
+        "stepConfig" : { "stepType":  "SCIENCE" },
+        "telescopeConfig": ${expectedTelescopeConfig(p, 0, StepGuideState.Enabled)},
+        "observeClass" : "ACQUISITION",
+        "breakpoint": ${breakpoint.tag.toScreamingSnakeCase.asJson}
+      }
+    """

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGmos.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGmos.scala
@@ -1,0 +1,336 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.query
+
+import cats.data.NonEmptySet
+import cats.effect.IO
+import cats.syntax.all.*
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.numeric.PosLong
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.enums.Breakpoint
+import lucuma.core.enums.GcalArc
+import lucuma.core.enums.GcalBaselineType
+import lucuma.core.enums.GcalContinuum
+import lucuma.core.enums.GcalDiffuser
+import lucuma.core.enums.GcalFilter
+import lucuma.core.enums.GcalShutter
+import lucuma.core.enums.GmosAmpCount
+import lucuma.core.enums.GmosAmpGain
+import lucuma.core.enums.GmosAmpReadMode
+import lucuma.core.enums.GmosDtax
+import lucuma.core.enums.GmosGratingOrder
+import lucuma.core.enums.GmosNorthFilter
+import lucuma.core.enums.GmosNorthFpu
+import lucuma.core.enums.GmosNorthGrating
+import lucuma.core.enums.GmosRoi
+import lucuma.core.enums.GmosXBinning
+import lucuma.core.enums.GmosYBinning
+import lucuma.core.enums.StepGuideState
+import lucuma.core.math.BoundedInterval
+import lucuma.core.math.Wavelength
+import lucuma.core.model.sequence.StepConfig
+import lucuma.core.model.sequence.StepConfig.Gcal
+import lucuma.core.model.sequence.gmos.DynamicConfig.GmosNorth
+import lucuma.core.model.sequence.gmos.GmosCcdMode
+import lucuma.core.model.sequence.gmos.GmosFpuMask
+import lucuma.core.model.sequence.gmos.GmosGratingConfig
+import lucuma.core.syntax.string.*
+import lucuma.core.util.TimeSpan
+import lucuma.odb.graphql.enums.Enums
+import lucuma.odb.service.Services
+import lucuma.odb.smartgcal.data.Gmos
+import lucuma.odb.smartgcal.data.SmartGcalValue
+import lucuma.odb.smartgcal.data.SmartGcalValue.LegacyInstrumentConfig
+import natchez.Trace.Implicits.noop
+import skunk.Session
+
+trait ExecutionTestSupportForGmos extends ExecutionTestSupport:
+
+  val gn_key_0_50: Gmos.TableKey[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu] =
+    Gmos.TableKey(
+      Gmos.GratingConfigKey(
+        GmosNorthGrating.R831_G5302,
+        GmosGratingOrder.One,
+        BoundedInterval.unsafeOpenUpper(Wavelength.Min, Wavelength.Max)
+      ).some,
+      GmosNorthFilter.RPrime.some,
+      GmosNorthFpu.LongSlit_0_50.some,
+      GmosXBinning.One,
+      GmosYBinning.Two,
+      GmosAmpGain.Low
+    )
+
+  // NB: 2x4, no filter
+  val gn_key_1_00: Gmos.TableKey[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu] =
+    Gmos.TableKey(
+      Gmos.GratingConfigKey(
+        GmosNorthGrating.R831_G5302,
+        GmosGratingOrder.One,
+        BoundedInterval.unsafeOpenUpper(Wavelength.Min, Wavelength.Max)
+      ).some,
+      none,
+      GmosNorthFpu.LongSlit_1_00.some,
+      GmosXBinning.Two,
+      GmosYBinning.Four,
+      GmosAmpGain.Low
+    )
+
+  val gn_key_5_00: Gmos.TableKey[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu] =
+    Gmos.TableKey(
+      Gmos.GratingConfigKey(
+        GmosNorthGrating.R831_G5302,
+        GmosGratingOrder.One,
+        BoundedInterval.unsafeOpenUpper(Wavelength.Min, Wavelength.Max)
+      ).some,
+      GmosNorthFilter.RPrime.some,
+      GmosNorthFpu.LongSlit_5_00.some,
+      GmosXBinning.One,
+      GmosYBinning.Two,
+      GmosAmpGain.Low
+    )
+
+  val gn_flat =
+    SmartGcalValue(
+      Gcal(
+        Gcal.Lamp.fromContinuum(GcalContinuum.QuartzHalogen5W),
+        GcalFilter.Gmos,
+        GcalDiffuser.Ir,
+        GcalShutter.Open
+      ),
+      GcalBaselineType.Night,
+      PosInt.unsafeFrom(1),
+      LegacyInstrumentConfig(
+        TimeSpan.unsafeFromMicroseconds(1_000_000L)
+      )
+    )
+
+  val gn_arc =
+    SmartGcalValue(
+      Gcal(
+        Gcal.Lamp.fromArcs(NonEmptySet.one(GcalArc.CuArArc)),
+        GcalFilter.None,
+        GcalDiffuser.Visible,
+        GcalShutter.Closed
+      ),
+      GcalBaselineType.Day,
+      PosInt.unsafeFrom(1),
+      LegacyInstrumentConfig(
+        TimeSpan.unsafeFromMicroseconds(1_000_000L)
+      )
+    )
+
+  override def dbInitialization: Option[Session[IO] => IO[Unit]] = Some { s =>
+    val rows: List[Gmos.TableRow.North] =
+      List(
+        Gmos.TableRow(PosLong.unsafeFrom(1), gn_key_0_50, gn_flat),
+        Gmos.TableRow(PosLong.unsafeFrom(1), gn_key_0_50, gn_arc),
+        Gmos.TableRow(PosLong.unsafeFrom(1), gn_key_1_00, gn_flat),
+        Gmos.TableRow(PosLong.unsafeFrom(1), gn_key_1_00, gn_arc),
+        Gmos.TableRow(PosLong.unsafeFrom(1), gn_key_5_00, gn_flat),
+        Gmos.TableRow(PosLong.unsafeFrom(1), gn_key_5_00, gn_arc)
+      )
+
+    Enums.load(s).flatMap: e =>
+      val services = Services.forUser(pi /* doesn't matter*/, e, None)(s)
+      services.transactionally:
+        rows.zipWithIndex.traverse_ : (r, i) =>
+          services.smartGcalService.insertGmosNorth(i, r)
+  }
+
+  val GmosAtomQuery: String =
+    s"""
+      description
+      observeClass
+      steps {
+        instrumentConfig {
+          exposure { seconds }
+          readout {
+            xBin
+            yBin
+          }
+          roi
+          gratingConfig {
+            grating
+            wavelength { nanometers }
+          }
+          filter
+          fpu { builtin }
+          centralWavelength { nanometers }
+        }
+        stepConfig {
+          stepType
+          ... on Gcal {
+            continuum
+            arcs
+          }
+        }
+        telescopeConfig {
+          offset {
+            p { arcseconds }
+            q { arcseconds }
+          }
+          guiding
+        }
+        observeClass
+        breakpoint
+      }
+    """
+
+  def gmosNorthAcquisitionQuery(futureLimit: Option[Int]): String =
+    excutionConfigQuery("gmosNorth", "acquisition", GmosAtomQuery, futureLimit)
+
+  def gmosNorthScienceQuery(futureLimit: Option[Int]): String =
+    excutionConfigQuery("gmosNorth", "science", GmosAtomQuery, futureLimit)
+
+  def gmosNorthScience(ditherNm: Int): GmosNorth =
+    GmosNorth(
+      fakeItcSpectroscopyResult.exposureTime,
+      GmosCcdMode(GmosXBinning.One, GmosYBinning.Two, GmosAmpCount.Twelve, GmosAmpGain.Low, GmosAmpReadMode.Slow),
+      GmosDtax.Zero,
+      GmosRoi.FullFrame,
+      GmosGratingConfig.North(GmosNorthGrating.R831_G5302, GmosGratingOrder.One, obsWavelengthAt(ditherNm)).some,
+      GmosNorthFilter.RPrime.some,
+      GmosFpuMask.Builtin(GmosNorthFpu.LongSlit_0_50).some
+    )
+
+  def gmosNorthArc(ditherNm: Int): GmosNorth =
+    gmosNorthScience(ditherNm).copy(exposure = gn_arc.instrumentConfig.exposureTime)
+
+  def gmosNorthFlat(ditherNm: Int): GmosNorth =
+    gmosNorthScience(ditherNm).copy(exposure = gn_flat.instrumentConfig.exposureTime)
+
+  val GmosNorthAcq0: GmosNorth =
+    gmosNorthScience(0).copy(
+      exposure      = fakeItcImagingResult.exposureTime,
+      readout       = GmosCcdMode(GmosXBinning.Two, GmosYBinning.Two, GmosAmpCount.Twelve, GmosAmpGain.Low, GmosAmpReadMode.Fast),
+      roi           = GmosRoi.Ccd2,
+      gratingConfig = none,
+      filter        = GmosNorthFilter.GPrime.some,
+      fpu           = none
+    )
+
+  val GmosNorthAcq1: GmosNorth =
+    GmosNorthAcq0.copy(
+      exposure = GmosNorthAcq0.exposure *| 2,
+      readout  = GmosCcdMode(GmosXBinning.One, GmosYBinning.One, GmosAmpCount.Twelve, GmosAmpGain.Low, GmosAmpReadMode.Fast),
+      roi      = GmosRoi.CentralStamp,
+      fpu      = gmosNorthScience(0).fpu
+    )
+
+  val GmosNorthAcq2: GmosNorth =
+    GmosNorthAcq1.copy(
+      exposure = GmosNorthAcq0.exposure *| 3
+    )
+
+  def gmosNorthAcq(step: Int): GmosNorth =
+    step match
+      case 0 => GmosNorthAcq0
+      case 1 => GmosNorthAcq1
+      case 2 => GmosNorthAcq2
+      case _ => sys.error("Only 3 steps in a GMOS North Acq")
+
+  val FlatStep: StepConfig.Gcal =
+    StepConfig.Gcal(Gcal.Lamp.fromContinuum(GcalContinuum.QuartzHalogen5W), GcalFilter.Gmos, GcalDiffuser.Ir, GcalShutter.Open)
+
+  val ArcStep: StepConfig.Gcal  =
+    StepConfig.Gcal(Gcal.Lamp.fromArcs(NonEmptySet.one(GcalArc.CuArArc)), GcalFilter.None, GcalDiffuser.Visible, GcalShutter.Closed)
+
+  protected def gmosNorthExpectedInstrumentConfig(gn: GmosNorth): Json =
+    json"""
+      {
+        "exposure": { "seconds": ${gn.exposure.toSeconds} },
+        "readout": {
+          "xBin": ${gn.readout.xBin},
+          "yBin": ${gn.readout.yBin}
+        },
+        "roi": ${gn.roi},
+        "gratingConfig": ${gn.gratingConfig.fold(Json.Null) { gc =>
+          json"""
+            {
+              "grating": ${gc.grating},
+              "wavelength": {
+                "nanometers": ${gc.wavelength.toNanometers.value.value}
+              }
+            }
+          """
+        }},
+        "filter": ${gn.filter},
+        "fpu": ${gn.fpu.fold(Json.Null) { fpu =>
+          json"""{ "builtin": ${fpu.builtin.map(_.value)} }"""
+        }},
+        "centralWavelength": ${gn.centralWavelength.fold(Json.Null) { cw =>
+          json"""
+            {
+              "nanometers": ${cw.toNanometers.value.value}
+            }
+          """
+        }}
+      }
+    """
+
+  protected def gmosNorthExpectedArc(ditherNm: Int, p: Int, q: Int): Json =
+    json"""
+      {
+        "instrumentConfig" : ${gmosNorthExpectedInstrumentConfig(gmosNorthArc(ditherNm))},
+        "stepConfig" : {
+          "stepType": "GCAL",
+          "continuum" : null,
+          "arcs" : ${gn_arc.gcalConfig.lamp.arcs.map(_.toList) }
+        },
+        "telescopeConfig": ${expectedTelescopeConfig(p, q, StepGuideState.Disabled)},
+        "observeClass" : "NIGHT_CAL",
+        "breakpoint": "DISABLED"
+      }
+    """
+
+  protected def gmosNorthExpectedFlat(ditherNm: Int, p: Int, q: Int): Json =
+    json"""
+      {
+        "instrumentConfig" : ${gmosNorthExpectedInstrumentConfig(gmosNorthFlat(ditherNm))},
+        "stepConfig" : {
+          "stepType": "GCAL",
+          "continuum" : ${gn_flat.gcalConfig.lamp.continuum},
+          "arcs" : []
+        },
+        "telescopeConfig": ${expectedTelescopeConfig(p, q, StepGuideState.Disabled)},
+        "observeClass" : "NIGHT_CAL",
+        "breakpoint": "DISABLED"
+      }
+    """
+
+  protected def gmosNorthExpectedScience(ditherNm: Int, p: Int, q: Int): Json =
+    json"""
+      {
+        "instrumentConfig" : ${gmosNorthExpectedInstrumentConfig(gmosNorthScience(ditherNm))},
+        "stepConfig" : { "stepType": "SCIENCE" },
+        "telescopeConfig": ${expectedTelescopeConfig(p, q, StepGuideState.Enabled)},
+        "observeClass" : "SCIENCE",
+        "breakpoint": "DISABLED"
+      }
+    """
+
+  protected def gmosNorthExpectedAcq(step: Int, p: Int, breakpoint: Breakpoint = Breakpoint.Disabled): Json =
+    json"""
+      {
+        "instrumentConfig" : ${gmosNorthExpectedInstrumentConfig(gmosNorthAcq(step))},
+        "stepConfig" : { "stepType":  "SCIENCE" },
+        "telescopeConfig": ${expectedTelescopeConfig(p, 0, StepGuideState.Enabled)},
+        "observeClass" : "ACQUISITION",
+        "breakpoint": ${breakpoint.tag.toScreamingSnakeCase.asJson}
+      }
+    """
+
+  protected def gmosNorthExpectedScienceAtom(ditherNm: Int, p: Int, q: Int, exposures: Int): Json =
+    val steps = List(
+      gmosNorthExpectedArc(ditherNm, p, q), gmosNorthExpectedFlat(ditherNm, p, q)
+    ) ++ List.fill(exposures)(gmosNorthExpectedScience(ditherNm, p, q))
+
+    Json.obj(
+      "description" -> s"$ditherNm.000 nm, $q.000000″".asJson,
+      "observeClass" -> "SCIENCE".asJson,
+      "steps" -> steps.asJson
+    )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqFlamingos2.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqFlamingos2.scala
@@ -12,7 +12,7 @@ import lucuma.core.enums.StepGuideState
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.TelescopeConfig
 
-class executionAcqFlamingos2 extends ExecutionTestSupport {
+class executionAcqFlamingos2 extends ExecutionTestSupportForFlamingos2 {
 
   def acqTelescopeConfig(p: Int): TelescopeConfig =
     telescopeConfig(p, 0, StepGuideState.Enabled)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGmosNorth.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGmosNorth.scala
@@ -23,7 +23,7 @@ import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.TelescopeConfig
 import lucuma.odb.json.all.transport.given
 
-class executionAcqGmosNorth extends ExecutionTestSupport {
+class executionAcqGmosNorth extends ExecutionTestSupportForGmos {
 
   def acqTelescopeConfig(p: Int): TelescopeConfig =
     telescopeConfig(p, 0, StepGuideState.Enabled)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAtomRecords.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAtomRecords.scala
@@ -31,7 +31,7 @@ import lucuma.odb.json.wavelength.transport.given
 import munit.Assertions.*
 
 class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
-                                            with ExecutionTestSupport {
+                                            with ExecutionTestSupportForGmos {
 
   val mode    = ObservingModeType.GmosNorthLongSlit
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
@@ -34,7 +34,7 @@ import lucuma.odb.data.Md5Hash
 import lucuma.odb.graphql.input.AddStepEventInput
 
 
-class executionDigest extends ExecutionTestSupport {
+class executionDigest extends ExecutionTestSupportForGmos {
 
   override def fakeItcSpectroscopyResult: IntegrationTime =
     IntegrationTime(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionFailures.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionFailures.scala
@@ -16,7 +16,7 @@ import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.odb.data.OdbError
 
-class executionFailures extends ExecutionTestSupport {
+class executionFailures extends ExecutionTestSupportForGmos {
 
   test("ITC failure") {
     // Creates an observation with a central wavelength of 666, which prompts

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionPlannedTime.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionPlannedTime.scala
@@ -18,7 +18,7 @@ import lucuma.core.syntax.timespan.*
 import lucuma.itc.IntegrationTime
 
 
-class executionPlannedTime extends ExecutionTestSupport {
+class executionPlannedTime extends ExecutionTestSupportForGmos {
   override def fakeItcSpectroscopyResult: IntegrationTime =
     IntegrationTime(
       20.minTimeSpan,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSci.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSci.scala
@@ -39,7 +39,7 @@ import lucuma.odb.util.Codecs.step_id
 import skunk.*
 import skunk.implicits.*
 
-class executionSci extends ExecutionTestSupport {
+class executionSci extends ExecutionTestSupportForGmos {
 
   def gcalTelescopeConfig(q: Int): TelescopeConfig =
     telescopeConfig(0, q, StepGuideState.Disabled)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSpecPhot.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSpecPhot.scala
@@ -15,7 +15,7 @@ import lucuma.core.model.Observation
 import lucuma.core.syntax.timespan.*
 import lucuma.itc.IntegrationTime
 
-class executionSpecPhot extends ExecutionTestSupport {
+class executionSpecPhot extends ExecutionTestSupportForGmos {
 
   override def fakeItcSpectroscopyResult: IntegrationTime =
     IntegrationTime(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionState.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionState.scala
@@ -21,7 +21,7 @@ import lucuma.core.util.TimeSpan
 import lucuma.itc.IntegrationTime
 import lucuma.odb.json.all.transport.given
 
-class executionState extends ExecutionTestSupport {
+class executionState extends ExecutionTestSupportForGmos {
 
   override def fakeItcSpectroscopyResult: IntegrationTime =
     IntegrationTime(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionTwilight.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionTwilight.scala
@@ -22,7 +22,7 @@ import lucuma.odb.json.timeaccounting.given
 
 import java.time.Instant
 
-class executionTwilight extends ExecutionTestSupport {
+class executionTwilight extends ExecutionTestSupportForGmos {
 
   // Need a timestamp to call the calibrations service
   val when: Instant =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideAvailability.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideAvailability.scala
@@ -24,7 +24,7 @@ import lucuma.odb.service.GuideService.AvailabilityPeriod
 import org.http4s.Request
 import org.http4s.Response
 
-class guideAvailability extends ExecutionTestSupport {
+class guideAvailability extends ExecutionTestSupportForGmos {
 
   val oct15_2023 = "2023-10-15T00:00:00Z"
   val oct25_2023 = "2023-10-25T00:00:00Z"

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironment.scala
@@ -21,7 +21,7 @@ import lucuma.core.util.Timestamp
 import org.http4s.Request
 import org.http4s.Response
 
-class guideEnvironment extends ExecutionTestSupport {
+class guideEnvironment extends ExecutionTestSupportForGmos {
 
   val gaiaSuccess = Timestamp.FromString.getOption("2023-08-30T00:00:00Z").get
   val gaiaEmpty   = Timestamp.FromString.getOption("3000-01-30T04:00:00Z").get

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironments.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironments.scala
@@ -15,7 +15,7 @@ import lucuma.core.model.Observation
 import org.http4s.Request
 import org.http4s.Response
 
-class guideEnvironments extends ExecutionTestSupport {
+class guideEnvironments extends ExecutionTestSupportForGmos {
 
   val aug2023 = "2023-08-30T00:00:00Z"
   val aug3000 = "3000-08-30T00:00:00Z"

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideTargetName.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideTargetName.scala
@@ -18,7 +18,7 @@ import lucuma.core.util.Timestamp
 import org.http4s.Request
 import org.http4s.Response
 
-class guideTargetName extends ExecutionTestSupport {
+class guideTargetName extends ExecutionTestSupportForGmos {
   
   val targetName1: String = GuideStarName.gaiaSourceId.reverseGet(1L).value.value
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programPlannedTime.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programPlannedTime.scala
@@ -25,7 +25,7 @@ import lucuma.itc.IntegrationTime
 import lucuma.odb.graphql.input.AllocationInput
 
 
-class programPlannedTime extends ExecutionTestSupport:
+class programPlannedTime extends ExecutionTestSupportForGmos:
 
   extension (s: String)
     def sec: BigDecimal =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEditOnCachedResultUpdate.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEditOnCachedResultUpdate.scala
@@ -9,14 +9,14 @@ import io.circe.literal.*
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.User
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 
 // OBSCALC TODO: At least some of these tests will be irrelevant and should be
 // removed.  They are about triggering obs edit events on cached execution
 // digest update but the cache itself will be deleted and replaced with the
 // obscalc backgroup update version.
 
-class observationEditOnCachedResultUpdate extends ExecutionTestSupport with SubscriptionUtils:
+class observationEditOnCachedResultUpdate extends ExecutionTestSupportForGmos with SubscriptionUtils:
 
   def observationUpdateSubscription(oid: Observation.Id): String =
     s"""

--- a/modules/service/src/test/scala/lucuma/odb/service/ObscalcServiceSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/ObscalcServiceSuite.scala
@@ -25,7 +25,7 @@ import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import lucuma.odb.data.Obscalc
 import lucuma.odb.data.OdbError
-import lucuma.odb.graphql.query.ExecutionTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 import lucuma.odb.logic.TimeEstimateCalculatorImplementation
 import lucuma.odb.sequence.util.CommitHash
 import lucuma.odb.service.Services.ServiceAccess
@@ -38,7 +38,7 @@ import skunk.implicits.*
 
 import scala.collection.immutable.SortedSet
 
-trait ObscalcServiceSuiteSupport extends ExecutionTestSupport:
+trait ObscalcServiceSuiteSupport extends ExecutionTestSupportForGmos:
 
   def instantiate(services: Services[IO]): IO[ObscalcService[IO]] =
       TimeEstimateCalculatorImplementation


### PR DESCRIPTION
This is a mechanical update that splits `ExecutionTestSupport` into three traits:

* `ExecutionTestSupport` - common 
* `ExecutionTestSupportForGmos`
* `ExecutionTestSupportForFlamingos2`