### PR TITLE
Shortcut 4365: Use the proper F2 acquisition filter

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForFlamingos2.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForFlamingos2.scala
@@ -153,7 +153,7 @@ trait ExecutionTestSupportForFlamingos2 extends ExecutionTestSupport:
     Flamingos2Science.copy(
       exposure  = fakeItcImagingResult.exposureTime,
       disperser = none,
-      filter    = Flamingos2Filter.H,
+      filter    = Flamingos2Filter.J,
       fpu       = Flamingos2FpuMask.Imaging,
       decker    = Flamingos2Decker.Imaging
     )


### PR DESCRIPTION
The acquisition filter to use is supposed to be the one (among the valid options `J`, `H` and `KShort`) which is closest to the science wavelength.