### PR TITLE
Shortcut 4365: F2 acquisition sequence tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ val pprintVersion              = "0.9.0"
 val skunkVersion               = "0.6.4"
 val testcontainersScalaVersion = "0.40.14" // check test output if you attempt to update this
 
-ThisBuild / tlBaseVersion      := "0.21"
+ThisBuild / tlBaseVersion      := "0.22"
 ThisBuild / scalaVersion       := "3.6.4"
 ThisBuild / crossScalaVersions := Seq("3.6.4")
 

--- a/modules/schema/src/main/scala/lucuma/odb/json/all.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/all.scala
@@ -9,6 +9,7 @@ object all {
     extends CalculatedValueCodec
        with CatalogInfoCodec
        with EpochCodec
+       with Flamingos2Codec
        with GmosCodec
        with NumericCodec
        with PartnerLinkCodec

--- a/modules/schema/src/main/scala/lucuma/odb/json/flamingos2.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/flamingos2.scala
@@ -43,7 +43,9 @@ trait Flamingos2Codec:
         "useElectronicOffsetting" -> a.useElectronicOffseting.asJson
       )
 
-  given Decoder[Flamingos2FpuMask.Custom] =
+  // This needs an explicit name because the default, given_Decoder_Custom
+  // would clash with the default for the GMOS custom mask.
+  given given_Decoder_Flamingos2FpuMask_Custom: Decoder[Flamingos2FpuMask.Custom] =
     Decoder.instance: c =>
       for
         f <- c.downField("filename").as[String].flatMap: s =>
@@ -52,7 +54,7 @@ trait Flamingos2Codec:
         s <- c.downField("slitWidth").as[Flamingos2CustomSlitWidth]
       yield Flamingos2FpuMask.Custom(f, s)
 
-  given Encoder[Flamingos2FpuMask.Custom] =
+  given given_Encoder_Flamingos2FpuMask_Custom: Encoder[Flamingos2FpuMask.Custom] =
     Encoder.instance: a =>
       Json.obj(
         "filename"  -> a.filename.value.asJson,

--- a/modules/schema/src/main/scala/lucuma/odb/json/gmos.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/gmos.scala
@@ -123,7 +123,9 @@ trait GmosCodec {
       } yield GmosCcdMode(x, y, n, g, m)
     }
 
-  given Decoder[GmosFpuMask.Custom] =
+  // This needs an explicit name because the default, given_Decoder_Custom
+  // would clash with the default for the Flamingos2 custom mask.
+  given given_Decoder_GmosFpuMask_Custom: Decoder[GmosFpuMask.Custom] =
     Decoder.instance { c =>
       for {
         f <- c.downField("filename").as[String].flatMap { s =>
@@ -196,7 +198,7 @@ trait GmosCodec {
       )
     }
 
-  given Encoder[GmosFpuMask.Custom] =
+  given given_Encoder_GmosFpuMask_Custom: Encoder[GmosFpuMask.Custom] =
     Encoder.instance { (a: GmosFpuMask.Custom) =>
       Json.obj(
         "filename"  -> a.filename.value.asJson,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
@@ -148,6 +148,9 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations {
       g
     )
 
+  def acqTelescopeConfig(p: Int): TelescopeConfig =
+    telescopeConfig(p, 0, StepGuideState.Enabled)
+
   protected def expectedTelescopeConfig(p: Int, q: Int, g: StepGuideState): Json =
     expectedTelescopeConfig(telescopeConfig(p, q, g))
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGmosNorth.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGmosNorth.scala
@@ -15,18 +15,13 @@ import lucuma.core.enums.DatasetQaState
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.SequenceType
-import lucuma.core.enums.StepGuideState
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.sequence.Step
 import lucuma.core.model.sequence.StepConfig
-import lucuma.core.model.sequence.TelescopeConfig
 import lucuma.odb.json.all.transport.given
 
 class executionAcqGmosNorth extends ExecutionTestSupportForGmos {
-
-  def acqTelescopeConfig(p: Int): TelescopeConfig =
-    telescopeConfig(p, 0, StepGuideState.Enabled)
 
   val InitialAcquisition: Json =
     json"""

--- a/modules/service/src/test/scala/lucuma/odb/testsyntax/execution.scala
+++ b/modules/service/src/test/scala/lucuma/odb/testsyntax/execution.scala
@@ -6,12 +6,25 @@ package lucuma.odb.testsyntax
 import lucuma.core.model.sequence.ExecutionConfig
 import lucuma.core.model.sequence.ExecutionSequence
 import lucuma.core.model.sequence.InstrumentExecutionConfig
+import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig
+import lucuma.core.model.sequence.flamingos2.Flamingos2StaticConfig
 import lucuma.core.model.sequence.gmos.DynamicConfig
 import lucuma.core.model.sequence.gmos.StaticConfig
 
 trait ToExecutionOps {
 
   extension (iec: InstrumentExecutionConfig)
+    def flamingos2: ExecutionConfig[Flamingos2StaticConfig, Flamingos2DynamicConfig] =
+      iec match
+        case InstrumentExecutionConfig.Flamingos2(ec) => ec
+        case _                                        => sys.error("Expected Flamingos2")
+
+    def flamingos2Acquisition: ExecutionSequence[Flamingos2DynamicConfig] =
+      flamingos2.acquisition.get
+
+    def flamingos2Science: ExecutionSequence[Flamingos2DynamicConfig] =
+      flamingos2.science.get
+
     def gmosNorth: ExecutionConfig[StaticConfig.GmosNorth, DynamicConfig.GmosNorth] =
       iec match
         case InstrumentExecutionConfig.GmosNorth(ec) => ec


### PR DESCRIPTION
Adds F2 acquisition sequence tests.

This is basically a copy of the GMOS acquisition sequence tests.  I played with factoring out the commonality and configuring GMOS and F2 specific versions but:

* it's a lot of configuration
* they seem to work the same, down to the offset in `p` in the second step, but there may be more differences that come to light with testing
* other observing modes probably won't have the same acquisition

So, it might be best left for when we see another acquisition sequence.

