### PR TITLE
Scala 3.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,10 +17,10 @@ val http4sJdkHttpClientVersion = "0.10.0"
 val jwtVersion                 = "5.0.0"
 val logbackVersion             = "1.5.18"
 val log4catsVersion            = "2.7.0"
-val lucumaItcVersion           = "0.35.4"
-val lucumaCoreVersion          = "0.131.0"
+val lucumaItcVersion           = "0.36.0"
+val lucumaCoreVersion          = "0.132.0"
 val lucumaGraphQLRoutesVersion = "0.9.0"
-val lucumaSsoVersion           = "0.8.17"
+val lucumaSsoVersion           = "0.8.18"
 val munitVersion               = "0.7.29"  // check test output if you attempt to update this
 val munitCatsEffectVersion     = "1.0.7"   // check test output if you attempt to update this
 val munitDisciplineVersion     = "1.0.9"   // check test output if you attempt to update this
@@ -33,8 +33,8 @@ val skunkVersion               = "0.6.4"
 val testcontainersScalaVersion = "0.40.14" // check test output if you attempt to update this
 
 ThisBuild / tlBaseVersion      := "0.23"
-ThisBuild / scalaVersion       := "3.6.4"
-ThisBuild / crossScalaVersions := Seq("3.6.4")
+ThisBuild / scalaVersion       := "3.7.1"
+ThisBuild / crossScalaVersions := Seq("3.7.1")
 
 ThisBuild / Test / fork              := false
 ThisBuild / Test / parallelExecution := false

--- a/modules/calibrations/src/main/scala/lucuma/odb/calibrations/Main.scala
+++ b/modules/calibrations/src/main/scala/lucuma/odb/calibrations/Main.scala
@@ -164,13 +164,13 @@ object CMain extends MainParams {
             }.compile.drain.start.void)
     } yield ()
 
-  def services[F[_]: Concurrent: Parallel: UUIDGen: Trace: Logger: SecureRandom](
+  def services[F[_]: Concurrent: Parallel: UUIDGen: Trace: Logger](
     user: Option[User],
     enums: Enums
   )(pool: Session[F]): F[Services[F]] =
     user match {
       case Some(u) if u.role.access === Access.Service =>
-        Services.forUser(u, enums, None)(pool).pure[F].flatTap { s =>
+        Services.forUser(u, enums, None)(pool).pure[F].flatTap { _ =>
           val us = UserService.fromSession(pool)
           Services.asSuperUser(us.canonicalizeUser(u))
         }

--- a/modules/obscalc/src/main/scala/lucuma/odb/obscalc/Main.scala
+++ b/modules/obscalc/src/main/scala/lucuma/odb/obscalc/Main.scala
@@ -142,7 +142,7 @@ object CalcMain extends MainParams:
         t <- Resource.eval(ObscalcTopic(p, 65536, s))
       yield t
 
-  def runObscalcDaemon[F[_]: Async: Parallel: Logger](
+  def runObscalcDaemon[F[_]: Async: Logger](
     connectionsLimit: Int,
     commitHash:       CommitHash,
     pollPeriod:       FiniteDuration,
@@ -212,12 +212,12 @@ object CalcMain extends MainParams:
       o <- calcAndUpdateStream.compile.drain.background
     yield o
 
-  def services[F[_]: Concurrent: Parallel: UUIDGen: Trace: Logger: SecureRandom](
+  def services[F[_]: Concurrent: Parallel: UUIDGen: Trace: Logger](
     user:    User,
     enums:   Enums,
     mapping: Mapping[F]
   )(pool: Session[F]): F[Services[F]] =
-    Services.forUser(user, enums, mapping.some)(pool).pure[F].flatTap: s =>
+    Services.forUser(user, enums, mapping.some)(pool).pure[F].flatTap: _ =>
       val us = UserService.fromSession(pool)
       Services.asSuperUser(us.canonicalizeUser(user))
 

--- a/modules/phase0/src/test/scala/lucuma/odb/phase0/Phase0LoaderSuite.scala
+++ b/modules/phase0/src/test/scala/lucuma/odb/phase0/Phase0LoaderSuite.scala
@@ -2,7 +2,6 @@
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 import cats.effect.IO
-import cats.syntax.all.*
 import lucuma.odb.phase0.FileReader
 import munit.CatsEffectSuite
 

--- a/modules/schema/src/main/scala/lucuma/odb/json/configurationrequest.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/configurationrequest.scala
@@ -57,8 +57,8 @@ object configurationrequest:
       hc.downField("grating").as[GmosSouthGrating].map(GmosSouthLongSlit(_))
 
     given Decoder[ObservingMode] = hc =>
-      hc.downField("gmosNorthLongSlit").as(DecodeGmosNorthLongSlit) orElse
-      hc.downField("gmosSouthLongSlit").as(DecodeGmosSouthLongSlit)
+      hc.downField("gmosNorthLongSlit").as(using DecodeGmosNorthLongSlit) orElse
+      hc.downField("gmosSouthLongSlit").as(using DecodeGmosSouthLongSlit)
 
     given Encoder[ObservingMode] = m => 
       Json.obj(

--- a/modules/schema/src/main/scala/lucuma/odb/json/flamingos2.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/flamingos2.scala
@@ -49,7 +49,7 @@ trait Flamingos2Codec:
     Decoder.instance: c =>
       for
         f <- c.downField("filename").as[String].flatMap: s =>
-               NonEmptyString.from(s).leftMap: m =>
+               NonEmptyString.from(s).leftMap: _ =>
                  DecodingFailure(s"Flamingos 2 custom mask file name cannot be empty", c.history)
         s <- c.downField("slitWidth").as[Flamingos2CustomSlitWidth]
       yield Flamingos2FpuMask.Custom(f, s)

--- a/modules/schema/src/main/scala/lucuma/odb/json/gmos.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/gmos.scala
@@ -129,7 +129,7 @@ trait GmosCodec {
     Decoder.instance { c =>
       for {
         f <- c.downField("filename").as[String].flatMap { s =>
-          NonEmptyString.from(s).leftMap { m => DecodingFailure(s"GMOS custom mask file name cannot be empty", c.history) }
+          NonEmptyString.from(s).leftMap { _ => DecodingFailure(s"GMOS custom mask file name cannot be empty", c.history) }
         }
         s <- c.downField("slitWidth").as[GmosCustomSlitWidth]
       } yield GmosFpuMask.Custom(f, s)

--- a/modules/schema/src/main/scala/lucuma/odb/json/rightascension.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/rightascension.scala
@@ -3,7 +3,6 @@
 
 package lucuma.odb.json
 
-import cats.syntax.all.*
 import io.circe.Decoder
 import io.circe.DecodingFailure
 import io.circe.Encoder

--- a/modules/schema/src/main/scala/lucuma/odb/json/sequence.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/sequence.scala
@@ -191,7 +191,7 @@ trait SequenceCodec {
   ): Encoder[R] =
     Encoder.instance { (a: R) => root(a).asJson }
 
-  given (using Encoder[Offset], Encoder[TimeSpan], Encoder[Wavelength]): Encoder[InstrumentExecutionConfig.Flamingos2] =
+  given (using Encoder[Offset], Encoder[TimeSpan]): Encoder[InstrumentExecutionConfig.Flamingos2] =
     rootEncoder(_.executionConfig)
 
   given (using Encoder[Offset], Encoder[TimeSpan], Encoder[Wavelength]): Encoder[InstrumentExecutionConfig.GmosNorth] =

--- a/modules/schema/src/main/scala/lucuma/odb/json/stepconfig.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/stepconfig.scala
@@ -63,7 +63,7 @@ trait StepConfigCodec:
         s <- c.downField("shutter").as[GcalShutter]
       yield StepConfig.Gcal(l, f, d, s)
 
-  given (using Encoder[Offset]): Encoder[StepConfig.Gcal] =
+  given Encoder[StepConfig.Gcal] =
     Encoder.instance: a =>
       given_Encoder_Lamp(a.lamp).mapObject { jo =>
         jo.add("filter",    a.filter.asJson)
@@ -75,7 +75,7 @@ trait StepConfigCodec:
     Decoder.instance: c =>
       c.downField("smartGcalType").as[SmartGcalType].map(StepConfig.SmartGcal.apply)
 
-  given (using Encoder[Offset]): Encoder[StepConfig.SmartGcal] =
+  given Encoder[StepConfig.SmartGcal] =
     Encoder.instance: a =>
       Json.obj(
         "smartGcalType" -> a.smartGcalType.asJson
@@ -91,7 +91,7 @@ trait StepConfigCodec:
         case StepType.SmartGcal => c.as[StepConfig.SmartGcal]
       }
 
-  given (using Encoder[Offset]): Encoder[StepConfig] =
+  given Encoder[StepConfig] =
     Encoder.instance: a =>
       (a match {
         case _: StepConfig.Bias.type    => Json.obj()

--- a/modules/schema/src/main/scala/lucuma/odb/json/target.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/target.scala
@@ -150,9 +150,9 @@ object target {
       Encoder[CatalogInfo]
     ): (String, Json) =
       target match
-        case s @ Sidereal(_, _, _, _) => "sidereal"    -> s.asJson(siderealDefinitionEncoderInternal)
-        case n @ Nonsidereal(_, _, _) => "nonsidereal" -> n.asJson(nonsiderealDefinitionEncoder)
-        case o @ Opportunity(_, _, _) => "opportunity" -> o.asJson(opportunityDefinitionEncoder)
+        case s @ Sidereal(_, _, _, _) => "sidereal"    -> s.asJson(using siderealDefinitionEncoderInternal)
+        case n @ Nonsidereal(_, _, _) => "nonsidereal" -> n.asJson(using nonsiderealDefinitionEncoder)
+        case o @ Opportunity(_, _, _) => "opportunity" -> o.asJson(using opportunityDefinitionEncoder)
 
     // NOTE: This does not include the id, existence and program that are part of the Target in the API
     protected def encoderTargetInternal(using

--- a/modules/schema/src/main/scala/lucuma/odb/json/time.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/time.scala
@@ -64,7 +64,7 @@ object time {
 
   trait CommonEncoders {
     given Encoder[DateInterval] =
-      Encoder { (a: DateInterval) =>
+      Encoder.instance { (a: DateInterval) =>
         Json.obj(
           "start" -> a.start.asJson,
           "end"   -> a.end.asJson
@@ -74,7 +74,7 @@ object time {
 
   trait QueryCodec extends TimeDecoders with CommonEncoders {
     given Encoder_TimeSpan: Encoder[TimeSpan] =
-      Encoder { (ts: TimeSpan) =>
+      Encoder.instance { (ts: TimeSpan) =>
         Json.obj(
           "microseconds" -> TimeSpan.FromMicroseconds.reverseGet(ts).asJson,
           "milliseconds" -> TimeSpan.FromMilliseconds.reverseGet(ts).asJson,
@@ -86,7 +86,7 @@ object time {
       }
 
     given Encoder_TimestampInterval: Encoder[TimestampInterval] =
-      Encoder { (a: TimestampInterval) =>
+      Encoder.instance { (a: TimestampInterval) =>
         Json.obj(
           "start"    -> a.start.asJson,
           "end"      -> a.end.asJson,
@@ -106,7 +106,7 @@ object time {
       }
 
     given Encoder_TimestampInterval: Encoder[TimestampInterval] =
-      Encoder { (a: TimestampInterval) =>
+      Encoder.instance { (a: TimestampInterval) =>
         Json.obj(
           "start"    -> a.start.asJson,
           "end"      -> a.end.asJson

--- a/modules/schema/src/test/scala/lucuma/odb/json/StepConfigSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/json/StepConfigSuite.scala
@@ -13,7 +13,6 @@ class StepConfigSuite extends DisciplineSuite with ArbitraryInstances {
 
   import ArbStepConfig.given
 
-  import offset.query.given
   import stepconfig.given
 
   checkAll("StepConfigCodec", CodecTests[StepConfig].codec)

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ProtoExecutionConfig.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ProtoExecutionConfig.scala
@@ -3,7 +3,6 @@
 
 package lucuma.odb.sequence.data
 
-import cats.syntax.apply.*
 import fs2.Pure
 import fs2.Stream
 

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/Flamingos2InitialDynamicConfig.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/Flamingos2InitialDynamicConfig.scala
@@ -9,7 +9,6 @@ import lucuma.core.enums.Flamingos2LyotWheel.F16
 import lucuma.core.enums.Flamingos2ReadMode.Bright
 import lucuma.core.enums.Flamingos2ReadoutMode.Science
 import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig
-import lucuma.core.model.sequence.flamingos2.Flamingos2FpuMask
 import lucuma.core.model.sequence.flamingos2.Flamingos2FpuMask.Imaging
 import lucuma.core.util.TimeSpan
 

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Acquisition.scala
@@ -9,7 +9,6 @@ import cats.Eq
 import cats.Order.catsKernelOrderingForOrder
 import cats.data.NonEmptyList
 import cats.data.State
-import cats.syntax.either.*
 import cats.syntax.option.*
 import cats.syntax.order.*
 import eu.timepit.refined.*

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/LongSlit.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/LongSlit.scala
@@ -6,7 +6,6 @@ package flamingos2.longslit
 
 import cats.Monad
 import cats.data.EitherT
-import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.MosPreImaging
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig as F2Dynamic
@@ -33,7 +32,6 @@ object LongSlit:
     config:         Config,
     acquisitionItc: Either[OdbError, IntegrationTime],
     scienceItc:     Either[OdbError, IntegrationTime],
-    calRole:        Option[CalibrationRole],
     lastAcqReset:   Option[Timestamp]
   ): F[Either[OdbError, ExecutionConfigGenerator[F2Static, F2Dynamic]]] =
     (for

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Science.scala
@@ -9,7 +9,6 @@ import cats.Eq
 import cats.Monad
 import cats.data.EitherT
 import cats.data.NonEmptyList
-import cats.syntax.either.*
 import cats.syntax.flatMap.*
 import cats.syntax.option.*
 import eu.timepit.refined.*

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Config.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Config.scala
@@ -29,7 +29,6 @@ import lucuma.core.math.Offset.Q
 import lucuma.core.math.Wavelength
 import lucuma.core.math.WavelengthDelta
 import lucuma.core.math.WavelengthDither
-import lucuma.core.math.units.Picometer
 import lucuma.core.math.units.Pixels
 import lucuma.core.model.ImageQuality
 import lucuma.core.model.SourceProfile

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/longslit/Science.scala
@@ -20,7 +20,6 @@ import cats.syntax.functor.*
 import cats.syntax.option.*
 import cats.syntax.order.*
 import eu.timepit.refined.types.numeric.NonNegInt
-import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.types.string.NonEmptyString
 import fs2.Pure
 import fs2.Stream

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/CommitHash.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/CommitHash.scala
@@ -43,9 +43,6 @@ object CommitHash {
     def format: String =
       hexFormat.formatHex(c)
 
-    def toString: String =
-      format
-
   }
 
   given Show[CommitHash] =

--- a/modules/sequence/src/test/scala/lucuma/odb/sequence/TestItcClient.scala
+++ b/modules/sequence/src/test/scala/lucuma/odb/sequence/TestItcClient.scala
@@ -12,13 +12,11 @@ import cats.syntax.option.*
 import eu.timepit.refined.types.numeric.*
 import lucuma.core.data.Zipper
 import lucuma.core.enums.Band
-import lucuma.core.math.SignalToNoise
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ExposureTimeMode
 import lucuma.core.util.TimeSpan
 import lucuma.itc.AsterismIntegrationTimeOutcomes
 import lucuma.itc.IntegrationTime
-import lucuma.itc.ItcCcd
 import lucuma.itc.ItcVersions
 import lucuma.itc.SignalToNoiseAt
 import lucuma.itc.SingleSN
@@ -26,7 +24,6 @@ import lucuma.itc.TargetIntegrationTime
 import lucuma.itc.TargetIntegrationTimeOutcome
 import lucuma.itc.TotalSN
 import lucuma.itc.client.ClientCalculationResult
-import lucuma.itc.client.GraphResult
 import lucuma.itc.client.ImagingInput
 import lucuma.itc.client.ItcClient
 import lucuma.itc.client.SpectroscopyGraphsInput
@@ -44,21 +41,18 @@ object TestItcClient {
     exposureTime:  TimeSpan,
     exposureCount: Int,
     bandOrLine:    Either[Band, Wavelength],
-    graphResult:   (NonEmptyList[ItcCcd], NonEmptyList[GraphResult])
   ): ItcClient[F] =
     withResult[F](
       IntegrationTime(
         exposureTime,
         NonNegInt.unsafeFrom(exposureCount),
       ),
-      bandOrLine,
-      graphResult
+      bandOrLine
     )
 
   def withResult[F[_]: Applicative](
     result:      IntegrationTime,
-    bandOrLine:  Either[Band, Wavelength],
-    graphResult: (NonEmptyList[ItcCcd], NonEmptyList[GraphResult])
+    bandOrLine:  Either[Band, Wavelength]
   ): ItcClient[F] =
     new ItcClient[F] {
 

--- a/modules/service/src/main/scala/lucuma/odb/data/Obscalc.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/Obscalc.scala
@@ -3,7 +3,6 @@
 
 package lucuma.odb.data
 
-import cats.syntax.monoid.*
 import cats.syntax.option.*
 import eu.timepit.refined.types.numeric.NonNegInt
 import lucuma.core.data.Zipper

--- a/modules/service/src/main/scala/lucuma/odb/graphql/AttachmentRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/AttachmentRoutes.scala
@@ -47,19 +47,19 @@ object AttachmentRoutes {
     )
 
   // used by tests
-  def apply[F[_]: Async: Trace: SecureRandom](
+  def apply[F[_]: Async](
     service:     AttachmentFileService[F],
     ssoClient:   SsoClient[F, User],
     maxUploadMb: Int,
   ): HttpRoutes[F] =
     apply(
-      [A] => (u: User) => (fa: AttachmentFileService[F] => F[A]) => fa(service),
+      [A] => (_: User) => (fa: AttachmentFileService[F] => F[A]) => fa(service),
       ssoClient,
       maxUploadMb
     )
 
 
-  def apply[F[_]: Concurrent: Trace: UUIDGen](
+  def apply[F[_]: Concurrent](
     service:               [A] => User => (AttachmentFileService[F] => F[A]) => F[A],
     ssoClient:             SsoClient[F, User],
     maxUploadMb:           Int

--- a/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
@@ -31,7 +31,6 @@ import natchez.TraceValue
 import org.http4s.Header
 import org.http4s.HttpRoutes
 import org.http4s.MediaType
-import org.http4s.Request
 import org.http4s.Response
 import org.http4s.client.Client
 import org.http4s.dsl.Http4sDsl

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -603,7 +603,7 @@ object OdbMapping {
    * A minimal read-only mapping that only knows how to return enum metadata. Other queries will
    * fail with errors.
    */
-  def forMetadata[F[_]: Async: Trace: Logger](
+  def forMetadata[F[_]: Async](
     database: Resource[F, Session[F]],
     monitor:  SkunkMonitor[F],
     enums:    Enums,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
@@ -18,7 +18,6 @@ import lucuma.core.enums.Instrument
 import lucuma.core.util.Enumerated
 import lucuma.core.util.TimeSpan
 import org.tpolecat.sourcepos.SourcePos
-import org.typelevel.log4cats.Logger
 import skunk.Session
 
 /**
@@ -141,7 +140,7 @@ object Enums {
     unreferencedTypes: List[EnumType]
   )
 
-  def load[F[_]: Monad: Logger](s: Session[F]): F[Enums] =
+  def load[F[_]: Monad](s: Session[F]): F[Enums] =
     for {
       te  <- TimeEstimateMeta.select(s)
       ps  <- ProposalStatusMeta.select(s)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/AngleInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/AngleInput.scala
@@ -6,7 +6,6 @@ package lucuma.odb.graphql
 package input
 
 import cats.syntax.all.*
-import grackle.Result
 import lucuma.core.math.Angle
 import lucuma.core.math.HourAngle
 import lucuma.odb.graphql.binding.*

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CoordinatesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CoordinatesInput.scala
@@ -5,7 +5,6 @@ package lucuma.odb.graphql
 package input
 
 import cats.syntax.parallel.*
-import grackle.Result
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
 import lucuma.core.math.RightAscension

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/Flamingos2LongSlitInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/Flamingos2LongSlitInput.scala
@@ -4,7 +4,6 @@
 package lucuma.odb.graphql
 package input
 
-import cats.syntax.foldable.*
 import cats.syntax.parallel.*
 import grackle.Result
 import lucuma.core.enums.Flamingos2Decker

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/LinkUserInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/LinkUserInput.scala
@@ -6,7 +6,6 @@ package lucuma.odb.graphql
 package input
 
 import cats.syntax.all.*
-import grackle.Result
 import lucuma.core.model.ProgramUser
 import lucuma.core.model.User
 import lucuma.odb.graphql.binding.*

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
@@ -9,7 +9,6 @@ import cats.data.NonEmptyList
 import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import eu.timepit.refined.types.string.NonEmptyString
-import grackle.Result
 import lucuma.core.enums.ScienceBand
 import lucuma.core.model.Attachment
 import lucuma.core.model.Group

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationTimesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationTimesInput.scala
@@ -6,7 +6,6 @@ package lucuma.odb.graphql
 package input
 
 import cats.syntax.all.*
-import grackle.Result
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import lucuma.odb.data.Nullable

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ProgramPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ProgramPropertiesInput.scala
@@ -8,7 +8,6 @@ package input
 import cats.data.Ior
 import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
-import grackle.Result
 import lucuma.odb.data.Existence
 import lucuma.odb.data.Nullable
 import lucuma.odb.graphql.binding.*

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ProgramReferencePropertiesExampleInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ProgramReferencePropertiesExampleInput.scala
@@ -3,7 +3,6 @@
 
 package lucuma.odb.graphql.input
 
-import cats.syntax.parallel.*
 import lucuma.core.enums.Instrument
 import lucuma.odb.graphql.binding.InstrumentBinding
 import lucuma.odb.graphql.binding.Matcher

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ProgramReferencePropertiesSystemInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ProgramReferencePropertiesSystemInput.scala
@@ -3,7 +3,6 @@
 
 package lucuma.odb.graphql.input
 
-import cats.syntax.parallel.*
 import lucuma.core.model.ProgramReference
 import lucuma.odb.graphql.binding.DescriptionBinding
 import lucuma.odb.graphql.binding.Matcher

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ProgramUserPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ProgramUserPropertiesInput.scala
@@ -6,7 +6,6 @@ package lucuma.odb.graphql
 package input
 
 import cats.syntax.all.*
-import grackle.Result
 import lucuma.core.enums.EducationalStatus
 import lucuma.core.enums.Gender
 import lucuma.core.model.PartnerLink

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/RevokeUserInvitationInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/RevokeUserInvitationInput.scala
@@ -3,7 +3,6 @@
 
 package lucuma.odb.graphql.input
 
-import cats.syntax.all.*
 import lucuma.core.model.UserInvitation
 import lucuma.odb.graphql.binding.Matcher
 import lucuma.odb.graphql.binding.ObjectFieldsBinding

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/SetGuideTargetNameInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/SetGuideTargetNameInput.scala
@@ -7,7 +7,6 @@ package input
 
 import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
-import grackle.Result
 import lucuma.core.model.Observation
 import lucuma.core.model.ObservationReference
 import lucuma.odb.graphql.binding.*

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/StepConfigInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/StepConfigInput.scala
@@ -5,7 +5,6 @@ package lucuma.odb.graphql
 package input
 
 import cats.syntax.all.*
-import grackle.Result
 import lucuma.core.model.sequence.StepConfig
 import lucuma.odb.graphql.binding.*
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/TimeSpanInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/TimeSpanInput.scala
@@ -6,7 +6,6 @@ package lucuma.odb.graphql
 package input
 
 import cats.syntax.all.*
-import grackle.Result
 import lucuma.core.util.TimeSpan
 import lucuma.odb.graphql.binding.*
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WavelengthDitherInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WavelengthDitherInput.scala
@@ -5,7 +5,6 @@ package lucuma.odb.graphql
 package input
 
 import cats.syntax.parallel.*
-import grackle.Result
 import lucuma.core.math.WavelengthDither
 import lucuma.core.optics.Format
 import lucuma.odb.graphql.binding.*

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WavelengthInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WavelengthInput.scala
@@ -5,7 +5,6 @@ package lucuma.odb.graphql
 package input
 
 import cats.syntax.parallel.*
-import grackle.Result
 import lucuma.core.math.Wavelength
 import lucuma.core.optics.Format
 import lucuma.odb.graphql.binding.*

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/FluxDensityContinuumInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/FluxDensityContinuumInput.scala
@@ -8,7 +8,6 @@ package sourceprofile
 import cats.syntax.all.*
 import grackle.Result
 import lucuma.core.math.BrightnessUnits.*
-import lucuma.core.math.dimensional.Measure
 import lucuma.core.math.dimensional.Units
 import lucuma.core.util.*
 import lucuma.odb.graphql.binding.*

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/LineFluxInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/LineFluxInput.scala
@@ -8,7 +8,6 @@ package sourceprofile
 import grackle.Result
 import lucuma.core.math.BrightnessUnits.*
 import lucuma.core.math.LineFluxValue
-import lucuma.core.math.dimensional.Measure
 import lucuma.core.util.*
 import lucuma.odb.graphql.binding.*
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
@@ -129,15 +129,18 @@ object AccessControl:
   }
 
   /** Construct a `CheckedWithIds` (requires SuperUser access). */
+  @annotation.nowarn("msg=unused implicit parameter")
   def unchecked[A,B](SET: A, ids: List[B], enc: Encoder[B])(using SuperUserAccess): CheckedWithIds[A,B] =
     NonEmptyList.fromList(ids).fold(Checked.Empty): ids =>
       new Checked.NonEmptyWithIds(SET, ids, enc) {}
 
   /** Construct a `CheckedWithId` (requires SuperUser access). */
+  @annotation.nowarn("msg=unused implicit parameter")
   def unchecked[A,B](SET: A, id: B, enc: Encoder[B])(using SuperUserAccess): CheckedWithId[A,B] =
       new Checked.NonEmptyWithId(SET, id, enc) {}
 
   /** Construct a `Checked` (requires SuperUser access). */
+  @annotation.nowarn("msg=unused implicit parameter")
   def unchecked[A](SET: A, which: AppliedFragment)(using SuperUserAccess): Checked[A] =
     new Checked.NonEmpty(SET, which) {}
 
@@ -180,6 +183,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Select and return the ids of observations that are editable by the current user and meet
    * all the specified filters.
    */
+  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForObservationUpdateImpl(
     includeDeleted:      Option[Boolean],
     WHERE:               Option[Predicate],
@@ -201,6 +205,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Select and return the ids of observations that are clonable by the current user and meet
    * all the specified filters.
    */
+  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForObservationCloneImpl(
     includeDeleted:      Option[Boolean],
     WHERE:               Option[Predicate],
@@ -220,6 +225,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Select and return the ids of programs that are editable by the current user and meet
    * all the specified filters.
    */
+  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForProgramUpdateImpl(
     includeDeleted: Option[Boolean],
     WHERE:          Option[Predicate]
@@ -250,6 +256,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
   /**
    * Compute the subset of `pids` that identify programs which are editable by the current user.
    */
+  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForProgramUpdateImpl(
     includeDeleted: Option[Boolean],
     pids:           List[Program.Id]
@@ -263,6 +270,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Select and return the ids of targets that are editable by the current user and meet
    * all the specified filters.
    */
+  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForTargetUpdateImpl(
     includeDeleted:      Option[Boolean],
     WHERE:               Option[Predicate],
@@ -297,6 +305,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Given an operation that defines a set of targets and a proposed edit, select and filter this
    * set based on access control policies and return a checked edit that is valid for execution.
    */
+  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: UpdateTargetsInput,
   )(using Services[F], NoTransaction[F]): F[Result[AccessControl.CheckedWithIds[TargetPropertiesInput.Edit, Target.Id]]] =
@@ -309,6 +318,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
         AccessControl.unchecked(input.SET, tids, target_id)
 
   /** Overload of `selectForObservationUpdateImpl` that takes a list of oids instead of a `Predicate`.  */
+  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForObservationUpdateImpl(
     includeDeleted:      Option[Boolean],
     oids:                List[Observation.Id],
@@ -326,6 +336,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Given an operation that defines a set of observations and a proposed edit, select and filter this
    * set based on access control policies and return a checked edit that is valid for execution.
    */
+  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: UpdateObservationsInput, 
     includeCalibrations: Boolean
@@ -367,6 +378,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Given an operation that defines a set of observations and a proposed edit, select and filter this
    * set based on access control policies and return a checked edit that is valid for execution.
    */
+  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: UpdateAsterismsInput,
     includeCalibrations: Boolean
@@ -386,6 +398,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Given an operation that defines a set of observations and a proposed edit, select and filter this
    * set based on access control policies and return a checked edit that is valid for execution.
    */
+  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: UpdateObservationsTimesInput,
     includeCalibrations: Boolean
@@ -405,6 +418,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Given an operation that defines a set of observations and a proposed edit, select and filter this
    * set based on access control policies and return a checked edit that is valid for execution.
    */
+  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: SetGuideTargetNameInput,
     includeCalibrations: Boolean
@@ -539,6 +553,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
                 ResultT.pure(AccessControl.unchecked(input.SET, pid, program_id))
     ).value
 
+  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: SetProgramReferenceInput
   )(using Services[F], Transaction[F]): F[Result[AccessControl.CheckedWithId[ProgramReferencePropertiesInput, Program.Id]]] =
@@ -550,6 +565,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
             Services.asSuperUser:
               Result(AccessControl.unchecked(input.SET, pid, program_id)).pure[F]
 
+  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: UpdateProgramsInput
   )(using Services[F], Transaction[F]): F[Result[AccessControl.Checked[ProgramPropertiesInput.Edit]]] =
@@ -577,6 +593,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
       Services.asSuperUser:
         Result(AccessControl.unchecked(input.allocations, input.programId, program_id)).pure[F]
 
+  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: UpdateAttachmentsInput
   )(using Services[F]): F[Result[AccessControl.Checked[AttachmentPropertiesInput.Edit]]] =
@@ -616,6 +633,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
           Services.asSuperUser:
             Result(AccessControl.unchecked(input.SET, which)).pure[F]
 
+  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForProgramNoteUpdateImpl(
     includeDeleted: Option[Boolean],
     WHERE:          Option[Predicate]
@@ -651,6 +669,8 @@ trait AccessControl[F[_]] extends Predicates[F] {
            Services.asSuperUser:
              AccessControl.unchecked(input.SET, nids, program_note_id)
         })
+
+  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: CloneTargetInput
   )(using Services[F], NoTransaction[F]): F[Result[CheckedWithId[CloneTargetInput, Program.Id]]] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AsterismGroupMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AsterismGroupMapping.scala
@@ -4,7 +4,6 @@
 package lucuma.odb.graphql
 package mapping
 
-import grackle.Query
 import grackle.Query.Binding
 import grackle.Query.Filter
 import grackle.QueryCompiler.Elab

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CallForProposalsMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CallForProposalsMapping.scala
@@ -5,7 +5,6 @@ package lucuma.odb.graphql
 package mapping
 
 import cats.effect.Resource
-import grackle.Query
 import grackle.Query.Binding
 import grackle.Query.OrderBy
 import grackle.Query.OrderSelection

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConstraintSetGroupMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConstraintSetGroupMapping.scala
@@ -8,7 +8,6 @@ package mapping
 import cats.syntax.all.*
 import grackle.Predicate
 import grackle.Predicate.*
-import grackle.Query
 import grackle.Query.*
 import grackle.QueryCompiler.Elab
 import grackle.TypeRef

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/DeclinationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/DeclinationMapping.scala
@@ -12,7 +12,6 @@ import lucuma.odb.graphql.table.CallForProposalsView
 import lucuma.odb.graphql.table.ConfigurationRequestView
 import lucuma.odb.graphql.table.ObservationView
 import lucuma.odb.graphql.table.TargetView
-import skunk.codec.all.*
 
 import scala.reflect.ClassTag
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
@@ -140,7 +140,7 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
 
   private lazy val executionStateHandler: EffectHandler[F] =
     val calculate: (Program.Id, Observation.Id, Unit) => F[Result[Json]] =
-      (pid, oid, limit) => {
+      (pid, oid, _) => {
         services.use: s =>
           s.generator(commitHash, itcClient, timeEstimateCalculator)
            .executionState(pid, oid)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GroupMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GroupMapping.scala
@@ -10,7 +10,6 @@ import cats.effect.Resource
 import cats.implicits.catsKernelOrderingForOrder
 import cats.syntax.functor.*
 import eu.timepit.refined.types.numeric.NonNegShort
-import grackle.Query
 import grackle.Query.Binding
 import grackle.Query.EffectHandler
 import grackle.Query.FilterOrderByOffsetLimit

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationMapping.scala
@@ -147,6 +147,7 @@ trait ObservationMapping[F[_]]
     // Pass the pid+oid pairs to configurationService.selectRequests to get the
     // applicable configuration requests for each pair, then use this information
     // to construct our list of outgoing cursors.
+    @annotation.nowarn("msg=unused implicit parameter")
     def query(using Services[F], Transaction[F]): ResultT[F, List[Cursor]] =
       sequence.flatMap: pairs =>
         ResultT(configurationService.selectRequests(pairs.map(_._1))).map: reqs =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
@@ -12,7 +12,6 @@ import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import grackle.Predicate
 import grackle.Predicate.*
-import grackle.Query
 import grackle.Query.*
 import grackle.QueryCompiler.Elab
 import grackle.TypeRef

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/RightAscensionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/RightAscensionMapping.scala
@@ -4,7 +4,6 @@
 package lucuma.odb.graphql
 package mapping
 
-import cats.syntax.all.*
 import grackle.Path
 import grackle.skunk.SkunkMapping
 import io.circe

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/StepRecordMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/StepRecordMapping.scala
@@ -5,7 +5,6 @@ package lucuma.odb.graphql
 package mapping
 
 import cats.effect.Resource
-import grackle.Query
 import grackle.Query.Binding
 import grackle.Query.EffectHandler
 import grackle.QueryCompiler.Elab

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetGroupMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetGroupMapping.scala
@@ -8,7 +8,6 @@ package mapping
 import cats.syntax.all.*
 import grackle.Predicate
 import grackle.Predicate.*
-import grackle.Query
 import grackle.Query.*
 import grackle.QueryCompiler.Elab
 import grackle.TypeRef

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/VisitMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/VisitMapping.scala
@@ -5,7 +5,6 @@ package lucuma.odb.graphql
 package mapping
 
 import cats.effect.Resource
-import grackle.Query
 import grackle.Query.Binding
 import grackle.Query.EffectHandler
 import grackle.QueryCompiler.Elab

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/CalibTimeTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/CalibTimeTopic.scala
@@ -44,7 +44,7 @@ object CalibTimeTopic {
       }
     }
 
-  def elements[F[_]: Concurrent: Logger](
+  def elements[F[_]: Logger](
     s:         Session[F],
     maxQueued: Int,
   ): Stream[F, Element] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/OdbTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/OdbTopic.scala
@@ -32,7 +32,7 @@ object OdbTopic:
   // in fs2 or skunk that releases the portal too early and you get portal not found
   // asynchronously when doing other things. This is a workaround for now that just
   // interpolates the strings directly rather than preparing a statement.
-  def selectProgramUsers[F[_]: Concurrent: Logger: Trace](
+  def selectProgramUsers[F[_]: Trace](
     s:   Session[F],
     pid: Program.Id,
   ): F[List[User.Id]] =
@@ -51,7 +51,7 @@ object OdbTopic:
   )(update: PartialFunction[Array[String], Option[U]]): OdbTopic[E] =
     new OdbTopic[E]:
 
-      def updates[F[_]: Concurrent: Logger](
+      def updates[F[_]: Logger](
         s:         Session[F],
         maxQueued: Int
       ): Stream[F, U] =
@@ -61,7 +61,7 @@ object OdbTopic:
             .flatten
             .fold(Stream.exec(Logger[F].warn(s"Invalid $name event: $n")))(Stream(_))
 
-      def elements[F[_]: Concurrent: Logger: Trace](
+      def elements[F[_]: Logger: Trace](
         s:         Session[F],
         maxQueued: Int
       ): Stream[F, E] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/util/PrettyPrinter.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/util/PrettyPrinter.scala
@@ -37,7 +37,7 @@ object PrettyPrinter {
   def prop(key: String, value: Doc): Doc =
     (text(key) + char(':') + space + value)
 
-  def elems(ds: List[Doc], delim: Doc = Comma): Doc =
+  def elems(ds: List[Doc]): Doc =
     intercalate(Comma + line, ds).grouped
 
   def quoted(s: String): Doc =

--- a/modules/service/src/main/scala/lucuma/odb/logic/DetectorEstimator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/DetectorEstimator.scala
@@ -73,7 +73,7 @@ object DetectorEstimator {
     }
 
     lazy val flamingos2: DetectorEstimator[Flamingos2StaticConfig, Flamingos2DynamicConfig] =
-      (static: Flamingos2StaticConfig, step: ProtoStep[Flamingos2DynamicConfig]) => List(
+      (_: Flamingos2StaticConfig, step: ProtoStep[Flamingos2DynamicConfig]) => List(
         DetectorEstimate(
           "Flamingos2",
           s"Flamingos 2 Detector Array",

--- a/modules/service/src/main/scala/lucuma/odb/logic/TimeEstimateService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/TimeEstimateService.scala
@@ -90,7 +90,7 @@ object TimeEstimateService:
 
       // CategorizedTime Ordering that sorts longest to shortest.
       val longestToShortest: Ordering[CategorizedTime] =
-        catsKernelOrderingForOrder(Order.reverse(Order[CategorizedTime]))
+        catsKernelOrderingForOrder(using Order.reverse(Order[CategorizedTime]))
 
       def combine(
         minRequired: Int,
@@ -103,12 +103,11 @@ object TimeEstimateService:
               // Combines the first minRequired elements after sorting by ascending min CategorizedTime
               children.map(_.value.min).sorted.take(minRequired).combineAllOption.getOrElse(CategorizedTime.Zero),
               // Combines the first minRequired elements after sorting by descending max CategorizedTime
-              children.map(_.value.max).sorted(longestToShortest).take(minRequired).combineAllOption.getOrElse(CategorizedTime.Zero)
+              children.map(_.value.max).sorted(using longestToShortest).take(minRequired).combineAllOption.getOrElse(CategorizedTime.Zero)
             )
           )
 
       def leafRange(
-        pid: Program.Id,
         oid: Observation.Id,
         m:   Map[Observation.Id, CalculatedValue[CategorizedTime]]
       ): Option[CalculatedValue[CategorizedTimeRange]] =
@@ -135,7 +134,7 @@ object TimeEstimateService:
         m:    Map[Observation.Id, CalculatedValue[CategorizedTime]]
       ): Option[CalculatedValue[CategorizedTimeRange]] =
         root match
-          case GroupTree.Leaf(oid)                                  => leafRange(pid, oid, m)
+          case GroupTree.Leaf(oid)                                  => leafRange(oid, m)
           case GroupTree.Branch(_, min, _, children, _, _, _, _, _) => parentRange(pid, min, children, m)
           case GroupTree.Root(_, children)                          => parentRange(pid, None, children, m)
 

--- a/modules/service/src/main/scala/lucuma/odb/service/AllocationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AllocationService.scala
@@ -11,7 +11,6 @@ import lucuma.core.enums.ScienceBand
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.syntax.string.*
-import lucuma.core.util.TimeSpan
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.graphql.input.AllocationInput
@@ -70,12 +69,14 @@ object AllocationService {
           validateObservations(bands, pid)
         }
 
+      @annotation.nowarn("msg=unused implicit parameter")
       private def deleteAllocations(pid: Program.Id)(using Transaction[F]): F[Unit] =
         session.execute(Statements.DeleteAllocations)(pid).void
 
       // If any observations have already been assigned bands which are not in
       // the given SetAllocationsInput, then generate a warning result listing
       // them.
+      @annotation.nowarn("msg=unused implicit parameter")
       private def validateObservations(bands: Set[ScienceBand], pid: Program.Id)(using Transaction[F]): F[Result[Unit]] =
         val noneBands  = session.execute(Statements.ObservationsWithNonNullBand)(pid)
         NonEmptyList.fromList(bands.toList).fold(noneBands) { nel =>

--- a/modules/service/src/main/scala/lucuma/odb/service/AttachmentFileService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AttachmentFileService.scala
@@ -6,7 +6,6 @@ package lucuma.odb.service
 import cats.Applicative
 import cats.data.EitherT
 import cats.effect.Concurrent
-import cats.effect.std.SecureRandom
 import cats.effect.std.UUIDGen
 import cats.syntax.all.*
 import eu.timepit.refined.types.string.NonEmptyString
@@ -117,6 +116,7 @@ object AttachmentFileService {
       EitherT.right(fa)
 
   extension [F[_]](svcs: Services[F])
+    @annotation.nowarn("msg=unused implicit parameter")
     def transactionallyEitherT[A](
       fa: (Transaction[F], Services[F]) ?=> EitherT[F, AttachmentException, A]
     )(using
@@ -145,7 +145,7 @@ object AttachmentFileService {
     if (fileSize <= 0) InvalidRequest("File cannot be empty").asLeft
     else ().asRight
 
-  def instantiate[F[_]: Concurrent: Trace: SecureRandom: UUIDGen](
+  def instantiate[F[_]: Concurrent: Trace: UUIDGen](
     s3FileSvc: S3FileService[F]
   )(using Services[F]): AttachmentFileService[F] = {
 

--- a/modules/service/src/main/scala/lucuma/odb/service/AttachmentMetadataService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AttachmentMetadataService.scala
@@ -13,7 +13,6 @@ import lucuma.odb.data.Nullable
 import lucuma.odb.graphql.input.AttachmentPropertiesInput
 import lucuma.odb.graphql.mapping.AccessControl
 import lucuma.odb.util.Codecs.*
-import natchez.Trace
 import skunk.*
 import skunk.codec.all.*
 import skunk.implicits.*
@@ -31,7 +30,7 @@ trait AttachmentMetadataService [F[_]] {
 
 object AttachmentMetadataService {
 
-  def instantiate[F[_]: Concurrent: Trace](using Services[F]): AttachmentMetadataService[F] =
+  def instantiate[F[_]: Concurrent](using Services[F]): AttachmentMetadataService[F] =
     new AttachmentMetadataService[F] {
 
       override def updateAttachments(

--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -47,7 +47,6 @@ import lucuma.odb.sequence.data.ItcInput
 import lucuma.odb.service.CalibrationConfigSubset.*
 import lucuma.odb.service.Services.ServiceAccess
 import lucuma.odb.service.Services.Syntax.*
-import lucuma.odb.util.*
 import lucuma.odb.util.Codecs.*
 import lucuma.refined.*
 import skunk.AppliedFragment
@@ -183,6 +182,7 @@ object CalibrationsService extends CalibrationObservations {
         }
 
       // Find all active observations in the program
+      @annotation.nowarn("msg=unused implicit parameter")
       private def activeObservations(pid: Program.Id)(using Transaction[F]): F[Set[Observation.Id]] =
         session.execute(Statements.selectActiveObservations)(pid).map(_.toSet)
 
@@ -271,6 +271,7 @@ object CalibrationsService extends CalibrationObservations {
       }
 
       // Set the calibration role of the observations in bulk
+      @annotation.nowarn("msg=unused implicit parameter")
       private def setCalibRoleAndGroup(oids: List[Observation.Id], calibrationRole: CalibrationRole)(using Transaction[F]): F[Unit] =
         session.executeCommand(Statements.setCalibRole(oids, calibrationRole)).void
 

--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsUtils.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsUtils.scala
@@ -41,7 +41,7 @@ import java.time.LocalTime
 
 trait CalibrationTargetLocator {
   def bestTargetInList(ref: Coordinates, tgts: List[(Target.Id, String, CalibrationRole, Coordinates)]): Option[(CalibrationRole, Target.Id)] =
-    tgts.minimumByOption(_._4.angularDistance(ref))(Angle.SignedAngleOrder).map(x => (x._3, x._1))
+    tgts.minimumByOption(_._4.angularDistance(ref))(using Angle.SignedAngleOrder).map(x => (x._3, x._1))
 
   def idealLocation(site: Site, referenceInstant: Instant): Coordinates
 

--- a/modules/service/src/main/scala/lucuma/odb/service/DatasetService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/DatasetService.scala
@@ -12,7 +12,6 @@ import cats.syntax.traverse.*
 import grackle.Result
 import grackle.ResultT
 import grackle.syntax.*
-import lucuma.core.enums.DatasetQaState
 import lucuma.core.model.Visit
 import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.Dataset

--- a/modules/service/src/main/scala/lucuma/odb/service/GroupService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GroupService.scala
@@ -164,6 +164,7 @@ object GroupService {
           } .map(moreIds => Result(moreIds.foldLeft(ids)((a, b) => (a ++ b).distinct)))
         }
 
+      @annotation.nowarn("msg=unused implicit parameter")
       def openHole(pid: Program.Id, gid: Option[Group.Id], index: Option[NonNegShort])(using Transaction[F]): F[NonNegShort] =
         session.prepareR(Statements.OpenHole).use(_.unique(pid, gid, index))
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -44,7 +44,6 @@ import lucuma.itc.AsterismIntegrationTimes
 import lucuma.itc.IntegrationTime
 import lucuma.itc.SignalToNoiseAt
 import lucuma.itc.SingleSN
-import lucuma.itc.TargetIntegrationTime
 import lucuma.itc.TotalSN
 import lucuma.itc.client.ClientCalculationResult
 import lucuma.itc.client.ItcClient
@@ -275,6 +274,7 @@ object ItcService {
         } yield r).value
 
       // Selects the parameters then selects the previously stored result set, if any.
+      @annotation.nowarn("msg=unused implicit parameter")
       private def attemptLookup(
         pid: Program.Id,
         oid: Observation.Id
@@ -312,7 +312,7 @@ object ItcService {
             .flattenOption
             .toMap
 
-      def selectAll(
+      override def selectAll(
         params: Map[Observation.Id, GeneratorParams]
       )(using Transaction[F], SuperUserAccess): F[Map[Observation.Id, AsterismResults]] =
         NonEmptyList.fromList(params.keys.toList).fold(Map.empty.pure[F]): nel =>
@@ -352,6 +352,7 @@ object ItcService {
             .partitionErrors
             .leftMap(convertErrors(targets))
 
+      @annotation.nowarn("msg=unused implicit parameter")
       private def callRemoteItc(
         targets: ItcInput
       )(using NoTransaction[F]): F[Either[OdbError, AsterismResults]] =
@@ -378,6 +379,7 @@ object ItcService {
         .handleError: t =>
           OdbError.RemoteServiceCallError(s"Error calling ITC service: ${t.getMessage}".some).asLeft
 
+      @annotation.nowarn("msg=unused implicit parameter")
       private def insertOrUpdate(
         pid:     Program.Id,
         oid:     Observation.Id,

--- a/modules/service/src/main/scala/lucuma/odb/service/ObscalcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObscalcService.scala
@@ -18,9 +18,7 @@ import cats.syntax.functor.*
 import cats.syntax.option.*
 import cats.syntax.traverse.*
 import lucuma.core.enums.ChargeClass
-import lucuma.core.enums.ExecutionState
 import lucuma.core.enums.ObservationWorkflowState
-import lucuma.core.enums.ObserveClass
 import lucuma.core.math.Offset
 import lucuma.core.model.Observation
 import lucuma.core.model.ObservationWorkflow
@@ -31,7 +29,6 @@ import lucuma.core.model.sequence.SequenceDigest
 import lucuma.core.model.sequence.SetupTime
 import lucuma.core.util.CalculatedValue
 import lucuma.core.util.CalculationState
-import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import lucuma.itc.IntegrationTime
 import lucuma.itc.SignalToNoiseAt
@@ -245,6 +242,7 @@ object ObscalcService:
             )
         )
 
+      @annotation.nowarn("msg=unused implicit parameter")
       private def storeResult(
         pending:  Obscalc.PendingCalc,
         result:   Obscalc.Result,
@@ -358,7 +356,7 @@ object ObscalcService:
         prefix.fold(col)(p => s"$p.$col")
       .mkString("", ",\n", "\n")
 
-    private def obscalcMetaDataColumns(prefix: Option[String] = None): String =
+    private def obscalcMetaDataColumns(prefix: Option[String]): String =
       prefixedColumns(
         prefix,
         "c_program_id",
@@ -370,7 +368,7 @@ object ObscalcService:
         "c_failure_count"
       )
 
-    private def obscalcResultColumns(prefix: Option[String] = None): String =
+    private def obscalcResultColumns(prefix: Option[String]): String =
       prefixedColumns(
         prefix,
         "c_odb_error",

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -44,7 +44,6 @@ import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.core.syntax.string.*
 import lucuma.core.util.TimeSpan
-import lucuma.core.util.Timestamp
 import lucuma.odb.data.Existence
 import lucuma.odb.data.ExposureTimeModeType
 import lucuma.odb.data.Nullable
@@ -204,9 +203,6 @@ object ObservationService {
 
   def instantiate[F[_]: Concurrent: Trace](using Services[F]): ObservationService[F] =
     new ObservationService[F] {
-
-      // A stable identifier (ie. a `val`) is needed for the enums.
-      val enumsVal = enums
 
       val resolver = new IdResolver("observation", Statements.selectOid, _.label)
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -47,7 +47,6 @@ import lucuma.odb.service.GeneratorParamsService.Error as GenParamsError
 import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.syntax.instrument.*
 import lucuma.odb.util.Codecs.*
-import natchez.Trace
 import skunk.*
 import skunk.codec.boolean.*
 import skunk.implicits.*
@@ -235,7 +234,7 @@ object ObservationWorkflowService {
       case _                             => ObservationValidation.configuration(ge.format)
 
   /* Construct an instance. */
-  def instantiate[F[_]: Concurrent: Trace](using Services[F]): ObservationWorkflowService[F] =
+  def instantiate[F[_]: Concurrent](using Services[F]): ObservationWorkflowService[F] =
     new ObservationWorkflowService[F] {
 
       // Make the enums available in a stable and implicit way
@@ -328,6 +327,7 @@ object ObservationWorkflowService {
               .toMap
 
 
+      @annotation.nowarn("msg=unused implicit parameter")
       private def validateConfigurations(infos: NonEmptyList[ObservationValidationInfo])(using Transaction[F]): ResultT[F, Map[Observation.Id, ObservationValidationMap]] =
         ResultT(configurationService.selectRequests(infos.toList.map(i => (i.pid, i.oid)))).map: rs =>
           rs.view
@@ -342,6 +342,7 @@ object ObservationWorkflowService {
                 }
             .toMap
 
+      @annotation.nowarn("msg=unused implicit parameter")
       // Computes the observation execution state if not cached
       private def executionStates(
         infos:      Map[Observation.Id, ObservationValidationInfo],
@@ -473,7 +474,7 @@ object ObservationWorkflowService {
 
         // Here are our composed validators
 
-        val calibrationValidator, engValidator: Validator = info =>
+        val calibrationValidator, engValidator: Validator = _ =>
           ObservationValidationMap.empty
 
         val scienceValidator1: Validator =
@@ -673,6 +674,7 @@ object ObservationWorkflowService {
           .flatMap: oids =>
             filterState(oids, states, commitHash, itcClient, ptc)
 
+      @annotation.nowarn("msg=unused implicit parameter")
       private def getObservationsForTargets(whichTargets: AppliedFragment)(using NoTransaction[F]): F[Map[Target.Id, List[Observation.Id]]] =
         services.transactionally:
           val af = Statements.selectObservationsForTargets(whichTargets)

--- a/modules/service/src/main/scala/lucuma/odb/service/PartnerSplitsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/PartnerSplitsService.scala
@@ -10,7 +10,6 @@ import lucuma.core.enums.Partner
 import lucuma.core.model.IntPercent
 import lucuma.core.model.Program
 import lucuma.odb.util.Codecs.*
-import natchez.Trace
 import skunk.*
 import skunk.syntax.all.*
 
@@ -30,7 +29,7 @@ object PartnerSplitsService {
    * Construct a `PartnerSplitsService` using the specified `Session`. This service is intended for
   * indirect use by `ProposalService`.
    */
-  def instantiate[F[_]: Concurrent: Trace](using Services[F]): PartnerSplitsService[F] =
+  def instantiate[F[_]: Concurrent](using Services[F]): PartnerSplitsService[F] =
     new PartnerSplitsService[F] {
 
       def insertSplits(splits: Map[Partner, IntPercent], pid: Program.Id)(using Transaction[F]): F[Unit] =
@@ -44,6 +43,7 @@ object PartnerSplitsService {
           _ <- insertSplits(splits, pid)
         } yield ()
 
+      @annotation.nowarn("msg=unused implicit parameter")
       private def deleteSplits(pid: Program.Id)(using Transaction[F]): F[Unit] =
         session.prepareR(Statements.DeleteSplits).use(_.execute(pid)).void
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ProgramNoteService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProgramNoteService.scala
@@ -10,7 +10,6 @@ import cats.syntax.flatMap.*
 import cats.syntax.foldable.*
 import cats.syntax.functor.*
 import cats.syntax.traverse.*
-import eu.timepit.refined.types.string.NonEmptyString
 import grackle.Result
 import grackle.syntax.*
 import lucuma.core.model.Program

--- a/modules/service/src/main/scala/lucuma/odb/service/ProgramService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProgramService.scala
@@ -22,7 +22,6 @@ import lucuma.core.model.ProgramReference.Description
 import lucuma.core.model.ProposalReference
 import lucuma.core.model.Semester
 import lucuma.core.model.ServiceUser
-import lucuma.core.model.User
 import lucuma.odb.data.*
 import lucuma.odb.graphql.input.GoaPropertiesInput
 import lucuma.odb.graphql.input.ProgramPropertiesInput

--- a/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
@@ -187,6 +187,7 @@ object SequenceService {
        * can compare a new step being recorded with the previous state and
        * determine the cost of making the prescribed changes.
        */
+      @annotation.nowarn("msg=unused implicit parameter")
       private def selectEstimatorState[S, D](
         observationId: Observation.Id,
         staticConfig:  Visit.Id => F[Option[S]],
@@ -287,6 +288,7 @@ object SequenceService {
           _ <- session.execute(Statements.AbandonOngoingStepsWithoutStepId)(observationId, stepId)
         } yield ()
 
+      @annotation.nowarn("msg=unused implicit parameter")
       def insertAtomRecordImpl(
         visitId:      Visit.Id,
         instrument:   Instrument,
@@ -322,6 +324,7 @@ object SequenceService {
           case s @ StepConfig.SmartGcal(_)     => session.execute(Statements.InsertStepConfigSmartGcal)(stepId, s).void
         }
 
+      @annotation.nowarn("msg=unused implicit parameter")
       private def insertStepRecord[S, D](
         atomId:              Atom.Id,
         instrument:          Instrument,

--- a/modules/service/src/main/scala/lucuma/odb/service/Services.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/Services.scala
@@ -10,7 +10,6 @@ import cats.Parallel
 import cats.effect.Concurrent
 import cats.effect.MonadCancelThrow
 import cats.effect.Resource
-import cats.effect.std.SecureRandom
 import cats.effect.std.UUIDGen
 import cats.syntax.all.*
 import grackle.Mapping
@@ -225,7 +224,7 @@ object Services:
    * lazily.
    */
   def forUser[F[_]](u: User, e: Enums, m: Option[Mapping[F]])(s: Session[F])(
-    using tf: Trace[F], uf: UUIDGen[F], sr: SecureRandom[F], cf: Concurrent[F], par: Parallel[F], log: Logger[F]
+    using tf: Trace[F], uf: UUIDGen[F], cf: Concurrent[F], par: Parallel[F], log: Logger[F]
   ): Services[F[_]] =
     new Services[F]:
 
@@ -400,6 +399,7 @@ object Services:
 
     extension [F[_]: MonadCancelThrow, A](s: Resource[F, Services[F]])
 
+      @annotation.nowarn("msg=unused implicit parameter")
       def useTransactionally(fa: (Transaction[F], Services[F]) ?=> F[A])(
         using NoTransaction[F], NotGiven[Services[F]] // discourage nested calls
       ): F[A] =

--- a/modules/service/src/main/scala/lucuma/odb/service/UserInvitationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/UserInvitationService.scala
@@ -89,6 +89,7 @@ object UserInvitationService:
           .use: pq =>
             pq.unique(emailId, invitationId).as(Result.unit)
 
+      @annotation.nowarn("msg=unused implicit parameter")
       def createInvitationAsPi(
         input: CreateUserInvitationInput,
         pid:   Program.Id
@@ -102,6 +103,7 @@ object UserInvitationService:
                 case SqlState.UniqueViolation(ex) =>
                   OdbError.UpdateFailed(s"There is already a pending invitation for program user '${input.programUserId}'.".some).asFailureF
 
+      @annotation.nowarn("msg=unused implicit parameter")
       def createInvitationAsSuperUser(
         input: CreateUserInvitationInput,
         pid:   Program.Id

--- a/modules/service/src/main/scala/lucuma/odb/service/VisitService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/VisitService.scala
@@ -1,9 +1,6 @@
 // Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
-// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
-
 package lucuma.odb.service
 
 import cats.effect.Concurrent
@@ -20,7 +17,6 @@ import lucuma.core.model.Visit
 import lucuma.core.model.sequence.flamingos2.Flamingos2StaticConfig
 import lucuma.core.model.sequence.gmos.StaticConfig.GmosNorth
 import lucuma.core.model.sequence.gmos.StaticConfig.GmosSouth
-import lucuma.core.util.Timestamp
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.graphql.input.RecordVisitInput
@@ -169,7 +165,7 @@ object VisitService:
         val update = (for
           v0 <- ResultT(lookupOrInsert(observationId))
           os <- ResultT.liftF(lookupStatic(v0))
-          v1 <- os.fold(insertStaticForVisit(v0).as(v0)): s =>
+          v1 <- os.fold(insertStaticForVisit(v0).as(v0)): _ =>
                   insertNewVisit.flatMap: v =>
                     insertStaticForVisit(v).as(v)
         yield v1).value

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -298,7 +298,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
 
   // tests that require successfully sending invitations can assign this to httpRequestHandler
   protected val invitationEmailRequestHandler: Request[IO] => Resource[IO, Response[IO]] =
-    req => {
+    _ => {
       val sio = UUIDGen[IO].randomUUID.map(uuid =>
         Json.obj(
           "id"      -> s"<$uuid>".asJson,
@@ -402,7 +402,7 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
         auth <- Resource.eval(authorizationHeader(user))
         xbe  <- JdkHttpClient.simple[IO].map(Http4sHttpBackend[IO](_))
         xc   <-
-          Resource.eval(Http4sHttpClient.of[IO, Nothing](uri, headers = Headers(auth))(Async[IO], xbe, Logger[IO]))
+          Resource.eval(Http4sHttpClient.of[IO, Nothing](uri, headers = Headers(auth))(using Async[IO], xbe, Logger[IO]))
       } yield xc
 
   private def streamingClient(user: User)(svr: Server): Resource[IO, WebSocketClient[IO, Nothing]] =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachmentRoutes.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachmentRoutes.scala
@@ -16,7 +16,6 @@ import lucuma.odb.service.AttachmentFileService
 import lucuma.odb.service.AttachmentFileService.AttachmentException
 import lucuma.odb.service.NoTransaction
 import lucuma.refined.*
-import natchez.Trace.Implicits.noop
 import org.http4s.*
 import org.http4s.implicits.*
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/obsAttachmentsAssignments.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/obsAttachmentsAssignments.scala
@@ -34,7 +34,6 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
 
   def assertObservation(
     user:        User,
-    pid:         Program.Id,
     oid:         Observation.Id,
     attachments: (Attachment.Id, TestAttachment)*
   ): IO[Unit] =
@@ -230,7 +229,7 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, mosMask).toAttachmentId
       oid <- createObservation(pi, pid, (aid, mosMask))
-      _   <- assertObservation(pi, pid, oid, (aid, mosMask))
+      _   <- assertObservation(pi, oid, (aid, mosMask))
     } yield ()
   }
 
@@ -240,7 +239,7 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       aid1 <- insertAttachment(pi, pid, mosMask).toAttachmentId
       aid2 <- insertAttachment(pi, pid, finder).toAttachmentId
       oid  <- createObservation(pi, pid, (aid1, mosMask), (aid2, finder))
-      _    <- assertObservation(pi, pid, oid, (aid1, mosMask), (aid2, finder))
+      _    <- assertObservation(pi, oid, (aid1, mosMask), (aid2, finder))
     } yield ()
   }
 
@@ -251,8 +250,8 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       aid2 <- insertAttachment(pi, pid, finder).toAttachmentId
       oid1 <- createObservation(pi, pid, (aid1, mosMask), (aid2, finder))
       oid2 <- createObservation(pi, pid, (aid2, finder))
-      _    <- assertObservation(pi, pid, oid1, (aid1, mosMask), (aid2, finder))
-      _    <- assertObservation(pi, pid, oid2, (aid2, finder))
+      _    <- assertObservation(pi, oid1, (aid1, mosMask), (aid2, finder))
+      _    <- assertObservation(pi, oid2, (aid2, finder))
     } yield ()
   }
 
@@ -260,7 +259,7 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
     for {
       pid <- createProgramAs(pi)
       oid <- createObservation(pi, pid)
-      _   <- assertObservation(pi, pid, oid)
+      _   <- assertObservation(pi, oid)
     } yield ()
   }
 
@@ -289,7 +288,7 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, mosMask).toAttachmentId
       oid <- createObservation(pi, pid, (aid, mosMask))
-      _   <- assertObservation(pi, pid, oid, (aid, mosMask))
+      _   <- assertObservation(pi, oid, (aid, mosMask))
       _   <- updateObservation(pi, oid, UpdateInput.Null)
     } yield ()
   }
@@ -299,7 +298,7 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, mosMask).toAttachmentId
       oid <- createObservation(pi, pid, (aid, mosMask))
-      _   <- assertObservation(pi, pid, oid, (aid, mosMask))
+      _   <- assertObservation(pi, oid, (aid, mosMask))
       _   <- updateObservation(pi, oid, updateEmpty)
     } yield ()
   }
@@ -342,9 +341,9 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       aid1 <- insertAttachment(pi, pid, mosMask).toAttachmentId
       aid2 <- insertAttachment(pi, pid, finder).toAttachmentId
       oid  <- createObservation(pi, pid, (aid1, mosMask), (aid2, finder))
-      _    <- assertObservation(pi, pid, oid, (aid1, mosMask), (aid2, finder))
+      _    <- assertObservation(pi, oid, (aid1, mosMask), (aid2, finder))
       _    <- deleteAttachment(pi, aid1).expectOk
-      _    <- assertObservation(pi, pid, oid, (aid2, finder))
+      _    <- assertObservation(pi, oid, (aid2, finder))
     } yield ()
   }
 
@@ -355,8 +354,8 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       aid2 <- insertAttachment(pi, pid, finder).toAttachmentId
       oid1 <- createObservation(pi, pid, (aid1, mosMask), (aid2, finder))
       oid2 <- createObservation(pi, pid, (aid2, finder))
-      _    <- assertObservation(pi, pid, oid1, (aid1, mosMask), (aid2, finder))
-      _    <- assertObservation(pi, pid, oid2, (aid2, finder))
+      _    <- assertObservation(pi, oid1, (aid1, mosMask), (aid2, finder))
+      _    <- assertObservation(pi, oid2, (aid2, finder))
       _    <- deleteObservation(pi, oid1)
     } yield ()
   }
@@ -367,9 +366,9 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       aid1 <- insertAttachment(pi, pid, mosMask).toAttachmentId
       aid2 <- insertAttachment(pi, pid, finder).toAttachmentId
       oid1 <- createObservation(pi, pid, (aid1, mosMask), (aid2, finder))
-      _    <- assertObservation(pi, pid, oid1, (aid1, mosMask), (aid2, finder))
+      _    <- assertObservation(pi, oid1, (aid1, mosMask), (aid2, finder))
       oid2 <- cloneObservationAs(pi, oid1)
-      _    <- assertObservation(pi, pid, oid2, (aid1, mosMask), (aid2, finder))
+      _    <- assertObservation(pi, oid2, (aid1, mosMask), (aid2, finder))
     } yield ()
   }
 
@@ -379,9 +378,9 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       aid1 <- insertAttachment(pi, pid, mosMask).toAttachmentId
       aid2 <- insertAttachment(pi, pid, finder).toAttachmentId
       oid1 <- createObservation(pi, pid, (aid1, mosMask))
-      _    <- assertObservation(pi, pid, oid1, (aid1, mosMask))
+      _    <- assertObservation(pi, oid1, (aid1, mosMask))
       oid2 <- cloneObservationWithAttachments(pi, oid1, aid2)
-      _    <- assertObservation(pi, pid, oid2, (aid2, finder))
+      _    <- assertObservation(pi, oid2, (aid2, finder))
     } yield ()
   }
 
@@ -410,7 +409,7 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       aid  <- insertAttachment(pi, pid1, mosMask).toAttachmentId
       pid2 <- createProgramAs(pi)
       oid  <- createObservationAs(pi, pid2)
-      _    <- assertObservation(pi, pid2, oid)
+      _    <- assertObservation(pi, oid)
       _    <- cloneObservationWithAttachmentsWithError(pi, oid, ObsAttachmentAssignmentService.ForeignKeyViolationMessage(pid2, NonEmptyList.one(aid)), aid)
     } yield ()
   }
@@ -437,7 +436,7 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, customSed).toAttachmentId
       oid <- createObservationAs(pi, pid)
-      _   <- assertObservation(pi, pid, oid)
+      _   <- assertObservation(pi, oid)
       _   <- cloneObservationWithAttachmentsWithError(pi, oid, ObsAttachmentAssignmentService.NonObservationAttachmentMessage(NonEmptyList.one(aid)), aid)
     } yield ()
   }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/input/Flamingos2LongSlitInputSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/input/Flamingos2LongSlitInputSuite.scala
@@ -9,7 +9,6 @@ import lucuma.core.enums.Flamingos2Filter
 import lucuma.core.enums.Flamingos2Fpu
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.util.arb.ArbEnumerated.given
-import lucuma.odb.data.Nullable
 import lucuma.odb.graphql.input.arb.ArbFlamingos2LongSlitInput.given
 import munit.DisciplineSuite
 import org.scalacheck.Prop.forAll

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/249.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/249.scala
@@ -12,7 +12,6 @@ import io.circe.syntax.*
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Target
-import lucuma.core.model.User
 
 // https://github.com/gemini-hlsw/lucuma-odb/issues/249
 class GitHub_249 extends OdbSuite {
@@ -20,7 +19,7 @@ class GitHub_249 extends OdbSuite {
   val pi       = TestUsers.Standard.pi(1, 30)
   val validUsers = List(pi)
 
-  def deleteTarget(user: User, tid: Target.Id): IO[Unit] =
+  def deleteTarget(tid: Target.Id): IO[Unit] =
     query(
       user = pi,
       query = s"""
@@ -51,7 +50,7 @@ class GitHub_249 extends OdbSuite {
         oid2 <- createObservationAs(user, pid, tids(0), tids(1))
         oid3 <- createObservationAs(user, pid, tids(0), tids(1), tids(2))
         oid4 <- createObservationAs(user, pid)
-        _    <- deleteTarget(user, tids(0))
+        _    <- deleteTarget(tids(0))
         _    <- expect(
           user = user,
           query =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/250.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/250.scala
@@ -10,14 +10,13 @@ import io.circe.Json
 import io.circe.literal.*
 import lucuma.core.model.Observation
 import lucuma.core.model.Target
-import lucuma.core.model.User
 
 class GitHub_250 extends OdbSuite {
 
   val pi       = TestUsers.Standard.pi(1, 30)
   val validUsers = List(pi)
 
-  def deleteTarget(user: User, tid: Target.Id): IO[Unit] =
+  def deleteTarget(tid: Target.Id): IO[Unit] =
     query(
       user = pi,
       query = s"""
@@ -38,7 +37,7 @@ class GitHub_250 extends OdbSuite {
       """
     ).void
 
-  def renameTarget(user: User, tid: Target.Id, name: String): IO[Unit] =
+  def renameTarget(tid: Target.Id, name: String): IO[Unit] =
     query(
       user = pi,
       query = s"""
@@ -67,7 +66,7 @@ class GitHub_250 extends OdbSuite {
       oid2 <- createObservationAs(pi, pid, tids(1), tids(2), tids(3))
       oid3 <- createObservationAs(pi, pid, tids(2))
       oid4 <- createObservationAs(pi, pid)
-      _    <- renameTarget(pi, tids(1), "fnord")
+      _    <- renameTarget(tids(1), "fnord")
       _  <- expect(
         user = pi,
         query =
@@ -122,7 +121,7 @@ class GitHub_250 extends OdbSuite {
       oid2 <- createObservationAs(pi, pid, tids(1), tids(2), tids(3))
       oid3 <- createObservationAs(pi, pid, tids(2))
       oid4 <- createObservationAs(pi, pid)
-      _    <- deleteTarget(pi, tids(1))
+      _    <- deleteTarget(tids(1))
       _  <- expect(
         user = pi,
         query =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/634.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/github/634.scala
@@ -4,7 +4,6 @@
 package lucuma.odb.graphql
 package issue.github
 
-import cats.syntax.all.*
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.model.Target

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4596.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4596.scala
@@ -25,7 +25,6 @@ import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.syntax.timespan.*
-import lucuma.core.util.TimeSpan
 import lucuma.itc.IntegrationTime
 import lucuma.odb.graphql.mutation.UpdateConstraintSetOps
 import lucuma.odb.graphql.query.ExecutionTestSupportForGmos

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5017.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5017.scala
@@ -22,7 +22,6 @@ import lucuma.core.model.sequence.Dataset
 import lucuma.core.model.sequence.Step
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.syntax.timespan.*
-import lucuma.core.util.TimeSpan
 import lucuma.itc.IntegrationTime
 import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 import lucuma.odb.json.all.transport.given

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5331.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5331.scala
@@ -4,7 +4,6 @@
 package lucuma.odb.graphql
 package issue.shortcut
 
-import cats.syntax.all.*
 import grackle.Problem
 import grackle.Result
 import grackle.Value

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addConditionsEntry.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addConditionsEntry.scala
@@ -4,7 +4,6 @@
 package lucuma.odb.graphql
 package mutation
 
-import cats.syntax.all.*
 import io.circe.Json
 import io.circe.literal.*
 import lucuma.core.model.User

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneGroup.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneGroup.scala
@@ -6,7 +6,6 @@ package mutation
 
 import eu.timepit.refined.types.numeric.NonNegShort
 import io.circe.literal.*
-import lucuma.core.model.Group
 import lucuma.core.model.User
 import lucuma.odb.data.OdbError
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
@@ -314,7 +314,7 @@ class cloneObservation extends OdbSuite {
     }
 
   test("can specify the observation to clone using its reference") {
-    referenceTest { (oid, ref) =>
+    referenceTest { (_, ref) =>
       s"""
          observationReference: ${ref.asJson}
       """

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createTarget.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createTarget.scala
@@ -14,7 +14,6 @@ import lucuma.core.enums.Partner
 import lucuma.core.model.ProgramReference
 import lucuma.core.model.Semester
 import lucuma.core.model.Target
-import lucuma.core.model.User
 
 class createTarget extends OdbSuite {
   import createTarget.FullTargetGraph

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createUserInvitation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createUserInvitation.scala
@@ -381,7 +381,7 @@ class createUserInvitation extends OdbSuite:
           ).asLeft
         )
 
-  def invitationsQuery(user: User, pid: Program.Id): String =
+  def invitationsQuery(pid: Program.Id): String =
     s"""
       query {
         programUsers(
@@ -406,7 +406,7 @@ class createUserInvitation extends OdbSuite:
       inv0 <- createUserInvitationAs(pi, mid)
       _    <- expect(
         user     = pi,
-        query    = invitationsQuery(pi, pid),
+        query    = invitationsQuery(pid),
         expected =
           json"""
             {
@@ -442,7 +442,7 @@ class createUserInvitation extends OdbSuite:
         _    <- redeemUserInvitationAs(pi2, inv1, true)
         _    <- expect(
           user     = pi,
-          query    = invitationsQuery(pi, pid),
+          query    = invitationsQuery(pid),
           expected =
             json"""
               {
@@ -472,7 +472,7 @@ class createUserInvitation extends OdbSuite:
         _    <- redeemUserInvitationAs(pi2, inv1, true)
         _    <- expect(
           user     = pi,
-          query    = invitationsQuery(pi, pid),
+          query    = invitationsQuery(pid),
           expected =
             json"""
               {
@@ -510,7 +510,7 @@ class createUserInvitation extends OdbSuite:
       _   <- deleteProgramUserAs(pi, mid)
       _   <- expect(
           user     = pi,
-          query    = invitationsQuery(pi, pid),
+          query    = invitationsQuery(pid),
           expected =
             json"""
               {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/linkUser.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/linkUser.scala
@@ -10,9 +10,7 @@ import lucuma.core.enums.Partner
 import lucuma.core.enums.ProgramUserRole
 import lucuma.core.enums.ScienceBand
 import lucuma.core.enums.TimeAccountingCategory
-import lucuma.core.model.User
 import lucuma.core.syntax.timespan.*
-import lucuma.core.util.TimeSpan
 import lucuma.odb.data.OdbError
 
 class linkUser extends OdbSuite:

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordAtom.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordAtom.scala
@@ -176,7 +176,7 @@ class recordAtom extends OdbSuite {
           }
         }
       """,
-      vid => json"""
+      _ => json"""
         {
           "recordAtom": {
             "atomRecord": {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordDataset.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/recordDataset.scala
@@ -211,7 +211,7 @@ class recordDataset extends OdbSuite {
           }
         }
       """,
-      (oid, sid) => "The filename 'N18630101S0002.fits' is already assigned".asLeft
+      (_, _) => "The filename 'N18630101S0002.fits' is already assigned".asLeft
     )
   }
 
@@ -219,7 +219,7 @@ class recordDataset extends OdbSuite {
     recordDatasetTest(
       ObservingModeType.GmosNorthLongSlit,
       service,
-      sid => s"""
+      _ => s"""
         mutation {
           recordDataset(input: {
             stepId: "s-d506e5d9-e5d1-4fcc-964c-90afedabc9e8",
@@ -231,7 +231,7 @@ class recordDataset extends OdbSuite {
           }
         }
       """,
-      (oid, sid) => "Step id 's-d506e5d9-e5d1-4fcc-964c-90afedabc9e8' not found".asLeft
+      (_, _) => "Step id 's-d506e5d9-e5d1-4fcc-964c-90afedabc9e8' not found".asLeft
     )
   }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/revokeUserInvitation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/revokeUserInvitation.scala
@@ -101,7 +101,7 @@ class revokeUserInvitation extends OdbSuite:
                 }
               }
             """
-          ).flatMap: json =>
+          ).flatMap: _ =>
             expect(
               user     = pi,
               query    = revoke(inv.id),
@@ -129,7 +129,7 @@ class revokeUserInvitation extends OdbSuite:
               """.asRight
             )
 
-  def badInvitation(u: User): PartialFunction[OdbError, Unit] =
+  val badInvitation: PartialFunction[OdbError, Unit] =
     case OdbError.InvitationError(_, Some("Invitation does not exist, is no longer pending, or was issued by someone else.")) => ()
 
   List(true, false).foreach: accept =>
@@ -141,7 +141,7 @@ class revokeUserInvitation extends OdbSuite:
             expectOdbError(
               user     = pi,
               query    = revoke(inv.id),
-              expected = badInvitation(pi)
+              expected = badInvitation
             )
 
   test("can't revoke an invitation twice"):
@@ -152,7 +152,7 @@ class revokeUserInvitation extends OdbSuite:
           expectOdbError(
             user     = pi,
             query    = revoke(inv.id),
-            expected = badInvitation(pi)
+            expected = badInvitation
           )
 
   test("guest can't revoke an invitation"):
@@ -175,7 +175,7 @@ class revokeUserInvitation extends OdbSuite:
             expectOdbError(
               user     = u,
               query    = revoke(inv.id),
-              expected = badInvitation(u)
+              expected = badInvitation
             )
 
   List(admin, staff, service).foreach: u =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setGuideTargetName.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setGuideTargetName.scala
@@ -180,7 +180,7 @@ class setGuideTargetName extends query.ExecutionTestSupportForGmos {
   }
 
   test("user must have access to the program") {
-    val expected = expectObsError(oid => OdbError.InvalidArgument().message)
+    val expected = expectObsError(_ => OdbError.InvalidArgument().message)
     for
       pid <- createProgramAs(pi)
       tid <- createTargetWithProfileAs(pi, pid)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setObservationWorkflowState.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setObservationWorkflowState.scala
@@ -17,7 +17,6 @@ import lucuma.core.model.ConfigurationRequest
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.syntax.timespan.*
-import lucuma.core.util.TimeSpan
 import lucuma.itc.IntegrationTime
 import lucuma.odb.data.OdbError
 import lucuma.odb.graphql.query.ExecutionTestSupportForGmos

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateCallsForProposals.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateCallsForProposals.scala
@@ -11,7 +11,6 @@ import cats.syntax.option.*
 import io.circe.Json
 import io.circe.literal.*
 import lucuma.core.model.CallForProposals
-import lucuma.core.model.User
 import lucuma.core.util.DateInterval
 
 import java.time.LocalDate

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateConfigurationRequests.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateConfigurationRequests.scala
@@ -26,7 +26,7 @@ class updateConfigurationRequests extends OdbSuite with ObservingModeSetupOperat
 
   object updateConfigurationRequestAs {
 
-    def query(user: User, rid: ConfigurationRequest.Id, status: ConfigurationRequestStatus, justification: Option[NonEmptyString] = None): String =
+    def query(rid: ConfigurationRequest.Id, status: ConfigurationRequestStatus, justification: Option[NonEmptyString] = None): String =
       s"""
         mutation {
           updateConfigurationRequests(input: {
@@ -49,7 +49,7 @@ class updateConfigurationRequests extends OdbSuite with ObservingModeSetupOperat
     def apply(user: User, rid: ConfigurationRequest.Id, status: ConfigurationRequestStatus, justification: Option[NonEmptyString] = None): IO[Unit] =
       expect(
         user = user,
-        query = query(user, rid, status, justification),
+        query = query(rid, status, justification),
         expected = Right(json"""
           {
             "updateConfigurationRequests" : {
@@ -95,7 +95,7 @@ class updateConfigurationRequests extends OdbSuite with ObservingModeSetupOperat
     setup.flatMap: rid =>
       expect(
         user = pi2,
-        query = updateConfigurationRequestAs.query(pi2, rid, ConfigurationRequestStatus.Withdrawn),
+        query = updateConfigurationRequestAs.query(rid, ConfigurationRequestStatus.Withdrawn),
         expected = Right(json"""
           {
             "updateConfigurationRequests" : {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateDatasets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateDatasets.scala
@@ -8,8 +8,6 @@ import cats.syntax.either.*
 import io.circe.Json
 import io.circe.syntax.*
 import lucuma.core.enums.ObservingModeType
-import lucuma.core.model.Observation
-import lucuma.core.model.User
 import lucuma.odb.data.OdbError
 
 class updateDatasets extends OdbSuite with query.DatasetSetupOperations {
@@ -106,7 +104,7 @@ class updateDatasets extends OdbSuite with query.DatasetSetupOperations {
                 f"N18630101S00$i%02d.fits"
               }
               .toList
-              .map(f => Json.obj("comment" -> "such very pass".asJson))
+              .map(_ => Json.obj("comment" -> "such very pass".asJson))
             )
           )
         ).asRight

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProgramNotes.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProgramNotes.scala
@@ -9,7 +9,6 @@ import cats.syntax.option.*
 import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
-import lucuma.core.model.User
 
 class updateProgramNotes extends OdbSuite:
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProgramUsers.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProgramUsers.scala
@@ -11,7 +11,6 @@ import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.EducationalStatus
 import lucuma.core.enums.Gender
-import lucuma.core.enums.Partner
 import lucuma.core.enums.Partner.US
 import lucuma.core.enums.ProgramUserRole
 import lucuma.core.model.PartnerLink
@@ -515,7 +514,7 @@ class updateProgramUsers extends OdbSuite:
           )
 
   test("cannot update another pi's partner as a PI"):
-    createProgramAs(piCharles).flatMap: pid =>
+    createProgramAs(piCharles).flatMap: _ =>
       expect(
         user     = piCharles,
         query    = updateUserMutation(pi, PartnerLink.HasPartner(US)),

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
@@ -22,8 +22,7 @@ trait ObservingModeSetupOperations extends DatabaseOperations { this: OdbSuite =
   def createFlamingos2LongSlitObservationAs(
     user:         User,
     pid:          Program.Id,
-    tids:         List[Target.Id],
-    offsetArcsec: Option[List[Int]] = None
+    tids:         List[Target.Id]
   ): IO[Observation.Id] =
     createObservationWithModeAs(
       user,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/dataset.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/dataset.scala
@@ -11,9 +11,7 @@ import io.circe.syntax.*
 import lucuma.core.enums.DatasetStage
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.model.Observation
-import lucuma.core.model.User
 import lucuma.core.model.sequence.Dataset
-import lucuma.core.model.sequence.Step
 import lucuma.core.util.TimestampInterval
 
 class dataset extends OdbSuite with DatasetSetupOperations {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/datasets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/datasets.scala
@@ -10,7 +10,6 @@ import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.DatasetStage
 import lucuma.core.enums.ObservingModeType
-import lucuma.core.model.User
 
 class datasets extends OdbSuite with DatasetSetupOperations {
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAtomRecords.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAtomRecords.scala
@@ -28,7 +28,6 @@ import lucuma.odb.data.AtomExecutionState
 import lucuma.odb.json.gmos.given
 import lucuma.odb.json.time.transport.given
 import lucuma.odb.json.wavelength.transport.given
-import munit.Assertions.*
 
 class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
                                             with ExecutionTestSupportForGmos {
@@ -385,7 +384,7 @@ class executionAtomRecords extends OdbSuite with ExecutionQuerySetupOperations
         Json.obj(
           "steps" -> Json.obj(
             "matches" ->
-              a.steps.map { s =>
+              a.steps.map { _ =>
                 Json.obj(
                   "gmosNorth" -> Json.obj(
                     "fpu" -> Json.obj("builtin" -> "LONG_SLIT_0_50".asJson)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDatasets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDatasets.scala
@@ -9,7 +9,6 @@ import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.ObservingModeType
-import lucuma.core.model.User
 import lucuma.core.model.sequence.Dataset
 
 class executionDatasets extends OdbSuite with ExecutionQuerySetupOperations {
@@ -115,7 +114,7 @@ class executionDatasets extends OdbSuite with ExecutionQuerySetupOperations {
         }
       """
 
-      val matches = on.allDatasets.map(id => Json.obj("observation" -> Json.obj("id" -> on.id.asJson)))
+      val matches = on.allDatasets.map(_ => Json.obj("observation" -> Json.obj("id" -> on.id.asJson)))
 
       val e = json"""
       {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
@@ -646,7 +646,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
         )
 
   test("executionState - COMPLETED"):
-    def atom(v: Visit.Id, ditherNm: Int, q: Int, n: Int): IO[Unit] =
+    def atom(v: Visit.Id, ditherNm: Int, q: Int): IO[Unit] =
       for
         a <- recordAtomAs(serviceUser, Instrument.GmosNorth, v, SequenceType.Science)
         c <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthArc(ditherNm), ArcStep, gcalTelescopeConfig(q), ObserveClass.NightCal)
@@ -663,10 +663,10 @@ class executionDigest extends ExecutionTestSupportForGmos {
         t <- createTargetWithProfileAs(pi, p)
         o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
         v <- recordVisitAs(serviceUser, Instrument.GmosNorth, o)
-        _ <- atom(v,  0,   0, 3)
-        _ <- atom(v,  5,  15, 3)
-        _ <- atom(v, -5, -15, 3)
-        _ <- atom(v,  0,   0, 1)
+        _ <- atom(v,  0,   0)
+        _ <- atom(v,  5,  15)
+        _ <- atom(v, -5, -15)
+        _ <- atom(v,  0,   0)
       yield o
 
     setup.flatMap: oid =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionState.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionState.scala
@@ -17,7 +17,6 @@ import lucuma.core.model.Observation
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.syntax.string.*
 import lucuma.core.syntax.timespan.*
-import lucuma.core.util.TimeSpan
 import lucuma.itc.IntegrationTime
 import lucuma.odb.json.all.transport.given
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionStepRecords.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionStepRecords.scala
@@ -14,7 +14,6 @@ import lucuma.core.enums.DatasetQaState
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.enums.StepStage
 import lucuma.core.model.Observation
-import lucuma.core.model.User
 import lucuma.core.model.sequence.Step
 import lucuma.odb.data.StepExecutionState
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionVisits.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionVisits.scala
@@ -12,7 +12,6 @@ import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.model.Observation
-import lucuma.core.model.User
 import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.Dataset
 import lucuma.core.util.TimeSpan

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_configuration.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_configuration.scala
@@ -92,7 +92,7 @@ class observation_configuration extends OdbSuite with ObservingModeSetupOperatio
   }
 
   test("select configuration for non-fully-configured observation (no proposal)") {
-    createCallForProposalsAs(admin).flatMap { cfpid =>
+    createCallForProposalsAs(admin).flatMap { _ =>
       createProgramAs(pi).flatMap { pid =>
         createTargetWithProfileAs(pi, pid).flatMap { tid =>
           createGmosNorthLongSlitObservationAs(pi, pid, List(tid)).flatMap { oid =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow.scala
@@ -12,7 +12,6 @@ import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.CalibrationRole
-import lucuma.core.enums.CallForProposalsType
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.ObserveClass
@@ -31,7 +30,6 @@ import lucuma.core.syntax.string.*
 import lucuma.core.syntax.timespan.*
 import lucuma.core.util.CalculatedValue
 import lucuma.core.util.CalculationState
-import lucuma.core.util.TimeSpan
 import lucuma.odb.graphql.input.AllocationInput
 import lucuma.odb.graphql.mutation.UpdateConstraintSetOps
 import lucuma.odb.json.all.transport.given

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observationsByWorkflowState.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observationsByWorkflowState.scala
@@ -15,10 +15,6 @@ class observationsByWorkflowState extends OdbSuite {
   val service = TestUsers.service(nextId)
   val validUsers = List(pi, service).toList
 
-  // Borrow some methods from this other test
-  val delegate = new observation_workflow()
-  import delegate.*
-
   test("ensure outer predicate works") {
     createProgramAs(pi).flatMap { pid =>
       createObservationAs(pi, pid)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observingModeGroup.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observingModeGroup.scala
@@ -40,8 +40,8 @@ class observingModeGroup extends OdbSuite:
     fpu:      String = "LONG_SLIT_0_25",
     xbin:     Option[GmosXBinning] = None,
     ybin:     Option[GmosYBinning] = None,
-    iq:       ImageQuality.Preset = ImageQuality.Preset.TwoPointZero,
-    asterism: List[Target.Id] = Nil
+    iq:       ImageQuality.Preset,
+    asterism: List[Target.Id]
   ): IO[Observation.Id] =
     query(
       user  = user,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programNotes.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programNotes.scala
@@ -8,7 +8,6 @@ import cats.syntax.all.*
 import io.circe.Json
 import io.circe.syntax.*
 import lucuma.core.model.ProgramNote
-import lucuma.core.model.User
 
 class programNotes extends OdbSuite:
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programUsers.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programUsers.scala
@@ -9,7 +9,6 @@ import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.Partner
-import lucuma.core.enums.ProgramUserRole
 import lucuma.core.model.PartnerLink
 import lucuma.core.model.Program
 import lucuma.core.model.StandardRole
@@ -276,7 +275,7 @@ class programUsers extends OdbSuite:
     yield ()
 
   test("program user selection limited by visibility"):
-    createProgramAs(guest1).flatMap: pid =>
+    createProgramAs(guest1).flatMap: _ =>
       expect(
         user = guest2,
         query = s"""

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programs.scala
@@ -14,7 +14,6 @@ import lucuma.core.model.PartnerLink
 import lucuma.core.model.Program
 import lucuma.core.model.ProgramReference.Description
 import lucuma.core.model.StandardRole
-import lucuma.core.model.User
 import lucuma.core.util.Gid
 import lucuma.odb.graphql.input.ProgramPropertiesInput
 import lucuma.odb.service.Services

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/smartgcal.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/smartgcal.scala
@@ -177,7 +177,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
           disperser:  GmosNorthGrating = GmosNorthGrating.R831_G5302,
           low:        Int              = Wavelength.Min.pm.value.value,
           high:       Int              = Wavelength.Max.pm.value.value,
-          expTimeSec: Int              = 1,
+          expTimeSec: Int,
           count:      Int              = 1
         ): IO[Unit] =
           defineGmos(id, stepOrder, disperser, low, high, expTimeSec, count)(row, services.smartGcalService.insertGmosNorth)
@@ -189,7 +189,7 @@ class smartgcal extends OdbSuite with ObservingModeSetupOperations {
           disperser:  GmosSouthGrating = GmosSouthGrating.R600_G5324,
           low:        Int              = Wavelength.Min.pm.value.value,
           high:       Int              = Wavelength.Max.pm.value.value,
-          expTimeSec: Int              = 1,
+          expTimeSec: Int,
           count:      Int              = 1
         ): IO[Unit] =
           defineGmos(id, stepOrder, disperser, low, high, expTimeSec, count)(row, services.smartGcalService.insertGmosSouth)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/target.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/target.scala
@@ -4,11 +4,9 @@
 package lucuma.odb.graphql
 package query
 
-import cats.syntax.all.*
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.model.Target
-import lucuma.core.model.User
 
 class target extends OdbSuite {
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/targets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/targets.scala
@@ -10,7 +10,6 @@ import io.circe.syntax.*
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.model.ProgramReference.Description
 import lucuma.core.model.Target
-import lucuma.core.model.User
 import lucuma.odb.graphql.input.ProgramPropertiesInput
 import lucuma.odb.service.Services
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/groupEdit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/groupEdit.scala
@@ -331,7 +331,7 @@ class groupEdit extends OdbSuite {
             } yield ()
           ),
         expectedF =
-          d.get.map { pid =>
+          d.get.map { _ =>
             List.empty[Json]
           }
       )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/obscalcUpdate.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/obscalcUpdate.scala
@@ -154,7 +154,7 @@ class obscalcUpdate extends ObscalcServiceSuiteSupport:
           }
         }
       """,
-      mutations = (setup.flatMap(oid => load.flatMap(lst => calculateAndUpdate(lst.head)))).asRight,
+      mutations = (setup.flatMap(_ => load.flatMap(lst => calculateAndUpdate(lst.head)))).asRight,
       expected  = List(
         // Just one event -- when moving from calculating to ready
         Json.obj(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/programEdit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/programEdit.scala
@@ -13,7 +13,6 @@ import lucuma.core.enums.ScienceBand
 import lucuma.core.enums.TimeAccountingCategory
 import lucuma.core.model.ServiceUser
 import lucuma.core.syntax.timespan.*
-import lucuma.core.util.TimeSpan
 
 import scala.concurrent.duration.*
 

--- a/modules/smartgcal/src/main/scala/lucuma/odb/smartgcal/parsers/Availability.scala
+++ b/modules/smartgcal/src/main/scala/lucuma/odb/smartgcal/parsers/Availability.scala
@@ -4,7 +4,6 @@
 package lucuma.odb.smartgcal.parsers
 
 import cats.Monad
-import cats.syntax.functor.*
 
 /**
  * Availability is a small ADT, isomorphic with Option, that is used for parsing

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("io.spray"            % "sbt-revolver"        % "0.10.0")
 addSbtPlugin("com.timushev.sbt"    % "sbt-updates"         % "0.6.4")
 addSbtPlugin("com.github.sbt"      % "sbt-native-packager" % "1.11.0")
-addSbtPlugin("edu.gemini"          % "sbt-lucuma-lib"      % "0.12.11")
+addSbtPlugin("edu.gemini"          % "sbt-lucuma-lib"      % "0.12.12")
 addSbtPlugin("com.github.reibitto" % "sbt-test-shards"     % "0.2.0")


### PR DESCRIPTION
Scala 3.7 has a lot more `unused` warnings. The `Transaction` and access implicits can trigger these warnings. For cases where the implicit is specified in an interface, implementations of those interface methods do not trigger the warning (as of 3.7.1). However, other methods need to be marked with `@nowarn`.

This also found unused explicit method parameters in some places. Probably leftovers from refactoring?