### PR TITLE
remove inner `run`

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/util/AtomBuilder.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/util/AtomBuilder.scala
@@ -36,11 +36,9 @@ trait AtomBuilder[D]:
     six:       Int,
     steps:     List[ProtoStep[D]]
   ): State[TimeEstimateCalculator.Last[D], Option[Atom[D]]] =
-    State(calcState =>
-      NonEmptyList.fromList(steps).fold((calcState, none[Atom[D]])) { nel =>
-        build(desc, aix, six, nel).map(_.some).run(calcState).value
-      }
-    )
+    NonEmptyList.fromList(steps) match
+      case None      => State.pure(None)
+      case Some(nel) => build(desc, aix, six, nel).map(_.some)
 
 object AtomBuilder:
 


### PR DESCRIPTION
Grasping at straws here but maybe calling `run` inside `flatMap` breaks stack safety somehow.