### PR TITLE
Go back to parEvalMapUnordered

### DIFF
--- a/modules/obscalc/src/main/scala/lucuma/odb/obscalc/Main.scala
+++ b/modules/obscalc/src/main/scala/lucuma/odb/obscalc/Main.scala
@@ -45,7 +45,6 @@ import skunk.{Command as _, *}
 
 import scala.concurrent.duration.*
 import scala.util.NotGiven
-import scala.util.Try
 
 sealed trait MainParams:
   val ServiceName: String =
@@ -91,8 +90,6 @@ object CalcMain extends MainParams:
             |Max Connections: ${config.database.maxObscalcConnections}
             |Poll Period....: ${config.obscalcPoll}
             |PID............: ${ProcessHandle.current.pid}
-            |
-            |JAVA_OPTS......: ${Try(Option(System.getenv("JAVA_OPTS")).getOrElse("<not set>")).getOrElse("<access denied>")}
             |
             |""".stripMargin
     banner.linesIterator.toList.traverse_(Logger[F].info(_))
@@ -145,7 +142,6 @@ object CalcMain extends MainParams:
         t <- Resource.eval(ObscalcTopic(p, 65536, s))
       yield t
 
-  @scala.annotation.nowarn("msg=unused explicit parameter")
   def runObscalcDaemon[F[_]: Async: Logger](
     connectionsLimit: Int,
     commitHash:       CommitHash,
@@ -197,8 +193,7 @@ object CalcMain extends MainParams:
         .merge(pollStream)
         .evalTap: pc =>
           Logger[F].debug(s"Loaded PendingCalc ${pc.observationId}. Last invalidated at ${pc.lastInvalidation}.")
-        .evalMap: pc =>
-//        .parEvalMapUnordered(connectionsLimit): pc =>
+        .parEvalMapUnordered(connectionsLimit): pc =>
           services.useNonTransactionally:
             requireServiceAccessOrThrow:
               obscalc


### PR DESCRIPTION
Rolls back a change that seems to have no impact on the crash issue.