### PR TITLE
Obscalc Crash Fix (🤞)

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -314,6 +314,7 @@ object OdbMapping {
                   emailConfig0,
                   false,                  // don't allow further sub-mappings; only one level of recursion is allowed
                   Some(schema),           // don't re-parse the schema
+                  shouldValidate = false  // already validated
                 ))
               )(session)
 


### PR DESCRIPTION
Applies @tpolecat workaround to skip schema (re)validation (thanks!) and builds a more complete `OdbMapping` for `Obscalc` in general.  It now only lacks subscription support.  Hopefully this will prevent the stack overflow.