### PR TITLE
fix deadlock (?)

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -302,23 +302,24 @@ object OdbMapping {
               Services.forUser(
                 user,
                 enums,
-                Option.when(allowSub)(apply(
-                  Resource.pure(session), // Always use this session
-                  monitor0,               // Same args as the outer mapping
-                  user0,
-                  topics0,
-                  gaiaClient0,
-                  itcClient0,
-                  commitHash0,
-                  goaUsers0,
-                  enums,
-                  tec,
-                  httpClient0,
-                  emailConfig0,
-                  false,                  // don't allow further sub-mappings; only one level of recursion is allowed
-                  Some(schema),           // don't re-parse the schema
-                  shouldValidate = false  // already validated
-                ))
+                Option.when(allowSub): (s: Session[F]) => 
+                  apply(
+                    Resource.pure(s),     // Always use the provided session
+                    monitor0,             // Same args as the outer mapping
+                    user0,
+                    topics0,
+                    gaiaClient0,
+                    itcClient0,
+                    commitHash0,
+                    goaUsers0,
+                    enums,
+                    tec,
+                    httpClient0,
+                    emailConfig0,
+                    false,                  // don't allow further sub-mappings; only one level of recursion is allowed
+                    Some(schema),           // don't re-parse the schema
+                    shouldValidate = false  // already validated
+                  )
               )(session)
 
           override val timeEstimateCalculator: TimeEstimateCalculatorImplementation.ForInstrumentMode = tec

--- a/modules/service/src/main/scala/lucuma/odb/service/Services.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/Services.scala
@@ -227,7 +227,7 @@ object Services:
    * Construct a `Services` for the given `User` and `Session`. Service instances are constructed
    * lazily.
    */
-  def forUser[F[_]](u: User, e: Enums, m: Option[Mapping[F]])(s: Session[F])(
+  def forUser[F[_]](u: User, e: Enums, m: Option[Session[F] => Mapping[F]])(s: Session[F])(
     using tf: Trace[F], uf: UUIDGen[F], cf: Concurrent[F], par: Parallel[F], log: Logger[F]
   ): Services[F[_]] =
     new Services[F]:
@@ -241,7 +241,7 @@ object Services:
       private val graphQlService: Result[GraphQLService[F]] =
         m match
           case None => Result.internalError("No GraphQL Mapping available for this Services instance.")
-          case Some(value) => Result(GraphQLService(value))
+          case Some(f) => Result(GraphQLService(f(session)))
 
       def runGraphQLQueryImpl(query: String, op: Option[String], vars: Option[JsonObject]): ResultT[F, Json] =
         for


### PR DESCRIPTION
@swalker2m There was a subtle problem here where nested GraphQL queries in the ObsCalc service were happening on new database sessions, which resulted in deadlocks. Same thing was happening in OdbMapping and I hacked around it, but this hack wasn't present in ObsCalc (because there was no reason at all to think you should do anything other than what you did). I made it a little bit harder to do this by changing the signature for `Services.forUser`, but I will try to improve the API in a followup to make it even harder. Anyway I *think* this fixes the problem.