### PR TITLE
sc-6006 fix access control issue

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
@@ -7,12 +7,14 @@ import cats.Functor
 import cats.data.NonEmptyList
 import cats.syntax.all.*
 import grackle.Context
+import grackle.Path
 import grackle.Predicate
 import grackle.Predicate.*
 import grackle.Query
 import grackle.Query.*
 import grackle.Result
 import grackle.ResultT
+import grackle.Type
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.model.Access
 import lucuma.core.model.Observation
@@ -166,19 +168,16 @@ trait AccessControl[F[_]] extends Predicates[F] {
     includeDeleted:      Option[Boolean],
     WHERE:               Option[Predicate],
     includeCalibrations: Boolean
-  ): Result[AppliedFragment] = {
-    val whereObservation: Predicate =
+  ): Result[AppliedFragment] =
+    idSelectFromPredicate(
+      ObservationType,
       and(List(
         Predicates.observation.program.isWritableBy(user),
         Predicates.observation.existence.includeDeleted(includeDeleted.getOrElse(false)),
         if (includeCalibrations) True else Predicates.observation.calibrationRole.isNull(true),
         WHERE.getOrElse(True)
       ))
-    MappedQuery(
-      Filter(whereObservation, Select("id", None, Query.Empty)),
-      Context(QueryType, List("observations"), List("observations"), List(ObservationType))
-    ).flatMap(_.fragment)
-  }
+    )
 
 
   /**
@@ -239,6 +238,17 @@ trait AccessControl[F[_]] extends Predicates[F] {
         case _           => Result.internalError("Unpossible: selectForObservationCloneImpl returned multiple ids, or the wrong id")
 
   /**
+   * Construct a `SELECT` statement that returns the `"id"` fields of all objects
+   * of type `Type` that match the given `Predicate`. Note that the query generated
+   * here is not subject to elaboration; the predicate passed here must express
+   * exactly what is needed.
+   */
+  protected def idSelectFromPredicate(tpe: Type, pred: Predicate): Result[Fragment] =
+    Context(Path.from(tpe)).flatMap: ctx =>
+      val q = Filter(pred, Select("id", None, Query.Empty))
+      MappedQuery(q, ctx).flatMap(_.fragment)
+
+  /**
    * Select and return the ids of programs that are editable by the current user and meet
    * all the specified filters.
    */
@@ -246,29 +256,20 @@ trait AccessControl[F[_]] extends Predicates[F] {
   private def selectForProgramUpdateImpl(
     includeDeleted: Option[Boolean],
     WHERE:          Option[Predicate]
-  )(using Services[F], NoTransaction[F]): F[Result[List[Program.Id]]] =  {
-
-    val programIdWhereClause: Result[AppliedFragment] = {
-      val whereProgram: Predicate =
-        and(List(
-          Predicates.program.isWritableBy(user),
-          Predicates.program.existence.includeDeleted(includeDeleted.getOrElse(false)),
-          WHERE.getOrElse(True)
-        ))
-      MappedQuery(
-        Filter(whereProgram, Select("id", None, Query.Empty)),
-        Context(QueryType, List("programs"), List("programs"), List(ProgramType))
-      ).flatMap(_.fragment)
-    }
-
-    programIdWhereClause.flatTraverse: frag =>
+  )(using Services[F], NoTransaction[F]): F[Result[List[Program.Id]]] =
+    idSelectFromPredicate(
+      ProgramType,
+      and(List(
+        Predicates.program.isWritableBy(user),
+        Predicates.program.existence.includeDeleted(includeDeleted.getOrElse(false)),
+        WHERE.getOrElse(True)
+      ))
+    ).flatTraverse: frag =>
       session.prepareR(frag.fragment.query(program_id)).use: pq =>
         pq.stream(frag.argument, 1024)
           .compile
           .toList
           .map(Result.success)
-
-  }
 
   /**
    * Compute the subset of `pids` that identify programs which are editable by the current user.
@@ -292,22 +293,16 @@ trait AccessControl[F[_]] extends Predicates[F] {
     includeDeleted:      Option[Boolean],
     WHERE:               Option[Predicate],
     allowedStates:       Set[ObservationWorkflowState]
-  )(using Services[F], NoTransaction[F]): F[Result[List[Target.Id]]] =  {
-
-    val rWhichTargets: Result[AppliedFragment] =
-      val whereTarget: Predicate =
+  )(using Services[F], NoTransaction[F]): F[Result[List[Target.Id]]] =
+    Services.asSuperUser:
+      idSelectFromPredicate(
+        TargetType,
         and(List(
           Predicates.target.program.isWritableBy(user),
           Predicates.target.existence.includeDeleted(includeDeleted.getOrElse(false)),
           WHERE.getOrElse(True)
         ))
-      MappedQuery(
-        Filter(whereTarget, Select("id", None, Query.Empty)),
-        Context(QueryType, List("targets"), List("targets"), List(TargetType))
-      ).flatMap(_.fragment)
-
-    Services.asSuperUser:
-      rWhichTargets.flatTraverse: which =>
+      ).flatTraverse: which =>
         observationWorkflowService.filterTargets(
           which,
           allowedStates,
@@ -315,8 +310,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
           itcClient,
           timeEstimateCalculator
         )
-      
-  }
 
   /**
    * Given an operation that defines a set of targets and a proposed edit, select and filter this
@@ -589,13 +582,14 @@ trait AccessControl[F[_]] extends Predicates[F] {
   def selectForUpdate(
     input: UpdateProgramsInput
   )(using Services[F], Transaction[F]): F[Result[AccessControl.Checked[ProgramPropertiesInput.Edit]]] =
-    MappedQuery(Filter(and(List(
-      Predicates.program.isWritableBy(user),
-      Predicates.program.existence.includeDeleted(input.includeDeleted.getOrElse(false)),
-      input.WHERE.getOrElse(True)
-    )), Select("id", None, Empty)), Context(QueryType, List("programs"), List("programs"), List(ProgramType)))
-      .flatMap(_.fragment)
-      .map: frag =>
+    idSelectFromPredicate(
+      ProgramType,
+      and(List(
+        Predicates.program.isWritableBy(user),
+        Predicates.program.existence.includeDeleted(input.includeDeleted.getOrElse(false)),
+        input.WHERE.getOrElse(True)
+      ))
+    ) .map: frag =>
         Services.asSuperUser:
           AccessControl.unchecked(input.SET, frag)
       .pure[F]
@@ -617,16 +611,15 @@ trait AccessControl[F[_]] extends Predicates[F] {
   def selectForUpdate(
     input: UpdateAttachmentsInput
   )(using Services[F]): F[Result[AccessControl.Checked[AttachmentPropertiesInput.Edit]]] =
-    MappedQuery(
-      Filter(and(List(
+    idSelectFromPredicate(
+      AttachmentType,
+      and(List(
         Predicates.attachment.program.isWritableBy(user),
         input.WHERE.getOrElse(True)
-      )), Select("id", Empty)),
-      Context(QueryType, List("attachments"), List("attachments"), List(AttachmentType))
-    ) .flatMap(_.fragment)
-      .traverse: af =>
-        Services.asSuperUser:
-          AccessControl.unchecked(input.SET, af).pure[F]
+      ))
+    ).traverse: af =>
+      Services.asSuperUser:
+        AccessControl.unchecked(input.SET, af).pure[F]
 
   def selectForUpdate(
     input: CreateCallForProposalsInput
@@ -639,44 +632,34 @@ trait AccessControl[F[_]] extends Predicates[F] {
     input: UpdateCallsForProposalsInput
   )(using Services[F]): F[Result[AccessControl.Checked[CallForProposalsPropertiesInput.Edit]]] =
     requireStaffAccess: // this is the only check
-      MappedQuery(
-        Filter(
-          and(List(
-            Predicates.callForProposals.existence.includeDeleted(input.includeDeleted.getOrElse(false)),
-            input.WHERE.getOrElse(True)
-          )), 
-          Select("id", None, Empty)
-        ),
-        Context(QueryType, List("callsForProposals"), List("callsForProposals"), List(CallForProposalsType))
-      ) .flatMap(_.fragment)
-        .flatTraverse: which =>
-          Services.asSuperUser:
-            Result(AccessControl.unchecked(input.SET, which)).pure[F]
+      idSelectFromPredicate(
+        CallForProposalsType,
+        and(List(
+          Predicates.callForProposals.existence.includeDeleted(input.includeDeleted.getOrElse(false)),
+          input.WHERE.getOrElse(True)
+        ))
+      ).flatTraverse: which =>
+        Services.asSuperUser:
+          Result(AccessControl.unchecked(input.SET, which)).pure[F]
 
   @annotation.nowarn("msg=unused implicit parameter")
   private def selectForProgramNoteUpdateImpl(
     includeDeleted: Option[Boolean],
     WHERE:          Option[Predicate]
   )(using Services[F], NoTransaction[F]): F[Result[List[ProgramNote.Id]]] =
-    val whereNote: Predicate =
+    idSelectFromPredicate(
+      ProgramNoteType,
       and(List(
         Predicates.programNote.isWritableBy(user),
         Predicates.programNote.existence.includeDeleted(includeDeleted.getOrElse(false)),
         WHERE.getOrElse(True)
       ))
-
-    MappedQuery(
-      Filter(whereNote, Select("id", None, Query.Empty)),
-      Context(QueryType, List("programNotes"), List("programNotes"), List(ProgramNoteType))
-    )
-      .flatMap(_.fragment)
-      .flatTraverse: af =>
-        session.prepareR(af.fragment.query(program_note_id)).use: pq =>
-          pq.stream(af.argument, 1024)
-            .compile
-            .toList
-            .map(Result.success)
-
+    ).flatTraverse: af =>
+      session.prepareR(af.fragment.query(program_note_id)).use: pq =>
+        pq.stream(af.argument, 1024)
+          .compile
+          .toList
+          .map(Result.success)
 
   def selectForUpdate(
     input: UpdateProgramNotesInput

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
@@ -220,7 +220,8 @@ trait AccessControl[F[_]] extends Predicates[F] {
             pq.stream(af.argument, 1024)
               .compile
               .toList
-              .map(Result.success)
+              .map: ids =>
+                Result.success(ids)
 
   /** Verify that `oid` is writable. */
   @annotation.nowarn("msg=unused implicit parameter")

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -442,7 +442,8 @@ object ObservationService {
                 .map: list =>
                   list.groupMap(_._1)(_._2)
 
-      private def cloneObservationImpl(
+      /** Clone the observation. We assume access has been checked already. */
+      private def cloneObservationUnconditionally(
         observationId: Observation.Id,
         SET:           Option[ObservationPropertiesInput.Edit]
       )(using Transaction[F]): F[Result[(Program.Id, Observation.Id)]] = {
@@ -458,7 +459,7 @@ object ObservationService {
 
             // Ok the obs exists, so let's clone its main row in t_observation. If this returns
             // None then it means the user doesn't have permission to see the obs.
-            val cObsStmt = Statements.cloneObservation(pid, observationId, user, destGroupIndex)
+            val cObsStmt = Statements.cloneObservation(observationId, destGroupIndex)
             val cloneObs = session.prepareR(cObsStmt.fragment.query(observation_id)).use(_.option(cObsStmt.argument))
 
             // Action to open a hole in the destination program/group after the observation we're cloning
@@ -509,7 +510,7 @@ object ObservationService {
         input: AccessControl.CheckedWithId[Option[ObservationPropertiesInput.Edit], Observation.Id]
       )(using Transaction[F]): F[Result[ObservationService.CloneIds]] =
         input.foldWithId(OdbError.InvalidArgument().asFailureF): (oSET, origOid) =>
-          cloneObservationImpl(origOid, oSET).flatMap: res =>
+          cloneObservationUnconditionally(origOid, oSET).flatMap: res =>
             res.flatTraverse: (pid, newOid) =>
               Services.asSuperUser:
                 asterismService
@@ -1027,7 +1028,7 @@ object ObservationService {
      * Clone the base slice (just t_observation) and return the new obs id, or none if the original
      * doesn't exist or isn't accessible.
      */
-    def cloneObservation(pid: Program.Id, oid: Observation.Id, user: User, gix: NonNegShort): AppliedFragment =
+    def cloneObservation(oid: Observation.Id, gix: NonNegShort): AppliedFragment =
       sql"""
         INSERT INTO t_observation (
           c_program_id,
@@ -1112,11 +1113,8 @@ object ObservationService {
           c_img_combined_filters
       FROM t_observation
       WHERE c_observation_id = $observation_id
-      """.apply(gix, oid) |+|
-      ProgramUserService.Statements.existsUserWriteAccess(user, pid).foldMap(void"AND " |+| _) |+|
-      void"""
-        RETURNING c_observation_id
-      """
+      RETURNING c_observation_id
+      """.apply(gix, oid)
 
     def moveObservations(gid: Option[Group.Id], index: Option[NonNegShort], which: AppliedFragment): AppliedFragment =
       sql"""

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -41,7 +41,6 @@ import lucuma.core.model.ObservationReference
 import lucuma.core.model.Program
 import lucuma.core.model.StandardRole.*
 import lucuma.core.model.Target
-import lucuma.core.model.User
 import lucuma.core.syntax.string.*
 import lucuma.core.util.TimeSpan
 import lucuma.odb.data.Existence

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/6006.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/6006.scala
@@ -13,13 +13,13 @@ class ShortCut_6006 extends OdbSuite:
   val admin = TestUsers.Standard.admin(nextId, nextId)
   val validUsers = List(bob, andy, admin)
 
-  test("foo"):
+  test("Secondary support user should be able to clone an observation."):
     for 
       _   <- createUsers(andy)
       pid <- createProgramAs(bob)
       mid <- addProgramUserAs(admin, pid, ProgramUserRole.SupportSecondary)
       _   <- linkUserAs(admin, mid, andy.id)
       oid <- createObservationAs(bob, pid)
-      _   <- cloneObservationAs(andy, oid)
+      _   <- cloneObservationAs(andy, oid) // was failing, should work now
     yield ()
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/6006.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/6006.scala
@@ -3,9 +3,9 @@
 
 package lucuma.odb.graphql.issue.shortcut
 
+import lucuma.core.enums.ProgramUserRole
 import lucuma.odb.graphql.OdbSuite
 import lucuma.odb.graphql.TestUsers
-import lucuma.core.enums.ProgramUserRole
 
 class ShortCut_6006 extends OdbSuite:
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/6006.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/6006.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.issue.shortcut
+
+import lucuma.odb.graphql.OdbSuite
+import lucuma.odb.graphql.TestUsers
+import lucuma.core.enums.ProgramUserRole
+
+class ShortCut_6006 extends OdbSuite:
+
+  val bob, andy = TestUsers.Standard.pi(nextId, nextId)
+  val admin = TestUsers.Standard.admin(nextId, nextId)
+  val validUsers = List(bob, andy, admin)
+
+  test("foo"):
+    for 
+      _   <- createUsers(andy)
+      pid <- createProgramAs(bob)
+      mid <- addProgramUserAs(admin, pid, ProgramUserRole.SupportSecondary)
+      _   <- linkUserAs(admin, mid, andy.id)
+      oid <- createObservationAs(bob, pid)
+      _   <- cloneObservationAs(andy, oid)
+    yield ()
+


### PR DESCRIPTION
SC-6006 describes a problem in which the secondary support program user was unable to perform actions that should have been available. This was happening because the service SQL included clauses that performed additional access control checks that were both unnecessary and too restrictive. I removed these clauses in all cases where pre-checks were happening, which leaves a few lingering ones that I need to fix in a followup. 

In reviewing filter subqueries generated via `Predicate` + `MappedQuery` (which I initially thought were at fault) I factored out the common case where we're just selecting a list of ids. Turns out they were fine but the refactoring is reasonable and I think most of this PR is due to that mechanical change.

In any case this resolves sc-6006.