### PR TITLE
Allow not specifying filters when editing gmos imaging modes.

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservingModeInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservingModeInput.scala
@@ -66,8 +66,8 @@ object ObservingModeInput {
     def observingModeType: Option[ObservingModeType] =
       gmosNorthLongSlit.map(_.observingModeType)
         .orElse(gmosSouthLongSlit.map(_.observingModeType))
-        .orElse(gmosNorthImaging.flatMap(_.toCreate.toOption).map(_.observingModeType))
-        .orElse(gmosSouthImaging.flatMap(_.toCreate.toOption).map(_.observingModeType))
+        .orElse(gmosNorthImaging.map(_.observingModeType))
+        .orElse(gmosSouthImaging.map(_.observingModeType))
         .orElse(flamingos2LongSlit.map(_.observingModeType))
 
   }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
@@ -3356,7 +3356,47 @@ class updateObservations extends OdbSuite
       )
     )
 
-  test("observing mode: (fail to) create GMOS imaging without filters"):
+  test("observing mode: update GMOS imaging binning without filters"):
+
+    val update = """
+      observingMode: {
+        gmosSouthImaging: {
+          explicitBin: FOUR
+        }
+      }
+    """
+
+    val query = """
+      observations {
+        observingMode {
+          gmosSouthImaging {
+            filters
+            explicitBin
+          }
+        }
+      }
+    """
+
+    val expected =
+      json"""
+        {
+          "updateObservations": {
+            "observations": [
+              {
+                "observingMode": {
+                  "gmosSouthImaging": {
+                    "filters": ["G_PRIME", "R_PRIME"],
+                    "explicitBin": "FOUR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      """.asRight
+    oneUpdateTest(pi, update, query, expected, ObservingModeType.GmosSouthImaging.some)
+
+  test("observing mode: (fail to) update GMOS imaging with empty filters"):
 
     val update = """
       observingMode: {
@@ -3376,7 +3416,7 @@ class updateObservations extends OdbSuite
       }
     """
 
-    val expected = "At least one filter must be specified for GMOS imaging observations.".asLeft
+    val expected = "Argument 'input.SET.observingMode.gmosNorthImaging' is invalid: At least one filter must be specified for GMOS imaging observations.".asLeft
     oneUpdateTest(pi, update, query, expected)
 
   test("observing mode: (fail to) update existing GMOS imaging with empty filters - rollback other changes"):
@@ -3439,7 +3479,7 @@ class updateObservations extends OdbSuite
           _ <- expect(
             user = pi,
             query = updateObservationsMutation(oid, failingUpdate, query),
-            expected = List("At least one filter must be specified for GMOS imaging observations.").asLeft
+            expected = List("Argument 'input.SET.observingMode.gmosNorthImaging' is invalid: At least one filter must be specified for GMOS imaging observations.").asLeft
           )
           // Verify that ALL values remain unchanged (transaction rollback)
           _ <- expect(


### PR DESCRIPTION
When updating an imaging configuration, a non-empty of list was always required. But, it should be `ignorable`.

Someone who works with grackle Inputs more should probably verify I'm not doing anything wrong here...