### PR TITLE
Replace `digest` mapping with `calculatedDigest`

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -6872,14 +6872,7 @@ type Execution {
   If a sequence cannot be generated for this observation, `null` is returned
   along with warning messages.
   """
-  digest: ExecutionDigest @deprecated(reason: "will be updated with a CalculatedExecutionDigest result, use calculatedDigest for now")
-
-  """
-  Calculations dependent on the sequence, such as planned time and offsets.
-  If a sequence cannot be generated for this observation, `null` is returned
-  along with warning messages.
-  """
-  calculatedDigest: CalculatedExecutionDigest
+  digest: CalculatedExecutionDigest
 
   """
   A summary of pending atoms in this observation's sequence.  This is intended

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
@@ -64,7 +64,6 @@ trait ExecutionMapping[F[_]: Logger] extends ObservationEffectHandler[F]
       SqlField("id", ObservationView.Id, key = true, hidden = true),
       SqlField("programId", ObservationView.ProgramId, hidden = true),
       EffectField("digest", digestHandler, List("id", "programId")),
-      EffectField("calculatedDigest", calculatedDigestHandler, List("id", "programId")),
       EffectField("config", configHandler, List("id", "programId")),
       EffectField("executionState",  executionStateHandler, List("id", "programId")),
       SqlObject("atomRecords"),
@@ -159,17 +158,6 @@ trait ExecutionMapping[F[_]: Logger] extends ObservationEffectHandler[F]
     effectHandler(_ => ().success, calculate)
 
   private lazy val digestHandler: EffectHandler[F] =
-    val calculate: (Program.Id, Observation.Id, Unit) => F[Result[Json]] =
-      (pid, oid, _) =>
-        services.use: s =>
-          Services.asSuperUser:
-            s.generator(commitHash, itcClient, timeEstimateCalculator)
-             .digest(pid, oid)
-             .map(_.bimap(_.asWarning(Json.Null), _.asJson.success).merge)
-
-    effectHandler(_ => ().success, calculate)
-
-  private lazy val calculatedDigestHandler: EffectHandler[F] =
     val calculate: (Program.Id, Observation.Id, Unit) => F[Result[Json]] =
       (_, oid, _) =>
         services.useTransactionally:

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/2887.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/2887.scala
@@ -44,7 +44,7 @@ class ShortCut_2887 extends ExecutionTestSupportForGmos {
              query {
                observation(observationId: "$oid") {
                  execution {
-                   calculatedDigest {
+                   digest {
                      value {
                        science {
                          observeClass
@@ -78,7 +78,7 @@ class ShortCut_2887 extends ExecutionTestSupportForGmos {
              query {
                observation(observationId: "$oid") {
                  execution {
-                   calculatedDigest {
+                   digest {
                      value {
                        science {
                          observeClass
@@ -94,7 +94,7 @@ class ShortCut_2887 extends ExecutionTestSupportForGmos {
             {
               "observation": {
                 "execution": {
-                  "calculatedDigest": {
+                  "digest": {
                     "value": {
                       "science" : {
                         "observeClass" : "SCIENCE"

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5017.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5017.scala
@@ -96,7 +96,7 @@ class ShortCut_5017 extends ExecutionTestSupportForGmos:
       query {
         observation(observationId: "$o") {
           execution {
-            calculatedDigest {
+            digest {
               value {
                 science {
                   timeEstimate {
@@ -121,7 +121,7 @@ class ShortCut_5017 extends ExecutionTestSupportForGmos:
         val c = json.hcursor.downField("observation")
         (for
           s <- c.downFields("calculatedWorkflow", "value", "state").as[ObservationWorkflowState]
-          t <- c.downFields("execution", "calculatedDigest", "value", "science", "timeEstimate", "total", "microseconds").as[Long]
+          t <- c.downFields("execution", "digest", "value", "science", "timeEstimate", "total", "microseconds").as[Long]
         yield (s, t)).leftMap(f => new RuntimeException(f.message)).liftTo[IO]
 
     val result =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5098.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5098.scala
@@ -59,7 +59,7 @@ class ShortCut_5098 extends ExecutionTestSupportForGmos:
                    }
                  }
                  execution {
-                   calculatedDigest {
+                   digest {
                      value {
                        science {
                          timeEstimate {
@@ -89,7 +89,7 @@ class ShortCut_5098 extends ExecutionTestSupportForGmos:
                   }
                 },
                 "execution": {
-                  "calculatedDigest": {
+                  "digest": {
                     "value": null
                   }
                 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest.scala
@@ -94,7 +94,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
       query {
         observation(observationId: "$oid") {
           execution {
-            calculatedDigest {
+            digest {
               state
               value {
                 setup {
@@ -126,7 +126,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
       {
         "observation": {
           "execution": {
-            "calculatedDigest": {
+            "digest": {
               "state": "READY",
               "value": {
                 "setup" : {
@@ -270,7 +270,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
                    matches {
                      id
                      execution {
-                       calculatedDigest {
+                       digest {
                          state
                          value {
                            setup {
@@ -295,7 +295,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
                       {
                         "id": $oid,
                         "execution": {
-                          "calculatedDigest": {
+                          "digest": {
                             "state": "READY",
                             "value": null
                           }
@@ -330,7 +330,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
                    matches {
                      id
                      execution {
-                       calculatedDigest {
+                       digest {
                          state
                          value {
                            setup {
@@ -354,7 +354,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
                     {
                       "id": $oid,
                       "execution": {
-                        "calculatedDigest": {
+                        "digest": {
                           "state": "READY",
                           "value": null
                         }
@@ -391,7 +391,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
                    matches {
                      id
                      execution {
-                       calculatedDigest {
+                       digest {
                          value {
                            setup {
                              full { seconds }
@@ -414,7 +414,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
                     {
                       "id": $oid0,
                       "execution": {
-                        "calculatedDigest": {
+                        "digest": {
                           "value": {
                             "setup" : {
                               "full" : {
@@ -428,7 +428,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
                     {
                       "id": $oid1,
                       "execution": {
-                        "calculatedDigest": {
+                        "digest": {
                           "value": null
                         }
                       }
@@ -464,7 +464,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
                    matches {
                      id
                      execution {
-                       calculatedDigest {
+                       digest {
                          value {
                            setup {
                              full { seconds }
@@ -487,7 +487,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
                     {
                       "id": $oid0,
                       "execution": {
-                        "calculatedDigest": {
+                        "digest": {
                           "value": null
                         }
                       }
@@ -495,7 +495,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
                     {
                       "id": $oid1,
                       "execution": {
-                        "calculatedDigest": {
+                        "digest": {
                           "value": {
                             "setup" : {
                               "full" : {
@@ -545,7 +545,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
     s"""
       query {
         observation(observationId: "$oid") {
-          execution { calculatedDigest { value { science { executionState } } } }
+          execution { digest { value { science { executionState } } } }
         }
       }
     """
@@ -555,7 +555,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
       {
         "observation": {
           "execution": {
-            "calculatedDigest": {
+            "digest": {
               "value": {
                 "science" : {
                   "executionState": ${e.tag.toScreamingSnakeCase}
@@ -660,7 +660,7 @@ class executionDigest extends ExecutionTestSupportForGmos {
             {
               "observation": {
                 "execution": {
-                  "calculatedDigest": {
+                  "digest": {
                     "state": "READY",
                     "value": {
                       "setup" : {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGmosNorth.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGmosNorth.scala
@@ -780,6 +780,7 @@ class executionSciGmosNorth extends ExecutionTestSupportForGmos {
             }
           """
         )
+        _ <- runObscalcUpdate(p, o)
       } yield o
 
     def telescopeConfig(arcsec: Int): Json =
@@ -831,9 +832,11 @@ class executionSciGmosNorth extends ExecutionTestSupportForGmos {
                observation(observationId: "$oid") {
                  execution {
                    digest {
-                     science {
-                       offsets {
-                         q { arcseconds }
+                     value {
+                       science {
+                         offsets {
+                           q { arcseconds }
+                         }
                        }
                      }
                    }
@@ -879,18 +882,20 @@ class executionSciGmosNorth extends ExecutionTestSupportForGmos {
               "observation": {
                 "execution": {
                   "digest": {
-                    "science": {
-                      "offsets": [
-                        {
-                          "q": { "arcseconds": -20.000000 }
-                        },
-                        {
-                          "q": { "arcseconds": 0.000000 }
-                        },
-                        {
-                          "q": { "arcseconds": 20.000000 }
-                        }
-                      ]
+                    "value": {
+                      "science": {
+                        "offsets": [
+                          {
+                            "q": { "arcseconds": -20.000000 }
+                          },
+                          {
+                            "q": { "arcseconds": 0.000000 }
+                          },
+                          {
+                            "q": { "arcseconds": 20.000000 }
+                          }
+                        ]
+                      }
                     }
                   },
                   "config": {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionTwilight.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionTwilight.scala
@@ -243,7 +243,8 @@ class executionTwilight extends ExecutionTestSupportForGmos {
     }
 
   test("twilight - observation timeEstimate"):
-    setup.flatMap { case (_, _, Calibrations(_, oid)) =>
+    setup.flatMap { case (pid, _, Calibrations(_, oid)) =>
+      runObscalcUpdate(pid, oid) *>
       expect(
         user  = pi,
         query = s"""
@@ -251,12 +252,14 @@ class executionTwilight extends ExecutionTestSupportForGmos {
             observation(observationId: "$oid") {
               execution {
                 digest {
-                  science {
-                    observeClass
-                    timeEstimate {
-                      program { seconds }
-                      nonCharged { seconds }
-                      total { seconds }
+                  value {
+                    science {
+                      observeClass
+                      timeEstimate {
+                        program { seconds }
+                        nonCharged { seconds }
+                        total { seconds }
+                      }
                     }
                   }
                 }
@@ -269,12 +272,14 @@ class executionTwilight extends ExecutionTestSupportForGmos {
             "observation": {
               "execution": {
                 "digest": {
-                  "science": {
-                    "observeClass": "DAY_CAL",
-                    "timeEstimate": {
-                      "program": { "seconds":  0.000000 },
-                      "nonCharged": { "seconds":  50.700000 },
-                      "total": { "seconds":  50.700000 }
+                  "value": {
+                    "science": {
+                      "observeClass": "DAY_CAL",
+                      "timeEstimate": {
+                        "program": { "seconds":  0.000000 },
+                        "nonCharged": { "seconds":  50.700000 },
+                        "total": { "seconds":  50.700000 }
+                      }
                     }
                   }
                 }
@@ -306,7 +311,6 @@ class executionTwilight extends ExecutionTestSupportForGmos {
     ).map: json =>
       json.hcursor.downFields("program", "timeEstimateRange", "value", "maximum").require[CategorizedTime]
 
-  // OBSCALC TODO: this will be work with the obscalc digest when the API is updated
   def obsTimeEstimate(oid: Observation.Id): IO[CategorizedTime] =
     query(
       user  = pi,
@@ -315,17 +319,19 @@ class executionTwilight extends ExecutionTestSupportForGmos {
           observation(observationId: "$oid") {
             execution {
               digest {
-                setup {
-                  full {
-                    seconds
+                value {
+                  setup {
+                    full {
+                      seconds
+                    }
                   }
-                }
-                science {
-                  observeClass
-                  timeEstimate {
-                    program { seconds }
-                    nonCharged { seconds }
-                    total { seconds }
+                  science {
+                    observeClass
+                    timeEstimate {
+                      program { seconds }
+                      nonCharged { seconds }
+                      total { seconds }
+                    }
                   }
                 }
               }
@@ -334,7 +340,7 @@ class executionTwilight extends ExecutionTestSupportForGmos {
         }
       """
     ).map: json =>
-      val digest   = json.hcursor.downFields("observation", "execution", "digest")
+      val digest   = json.hcursor.downFields("observation", "execution", "digest", "value")
       val setup    = digest.downFields("setup", "full").require[TimeSpan]
       val obsClass = digest.downFields("science", "observeClass").require[ObserveClass]
       val catTime  = digest.downFields("science", "timeEstimate").require[CategorizedTime]

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEditOnCachedResultUpdate.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEditOnCachedResultUpdate.scala
@@ -73,8 +73,10 @@ class observationEditOnCachedResultUpdate extends ExecutionTestSupportForGmos wi
             observation(observationId: "$oid") {
               execution {
                 digest {
-                  science {
-                    atomCount
+                  value {
+                    science {
+                      atomCount
+                    }
                   }
                 }
               }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEditOnCachedResultUpdate.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEditOnCachedResultUpdate.scala
@@ -4,7 +4,9 @@
 package lucuma.odb.graphql
 package subscription
 
+import cats.syntax.either.*
 import io.circe.Json
+import io.circe.JsonObject
 import io.circe.literal.*
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
@@ -108,7 +110,7 @@ class observationEditOnCachedResultUpdate extends ExecutionTestSupportForGmos wi
       _   <- subscriptionExpect(
         user      = pi,
         query     = observationUpdateSubscription(oid),
-        mutations = Right(requestSequenceDigest(pi, oid)),
+        mutations = runObscalcUpdate(pid, oid).asRight[List[(String, Option[JsonObject])]],
         expected  = List(updateResponse, updateResponse)  // caches ITC and then sequence digest
       )
     yield ()


### PR DESCRIPTION
Removes the unpredictable-delay version of `digest` in favor of the `calculatedDigest` version, which is then renamed to `digest`.  This will require some renaming changes in Explore I imagine.