### PR TITLE
`calculatedWorkflow` → `workflow`

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -10093,18 +10093,14 @@ type Observation {
   """
   configurationRequests: [ConfigurationRequest!]!
 
-  workflow: ObservationWorkflow! @deprecated(reason: "will be updated with a CalculatedObservationWorkflow result, use calculatedWorkflow for now")
-
   """
   Obtains the current observation workflow state and valid transitions (and any
   validation errors). Because this calculation is expensive, it is performed in
   the background when something relevant changes and may be in a state of flux
   when queried.  The calculation state in the result can be used to determine
   whether a pending update is expected.
-
-  NOTE: Temporary - will replace the 'workflow' field.
   """
-  calculatedWorkflow: CalculatedObservationWorkflow
+  workflow: CalculatedObservationWorkflow
 }
 
 enum ExecutionState {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
@@ -60,7 +60,7 @@ object WhereObservation {
     val ScienceBandBinding = WhereOptionOrder.binding(path / "scienceBand", enumeratedBinding[ScienceBand])
     val InstrumentBinding = WhereOptionEq.binding(path / "instrument", enumeratedBinding[Instrument])
     val SiteBinding = siteBinding(enumeratedBinding[Site])
-    val WorkflowBinding = WhereCalculatedObservationWorkflow.binding(path / "calculatedWorkflow")
+    val WorkflowBinding = WhereCalculatedObservationWorkflow.binding(path / "workflow")
 
     lazy val WhereObservationBinding = binding(path)
     ObjectFieldsBinding.rmap {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4457.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/4457.scala
@@ -21,6 +21,7 @@ class ShortCut_4457 extends OdbSuite with ObservingModeSetupOperations:
   val pi:    User = TestUsers.Standard.pi(1, 101)
   val coiRo: User = TestUsers.Standard.pi(2, 102)
   val staff: User = TestUsers.Standard.staff(3, 103)
+  val serviceUser = TestUsers.service(4)
 
   override val validUsers: List[User] =
     List(pi, coiRo, staff)
@@ -39,6 +40,7 @@ class ShortCut_4457 extends OdbSuite with ObservingModeSetupOperations:
       _ <- acceptProposal(staff, p)
       m <- addProgramUserAs(pi, p, CoiRO)
       _ <- linkUserAs(pi, m, coiRo.id)
+      _ <- runObscalcUpdateAs(serviceUser, p, o)
     yield (p, o)
 
   test("Read-only Co-Investigators can access accepted program"):
@@ -74,7 +76,7 @@ class ShortCut_4457 extends OdbSuite with ObservingModeSetupOperations:
       query {
         observation(observationId: "$o") {
           index
-          workflow { state }
+          workflow { value { state } }
         }
       }
     """
@@ -84,7 +86,7 @@ class ShortCut_4457 extends OdbSuite with ObservingModeSetupOperations:
         {
           "observation": {
             "index": 1,
-            "workflow": { "state": "UNAPPROVED" }
+            "workflow": { "value" : { "state": "UNAPPROVED" } }
           }
         }
       """
@@ -105,7 +107,7 @@ class ShortCut_4457 extends OdbSuite with ObservingModeSetupOperations:
           observations {
             matches {
               index
-              workflow { state }
+              workflow { value { state } }
             }
           }
         }
@@ -120,7 +122,7 @@ class ShortCut_4457 extends OdbSuite with ObservingModeSetupOperations:
               "matches": [
                 {
                   "index": 1,
-                  "workflow": { "state": "UNAPPROVED" }
+                  "workflow": { "value": { "state": "UNAPPROVED" } }
                 }
               ]
             }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5017.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5017.scala
@@ -106,7 +106,7 @@ class ShortCut_5017 extends ExecutionTestSupportForGmos:
               }
             }
           }
-          calculatedWorkflow { value { state } }
+          workflow { value { state } }
         }
       }
     """
@@ -120,7 +120,7 @@ class ShortCut_5017 extends ExecutionTestSupportForGmos:
       ).flatMap: json =>
         val c = json.hcursor.downField("observation")
         (for
-          s <- c.downFields("calculatedWorkflow", "value", "state").as[ObservationWorkflowState]
+          s <- c.downFields("workflow", "value", "state").as[ObservationWorkflowState]
           t <- c.downFields("execution", "digest", "value", "science", "timeEstimate", "total", "microseconds").as[Long]
         yield (s, t)).leftMap(f => new RuntimeException(f.message)).liftTo[IO]
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5098.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/5098.scala
@@ -51,7 +51,7 @@ class ShortCut_5098 extends ExecutionTestSupportForGmos:
           s"""
              query {
                observation(observationId: "$oid") {
-                 calculatedWorkflow {
+                 workflow {
                    value {
                      validationErrors {
                        messages
@@ -79,7 +79,7 @@ class ShortCut_5098 extends ExecutionTestSupportForGmos:
           json"""
             {
               "observation": {
-                "calculatedWorkflow": {
+                "workflow": {
                   "value": {
                     "validationErrors": [
                       {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setObservationWorkflowState.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setObservationWorkflowState.scala
@@ -15,6 +15,7 @@ import lucuma.core.enums.SequenceType
 import lucuma.core.enums.StepGuideState
 import lucuma.core.model.ConfigurationRequest
 import lucuma.core.model.Observation
+import lucuma.core.model.Program
 import lucuma.core.model.sequence.StepConfig
 import lucuma.core.syntax.timespan.*
 import lucuma.itc.IntegrationTime
@@ -50,29 +51,33 @@ class setObservationWorkflowState
         query {
           observation(observationId: "$oid") {
             workflow {
-              state
+              value {
+                state
+              }
             }
           }
         }
         """
     ).map: json =>
-      json.hcursor.downFields("observation", "workflow", "state").require[ObservationWorkflowState]
+      json.hcursor.downFields("observation", "workflow", "value", "state").require[ObservationWorkflowState]
 
   /** Test that we can change to this specified state, and then back. */
-  def testTransition(oid: Observation.Id, state: ObservationWorkflowState): IO[Unit] =
+  def testTransition(pid: Program.Id, oid: Observation.Id, state: ObservationWorkflowState): IO[Unit] =
     queryObservationWorkflowState(oid).flatMap: current =>
       setObservationWorkflowState(pi, oid, state) >>
+      runObscalcUpdate(pid, oid) >>
       assertIO(queryObservationWorkflowState(oid), state) >>
       setObservationWorkflowState(pi, oid, current) >>
+      runObscalcUpdate(pid, oid) >>
       assertIO(queryObservationWorkflowState(oid), current)
 
   /** Test that we can change to the specified states and back, and CANNOT change to anything else. */
-  def testTransitions(oid: Observation.Id, allowedTransitions: ObservationWorkflowState*): IO[Unit] =
+  def testTransitions(pid: Program.Id, oid: Observation.Id, allowedTransitions: ObservationWorkflowState*): IO[Unit] =
     val legal = allowedTransitions.toList
     val illegal = ObservationWorkflowState.values.toList.filterNot(legal.contains)
-    legal.traverse_(testTransition(oid, _)) >>
+    legal.traverse_(testTransition(pid, oid, _)) >>
     illegal.traverse_ : state =>
-      interceptOdbError(testTransition(oid, state)):
+      interceptOdbError(testTransition(pid, oid, state)):
         case OdbError.InvalidWorkflowTransition(_, `state`, _) => () // ok
 
   //
@@ -85,8 +90,9 @@ class setObservationWorkflowState
     for {
       pid <- createProgramAs(pi)
       oid <- createObservationAs(pi, pid)
+      _   <- runObscalcUpdate(pid, oid)
       _   <- assertIO(queryObservationWorkflowState(oid), Undefined)
-      _   <- testTransitions(oid, Undefined, Inactive)
+      _   <- testTransitions(pid, oid, Undefined, Inactive)
     } yield ()
 
   test("Unapproved <-> Inactive") {
@@ -99,9 +105,9 @@ class setObservationWorkflowState
       _   <- setProposalStatus(staff, pid, "ACCEPTED")
       tid <- createTargetWithProfileAs(pi, pid)
       oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
-      _   <- computeItcResultAs(pi, oid)
+      _   <- runObscalcUpdate(pid, oid)
       _   <- assertIO(queryObservationWorkflowState(oid), Unapproved)
-      _   <- testTransitions(oid, Unapproved, Inactive)
+      _   <- testTransitions(pid, oid, Unapproved, Inactive)
     } yield ()
   }
 
@@ -113,9 +119,9 @@ class setObservationWorkflowState
       tid <- createTargetWithProfileAs(pi, pid)
       oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
       _   <- createConfigurationRequestAs(pi, oid).flatMap(approveConfigurationRequest)
-      _   <- computeItcResultAs(pi, oid)
+      _   <- runObscalcUpdate(pid, oid)
       _   <- assertIO(queryObservationWorkflowState(oid), Defined)
-      _   <- testTransitions(oid, Defined, Inactive)
+      _   <- testTransitions(pid, oid, Defined, Inactive)
     } yield ()
 
 
@@ -130,9 +136,9 @@ class setObservationWorkflowState
       tid <- createTargetWithProfileAs(pi, pid)
       oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
       _   <- createConfigurationRequestAs(pi, oid).flatMap(approveConfigurationRequest)
-      _   <- computeItcResultAs(pi, oid)
+      _   <- runObscalcUpdate(pid, oid)
       _   <- assertIO(queryObservationWorkflowState(oid), Defined)
-      _   <- testTransitions(oid, Defined, Inactive, Ready)
+      _   <- testTransitions(pid, oid, Defined, Inactive, Ready)
     } yield ()
 
   // (see executionState.scala)
@@ -149,9 +155,9 @@ class setObservationWorkflowState
       _  <- addEndStepEvent(s1)
       s2 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, telescopeConfig(0, 0, StepGuideState.Enabled), ObserveClass.Science)
       _  <- addEndStepEvent(s2)
-      _  <- computeItcResultAs(pi, o)
+      _  <- runObscalcUpdate(p, o)
       _  <- assertIO(queryObservationWorkflowState(o), Ongoing)
-      _  <- testTransitions(o, Ongoing, Inactive, Completed)
+      _  <- testTransitions(p, o, Ongoing, Inactive, Completed)
     yield ()
 
 // (see executionState.scala)
@@ -170,9 +176,9 @@ class setObservationWorkflowState
       _  <- addEndStepEvent(s2)
       s3 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, telescopeConfig(0, 0, StepGuideState.Enabled), ObserveClass.Science)
       _  <- addEndStepEvent(s3)
-      _  <- computeItcResultAs(pi, o)
+      _  <- runObscalcUpdate(p, o)
       _  <- assertIO(queryObservationWorkflowState(o), Completed)
-      _  <- testTransitions(o, Completed)
+      _  <- testTransitions(p, o, Completed)
     yield ()
 
   test("Completed  <-> Ongoing, if explicitly declared complete"):
@@ -188,11 +194,12 @@ class setObservationWorkflowState
       _  <- addEndStepEvent(s1)
       s2 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, telescopeConfig(0, 0, StepGuideState.Enabled), ObserveClass.Science)
       _  <- addEndStepEvent(s2)
-      _  <- computeItcResultAs(pi, o)
+      _  <- runObscalcUpdate(p, o)
       _  <- assertIO(queryObservationWorkflowState(o), Ongoing)
       _  <- setObservationWorkflowState(pi, o, Completed)
+      _  <- runObscalcUpdate(p, o)
       _  <- assertIO(queryObservationWorkflowState(o), Completed)
-      _  <- testTransitions(o, Completed, Ongoing)
+      _  <- testTransitions(p, o, Completed, Ongoing)
     yield ()
 
   test("[Eng] Defined   <-> Inactive, Ready"):
@@ -200,8 +207,9 @@ class setObservationWorkflowState
       pid <- createProgramAs(pi)
         _ <- setProgramReference(staff, pid, """engineering: { semester: "2025B", instrument: GMOS_SOUTH }""")
       oid <- createObservationAs(pi, pid)
+      _   <- runObscalcUpdate(pid, oid)
       _   <- assertIO(queryObservationWorkflowState(oid), Defined)
-      _   <- testTransitions(oid, Defined, Inactive, Ready)
+      _   <- testTransitions(pid, oid, Defined, Inactive, Ready)
     } yield ()
 
   test("[Eng] Ongoing   <-> Inactive, Completed"):
@@ -218,9 +226,9 @@ class setObservationWorkflowState
       _  <- addEndStepEvent(s1)
       s2 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, telescopeConfig(0, 0, StepGuideState.Enabled), ObserveClass.Science)
       _  <- addEndStepEvent(s2)
-      _  <- computeItcResultAs(pi, o)
+      _  <- runObscalcUpdate(p, o)
       _  <- assertIO(queryObservationWorkflowState(o), Ongoing)
-      _  <- testTransitions(o, Ongoing, Inactive, Completed)
+      _  <- testTransitions(p, o, Ongoing, Inactive, Completed)
     yield ()
 
   test("[Eng] Completed <->"):
@@ -239,9 +247,9 @@ class setObservationWorkflowState
       _  <- addEndStepEvent(s2)
       s3 <- recordStepAs(serviceUser, a, Instrument.GmosNorth, gmosNorthScience(0), StepConfig.Science, telescopeConfig(0, 0, StepGuideState.Enabled), ObserveClass.Science)
       _  <- addEndStepEvent(s3)
-      _  <- computeItcResultAs(pi, o)
+      _  <- runObscalcUpdate(p, o)
       _  <- assertIO(queryObservationWorkflowState(o), Completed)
-      _  <- testTransitions(o, Completed)
+      _  <- testTransitions(p, o, Completed)
     yield ()
 
     


### PR DESCRIPTION
Along the lines of #1869, this PR renames `calculatedWorkflow` to `workflow` removing the unpredictable-wait version.