### PR TITLE
Shortcut 5684: read binning from mode table

### DIFF
--- a/modules/sequence/src/test/scala/lucuma/odb/sequence/gmos/longslit/arb/ArbGmosLongSlitConfig.scala
+++ b/modules/sequence/src/test/scala/lucuma/odb/sequence/gmos/longslit/arb/ArbGmosLongSlitConfig.scala
@@ -27,76 +27,53 @@ import lucuma.core.util.arb.ArbEnumerated
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 
-object ArbGmosLongSlitConfig {
+object ArbGmosLongSlitConfig:
 
   import ArbEnumerated.given
   import ArbOffset.given
   import ArbWavelength.given
   import ArbWavelengthDither.given
+
+  given Arbitrary[Config.Common] =
+    Arbitrary:
+      for
+        w <- arbitrary[Wavelength]
+        dx <- arbitrary[GmosXBinning]
+        x <- arbitrary[Option[GmosXBinning]]
+        dy <- arbitrary[GmosYBinning]
+        y <- arbitrary[Option[GmosYBinning]]
+        m <- arbitrary[Option[GmosAmpReadMode]]
+        n <- arbitrary[Option[GmosAmpGain]]
+        r <- arbitrary[Option[GmosRoi]]
+        d <- arbitrary[Option[List[WavelengthDither]]]
+        s <- arbitrary[Option[List[Q]]]
+      yield Config.Common(
+        w,
+        dx,
+        x,
+        dy,
+        y,
+        m,
+        n,
+        r,
+        d,
+        s
+      )
+
   given Arbitrary[Config.GmosNorth] =
-    Arbitrary {
-      for {
+    Arbitrary:
+      for
         g <- arbitrary[GmosNorthGrating]
         f <- arbitrary[Option[GmosNorthFilter]]
         u <- arbitrary[GmosNorthFpu]
-        w <- arbitrary[Wavelength]
-        dx <- arbitrary[GmosXBinning]
-        x <- arbitrary[Option[GmosXBinning]]
-        dy <- arbitrary[GmosYBinning]
-        y <- arbitrary[Option[GmosYBinning]]
-        m <- arbitrary[Option[GmosAmpReadMode]]
-        n <- arbitrary[Option[GmosAmpGain]]
-        r <- arbitrary[Option[GmosRoi]]
-        d <- arbitrary[Option[List[WavelengthDither]]]
-        s <- arbitrary[Option[List[Q]]]
-      } yield Config.GmosNorth(
-        g,
-        f,
-        u,
-        w,
-        dx,
-        x,
-        dy,
-        y,
-        m,
-        n,
-        r,
-        d,
-        s
-      )
-    }
+        c <- arbitrary[Config.Common]
+      yield Config.GmosNorth(g, f, u, c)
 
   given Arbitrary[Config.GmosSouth] =
-    Arbitrary {
-      for {
+    Arbitrary:
+      for
         g <- arbitrary[GmosSouthGrating]
         f <- arbitrary[Option[GmosSouthFilter]]
         u <- arbitrary[GmosSouthFpu]
-        w <- arbitrary[Wavelength]
-        dx <- arbitrary[GmosXBinning]
-        x <- arbitrary[Option[GmosXBinning]]
-        dy <- arbitrary[GmosYBinning]
-        y <- arbitrary[Option[GmosYBinning]]
-        m <- arbitrary[Option[GmosAmpReadMode]]
-        n <- arbitrary[Option[GmosAmpGain]]
-        r <- arbitrary[Option[GmosRoi]]
-        d <- arbitrary[Option[List[WavelengthDither]]]
-        s <- arbitrary[Option[List[Q]]]
-      } yield Config.GmosSouth(
-        g,
-        f,
-        u,
-        w,
-        dx,
-        x,
-        dy,
-        y,
-        m,
-        n,
-        r,
-        d,
-        s
-      )
-    }
-
-}
+        c <- arbitrary[Config.Common]
+      yield Config.GmosSouth(g, f, u, c)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/Flamingos2LongSlitInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/Flamingos2LongSlitInput.scala
@@ -19,7 +19,6 @@ import lucuma.odb.data.Nullable
 import lucuma.odb.data.Nullable.NonNull
 import lucuma.odb.format.spatialOffsets.*
 import lucuma.odb.graphql.binding.*
-import lucuma.odb.sequence.flamingos2.longslit.Config
 
 object Flamingos2LongSlitInput {
 
@@ -44,22 +43,6 @@ object Flamingos2LongSlitInput {
 
     val formattedSpatialOffsets: Option[String] =
       explicitSpatialOffsets.map(OffsetsFormat.reverseGet)
-
-    /**
-      * Creates a F2 long slit observing mode based on input parameters.
-      */
-    def toObservingMode: Config =
-      Config(
-        disperser,
-        filter,
-        fpu,
-        explicitReadMode,
-        explicitReads,
-        explicitDecker,
-        explicitReadoutMode,
-        explicitSpatialOffsets
-      )
-
   }
 
   object Create {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosLongSlitInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GmosLongSlitInput.scala
@@ -8,7 +8,6 @@ import cats.syntax.foldable.*
 import cats.syntax.parallel.*
 import cats.syntax.traverse.*
 import coulomb.Quantity
-import eu.timepit.refined.types.numeric.PosDouble
 import grackle.Result
 import lucuma.core.enums.GmosAmpGain
 import lucuma.core.enums.GmosAmpReadMode
@@ -26,13 +25,10 @@ import lucuma.core.enums.Site
 import lucuma.core.math.Offset.Q
 import lucuma.core.math.Wavelength
 import lucuma.core.math.WavelengthDither
-import lucuma.core.model.ImageQuality
-import lucuma.core.model.SourceProfile
 import lucuma.core.optics.Format
 import lucuma.odb.data.Nullable
 import lucuma.odb.format.spatialOffsets.*
 import lucuma.odb.graphql.binding.*
-import lucuma.odb.sequence.gmos.longslit.Config
 
 import scala.util.Try
 
@@ -84,37 +80,9 @@ object GmosLongSlitInput {
       filter:  Option[GmosNorthFilter],
       fpu:     GmosNorthFpu,
       common:  Common
-    ) extends Create[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu] {
-
+    ) extends Create[GmosNorthGrating, GmosNorthFilter, GmosNorthFpu]:
       def observingModeType: ObservingModeType =
         ObservingModeType.GmosNorthLongSlit
-
-      /**
-       * Creates a GMOS long slit observing mode based on input parameters.
-       */
-      def toObservingMode(
-        sourceProfile: SourceProfile,
-        imageQuality:  ImageQuality.Preset,
-        sampling:      PosDouble
-      ): Config.GmosNorth =
-        Config.GmosNorth(
-          sourceProfile,
-          imageQuality,
-          sampling,
-          grating,
-          filter,
-          fpu,
-          common.centralWavelength,
-          common.explicitXBin,
-          common.explicitYBin,
-          common.explicitAmpReadMode,
-          common.explicitAmpGain,
-          common.explicitRoi,
-          common.explicitλDithers,
-          common.explicitSpatialOffsets
-        )
-
-    }
 
     object North {
 
@@ -159,37 +127,9 @@ object GmosLongSlitInput {
       filter:  Option[GmosSouthFilter],
       fpu:     GmosSouthFpu,
       common:  Common
-    ) extends Create[GmosSouthGrating, GmosSouthFilter, GmosSouthFpu] {
-
+    ) extends Create[GmosSouthGrating, GmosSouthFilter, GmosSouthFpu]:
       def observingModeType: ObservingModeType =
         ObservingModeType.GmosSouthLongSlit
-
-      /**
-       * Creates a GMOS long slit observing mode based on input parameters.
-       */
-      def toObservingMode(
-        sourceProfile: SourceProfile,
-        imageQuality:  ImageQuality.Preset,
-        sampling:      PosDouble
-      ): Config.GmosSouth =
-        Config.GmosSouth(
-          sourceProfile,
-          imageQuality,
-          sampling,
-          grating,
-          filter,
-          fpu,
-          common.centralWavelength,
-          common.explicitXBin,
-          common.explicitYBin,
-          common.explicitAmpReadMode,
-          common.explicitAmpGain,
-          common.explicitRoi,
-          common.explicitλDithers,
-          common.explicitSpatialOffsets
-        )
-
-    }
 
     object South {
 

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -248,9 +248,9 @@ object GeneratorParamsService {
         config:    Option[SourceProfile => ObservingMode]
       ): Either[Error, GeneratorParams] =
         observingMode(obsParams.targets, config).map:
-          case gn @ gmos.longslit.Config.GmosNorth(g, f, u, cw, _, _, _, _, _, _, _, _, _) =>
+          case gn @ gmos.longslit.Config.GmosNorth(g, f, u, c) =>
             val mode = InstrumentMode.GmosNorthSpectroscopy(
-              cw,
+              c.centralWavelength,
               g,
               f,
               GmosFpu.North.builtin(u),
@@ -259,9 +259,9 @@ object GeneratorParamsService {
             )
             GeneratorParams(itcObsParams(obsParams, mode), obsParams.scienceBand, gn, obsParams.calibrationRole, obsParams.declaredComplete, obsParams.acqResetTime)
 
-          case gs @ gmos.longslit.Config.GmosSouth(g, f, u, cw, _, _, _, _, _, _, _, _, _) =>
+          case gs @ gmos.longslit.Config.GmosSouth(g, f, u, c) =>
             val mode = InstrumentMode.GmosSouthSpectroscopy(
-              cw,
+              c.centralWavelength,
               g,
               f,
               GmosFpu.South.builtin(u),

--- a/modules/service/src/main/scala/lucuma/odb/service/GmosLongSlitService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GmosLongSlitService.scala
@@ -19,11 +19,9 @@ import lucuma.core.enums.GmosSouthGrating
 import lucuma.core.enums.GmosXBinning
 import lucuma.core.enums.GmosYBinning
 import lucuma.core.math.Wavelength
-import lucuma.core.model.ImageQuality
 import lucuma.core.model.Observation
-import lucuma.core.model.SourceProfile
-import lucuma.core.model.sequence.gmos.binning.DefaultSampling
 import lucuma.odb.graphql.input.GmosLongSlitInput
+import lucuma.odb.sequence.gmos.longslit.Config.Common
 import lucuma.odb.sequence.gmos.longslit.Config.GmosNorth
 import lucuma.odb.sequence.gmos.longslit.Config.GmosSouth
 import lucuma.odb.util.Codecs.*
@@ -38,11 +36,11 @@ trait GmosLongSlitService[F[_]] {
 
   def selectNorth(
     which: List[Observation.Id]
-  ): F[Map[Observation.Id, SourceProfile => GmosNorth]]
+  ): F[Map[Observation.Id, GmosNorth]]
 
   def selectSouth(
     which: List[Observation.Id]
-  ): F[Map[Observation.Id, SourceProfile => GmosSouth]]
+  ): F[Map[Observation.Id, GmosSouth]]
 
   def insertNorth(
     input: GmosLongSlitInput.Create.North
@@ -82,61 +80,69 @@ object GmosLongSlitService {
 
     new GmosLongSlitService[F] {
 
-      val common: Decoder[GmosLongSlitInput.Create.Common] =
-        (wavelength_pm          ~
-         gmos_binning.opt     ~
-         gmos_binning.opt     ~
-         gmos_amp_read_mode.opt ~
-         gmos_amp_gain.opt      ~
-         gmos_roi.opt           ~
-         text.opt               ~
-         text.opt
-        ).emap { case (((((((w, x), y), arm), ag), roi), owd), osd) =>
-          for {
+      val common: Decoder[Common] =
+        (wavelength_pm          *:   // centralWavelength
+         gmos_binning           *:   // defaultXBin
+         gmos_binning.opt       *:   // explicitXBin
+         gmos_binning           *:   // defaultYBin
+         gmos_binning.opt       *:   // explicitYBin
+         gmos_amp_read_mode.opt *:   // explicitAmpReadMode
+         gmos_amp_gain.opt      *:   // explicitAmpGain
+         gmos_roi.opt           *:   // explicitRoi
+         text.opt               *:   // explicitWavelengthDithers
+         text.opt                    // explicitSpatialOffsets
+        ).emap: (w, defaultX, x, defaultY, y, arm, ag, roi, owd, osd) =>
+          for
             wavelengthDithers <- owd.traverse(wd => GmosLongSlitInput.WavelengthDithersFormat.getOption(wd).toRight(s"Could not parse '$wd' as a wavelength dithers list."))
             spatialDithers    <- osd.traverse(sd => GmosLongSlitInput.SpatialOffsetsFormat.getOption(sd).toRight(s"Could not parse '$sd' as a spatial offsets list."))
-          } yield GmosLongSlitInput.Create.Common(w, x.map(GmosXBinning(_)), y.map(GmosYBinning(_)), arm, ag, roi, wavelengthDithers, spatialDithers)
-        }
+          yield Common(
+            w,
+            GmosXBinning(defaultX),
+            x.map(GmosXBinning(_)),
+            GmosYBinning(defaultY),
+            y.map(GmosYBinning(_)),
+            arm,
+            ag,
+            roi,
+            wavelengthDithers,
+            spatialDithers
+          )
 
-      val north: Decoder[GmosLongSlitInput.Create.North] =
+      val north: Decoder[GmosNorth] =
         (gmos_north_grating     *:
          gmos_north_filter.opt  *:
          gmos_north_fpu         *:
          common
-        ).to[GmosLongSlitInput.Create.North]
+        ).to[GmosNorth]
 
-      val south: Decoder[GmosLongSlitInput.Create.South] =
+      val south: Decoder[GmosSouth] =
         (gmos_south_grating     *:
          gmos_south_filter.opt  *:
          gmos_south_fpu         *:
          common
-        ).to[GmosLongSlitInput.Create.South]
+        ).to[GmosSouth]
 
       private def select[A](
         which:   List[Observation.Id],
         f:       NonEmptyList[Observation.Id] => AppliedFragment,
         decoder: Decoder[A]
-      ): F[List[(Observation.Id, ImageQuality.Preset, A)]] =
+      ): F[List[(Observation.Id, A)]] =
         NonEmptyList
           .fromList(which)
-          .fold(Applicative[F].pure(List.empty)) { oids =>
+          .fold(Applicative[F].pure(List.empty)): oids =>
             val af = f(oids)
-            session.prepareR(af.fragment.query(observation_id *: image_quality_preset *: decoder)).use { pq =>
+            session.prepareR(af.fragment.query(observation_id *: decoder)).use: pq =>
               pq.stream(af.argument, chunkSize = 1024).compile.toList
-            }
-          }
 
       override def selectNorth(
         which: List[Observation.Id]
-      ): F[Map[Observation.Id, SourceProfile => GmosNorth]] =
-        select(which, Statements.selectGmosNorthLongSlit, north)
-          .map(_.map { case (oid, iq, gn) => (oid, gn.toObservingMode(_, iq, DefaultSampling)) }.toMap)
+      ): F[Map[Observation.Id, GmosNorth]] =
+        select(which, Statements.selectGmosNorthLongSlit, north).map(_.toMap)
 
       override def selectSouth(
         which: List[Observation.Id]
-      ): F[Map[Observation.Id, SourceProfile => GmosSouth]] =
-        select(which, Statements.selectGmosSouthLongSlit, south)
-          .map(_.map { case (oid, iq, gs) => (oid, gs.toObservingMode(_, iq, DefaultSampling)) }.toMap)
+      ): F[Map[Observation.Id, GmosSouth]] =
+        select(which, Statements.selectGmosSouthLongSlit, south).map(_.toMap)
 
       override def insertNorth(
         input: GmosLongSlitInput.Create.North,
@@ -187,12 +193,13 @@ object GmosLongSlitService {
       sql"""
         SELECT
           ls.c_observation_id,
-          ob.c_image_quality,
           ls.c_grating,
           ls.c_filter,
           ls.c_fpu,
           ls.c_central_wavelength,
+          ls.c_xbin_default,
           ls.c_xbin,
+          ls.c_ybin_default,
           ls.c_ybin,
           ls.c_amp_read_mode,
           ls.c_amp_gain,
@@ -201,7 +208,6 @@ object GmosLongSlitService {
           ls.c_spatial_offsets
         FROM
           #$table ls
-        INNER JOIN t_observation ob ON ls.c_observation_id = ob.c_observation_id
       """(Void) |+|
       void"""
         WHERE

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservingModeServices.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservingModeServices.scala
@@ -60,12 +60,12 @@ object ObservingModeServices {
           case (Flamingos2LongSlit, oids) =>
             flamingos2LongSlitService
               .select(oids)
-              .map(_.view.mapValues(_.widen[ObservingMode]).toMap)
+              .map(_.view.mapValues(c => ((_: SourceProfile) => c).widen[ObservingMode]).toMap)
 
           case (GmosNorthLongSlit, oids) =>
             gmosLongSlitService
               .selectNorth(oids)
-              .map(_.view.mapValues(_.widen[ObservingMode]).toMap)
+              .map(_.view.mapValues(c => ((_: SourceProfile) => c).widen[ObservingMode]).toMap)
 
           case (GmosNorthImaging, oids) =>
             gmosImagingService
@@ -75,7 +75,7 @@ object ObservingModeServices {
           case (GmosSouthLongSlit, oids) =>
             gmosLongSlitService
               .selectSouth(oids)
-              .map(_.view.mapValues(_.widen[ObservingMode]).toMap)
+              .map(_.view.mapValues(c => ((_: SourceProfile) => c).widen[ObservingMode]).toMap)
 
           case (GmosSouthImaging, oids) =>
             gmosImagingService

--- a/modules/service/src/test/scala/lucuma/odb/graphql/input/Flamingos2LongSlitInputSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/input/Flamingos2LongSlitInputSuite.scala
@@ -21,17 +21,6 @@ class Flamingos2LongSlitInputSuite extends DisciplineSuite with ArbitraryInstanc
     forAll: (c: Flamingos2LongSlitInput.Create) =>
       assertEquals(c.observingModeType, ObservingModeType.Flamingos2LongSlit)
 
-  test("Flamingos2LongSlitInput.Create toObservingMode should preserve values"):
-    forAll: (c: Flamingos2LongSlitInput.Create) =>
-      val om = c.toObservingMode
-      assertEquals(om.disperser, c.disperser)
-      assertEquals(om.filter, c.filter)
-      assertEquals(om.fpu, c.fpu)
-      assertEquals(om.explicitReadMode, c.explicitReadMode)
-      assertEquals(om.explicitDecker, c.explicitDecker)
-      assertEquals(om.explicitReadoutMode, c.explicitReadoutMode)
-      assertEquals(om.explicitReads, c.explicitReads)
-
   test("Flamingos2LongSlitInput.Edit should have correct observingModeType"):
     forAll: (e: Flamingos2LongSlitInput.Edit) =>
       assertEquals(e.observingModeType, ObservingModeType.Flamingos2LongSlit)


### PR DESCRIPTION
Refactors the GMOS long slit mode selection to read the default binning from the `t_gmos_long_slit` table directly instead of recomputing it in Scala.  This not only simplifies the code considerably but also works around an apparent discrepancy between the Scala binning calculation and the database version.

Unfortunately I was stopped in the refactoring, for now, by the GMOS imaging mode.  We will need to compute and maintain the binning in the database the way it is done for long slit so that grouping by mode will work.  I can then take advantage of that to continue refactoring the mode selection.