### PR TITLE
Shortcut 6246: Update smart gcal tables

### DIFF
--- a/modules/smartgcal/src/main/resources/smartgcal/GMOS-N_ARC.csv
+++ b/modules/smartgcal/src/main/resources/smartgcal/GMOS-N_ARC.csv
@@ -1,5 +1,7 @@
-471,2022/09/08 11:56:50 HST
+506,2024/03/22 15:00:55 HST
 #0,,,,,,,,,,,,,,,,,,
+#,,Vxx "KC, 2024Mar22 B480 (Update arcs for B480 IFU)",,,,,,,,,,,,,,,
+#,,Vxx "KC, 2023Jun13 B480 (Update arcs for B480)",,,,,,,,,,,,,,,
 #,,V "TM, 2022Sep08 B480 (copy of B600)",,,,,,,,,,,,,,,
 #,,V "JS, 2017apr17 IFU2 GMOS-N Hamamatsu update complete for all gratings (R600 is copy of B600); IFUR needs to be verified",,,,,,,,,,,,,,,
 #,,V ,"KC, 2017apr12 LS complete for all gratings",,,,,,,,,,,,,,,
@@ -213,70 +215,104 @@ $B600.*,$.*,IFU *,4,1,1000 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr ar
 #,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,25,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,6,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 490,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,240,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 490,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 490,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 490,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 490,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 490,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 490,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,45,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 490,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,45,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 490,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,22,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*,IFU *,1,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
-$B480.*,$.*,IFU *,2,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
-$B480.*,$.*,IFU *,4,1,350 - 555,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+$B480.*,$.*,IFU *,1,1,350 - 500,1,Low,,,,1,         None,Visible,CuAr arc,Closed,300,1,Day
+$B480.*,$.*,IFU *,2,1,350 - 500,1,Low,,,,1,         None,Visible,CuAr arc,Closed,240,1,Day
+$B480.*,$.*,IFU *,4,1,350 - 500,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,160,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,20,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,525 - 610,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,10,1,Day
+$B480.*,$.*,IFU *,1,1,500 - 525,1,Low,,,,1,         None,Visible,CuAr arc,Closed,300,1,Day
+$B480.*,$.*,IFU *,2,1,500 - 525,1,Low,,,,1,         None,Visible,CuAr arc,Closed,180,1,Day
+$B480.*,$.*,IFU *,4,1,500 - 525,1,Low,,,,1,         None,Visible,CuAr arc,Closed,120,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*,IFU *,1,1,555 - 690,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
-$B480.*,$.*,IFU *,2,1,555 - 690,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
-$B480.*,$.*,IFU *,4,1,555 - 690,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
+$B480.*,$.*,IFU *,1,1,525 - 540,1,Low,,,,1,         None,Visible,CuAr arc,Closed,300,1,Day
+$B480.*,$.*,IFU *,2,1,525 - 540,1,Low,,,,1,         None,Visible,CuAr arc,Closed,160,1,Day
+$B480.*,$.*,IFU *,4,1,525 - 540,1,Low,,,,1,         None,Visible,CuAr arc,Closed,80,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,35,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,17,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,9,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,9,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,610 - 815,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,490 - 550,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,490 - 550,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,100,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,490 - 550,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,100,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,490 - 550,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,490 - 550,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,490 - 550,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,490 - 550,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,490 - 550,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,25,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,490 - 550,1,Low,,,,1,      GMOS balance,Visible,CuAr arc,Closed,13,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*,IFU *,1,1,690 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
-$B480.*,$.*,IFU *,2,1,690 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
-$B480.*,$.*,IFU *,4,1,690 - 800,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
+$B480.*,$.*,IFU *,1,1,540 - 570,1,Low,,,,1,         GMOS balance,Visible,CuAr arc,Closed,300,1,Day
+$B480.*,$.*,IFU *,2,1,540 - 570,1,Low,,,,1,         GMOS balance,Visible,CuAr arc,Closed,200,1,Day
+$B480.*,$.*,IFU *,4,1,540 - 570,1,Low,,,,1,         GMOS balance,Visible,CuAr arc,Closed,100,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,815 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,3,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,550 - 565,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,550 - 565,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,550 - 565,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,550 - 565,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,550 - 565,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,550 - 565,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,550 - 565,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,550 - 565,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,550 - 565,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,10,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*,IFU *,1,1,800 - 860,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
-$B480.*,$.*,IFU *,2,1,800 - 860,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
-$B480.*,$.*,IFU *,4,1,800 - 860,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,16,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,565 - 715,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,96,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,565 - 715,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,565 - 715,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,565 - 715,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,565 - 715,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,565 - 715,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,565 - 715,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,565 - 715,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,565 - 715,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*,IFU *,1,1,860 - 1000,1,Low,,,,1,         None,Visible,CuAr arc,Closed,3,1,Day
-$B480.*,$.*,IFU *,2,1,860 - 1000,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
-$B480.*,$.*,IFU *,4,1,860 - 1000,1,Low,,,,1,        GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,715 - 770,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,72,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,715 - 770,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,36,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,715 - 770,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,36,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,715 - 770,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,715 - 770,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,715 - 770,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,715 - 770,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,9,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,715 - 770,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,9,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,715 - 770,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,5,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*,IFU *,1,1,1000 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
-$B480.*,$.*,IFU *,2,1,1000 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,2,1,Day
-$B480.*,$.*,IFU *,4,1,1000 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B480.*,$.*,IFU *,1,1,570 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
+$B480.*,$.*,IFU *,2,1,570 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+$B480.*,$.*,IFU *,4,1,570 - 610,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B480.*,$.*,IFU *,1,1,610 - 900,1,Low,,,,1,         None,Visible,CuAr arc,Closed,14,1,Day
+$B480.*,$.*,IFU *,2,1,610 - 900,1,Low,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
+$B480.*,$.*,IFU *,4,1,610 - 900,1,Low,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,770 - 850,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,770 - 850,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,770 - 850,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,770 - 850,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,770 - 850,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,770 - 850,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,770 - 850,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,770 - 850,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,770 - 850,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,3,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B480.*,$.*,IFU *,1,1,900 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,10,1,Day
+$B480.*,$.*,IFU *,2,1,900 - 1200,1,Low,,,,1,         None,Visible,CuAr arc,Closed,5,1,Day
+$B480.*,$.*,IFU *,4,1,900 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,30,1,Day
 # ,,,,,,,,,,,,,,,,,,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,850 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,56,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,850 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,28,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,850 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,28,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,850 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,14,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,850 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,14,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,850 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,14,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,850 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,7,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,850 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,7,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,850 - 1200,1,Low,,,,1,       GMOS balance,Visible,CuAr arc,Closed,4,1,Day
+#,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
 $R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,90,1,Day
 $R600.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 525,1,Low,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
@@ -623,61 +659,91 @@ $B600.*,$.*,IFU *,4,1,1000 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr a
 #,,,,,,,,,,,,,,,,,,Day
 # ,,,,,,,,,,,,,,,,,,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,180,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,100,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,100,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,50,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,24,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 525,1,High,,,,1,        None,Visible,CuAr arc,Closed,12,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,350 - 490,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,480,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,350 - 490,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,360,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,350 - 490,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,360,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,350 - 490,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,350 - 490,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,350 - 490,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,180,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,350 - 490,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,350 - 490,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,90,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,350 - 490,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,45,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 $B480.*,$.*,IFU *,1,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
 $B480.*,$.*,IFU *,2,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,480,1,Day
 $B480.*,$.*,IFU *,4,1,350 - 555,1,High,,,,1,         None,Visible,CuAr arc,Closed,360,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,320,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,525 - 610,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,490 - 550,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,360,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,490 - 550,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,200,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,490 - 550,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,200,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,490 - 550,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,100,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,490 - 550,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,100,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,490 - 550,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,100,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,490 - 550,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,490 - 550,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,490 - 550,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 $B480.*,$.*,IFU *,1,1,555 - 690,1,High,,,,1,         None,Visible,CuAr arc,Closed,30,1,Day
 $B480.*,$.*,IFU *,2,1,555 - 690,1,High,,,,1,         None,Visible,CuAr arc,Closed,15,1,Day
 $B480.*,$.*,IFU *,4,1,555 - 690,1,High,,,,1,         None,Visible,CuAr arc,Closed,7,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,140,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,70,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,34,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,34,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,34,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,610 - 815,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,8,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,550 - 565,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,320,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,550 - 565,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,550 - 565,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,160,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,550 - 565,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,550 - 565,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,550 - 565,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,80,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,550 - 565,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,550 - 565,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,40,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,550 - 565,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,20,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,565 - 715,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,192,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,565 - 715,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,96,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,565 - 715,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,96,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,565 - 715,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,565 - 715,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,565 - 715,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,565 - 715,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,565 - 715,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,565 - 715,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,715 - 770,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,144,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,715 - 770,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,72,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,715 - 770,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,72,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,715 - 770,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,36,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,715 - 770,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,36,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,715 - 770,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,36,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,715 - 770,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,715 - 770,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,18,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,715 - 770,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,9,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 $B480.*,$.*,IFU *,1,1,690 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,14,1,Day
 $B480.*,$.*,IFU *,2,1,690 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
 $B480.*,$.*,IFU *,4,1,690 - 800,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
 #,,,,,,,,,,,,,,,,,,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,100,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,50,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,25,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
-$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,815 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,770 - 850,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,96,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,770 - 850,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,770 - 850,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,48,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,770 - 850,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,770 - 850,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,770 - 850,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,24,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,770 - 850,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,770 - 850,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,12,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,770 - 850,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,6,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 $B480.*,$.*,IFU *,1,1,800 - 860,1,High,,,,1,         None,Visible,CuAr arc,Closed,8,1,Day
 $B480.*,$.*,IFU *,2,1,800 - 860,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day
 $B480.*,$.*,IFU *,4,1,800 - 860,1,High,,,,1,        GMOS balance,Visible,CuAr arc,Closed,32,1,Day
+#,,,,,,,,,,,,,,,,,,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,1,850 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,112,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,1,850 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,56,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,2,850 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,56,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,2,850 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,28,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,1,850 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,28,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,1,4,850 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,28,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,2,850 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,14,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,2,4,850 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,14,1,Day
+$B480.*,$.*one|.*G.*,$.*arcsec.*|Custom Mask,4,4,850 - 1200,1,High,,,,1,       GMOS balance,Visible,CuAr arc,Closed,7,1,Day
 #,,,,,,,,,,,,,,,,,,Day
 $B480.*,$.*,IFU *,1,1,860 - 1000,1,High,,,,1,         None,Visible,CuAr arc,Closed,6,1,Day
 $B480.*,$.*,IFU *,2,1,860 - 1000,1,High,,,,1,         None,Visible,CuAr arc,Closed,4,1,Day

--- a/modules/smartgcal/src/main/resources/smartgcal/GMOS-N_FLAT.csv
+++ b/modules/smartgcal/src/main/resources/smartgcal/GMOS-N_FLAT.csv
@@ -1,6 +1,9 @@
-484,2022/10/05 22:33:41 HST
+503,2024/01/03 12:02:07 HST
 # GMOS_FLAT
 #
+# V , HS 2024Jan3 for B480/IFU-R, Updated
+# V , HS 2023Jun07 for B480, Updated
+# V , HS 2023Jun06 for B480, Updated
 # V , HS 2022oct05 for B480, Updated
 # V , HS 2022sep23 for B480, Updated
 # V , TM 2022sep08 for B480 (copy of B600)
@@ -952,7 +955,7 @@ $B480.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quart
 $B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-$B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
@@ -980,7 +983,7 @@ $B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300-450,1,Low,,,,1,GMOS balance,Visible
 $B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-$B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
@@ -1000,14 +1003,14 @@ $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quart
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,7,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
@@ -1028,14 +1031,14 @@ $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300-450,1,Low,,,,1,GMOS balance,Visible
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,450-725,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
@@ -1045,68 +1048,68 @@ $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quart
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,3,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,9,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,9,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,450-725,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,450-725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300-450,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,5,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,725-1200,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,450-725,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,450-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300-450,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,450-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,3,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300-450,1,Low,,,,1,ND3.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,450-725,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,725-1200,1,Low,,,,1,ND4.0,Visible,Quartz Halogen,Closed,1,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
 $B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
 $B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,45,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 420,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,35,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,420 - 500,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,500 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,25,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 725,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
 $B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,725 - 1200,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,15,1,Night
-$B480.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
-$B480.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B480.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
+$B480.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,110,1,Night
 $B480.*,$g.*,$IFU.* 2 Slits,4,1,400 - 560,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
 $B480.*,$r.{6},$IFU.* 2 Slits,1,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,130,1,Night
 $B480.*,$r.{6},$IFU.* 2 Slits,2,1,560 - 700,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
@@ -2917,7 +2920,7 @@ $B480.*,$.*one|.*G.*,$.* 0.50 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quar
 $B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-$B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.50 arcsec,4,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.75 arcsec,1,1,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,32,1,Night
@@ -2945,7 +2948,7 @@ $B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,300-450,1,High,,,,1,GMOS balance,Visibl
 $B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 0.75 arcsec,4,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,24,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
@@ -2965,14 +2968,14 @@ $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quar
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,14,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.00 arcsec,4,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,16,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,1,1,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
@@ -2993,14 +2996,14 @@ $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,300-450,1,High,,,,1,GMOS balance,Visibl
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,450-725,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 1.50 arcsec,4,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,12,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,8,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
@@ -3010,65 +3013,65 @@ $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quar
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,6,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,18,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,18,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,12,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
 $B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
-$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,8,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,450-725,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 2.00 arcsec,4,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,450-725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,300-450,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,20,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,2,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,1,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,16,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,10,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,3,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,1,4,725-1200,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,8,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
-$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,450-725,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,450-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,2,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,300-450,1,High,,,,1,ND2.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,450-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,6,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,2,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,300-450,1,High,,,,1,ND3.0,Visible,Quartz Halogen,Closed,4,1,Night
+$B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,450-725,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,4,1,Night
 $B480.*,$.*one|.*G.*,$.* 5.00 arcsec,4,4,725-1200,1,High,,,,1,ND4.0,Visible,Quartz Halogen,Closed,2,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,400,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,360,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,280,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,280,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
 $B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,1,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,200,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,180,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,140,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,120,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
 $B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,2,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,100,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,90,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
-$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,350 - 420,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,70,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,420 - 500,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,60,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,500 - 650,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,50,1,Night
+$B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,650 - 725,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
 $B480.*,$.*one|.*G.*,$IFU.* Right Slit .*,4,1,725 - 1200,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,30,1,Night
 $B480.*,$g.*,$IFU.* 2 Slits,1,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,400,1,Night
 $B480.*,$g.*,$IFU.* 2 Slits,2,1,400 - 560,1,High,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,240,1,Night

--- a/modules/smartgcal/src/main/resources/smartgcal/GMOS-S_FLAT.csv
+++ b/modules/smartgcal/src/main/resources/smartgcal/GMOS-S_FLAT.csv
@@ -1,4 +1,4 @@
-488,2023/02/28 04:39:16 HST
+520,2025/05/20 07:47:32 HST
 # GMOS_FLAT,,,,,,,,,,,,,,,,,,
 # V 487, GG 2023Feb28,,,,,,,,,,,,,,,,,
 # updated R150 2x1 0.5 (2 sec from 3) and added B480,,,,,,,,,,,,,,,,,,
@@ -18,6 +18,7 @@
 # update for  R400 0.25arcsec 2x2 (GG 20190628),,,,,,,,,,,,,,,,,,
 # update for  R831 IFU-2+z+CaT 8sec->5sec, and  2sec -> 1sec for R400, 785 2"" slit 1x2 (GG 20210720)",,,,,,,,,,,,,,,,,,
 # update for  R150  720nm  1"" slit 4x2 (GG 20220126) ND = ND4.0",,,,,,,,,,,,,,,,,,
+# Updated exposure time for R400 flats 700nm 1x1 and 2x2 - GG 20250520,,,,,,,,,,,,,,,,,,
 # this is a copy of GMOS-N flat version 240, starting point for Hamamatsu CCDs,,,,,,,,,,,,,,,,,
 # Site dependent instrument specifications removed.,,,,,,,,,,,,,,,,,,
 #,,,,,,,,,,,,,,,,,,
@@ -212,7 +213,7 @@ $R150.*,$GG455.*,$IFU.* 2 Slits,4,1,300 - 1200,1,Low,,,,1,GMOS balance,Visible,Q
 #,,,,,,,,,,,,,,,,,1,Night
 $R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,400 - 590,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,10,1,Night
 $R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,590 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
-$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,1,650 - 1000,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,4,1,Night
 $R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,400 - 590,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
 $R400.*,$.*one|.*G.*,$.* 1.00 arcsec,1,2,400 - 590,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,5,1,Night
 $R400.*,$.*one|.*G.*,$.* 1.00 arcsec,2,1,590 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,2,1,Night
@@ -258,9 +259,9 @@ $R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,2,650 - 1000,1,Low,,,,1,GMOS balance,Visi
 $R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
 $R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
 $R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,400 - 650,1,Low,,,,1,GMOS balance,Visible,Quartz Halogen,Closed,1,1,Night
-$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,650 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,650 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
-$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,650 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,2,650 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,1,650 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
+$R400.*,$.*one|.*G.*,$.* 2.00 arcsec,1,4,650 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
 $R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
 $R400.*,$.*one|.*G.*,$.* 2.00 arcsec,4,2,400 - 700,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,2,1,Night
 $R400.*,$.*one|.*G.*,$.* 2.00 arcsec,2,4,700 - 1000,1,Low,,,,1,ND2.0,Visible,Quartz Halogen,Closed,1,1,Night


### PR DESCRIPTION
These will be re-parsed and the tables updated on the next startup.  I recall there were issues with that taking too long the last time but I think we addressed it with bigger dynos or longer timeouts or something.

On my MacBook Air:

```
service Completed migration: GMOS North smart gcal loader in 18583 ms
service Completed migration: GMOS South smart gcal loader in 17131 ms
```