### PR TITLE
Shortcut 6298: CfP title override

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -462,11 +462,19 @@ scalar CallForProposalsId
 The properties of a Call for Proposal in an input for creation and editing.
 """
 input CallForProposalsPropertiesInput {
+
   "Type of the call. Required on create."
   type: CallForProposalsType
 
   "Semester associated with the call. Required on create."
   semester: Semester
+
+  """
+  An explicit title.  If not set then a title will be determined from the CfP
+  properties.  This property is not required on create and may be assigned
+  a null value to return to the default.
+  """
+  titleOverride: NonEmptyString
 
   """
   Coordinate limits.  If not specified, they will default according to the

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -470,11 +470,11 @@ input CallForProposalsPropertiesInput {
   semester: Semester
 
   """
-  An explicit title.  If not set then a title will be determined from the CfP
+  The CfP title.  If not set then a title will be determined from the CfP
   properties.  This property is not required on create and may be assigned
   a null value to return to the default.
   """
-  titleOverride: NonEmptyString
+  title: NonEmptyString
 
   """
   Coordinate limits.  If not specified, they will default according to the

--- a/modules/service/src/main/resources/db/migration/V1016__cfp_title_override.sql
+++ b/modules/service/src/main/resources/db/migration/V1016__cfp_title_override.sql
@@ -1,6 +1,6 @@
 -- Add a nullable title override column.
 ALTER TABLE t_cfp
-  ADD COLUMN c_title_override text NULL DEFAULT NULL;
+  ADD COLUMN c_title_override text NULL DEFAULT NULL CHECK (c_title_override IS NULL OR length(c_title_override) > 0);
 
 -- Drop the v_cfp view which calls the title formatting function.
 DROP VIEW v_cfp;
@@ -8,9 +8,9 @@ DROP VIEW v_cfp;
 -- Update the title formatting function to consider the title override.
 DROP FUNCTION format_cfp_title;
 CREATE FUNCTION format_cfp_title(
-  titleOverride text,
   cfpType       e_cfp_type,
   semester      d_semester,
+  titleOverride text,
   startDate     date,
   endDate       date,
   instruments   d_tag[]
@@ -76,7 +76,7 @@ CREATE VIEW v_cfp AS
       c.*,
       cte_instrument.c_instruments,
       cte_partner.c_is_open,
-      format_cfp_title(c.c_title_override, c.c_type, c.c_semester, c.c_active_start, c.c_active_end, cte_instrument.c_instrument_names) AS c_title,
+      format_cfp_title(c.c_type, c.c_semester, c.c_title_override, c.c_active_start, c.c_active_end, cte_instrument.c_instrument_names) AS c_title,
       cte_partner.c_non_partner = 1 AS c_allows_non_partner,
       (CASE WHEN cte_partner.c_non_partner = 1 THEN cte_partner.c_us_deadline ELSE NULL END) AS c_non_partner_deadline
     FROM

--- a/modules/service/src/main/resources/db/migration/V1016__cfp_title_override.sql
+++ b/modules/service/src/main/resources/db/migration/V1016__cfp_title_override.sql
@@ -1,0 +1,87 @@
+-- Add a nullable title override column.
+ALTER TABLE t_cfp
+  ADD COLUMN c_title_override text NULL DEFAULT NULL;
+
+-- Drop the v_cfp view which calls the title formatting function.
+DROP VIEW v_cfp;
+
+-- Update the title formatting function to consider the title override.
+DROP FUNCTION format_cfp_title;
+CREATE FUNCTION format_cfp_title(
+  titleOverride text,
+  cfpType       e_cfp_type,
+  semester      d_semester,
+  startDate     date,
+  endDate       date,
+  instruments   d_tag[]
+) RETURNS text AS $$
+DECLARE
+  instrument_list text;
+  name text;
+BEGIN
+  SELECT c_name INTO name FROM t_cfp_type WHERE c_type = cfpType;
+  instrument_list := array_to_string(instruments, ', ');
+  IF (titleOverride IS NOT NULL) THEN
+    RETURN titleOverride;
+  ELSE
+    RETURN CASE
+      WHEN cfpType = 'fast_turnaround' THEN
+        concat(
+          left(semester, -1),
+          ' ',
+          to_char(date_trunc('month', startDate) - INTERVAL '2 months', 'FMMonth'),
+          ' ',
+          name
+        )
+      WHEN cfpType = 'system_verification' THEN
+            concat(semester, nullif(' ' || instrument_list, ' '), ' ', name)
+      ELSE concat(semester, ' ', name)
+    END CASE;
+  END IF;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Update the view to call the title formatting function with the new
+-- override argument.
+CREATE VIEW v_cfp AS
+  WITH
+    cte_instrument AS (
+      SELECT
+        c.c_cfp_id,
+        array_remove(array_agg(ci.c_instrument ORDER BY ci.c_instrument), NULL) AS c_instruments,
+        array_remove(array_agg(i.c_long_name ORDER BY i.c_long_name), NULL) AS c_instrument_names
+      FROM
+        t_cfp c
+      LEFT JOIN
+        t_cfp_instrument ci ON c.c_cfp_id = ci.c_cfp_id
+      LEFT JOIN
+        t_instrument i ON i.c_tag = ci.c_instrument
+      GROUP BY
+        c.c_cfp_id
+    ),
+    cte_partner AS (
+      SELECT
+        c.c_cfp_id,
+        (COUNT(*) FILTER (WHERE p.c_deadline IS NOT NULL AND p.c_deadline > CURRENT_TIMESTAMP) > 0) AS c_is_open,
+        MAX(CASE WHEN p.c_partner = 'us' AND (c.c_type = 'regular_semester' OR c.c_type = 'directors_time') THEN 1 ELSE 0 END) AS c_non_partner,
+        MAX(CASE WHEN p.c_partner = 'us' THEN p.c_deadline ELSE NULL END) AS c_us_deadline
+      FROM
+        t_cfp c
+      LEFT JOIN
+        v_cfp_partner p ON c.c_cfp_id = p.c_cfp_id
+      GROUP BY
+        c.c_cfp_id
+    )
+    SELECT
+      c.*,
+      cte_instrument.c_instruments,
+      cte_partner.c_is_open,
+      format_cfp_title(c.c_title_override, c.c_type, c.c_semester, c.c_active_start, c.c_active_end, cte_instrument.c_instrument_names) AS c_title,
+      cte_partner.c_non_partner = 1 AS c_allows_non_partner,
+      (CASE WHEN cte_partner.c_non_partner = 1 THEN cte_partner.c_us_deadline ELSE NULL END) AS c_non_partner_deadline
+    FROM
+      t_cfp c
+    LEFT JOIN
+      cte_instrument ON c.c_cfp_id = cte_instrument.c_cfp_id
+    LEFT JOIN
+      cte_partner ON c.c_cfp_id = cte_partner.c_cfp_id;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CallForProposalsPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CallForProposalsPropertiesInput.scala
@@ -8,6 +8,7 @@ import cats.Traverse
 import cats.data.Ior
 import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.NonNegInt
+import eu.timepit.refined.types.string.NonEmptyString
 import grackle.Result
 import grackle.syntax.*
 import lucuma.core.enums.CallForProposalsType
@@ -27,18 +28,19 @@ import java.time.LocalDate
 object CallForProposalsPropertiesInput {
 
   case class Create(
-    cfpType:     CallForProposalsType,
-    semester:    Semester,
-    gnRaLimit:   (RightAscension, RightAscension),
-    gnDecLimit:  (Declination, Declination),
-    gsRaLimit:   (RightAscension, RightAscension),
-    gsDecLimit:  (Declination, Declination),
-    active:      DateInterval,
-    deadline:    Option[Timestamp],
-    partners:    Option[List[CallForProposalsPartnerInput]],
-    instruments: List[Instrument],
-    proprietary: Option[NonNegInt],
-    existence:   Existence
+    cfpType:       CallForProposalsType,
+    semester:      Semester,
+    titleOverride: Option[NonEmptyString],
+    gnRaLimit:     (RightAscension, RightAscension),
+    gnDecLimit:    (Declination, Declination),
+    gsRaLimit:     (RightAscension, RightAscension),
+    gsDecLimit:    (Declination, Declination),
+    active:        DateInterval,
+    deadline:      Option[Timestamp],
+    partners:      Option[List[CallForProposalsPartnerInput]],
+    instruments:   List[Instrument],
+    proprietary:   Option[NonNegInt],
+    existence:     Existence
   )
 
   object Create {
@@ -48,6 +50,7 @@ object CallForProposalsPropertiesInput {
         case List(
           CallForProposalsTypeBinding("type", rType),
           SemesterBinding("semester", rSemester),
+          NonEmptyStringBinding.Option("titleOverride", rTitleOverride),
           SiteCoordinateLimitsInput.Create.Binding.Option("coordinateLimits", rLimits),
           DateBinding("activeStart", rActiveStart),
           DateBinding("activeEnd",   rActiveEnd),
@@ -63,6 +66,7 @@ object CallForProposalsPropertiesInput {
           (
             rType,
             rSemester,
+            rTitleOverride,
             rLimits,
             rActive,
             rDeadline,
@@ -70,11 +74,12 @@ object CallForProposalsPropertiesInput {
             rInstrumentsʹ,
             rProprietary,
             rExistence.map(_.getOrElse(Existence.Present))
-          ).parMapN { (cfpType, semester, limits, active, deadline, partners, instruments, proprietary, exist) =>
+          ).parMapN { (cfpType, semester, titleOverride, limits, active, deadline, partners, instruments, proprietary, exist) =>
             val coords = limits.fold(SiteCoordinateLimitsInput.Create.default(active))(f => f(active))
             Create(
               cfpType,
               semester,
+              titleOverride,
               (coords.north.raStart, coords.north.raEnd),
               (coords.north.decStart, coords.north.decEnd),
               (coords.south.raStart, coords.south.raEnd),
@@ -93,18 +98,19 @@ object CallForProposalsPropertiesInput {
   }
 
   case class Edit(
-    cfpType:     Option[CallForProposalsType],
-    semester:    Option[Semester],
-    gnRaLimit:   (Option[RightAscension], Option[RightAscension]),
-    gnDecLimit:  (Option[Declination], Option[Declination]),
-    gsRaLimit:   (Option[RightAscension], Option[RightAscension]),
-    gsDecLimit:  (Option[Declination], Option[Declination]),
-    active:      Option[Ior[LocalDate, LocalDate]],
-    deadline:    Nullable[Timestamp],
-    partners:    Nullable[List[CallForProposalsPartnerInput]],
-    instruments: Nullable[List[Instrument]],
-    proprietary: Option[NonNegInt],
-    existence:   Option[Existence]
+    cfpType:       Option[CallForProposalsType],
+    semester:      Option[Semester],
+    titleOverride: Nullable[NonEmptyString],
+    gnRaLimit:     (Option[RightAscension], Option[RightAscension]),
+    gnDecLimit:    (Option[Declination], Option[Declination]),
+    gsRaLimit:     (Option[RightAscension], Option[RightAscension]),
+    gsDecLimit:    (Option[Declination], Option[Declination]),
+    active:        Option[Ior[LocalDate, LocalDate]],
+    deadline:      Nullable[Timestamp],
+    partners:      Nullable[List[CallForProposalsPartnerInput]],
+    instruments:   Nullable[List[Instrument]],
+    proprietary:   Option[NonNegInt],
+    existence:     Option[Existence]
   )
 
   object Edit {
@@ -114,6 +120,7 @@ object CallForProposalsPropertiesInput {
         case List(
           CallForProposalsTypeBinding.NonNullable("type", rType),
           SemesterBinding.NonNullable("semester", rSemester),
+          NonEmptyStringBinding.Nullable("titleOverride", rTitleOverride),
           SiteCoordinateLimitsInput.Edit.Binding.Option("coordinateLimits", rLimits),
           DateBinding.NonNullable("activeStart", rActiveStart),
           DateBinding.NonNullable("activeEnd",   rActiveEnd),
@@ -132,6 +139,7 @@ object CallForProposalsPropertiesInput {
           (
             rType,
             rSemester,
+            rTitleOverride,
             rLimNorth.map(lim => (lim.flatMap(_.raStart), lim.flatMap(_.raEnd))),
             rLimNorth.map(lim => (lim.flatMap(_.decStart), lim.flatMap(_.decEnd))),
             rLimSouth.map(lim => (lim.flatMap(_.raStart), lim.flatMap(_.raEnd))),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CallForProposalsPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CallForProposalsPropertiesInput.scala
@@ -28,19 +28,19 @@ import java.time.LocalDate
 object CallForProposalsPropertiesInput {
 
   case class Create(
-    cfpType:       CallForProposalsType,
-    semester:      Semester,
-    titleOverride: Option[NonEmptyString],
-    gnRaLimit:     (RightAscension, RightAscension),
-    gnDecLimit:    (Declination, Declination),
-    gsRaLimit:     (RightAscension, RightAscension),
-    gsDecLimit:    (Declination, Declination),
-    active:        DateInterval,
-    deadline:      Option[Timestamp],
-    partners:      Option[List[CallForProposalsPartnerInput]],
-    instruments:   List[Instrument],
-    proprietary:   Option[NonNegInt],
-    existence:     Existence
+    cfpType:     CallForProposalsType,
+    semester:    Semester,
+    title:       Option[NonEmptyString],
+    gnRaLimit:   (RightAscension, RightAscension),
+    gnDecLimit:  (Declination, Declination),
+    gsRaLimit:   (RightAscension, RightAscension),
+    gsDecLimit:  (Declination, Declination),
+    active:      DateInterval,
+    deadline:    Option[Timestamp],
+    partners:    Option[List[CallForProposalsPartnerInput]],
+    instruments: List[Instrument],
+    proprietary: Option[NonNegInt],
+    existence:   Existence
   )
 
   object Create {
@@ -50,7 +50,7 @@ object CallForProposalsPropertiesInput {
         case List(
           CallForProposalsTypeBinding("type", rType),
           SemesterBinding("semester", rSemester),
-          NonEmptyStringBinding.Option("titleOverride", rTitleOverride),
+          NonEmptyStringBinding.Option("title", rTitle),
           SiteCoordinateLimitsInput.Create.Binding.Option("coordinateLimits", rLimits),
           DateBinding("activeStart", rActiveStart),
           DateBinding("activeEnd",   rActiveEnd),
@@ -66,7 +66,7 @@ object CallForProposalsPropertiesInput {
           (
             rType,
             rSemester,
-            rTitleOverride,
+            rTitle,
             rLimits,
             rActive,
             rDeadline,
@@ -74,12 +74,12 @@ object CallForProposalsPropertiesInput {
             rInstrumentsʹ,
             rProprietary,
             rExistence.map(_.getOrElse(Existence.Present))
-          ).parMapN { (cfpType, semester, titleOverride, limits, active, deadline, partners, instruments, proprietary, exist) =>
+          ).parMapN { (cfpType, semester, title, limits, active, deadline, partners, instruments, proprietary, exist) =>
             val coords = limits.fold(SiteCoordinateLimitsInput.Create.default(active))(f => f(active))
             Create(
               cfpType,
               semester,
-              titleOverride,
+              title,
               (coords.north.raStart, coords.north.raEnd),
               (coords.north.decStart, coords.north.decEnd),
               (coords.south.raStart, coords.south.raEnd),
@@ -98,19 +98,19 @@ object CallForProposalsPropertiesInput {
   }
 
   case class Edit(
-    cfpType:       Option[CallForProposalsType],
-    semester:      Option[Semester],
-    titleOverride: Nullable[NonEmptyString],
-    gnRaLimit:     (Option[RightAscension], Option[RightAscension]),
-    gnDecLimit:    (Option[Declination], Option[Declination]),
-    gsRaLimit:     (Option[RightAscension], Option[RightAscension]),
-    gsDecLimit:    (Option[Declination], Option[Declination]),
-    active:        Option[Ior[LocalDate, LocalDate]],
-    deadline:      Nullable[Timestamp],
-    partners:      Nullable[List[CallForProposalsPartnerInput]],
-    instruments:   Nullable[List[Instrument]],
-    proprietary:   Option[NonNegInt],
-    existence:     Option[Existence]
+    cfpType:     Option[CallForProposalsType],
+    semester:    Option[Semester],
+    title:       Nullable[NonEmptyString],
+    gnRaLimit:   (Option[RightAscension], Option[RightAscension]),
+    gnDecLimit:  (Option[Declination], Option[Declination]),
+    gsRaLimit:   (Option[RightAscension], Option[RightAscension]),
+    gsDecLimit:  (Option[Declination], Option[Declination]),
+    active:      Option[Ior[LocalDate, LocalDate]],
+    deadline:    Nullable[Timestamp],
+    partners:    Nullable[List[CallForProposalsPartnerInput]],
+    instruments: Nullable[List[Instrument]],
+    proprietary: Option[NonNegInt],
+    existence:   Option[Existence]
   )
 
   object Edit {
@@ -120,7 +120,7 @@ object CallForProposalsPropertiesInput {
         case List(
           CallForProposalsTypeBinding.NonNullable("type", rType),
           SemesterBinding.NonNullable("semester", rSemester),
-          NonEmptyStringBinding.Nullable("titleOverride", rTitleOverride),
+          NonEmptyStringBinding.Nullable("title", rTitle),
           SiteCoordinateLimitsInput.Edit.Binding.Option("coordinateLimits", rLimits),
           DateBinding.NonNullable("activeStart", rActiveStart),
           DateBinding.NonNullable("activeEnd",   rActiveEnd),
@@ -139,7 +139,7 @@ object CallForProposalsPropertiesInput {
           (
             rType,
             rSemester,
-            rTitleOverride,
+            rTitle,
             rLimNorth.map(lim => (lim.flatMap(_.raStart), lim.flatMap(_.raEnd))),
             rLimNorth.map(lim => (lim.flatMap(_.decStart), lim.flatMap(_.decEnd))),
             rLimSouth.map(lim => (lim.flatMap(_.raStart), lim.flatMap(_.raEnd))),

--- a/modules/service/src/main/scala/lucuma/odb/service/CallForProposalsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CallForProposalsService.scala
@@ -244,7 +244,7 @@ object CallForProposalsService {
       """.query(cfp_id).contramap { input => (
         input.cfpType,
         input.semester,
-        input.titleOverride,
+        input.title,
         input.gnRaLimit._1,
         input.gnRaLimit._2,
         input.gnDecLimit._1,
@@ -344,7 +344,7 @@ object CallForProposalsService {
 
       val ups: Option[NonEmptyList[AppliedFragment]] =
         NonEmptyList.fromList(List(
-          SET.titleOverride.foldPresent(sql"c_title_override = ${text_nonempty.opt}"),
+          SET.title.foldPresent(sql"c_title_override = ${text_nonempty.opt}"),
           SET.gnRaLimit._1.map(gnRaStart),
           SET.gnRaLimit._2.map(gnRaEnd),
           SET.gnDecLimit._1.map(gnDecStart),

--- a/modules/service/src/main/scala/lucuma/odb/service/CallForProposalsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CallForProposalsService.scala
@@ -207,6 +207,7 @@ object CallForProposalsService {
         INSERT INTO t_cfp (
           c_type,
           c_semester,
+          c_title_override,
           c_north_ra_start,
           c_north_ra_end,
           c_north_dec_start,
@@ -224,6 +225,7 @@ object CallForProposalsService {
         SELECT
           $cfp_type,
           $semester,
+          ${text_nonempty.opt},
           ${right_ascension},
           ${right_ascension},
           ${declination},
@@ -242,6 +244,7 @@ object CallForProposalsService {
       """.query(cfp_id).contramap { input => (
         input.cfpType,
         input.semester,
+        input.titleOverride,
         input.gnRaLimit._1,
         input.gnRaLimit._2,
         input.gnDecLimit._1,
@@ -341,6 +344,7 @@ object CallForProposalsService {
 
       val ups: Option[NonEmptyList[AppliedFragment]] =
         NonEmptyList.fromList(List(
+          SET.titleOverride.foldPresent(sql"c_title_override = ${text_nonempty.opt}"),
           SET.gnRaLimit._1.map(gnRaStart),
           SET.gnRaLimit._2.map(gnRaEnd),
           SET.gnDecLimit._1.map(gnDecStart),

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateCallsForProposals.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateCallsForProposals.scala
@@ -964,4 +964,81 @@ class updateCallsForProposals extends OdbSuite {
       )
   }
 
+  test("titleOverride"):
+    createCall.flatMap: id =>
+      expect(
+        staff,
+        s"""
+          mutation {
+            updateCallsForProposals(input: {
+              SET: {
+                titleOverride: "Foo"
+              },
+              WHERE: {
+                id: { EQ: "$id" }
+              }
+            }) {
+              callsForProposals {
+                title
+              }
+            }
+          }
+        """,
+        json"""
+          {
+            "updateCallsForProposals": {
+              "callsForProposals": [
+                {
+                  "title": "Foo"
+                }
+              ]
+            }
+          }
+        """.asRight
+      )
+
+  test("unset titleOverride"):
+    createCall.flatMap: id =>
+      query(
+        staff,
+        s"""
+          mutation {
+            updateCallsForProposals(input: {
+              SET: { titleOverride: "Foo" },
+              WHERE: { id: { EQ: "$id" } }
+            }) {
+              callsForProposals { title }
+            }
+          }
+        """
+      ) >> expect(
+        staff,
+        s"""
+          mutation {
+            updateCallsForProposals(input: {
+              SET: {
+                titleOverride: null
+              },
+              WHERE: {
+                id: { EQ: "$id" }
+              }
+            }) {
+              callsForProposals {
+                title
+              }
+            }
+          }
+        """,
+        json"""
+          {
+            "updateCallsForProposals": {
+              "callsForProposals": [
+                {
+                  "title": "2025A Regular Semester"
+                }
+              ]
+            }
+          }
+        """.asRight
+      )
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateCallsForProposals.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateCallsForProposals.scala
@@ -964,7 +964,7 @@ class updateCallsForProposals extends OdbSuite {
       )
   }
 
-  test("titleOverride"):
+  test("title"):
     createCall.flatMap: id =>
       expect(
         staff,
@@ -972,7 +972,7 @@ class updateCallsForProposals extends OdbSuite {
           mutation {
             updateCallsForProposals(input: {
               SET: {
-                titleOverride: "Foo"
+                title: "Foo"
               },
               WHERE: {
                 id: { EQ: "$id" }
@@ -997,14 +997,14 @@ class updateCallsForProposals extends OdbSuite {
         """.asRight
       )
 
-  test("unset titleOverride"):
+  test("unset title"):
     createCall.flatMap: id =>
       query(
         staff,
         s"""
           mutation {
             updateCallsForProposals(input: {
-              SET: { titleOverride: "Foo" },
+              SET: { title: "Foo" },
               WHERE: { id: { EQ: "$id" } }
             }) {
               callsForProposals { title }
@@ -1017,7 +1017,7 @@ class updateCallsForProposals extends OdbSuite {
           mutation {
             updateCallsForProposals(input: {
               SET: {
-                titleOverride: null
+                title: null
               },
               WHERE: {
                 id: { EQ: "$id" }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/callForProposals.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/callForProposals.scala
@@ -6,6 +6,7 @@ package query
 
 import cats.effect.IO
 import cats.syntax.either.*
+import cats.syntax.option.*
 import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
@@ -89,7 +90,8 @@ class callForProposals extends OdbSuite {
   }
 
   private def getTitle(
-    cfpType: CallForProposalsType
+    cfpType:       CallForProposalsType,
+    titleOverride: Option[String] = None
   ): IO[String] =
     query(
       user = staff,
@@ -100,6 +102,7 @@ class callForProposals extends OdbSuite {
               SET: {
                 type:        ${cfpType.tag.toScreamingSnakeCase}
                 semester:    "2025A"
+                ${titleOverride.fold("")(title => s"titleOverride: \"$title\"")}
                 activeStart: "2025-02-01"
                 activeEnd:   "2025-07-31"
               }
@@ -122,6 +125,9 @@ class callForProposals extends OdbSuite {
   test("demo science") {
     assertIO(getTitle(CallForProposalsType.DemoScience), "2025A Demo Science")
   }
+
+  test("title override"):
+    assertIO(getTitle(CallForProposalsType.DemoScience, "Foo".some), "Foo")
 
   test("director's time") {
     assertIO(getTitle(CallForProposalsType.DirectorsTime), "2025A Director's Time")

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/callForProposals.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/callForProposals.scala
@@ -90,8 +90,8 @@ class callForProposals extends OdbSuite {
   }
 
   private def getTitle(
-    cfpType:       CallForProposalsType,
-    titleOverride: Option[String] = None
+    cfpType: CallForProposalsType,
+    title:   Option[String] = None
   ): IO[String] =
     query(
       user = staff,
@@ -102,7 +102,7 @@ class callForProposals extends OdbSuite {
               SET: {
                 type:        ${cfpType.tag.toScreamingSnakeCase}
                 semester:    "2025A"
-                ${titleOverride.fold("")(title => s"titleOverride: \"$title\"")}
+                ${title.fold("")(title => s"title: \"$title\"")}
                 activeStart: "2025-02-01"
                 activeEnd:   "2025-07-31"
               }


### PR DESCRIPTION
Adds a `title` property to the Call for Proposals creation and update properties. If set, the normal title computation is short-circuited to use the override.  The override is optional and nullable.