### PR TITLE
Shortcut 4938: `WhereDatasetChronicleEntry`

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -6647,6 +6647,37 @@ type DatasetChronicleEntry { # implements ChronicleEntry
 
 }
 
+input WhereDatasetChronicleEntry {
+
+  AND: [WhereDatasetChronicleEntry!]
+
+  OR: [WhereDatasetChronicleEntry!]
+
+  NOT: WhereDatasetChronicleEntry
+
+  id: WhereOrderChronicleId
+
+  user: WhereUser
+
+  operation: WhereEqDatabaseOperation
+
+  timestamp: WhereOrderTimestamp
+
+  dataset: WhereOrderDatasetId
+
+  modDatasetId: WhereBoolean
+  modStepId: WhereBoolean
+  modObservationId: WhereBoolean
+  modVisitId: WhereBoolean
+
+  modReference: WhereBoolean
+  modFilename: WhereBoolean
+  modQaState: WhereBoolean
+  modInterval: WhereBoolean
+  modComment: WhereBoolean
+
+}
+
 type DatasetChronicleEntrySelectResult {
 
   """
@@ -11047,6 +11078,11 @@ type Query {
   datasetChronicleEntries(
 
     """
+    Filters the selection of chronicle entries.
+    """
+    WHERE: WhereDatasetChronicleEntry
+
+    """
     Starts the result set at (or after if not existent) the given id.
     """
     OFFSET: ChronicleId
@@ -14323,6 +14359,33 @@ input WhereEqCallForProposalsType {
 }
 
 """
+Filters on equality (or not) of the database operation.  All supplied
+criteria must match, but usually only one is selected.
+"""
+input WhereEqDatabaseOperation {
+
+  """
+  Matches if the database operation is exactly the supplied value.
+  """
+  EQ: DatabaseOperation
+
+  """
+  Matches if the database operation is not the supplied value.
+  """
+  NEQ: DatabaseOperation
+
+  """
+  Matches if the database operation is any of the supplied options.
+  """
+  IN: [DatabaseOperation!]
+
+  """
+  Matches if the database operation is none of the supplied values.
+  """
+  NIN: [DatabaseOperation!]
+}
+
+"""
 Filters on equality (or not) of the user educational status and the supplied
 criteria. All supplied criteria must match, but usually only one is selected.
 """
@@ -15326,6 +15389,52 @@ input WhereOrderCallForProposalsId {
   Matches if the id is ordered before or equal (<=) the supplied value.
   """
   LTE: CallForProposalsId
+}
+
+"""
+Filters on equality or order comparisons of the chronicle id.  All supplied
+criteria must match, but usually only one is selected.
+"""
+input WhereOrderChronicleId {
+  """
+  Matches if the property is exactly the supplied value.
+  """
+  EQ: ChronicleId
+
+  """
+  Matches if the property is not the supplied value.
+  """
+  NEQ: ChronicleId
+
+  """
+  Matches if the property value is any of the supplied options.
+  """
+  IN: [ChronicleId!]
+
+  """
+  Matches if the property value is none of the supplied values.
+  """
+  NIN: [ChronicleId!]
+
+  """
+  Matches if the property is ordered after (>) the supplied value.
+  """
+  GT: ChronicleId
+
+  """
+  Matches if the property is ordered before (<) the supplied value.
+  """
+  LT: ChronicleId
+
+  """
+  Matches if the property is ordered after or equal (>=) the supplied value.
+  """
+  GTE: ChronicleId
+
+  """
+  Matches if the property is ordered before or equal (<=) the supplied value.
+  """
+  LTE: ChronicleId
 }
 
 """

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -6647,6 +6647,10 @@ type DatasetChronicleEntry { # implements ChronicleEntry
 
 }
 
+"""
+Allows filtering of DatasetChronicleEntry (see Query -> datasetChronicleEntries)
+based on a number of criteria.
+"""
 input WhereDatasetChronicleEntry {
 
   AND: [WhereDatasetChronicleEntry!]
@@ -6655,25 +6659,75 @@ input WhereDatasetChronicleEntry {
 
   NOT: WhereDatasetChronicleEntry
 
+  """
+  Limits the results to those matching a chronicle id.
+  """
   id: WhereOrderChronicleId
 
+  """
+  Limits the results to a particular user or users.
+  """
   user: WhereUser
 
+  """
+  Limits the results to particular database operations.
+  """
   operation: WhereEqDatabaseOperation
 
+  """
+  Limits the results based on timestamp of the change.
+  """
   timestamp: WhereOrderTimestamp
 
+  """
+  Limits the results to specified datasets.
+  """
   dataset: WhereOrderDatasetId
 
+  """
+  Add this item to match only when a dataset id is or isn't updated.
+  """
   modDatasetId: WhereBoolean
+
+  """
+  Add this item to match only when a step id is or isn't updated.
+  """
   modStepId: WhereBoolean
+
+  """
+  Add this item to match only when an observation id is or isn't updated.
+  """
   modObservationId: WhereBoolean
+
+  """
+  Add this item to match only when a visit id is or isn't updated.
+  """
   modVisitId: WhereBoolean
 
+  """
+  Add this item to match only when a dataset reference is or isn't updated.
+  """
   modReference: WhereBoolean
+
+  """
+  Add this item to match only when a dataset filename is or isn't updated.
+  """
   modFilename: WhereBoolean
+
+  """
+  Add this item to match only when a dataset QA state is or isn't updated.
+  """
   modQaState: WhereBoolean
+
+  """
+  Add this item to match only when a dataset time interval (the range of time
+  during which it was collected) is or isn't updated.
+  """
   modInterval: WhereBoolean
+
+  """
+  Add this item to match only when a dataset comment is or isn't updated.
+  """
   modComment: WhereBoolean
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereDatasetChronicleEntry.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereDatasetChronicleEntry.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.input
+
+import cats.syntax.parallel.*
+import grackle.Path
+import grackle.Predicate
+import grackle.Predicate.*
+import lucuma.core.model.sequence.Dataset
+import lucuma.core.util.Timestamp
+import lucuma.odb.data.DatabaseOperation
+import lucuma.odb.graphql.binding.*
+
+object WhereDatasetChronicleEntry:
+
+  def binding(path: Path): Matcher[Predicate] =
+
+    val WhereOrderChronicleId    = WhereOrder.binding[Long](path / "id", LongBinding)
+    val WhereUserBinding         = WhereUser.binding(path / "user")
+    val WhereEqDatabaseOperation = WhereEq.binding[DatabaseOperation](path / "operation", DatabaseOperationBinding)
+    val WhereOrderTimestamp      = WhereOrder.binding[Timestamp](path / "timestamp", TimestampBinding)
+    val WhereOrderDatasetId      = WhereOrder.binding[Dataset.Id](path / "dataset" / "id", DatasetIdBinding)
+
+    val WhereModDatasetId        = WhereBoolean.binding(path / "modDatasetId", BooleanBinding)
+    val WhereModStepId           = WhereBoolean.binding(path / "modStepId", BooleanBinding)
+    val WhereModObservationId    = WhereBoolean.binding(path / "modObservationId", BooleanBinding)
+    val WhereModVisitId          = WhereBoolean.binding(path / "modVisitId", BooleanBinding)
+
+    val WhereModReference        = WhereBoolean.binding(path / "modReference", BooleanBinding)
+    val WhereModFilename         = WhereBoolean.binding(path / "modFilename", BooleanBinding)
+    val WhereModQaState          = WhereBoolean.binding(path / "modQaState", BooleanBinding)
+    val WhereModInterval         = WhereBoolean.binding(path / "modInterval", BooleanBinding)
+    val WhereModComment          = WhereBoolean.binding(path / "modComment", BooleanBinding)
+
+    lazy val WhereDatasetChronicleEntryBinding = binding(path)
+
+    ObjectFieldsBinding.rmap:
+      case List(
+        WhereDatasetChronicleEntryBinding.List.Option("AND", rAND),
+        WhereDatasetChronicleEntryBinding.List.Option("OR", rOR),
+        WhereDatasetChronicleEntryBinding.Option("NOT", rNOT),
+
+        WhereOrderChronicleId.Option("id", rId),
+        WhereUserBinding.Option("user", rUser),
+        WhereEqDatabaseOperation.Option("operation", rOp),
+        WhereOrderTimestamp.Option("timestamp", rTimestamp),
+        WhereOrderDatasetId.Option("dataset", rDatasetId),
+
+        WhereModDatasetId.Option("modDatasetId", rModDatasetId),
+        WhereModStepId.Option("modStepId", rModStepId),
+        WhereModObservationId.Option("modObservationId", rModObservationId),
+        WhereModVisitId.Option("modVisitId", rModVisitId),
+
+        WhereModReference.Option("modReference", rModReference),
+        WhereModFilename.Option("modFilename", rModFilename),
+        WhereModQaState.Option("modQaState", rModQa),
+        WhereModInterval.Option("modInterval", rModInterval),
+        WhereModComment.Option("modComment", rModComment)
+
+      ) =>
+        (rAND, rOR, rNOT, rId, rUser, rOp, rTimestamp, rDatasetId, rModDatasetId, rModStepId, rModObservationId, rModVisitId, rModReference, rModFilename, rModQa, rModInterval, rModComment).parMapN:
+          (AND, OR, NOT, id, user, op, timestamp, datasetId, modDatasetId, modStepId, modObservationId, modVisitId, modReference, modFilename, modQa, modInterval, modComment) =>
+            and(List(
+              AND.map(and),
+              OR.map(or),
+              NOT.map(Not(_)),
+              id,
+              user,
+              op,
+              timestamp,
+              datasetId,
+              modDatasetId,
+              modStepId,
+              modObservationId,
+              modVisitId,
+              modReference,
+              modFilename,
+              modQa,
+              modInterval,
+              modComment
+            ).flatten)


### PR DESCRIPTION
Adds `WHERE` clause filtering for the dataset chronicle entries.  With this, the GOA should be able to get the information it needs.