### PR TITLE
Change Program User fallbackProfile to preferredProfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
       - name: Docker compose up
         run: docker compose up -d
 
+      - name: Validate Migrations
+        if: github.event_name == 'pull_request'  && matrix.shard == '1'
+        uses: gemini-hlsw/migration-validator-action@main
+        with:
+          path: modules/service/src/main/resources/db/migration/
+
       - name: Validate GraphQL schema changes
         if: github.event_name == 'pull_request' && matrix.shard == '1'
         uses: kamilkisiela/graphql-inspector@master

--- a/build.sbt
+++ b/build.sbt
@@ -40,13 +40,14 @@ ThisBuild / Test / fork              := false
 ThisBuild / Test / parallelExecution := false
 
 ThisBuild / githubWorkflowSbtCommand := "sbt -v -J-Xmx6g"
-// ThisBuild / githubWorkflowBuildPreamble +=
-//   WorkflowStep.Use(
-//     UseRef.Public("gemini-hlsw", "migration-validator-action", "main"),
-//     name = Some("Validate Migrations"),
-//     params = Map("path" -> "modules/service/src/main/resources/db/migration/"),
-//     cond = Some("github.event_name == 'pull_request'  && matrix.shard == '1'")
-//   )
+
+ThisBuild / githubWorkflowBuildPreamble +=
+  WorkflowStep.Use(
+    UseRef.Public("gemini-hlsw", "migration-validator-action", "main"),
+    name = Some("Validate Migrations"),
+    params = Map("path" -> "modules/service/src/main/resources/db/migration/"),
+    cond = Some("github.event_name == 'pull_request'  && matrix.shard == '1'")
+  )
 
 ThisBuild / githubWorkflowBuildPreamble +=
   WorkflowStep.Use(

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -3681,10 +3681,9 @@ input ProgramUserPropertiesInput {
   partnerLink: PartnerLinkInput
 
   """
-  The fallback profile may used when the ORCiD user profile is not set or not
-  shared publicly.
+  The preferred profile overrides any values that may be in the Orcid profile (user.profile).
   """
-  fallbackProfile: UserProfileInput
+  preferredProfile: UserProfileInput
 
   "The user's educational status."
   educationalStatus: EducationalStatus
@@ -3748,10 +3747,9 @@ type ProgramUser {
   partnerLink: PartnerLink!
 
   """
-  Profile information reported when the corresponding ORCiD profile is not set
-  or is not public.
+  The preferred profile overrides any values that may be in the Orcid profile (user.profile).
   """
-  fallbackProfile: UserProfile!
+  preferredProfile: UserProfile!
 
   "User educational status. PHD/Undergrad/Grad/Other."
   educationalStatus: EducationalStatus
@@ -3770,6 +3768,18 @@ type ProgramUser {
 
   "Has access to data."
   hasDataAccess: Boolean!
+
+  """
+  Name created preferentially from the fields of the preferred profile, falling back
+  to the Orcid profile if the preferred fields are not set.
+  """
+  displayName: String
+
+  """
+  The user's email address from the preferred profile, falling back to the Orcid profile
+  if the preferred email is not set.
+  """
+  email: String
 }
 
 """
@@ -16778,9 +16788,9 @@ input WhereProgramUser {
   partnerLink: WherePartnerLink
 
   """
-  Matches the fallback profile.
+  Matches the preferred profile.
   """
-  fallbackProfile: WhereUserProfile
+  preferredProfile: WhereUserProfile
 
   """
   Matches the educational status.

--- a/modules/service/src/main/resources/db/migration/V1024__fallback_to_preferred.sql
+++ b/modules/service/src/main/resources/db/migration/V1024__fallback_to_preferred.sql
@@ -1,0 +1,25 @@
+-- Rename the fallback profile columns to preferred profile columns on t_program_user
+DROP VIEW v_program_user;
+
+ALTER TABLE t_program_user
+  RENAME COLUMN c_fallback_given_name TO c_preferred_given_name;
+
+ALTER TABLE t_program_user
+  RENAME COLUMN c_fallback_family_name TO c_preferred_family_name;
+
+ALTER TABLE t_program_user
+  RENAME COLUMN c_fallback_credit_name TO c_preferred_credit_name;
+
+ALTER TABLE t_program_user
+  RENAME COLUMN c_fallback_email TO c_preferred_email;
+
+CREATE VIEW v_program_user AS
+SELECT
+  p.*,
+  COALESCE(p.c_preferred_email, u.c_orcid_email) AS c_email,
+  COALESCE(
+    user_profile_display_name(p.c_preferred_credit_name, p.c_preferred_given_name, p.c_preferred_family_name),
+    user_profile_display_name(u.c_orcid_credit_name, u.c_orcid_given_name, u.c_orcid_family_name)
+  ) AS c_display_name
+FROM t_program_user p
+LEFT JOIN t_user u ON p.c_user_id = u.c_user_id;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ProgramUserPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ProgramUserPropertiesInput.scala
@@ -17,7 +17,7 @@ import monocle.Lens
 
 case class ProgramUserPropertiesInput(
   partnerLink:       Option[PartnerLink],
-  fallbackProfile:   Nullable[UserProfileInput],
+  preferredProfile:   Nullable[UserProfileInput],
   educationalStatus: Nullable[EducationalStatus],
   thesis:            Nullable[Boolean],
   gender:            Nullable[Gender],
@@ -45,10 +45,10 @@ object ProgramUserPropertiesInput:
     ObjectFieldsBinding.rmap:
       case List(
         PartnerLinkInput.Binding.Option("partnerLink", rPartnerLink),
-        UserProfileInput.Binding.Nullable("fallbackProfile", rFallbackProfile),
+        UserProfileInput.Binding.Nullable("preferredProfile", rPreferredProfile),
         EducationalStatusBinding.Nullable("educationalStatus", rEducationalStatus),
         BooleanBinding.Nullable("thesis", rThesis),
         GenderBinding.Nullable("gender", rGender),
         NonEmptyStringBinding.Nullable("affiliation", rAffiliation),
         BooleanBinding.Option("hasDataAccess", rDataAccess)
-      ) => (rPartnerLink, rFallbackProfile, rEducationalStatus, rThesis, rGender, rAffiliation, rDataAccess).parMapN(ProgramUserPropertiesInput.apply)
+      ) => (rPartnerLink, rPreferredProfile, rEducationalStatus, rThesis, rGender, rAffiliation, rDataAccess).parMapN(ProgramUserPropertiesInput.apply)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereProgramUser.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereProgramUser.scala
@@ -28,7 +28,7 @@ object WhereProgramUser {
     val WhereUserBinding              = WhereUser.binding(path / "user")
     val WhereRoleBinding              = WhereEq.binding(path / "role", ProgramUserRoleBinding)
     val WherePartnerLinkBinding       = WherePartnerLink.binding(path)
-    val WhereFallbackProfileBinding   = WhereUserProfile.binding(path / "fallbackProfile")
+    val WherePreferredProfileBinding   = WhereUserProfile.binding(path / "preferredProfile")
     val WhereEducationalStatusBinding = WhereOptionEq.binding(path / "educationalStatus", EducationalStatusBinding)
     val WhereThesisBinding            = WhereOptionBoolean.binding(path / "thesis", BooleanBinding)
     val WhereGenderBinding            = WhereOptionEq.binding(path / "gender", GenderBinding)
@@ -45,14 +45,14 @@ object WhereProgramUser {
         WhereUserBinding.Option("user", rUser),
         WhereRoleBinding.Option("role", rRole),
         WherePartnerLinkBinding.Option("partnerLink", rPartnerLink),
-        WhereFallbackProfileBinding.Option("fallbackProfile", rFallbackProfile),
+        WherePreferredProfileBinding.Option("preferredProfile", rPreferredProfile),
         WhereEducationalStatusBinding.Option("educationalStatus", rEducationalStatus),
         WhereThesisBinding.Option("thesis", rThesis),
         WhereGenderBinding.Option("gender", rGender),
         WhereHasDataAccessBinding.Option("hasDataAccess", rDataAccess)
       ) =>
-        (rAND, rOR, rNOT, rId, rProgram, rUser, rRole, rPartnerLink, rFallbackProfile, rEducationalStatus, rThesis, rGender, rDataAccess).parMapN {
-          (AND, OR, NOT, id, program, user, role, partnerLink, fallbackProfile, educationalStatus, thesis, gender, hasDataAccess) =>
+        (rAND, rOR, rNOT, rId, rProgram, rUser, rRole, rPartnerLink, rPreferredProfile, rEducationalStatus, rThesis, rGender, rDataAccess).parMapN {
+          (AND, OR, NOT, id, program, user, role, partnerLink, preferredProfile, educationalStatus, thesis, gender, hasDataAccess) =>
             and(List(
               AND.map(and),
               OR.map(or),
@@ -63,7 +63,7 @@ object WhereProgramUser {
               role,
               onlyRole.map(r => Eql(path / "role", Const(r))),
               partnerLink,
-              fallbackProfile,
+              preferredProfile,
               educationalStatus,
               thesis,
               gender,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AddProgramUserResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AddProgramUserResultMapping.scala
@@ -6,12 +6,12 @@ package mapping
 
 import grackle.skunk.SkunkMapping
 
-import table.ProgramUserTable
+import table.ProgramUserView
 
-trait AddProgramUserResultMapping[F[_]] extends ProgramUserTable[F]:
+trait AddProgramUserResultMapping[F[_]] extends ProgramUserView[F]:
 
   lazy val AddProgramUserResultMapping: ObjectMapping =
     ObjectMapping(AddProgramUserResultType)(
-      SqlField("id", ProgramUserTable.ProgramUserId, key = true, hidden = true),
+      SqlField("id", ProgramUserView.ProgramUserId, key = true, hidden = true),
       SqlObject("programUser")
     )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ChangeProgramUserRoleResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ChangeProgramUserRoleResultMapping.scala
@@ -6,12 +6,12 @@ package mapping
 
 import grackle.skunk.SkunkMapping
 
-import table.ProgramUserTable
+import table.ProgramUserView
 
-trait ChangeProgramUserRoleResultMapping[F[_]] extends ProgramUserTable[F]:
+trait ChangeProgramUserRoleResultMapping[F[_]] extends ProgramUserView[F]:
 
   lazy val ChangeProgramUserRoleResultMapping: ObjectMapping =
     ObjectMapping(ChangeProgramUserRoleResultType)(
-      SqlField("id", ProgramUserTable.ProgramUserId, key = true, hidden = true),
+      SqlField("id", ProgramUserView.ProgramUserId, key = true, hidden = true),
       SqlObject("programUser")
     )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LinkUserResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LinkUserResultMapping.scala
@@ -7,13 +7,13 @@ package mapping
 
 import grackle.skunk.SkunkMapping
 
-import table.ProgramUserTable
+import table.ProgramUserView
 
-trait LinkUserResultMapping[F[_]] extends ProgramUserTable[F]  {
+trait LinkUserResultMapping[F[_]] extends ProgramUserView[F]  {
 
   lazy val LinkUserResultMapping =
     ObjectMapping(LinkUserResultType)(
-      SqlField("id", ProgramUserTable.ProgramUserId, hidden = true, key = true),
+      SqlField("id", ProgramUserView.ProgramUserId, hidden = true, key = true),
       SqlObject("user")
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramMapping.scala
@@ -48,7 +48,7 @@ trait ProgramMapping[F[_]]
   extends ProgramTable[F]
      with UserTable[F]
      with ProgramNoteTable[F]
-     with ProgramUserTable[F]
+     with ProgramUserView[F]
      with ProposalView[F]
      with ObservationView[F]
      with AttachmentTable[F]
@@ -81,8 +81,8 @@ trait ProgramMapping[F[_]]
       SqlObject("reference",  Join(ProgramTable.Id, ProgramReferenceView.Id)),
 
       SqlField("proposalStatus", ProgramTable.ProposalStatus),
-      SqlObject("pi", Join(ProgramTable.Id, ProgramUserTable.ProgramId)),
-      SqlObject("users", Join(ProgramTable.Id, ProgramUserTable.ProgramId)),
+      SqlObject("pi", Join(ProgramTable.Id, ProgramUserView.ProgramId)),
+      SqlObject("users", Join(ProgramTable.Id, ProgramUserView.ProgramId)),
       SqlObject("observations"),
       SqlObject("configurationRequests"),
       SqlObject("proposal", Join(ProgramTable.Id, ProposalView.ProgramId)),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramUserMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProgramUserMapping.scala
@@ -26,21 +26,23 @@ trait ProgramUserMapping[F[_]]
   extends ProgramTable[F]
      with UserTable[F]
      with UserInvitationTable[F]
-     with ProgramUserTable[F] { this: SkunkMapping[F] =>
+     with ProgramUserView[F] { this: SkunkMapping[F] =>
 
   lazy val ProgramUserMapping =
     ObjectMapping(ProgramUserType)(
-      SqlField("id", ProgramUserTable.ProgramUserId, key = true),
-      SqlField("programId", ProgramUserTable.ProgramId, hidden = true),
-      SqlField("userId", ProgramUserTable.UserId, hidden = true),
-      SqlField("role", ProgramUserTable.Role),
-      SqlField("linkType", ProgramUserTable.PartnerLink, hidden = true),
-      SqlField("partner", ProgramUserTable.Partner, hidden = true),
-      SqlField("educationalStatus", ProgramUserTable.EducationalStatus),
-      SqlField("thesis", ProgramUserTable.Thesis),
-      SqlField("gender", ProgramUserTable.Gender),
-      SqlField("affiliation", ProgramUserTable.Affiliation),
-      SqlField("hasDataAccess", ProgramUserTable.HasDataAccess),
+      SqlField("id", ProgramUserView.ProgramUserId, key = true),
+      SqlField("programId", ProgramUserView.ProgramId, hidden = true),
+      SqlField("userId", ProgramUserView.UserId, hidden = true),
+      SqlField("role", ProgramUserView.Role),
+      SqlField("linkType", ProgramUserView.PartnerLink, hidden = true),
+      SqlField("partner", ProgramUserView.Partner, hidden = true),
+      SqlField("educationalStatus", ProgramUserView.EducationalStatus),
+      SqlField("thesis", ProgramUserView.Thesis),
+      SqlField("gender", ProgramUserView.Gender),
+      SqlField("affiliation", ProgramUserView.Affiliation),
+      SqlField("hasDataAccess", ProgramUserView.HasDataAccess),
+      SqlField("displayName", ProgramUserView.DisplayName),
+      SqlField("email", ProgramUserView.Email),
       CursorFieldJson("partnerLink", c =>
         for {
           l <- c.fieldAs[PartnerLinkType]("linkType")
@@ -49,10 +51,10 @@ trait ProgramUserMapping[F[_]]
         } yield r.asJson,
         List("partner", "linkType")
       ),
-      SqlObject("program", Join(ProgramUserTable.ProgramId, ProgramTable.Id)),
-      SqlObject("user", Join(ProgramUserTable.UserId, UserTable.UserId)),
-      SqlObject("fallbackProfile"),
-      SqlObject("invitations", Join(ProgramUserTable.ProgramUserId, UserInvitationTable.ProgramUserId))
+      SqlObject("program", Join(ProgramUserView.ProgramId, ProgramTable.Id)),
+      SqlObject("user", Join(ProgramUserView.UserId, UserTable.UserId)),
+      SqlObject("preferredProfile"),
+      SqlObject("invitations", Join(ProgramUserView.ProgramUserId, UserInvitationTable.ProgramUserId))
     )
 
   lazy val ProgramUserElaborator: PartialFunction[(TypeRef, String, List[Binding]), Elab[Unit]] = {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProposalTypeMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProposalTypeMapping.scala
@@ -24,13 +24,13 @@ import lucuma.core.enums.ScienceSubtype
 import lucuma.core.model.IntPercent
 import lucuma.odb.graphql.predicate.Predicates
 import lucuma.odb.graphql.table.PartnerSplitTable
-import lucuma.odb.graphql.table.ProgramUserTable
+import lucuma.odb.graphql.table.ProgramUserView
 import lucuma.odb.graphql.table.ProposalView
 
 trait ProposalTypeMapping[F[_]] extends BaseMapping[F]
                                    with Predicates[F]
                                    with PartnerSplitTable[F]
-                                   with ProgramUserTable[F]
+                                   with ProgramUserView[F]
                                    with ProposalView[F] {
 
   lazy val ProposalTypeMapping: ObjectMapping =
@@ -98,8 +98,8 @@ trait ProposalTypeMapping[F[_]] extends BaseMapping[F]
       SqlField("id", ProposalView.FastTurnaround.Id, key = true, hidden = true),
       SqlField("toOActivation",   ProposalView.TooActivation),
       SqlField("minPercentTime",  ProposalView.MinPercent),
-      SqlObject("reviewer",       Join(ProposalView.FastTurnaround.ReviewerId, ProgramUserTable.ProgramUserId)),
-      SqlObject("mentor",         Join(ProposalView.FastTurnaround.MentorId, ProgramUserTable.ProgramUserId))
+      SqlObject("reviewer",       Join(ProposalView.FastTurnaround.ReviewerId, ProgramUserView.ProgramUserId)),
+      SqlObject("mentor",         Join(ProposalView.FastTurnaround.MentorId, ProgramUserView.ProgramUserId))
     )
 
   lazy val LargeProgramMapping: ObjectMapping =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/UserInvitationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/UserInvitationMapping.scala
@@ -10,7 +10,7 @@ import table.*
 
 trait UserInvitationMapping[F[_]]
   extends ProgramTable[F]
-  with ProgramUserTable[F]
+  with ProgramUserView[F]
   with UserTable[F]
   with UserInvitationTable[F]
   with EmailTable[F]:
@@ -21,6 +21,6 @@ trait UserInvitationMapping[F[_]]
       SqlField("status", UserInvitationTable.Status),
       SqlObject("issuer", Join(UserInvitationTable.IssuerId, UserTable.UserId)),
       SqlField("recipientEmail", UserInvitationTable.RecipientEmail),
-      SqlObject("programUser", Join(UserInvitationTable.ProgramUserId, ProgramUserTable.ProgramUserId)),
+      SqlObject("programUser", Join(UserInvitationTable.ProgramUserId, ProgramUserView.ProgramUserId)),
       SqlObject("email", Join(UserInvitationTable.EmailId, EmailTable.EmailId))
     )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/UserProfileMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/UserProfileMapping.scala
@@ -6,11 +6,11 @@ package mapping
 
 import grackle.Path
 import grackle.skunk.SkunkMapping
-import lucuma.odb.graphql.table.ProgramUserTable
+import lucuma.odb.graphql.table.ProgramUserView
 import lucuma.odb.graphql.table.UserProfileTable
 import lucuma.odb.graphql.table.UserTable
 
-trait UserProfileMapping[F[_]] extends UserTable[F] with ProgramUserTable[F]:
+trait UserProfileMapping[F[_]] extends UserTable[F] with ProgramUserView[F]:
 
   private def profileMappingAt(
     path:    Path,
@@ -28,5 +28,5 @@ trait UserProfileMapping[F[_]] extends UserTable[F] with ProgramUserTable[F]:
   lazy val UserProfileMappings: List[TypeMapping] =
     List(
       profileMappingAt(UserType / "profile",  UserTable.Profile, UserTable.UserId),
-      profileMappingAt(ProgramUserType / "fallbackProfile", ProgramUserTable.Fallback, ProgramUserTable.UserId)
+      profileMappingAt(ProgramUserType / "preferredProfile", ProgramUserView.Preferred, ProgramUserView.UserId)
     )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ProgramUserView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ProgramUserView.scala
@@ -9,9 +9,9 @@ import grackle.skunk.SkunkMapping
 import lucuma.odb.util.Codecs.*
 import skunk.codec.all.*
 
-trait ProgramUserTable[F[_]] extends BaseMapping[F] {
+trait ProgramUserView[F[_]] extends BaseMapping[F] {
 
-  object ProgramUserTable extends TableDef("t_program_user") {
+  object ProgramUserView extends TableDef("v_program_user") {
     val ProgramUserId     = col("c_program_user_id", program_user_id)
     val ProgramId         = col("c_program_id", program_id)
     val UserId            = col("c_user_id", user_id.opt)
@@ -23,11 +23,13 @@ trait ProgramUserTable[F[_]] extends BaseMapping[F] {
     val Gender            = col("c_gender", gender.opt)
     val Affiliation       = col("c_affiliation", varchar_nonempty.opt)
     val HasDataAccess     = col("c_has_data_access", bool)
+    val DisplayName       = col("c_display_name", varchar.opt)
+    val Email             = col("c_email", varchar.opt)
 
-    object Fallback extends UserProfileTable[ColumnRef]:
-      override val GivenName  = col("c_fallback_given_name", varchar.opt)
-      override val FamilyName = col("c_fallback_family_name", varchar.opt)
-      override val CreditName = col("c_fallback_credit_name", varchar.opt)
-      override val Email      = col("c_fallback_email", varchar.opt)  }
+    object Preferred extends UserProfileTable[ColumnRef]:
+      override val GivenName  = col("c_preferred_given_name", varchar.opt)
+      override val FamilyName = col("c_preferred_family_name", varchar.opt)
+      override val CreditName = col("c_preferred_credit_name", varchar.opt)
+      override val Email      = col("c_preferred_email", varchar.opt)  }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/service/ProgramUserService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProgramUserService.scala
@@ -75,7 +75,7 @@ trait ProgramUserService[F[_]]:
   )(using Transaction[F]): F[Result[ProgramUser.Id]]
 
   /**
-   * Updates program user properties such as fallback profile, thesis and
+   * Updates program user properties such as preferred profile, thesis and
    * gender.
    *
    * @param SET property edits to apply
@@ -629,10 +629,10 @@ object ProgramUserService:
 
       val alias = "o"
 
-      val upGivenName         = sql"c_fallback_given_name  = ${varchar.opt}"
-      val upFamilyName        = sql"c_fallback_family_name = ${varchar.opt}"
-      val upCreditName        = sql"c_fallback_credit_name = ${varchar.opt}"
-      val upEmail             = sql"c_fallback_email       = ${varchar.opt}"
+      val upGivenName         = sql"c_preferred_given_name  = ${varchar.opt}"
+      val upFamilyName        = sql"c_preferred_family_name = ${varchar.opt}"
+      val upCreditName        = sql"c_preferred_credit_name = ${varchar.opt}"
+      val upEmail             = sql"c_preferred_email       = ${varchar.opt}"
 
       val upEducationalStatus = sql"c_educational_status   = ${educational_status.opt}"
       val upThesis            = sql"c_thesis               = ${bool.opt}"
@@ -642,10 +642,10 @@ object ProgramUserService:
 
       val ups: Option[NonEmptyList[AppliedFragment]] = NonEmptyList.fromList(
         List(
-          SET.fallbackProfile.flatMap(_.givenName).foldPresent(upGivenName),
-          SET.fallbackProfile.flatMap(_.familyName).foldPresent(upFamilyName),
-          SET.fallbackProfile.flatMap(_.creditName).foldPresent(upCreditName),
-          SET.fallbackProfile.flatMap(_.email).foldPresent(upEmail),
+          SET.preferredProfile.flatMap(_.givenName).foldPresent(upGivenName),
+          SET.preferredProfile.flatMap(_.familyName).foldPresent(upFamilyName),
+          SET.preferredProfile.flatMap(_.creditName).foldPresent(upCreditName),
+          SET.preferredProfile.flatMap(_.email).foldPresent(upEmail),
           SET.educationalStatus.foldPresent(upEducationalStatus),
           SET.thesis.foldPresent(upThesis),
           SET.gender.foldPresent(upGender),

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -1968,7 +1968,7 @@ trait DatabaseOperations { this: OdbSuite =>
     pid:         Program.Id,
     role:        ProgramUserRole   = ProgramUserRole.Coi,
     partnerLink: PartnerLink       = PartnerLink.HasPartner(Partner.US),
-    fallback:    UserProfile       = UserProfile.Empty,
+    preferred:   UserProfile       = UserProfile.Empty,
     education:   EducationalStatus = EducationalStatus.PhD,
     thesis:      Boolean           = false,
     gender:      Gender            = Gender.NotSpecified
@@ -1991,11 +1991,11 @@ trait DatabaseOperations { this: OdbSuite =>
                       case _                                 => s"linkType: ${partnerLink.linkType.tag.toScreamingSnakeCase}"
                   }
                 }
-                fallbackProfile: {
-                  givenName: ${fallback.givenName.strOrNull}
-                  familyName: ${fallback.familyName.strOrNull}
-                  creditName: ${fallback.creditName.strOrNull}
-                  email: ${fallback.email.strOrNull}
+                preferredProfile: {
+                  givenName: ${preferred.givenName.strOrNull}
+                  familyName: ${preferred.familyName.strOrNull}
+                  creditName: ${preferred.creditName.strOrNull}
+                  email: ${preferred.email.strOrNull}
                 }
                 educationalStatus: ${education.tag.toScreamingSnakeCase}
                 thesis: $thesis
@@ -2016,9 +2016,9 @@ trait DatabaseOperations { this: OdbSuite =>
     partnerLink: PartnerLink, 
     email: Option[NonEmptyString] = defaultPiEmail.some
   ): IO[Unit] =
-    val fallback = email.foldMap(e =>
+    val preferred = email.foldMap(e =>
       s"""
-        fallbackProfile: {
+        preferredProfile: {
           email: "$e"
         }
       """
@@ -2041,7 +2041,7 @@ trait DatabaseOperations { this: OdbSuite =>
                     case _                                 => s"linkType: ${partnerLink.linkType.tag.toScreamingSnakeCase}"
                 }
               }
-              $fallback
+              $preferred
             }
           }) {
             programUsers { id }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addProgramUser.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addProgramUser.scala
@@ -49,7 +49,7 @@ class addProgramUser extends OdbSuite:
                 role: COI
                 SET: {
                   partnerLink: { partner: CA }
-                  fallbackProfile: {
+                  preferredProfile: {
                     givenName: "Gavrilo"
                     familyName: "Princip"
                     creditName: "Гаврило Принцип"
@@ -69,7 +69,7 @@ class addProgramUser extends OdbSuite:
                     partner
                   }
                 }
-                fallbackProfile {
+                preferredProfile {
                   givenName
                   familyName
                   creditName
@@ -92,7 +92,7 @@ class addProgramUser extends OdbSuite:
                   "linkType": "HAS_PARTNER",
                   "partner": "CA"
                 },
-                "fallbackProfile": {
+                "preferredProfile": {
                   "givenName": "Gavrilo",
                   "familyName": "Princip",
                   "creditName": "Гаврило Принцип",

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProgramUsers.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProgramUsers.scala
@@ -229,13 +229,13 @@ class updateProgramUsers extends OdbSuite:
         }
       """
 
-  def updateFallback(p: Program.Id, u: User, profile: Option[UserProfile]): String =
+  def updatePreferred(p: Program.Id, u: User, profile: Option[UserProfile]): String =
     s"""
       mutation {
         updateProgramUsers(
           input: {
             SET: {
-              fallbackProfile: ${profileInput(profile)}
+              preferredProfile: ${profileInput(profile)}
             }
             WHERE: {
               user: {
@@ -250,7 +250,7 @@ class updateProgramUsers extends OdbSuite:
           programUsers {
             program { id }
             user { id }
-            fallbackProfile {
+            preferredProfile {
               givenName
               familyName
               creditName
@@ -261,13 +261,13 @@ class updateProgramUsers extends OdbSuite:
       }
     """
 
-  def updateFallbackEmail(p: Program.Id, u: User, email: Option[String]): String =
+  def updatePreferredEmail(p: Program.Id, u: User, email: Option[String]): String =
     s"""
       mutation {
         updateProgramUsers(
           input: {
             SET: {
-              fallbackProfile: {
+              preferredProfile: {
                 email: ${quotedOption(email)}
               }
             }
@@ -284,7 +284,7 @@ class updateProgramUsers extends OdbSuite:
           programUsers {
             program { id }
             user { id }
-            fallbackProfile {
+            preferredProfile {
               email
             }
           }
@@ -375,7 +375,7 @@ class updateProgramUsers extends OdbSuite:
       )
     )
 
-  def expectedFallback(ts: (Program.Id, User, Option[UserProfile])*): Json =
+  def expectedPreferred(ts: (Program.Id, User, Option[UserProfile])*): Json =
     Json.obj(
       "updateProgramUsers" -> Json.obj(
         "programUsers" -> ts.toList.map { case (pid, user, prof) =>
@@ -383,7 +383,7 @@ class updateProgramUsers extends OdbSuite:
            Json.obj(
              "program" -> Json.obj("id" -> pid.asJson),
              "user"    -> Json.obj("id" -> user.id.asJson),
-             "fallbackProfile" -> Json.obj(
+             "preferredProfile" -> Json.obj(
                "givenName"  -> p.givenName.fold(Json.Null)(_.asJson),
                "familyName" -> p.familyName.fold(Json.Null)(_.asJson),
                "creditName" -> p.creditName.fold(Json.Null)(_.asJson),
@@ -394,14 +394,14 @@ class updateProgramUsers extends OdbSuite:
       )
     )
 
-  def expectedFallbackEmail(ts: (Program.Id, User, Option[String])*): Json =
+  def expectedPreferredEmail(ts: (Program.Id, User, Option[String])*): Json =
     Json.obj(
       "updateProgramUsers" -> Json.obj(
         "programUsers" -> ts.toList.map { case (pid, user, email) =>
            Json.obj(
              "program" -> Json.obj("id" -> pid.asJson),
              "user"    -> Json.obj("id" -> user.id.asJson),
-             "fallbackProfile" -> Json.obj(
+             "preferredProfile" -> Json.obj(
                "email" -> email.fold(Json.Null)(_.asJson)
              )
            )
@@ -533,46 +533,46 @@ class updateProgramUsers extends OdbSuite:
       "gprincip@mladabosna.org".some
     )
 
-  test("update fallback"):
+  test("update preferred"):
     createProgramAs(pi).flatMap: pid =>
       addProgramUserAs(pi, pid).flatMap: mid =>
         linkUserAs(pi, mid, pi2.id) >>
         expect(
           user     = pi,
-          query    = updateFallback(pid, pi2, GavriloPrincip.some),
-          expected = expectedFallback((pid, pi2, GavriloPrincip.some)).asRight
+          query    = updatePreferred(pid, pi2, GavriloPrincip.some),
+          expected = expectedPreferred((pid, pi2, GavriloPrincip.some)).asRight
         )
 
-  test("unset fallback"):
+  test("unset preferred"):
     createProgramAs(pi).flatMap: pid =>
       addProgramUserAs(pi, pid).flatMap: mid =>
         linkUserAs(pi, mid, pi2.id) >>
-        query(pi, updateFallback(pid, pi2, GavriloPrincip.some)) >>
+        query(pi, updatePreferred(pid, pi2, GavriloPrincip.some)) >>
           expect(
             user     = pi,
-            query    = updateFallback(pid, pi2, none),
-            expected = expectedFallback((pid, pi2, none)).asRight
+            query    = updatePreferred(pid, pi2, none),
+            expected = expectedPreferred((pid, pi2, none)).asRight
           )
 
-  test("update fallback email"):
+  test("update preferred email"):
     createProgramAs(pi).flatMap: pid =>
       addProgramUserAs(pi, pid).flatMap: mid =>
         linkUserAs(pi, mid, pi2.id) >>
         expect(
           user     = pi,
-          query    = updateFallbackEmail(pid, pi2, GavriloPrincip.email),
-          expected = expectedFallbackEmail((pid, pi2, GavriloPrincip.email)).asRight
+          query    = updatePreferredEmail(pid, pi2, GavriloPrincip.email),
+          expected = expectedPreferredEmail((pid, pi2, GavriloPrincip.email)).asRight
         )
 
-  test("unset fallback email"):
+  test("unset preferred email"):
     createProgramAs(pi).flatMap: pid =>
       addProgramUserAs(pi, pid).flatMap: mid =>
         linkUserAs(pi, mid, pi2.id) >>
-        query(pi, updateFallbackEmail(pid, pi2, GavriloPrincip.email)) >>
+        query(pi, updatePreferredEmail(pid, pi2, GavriloPrincip.email)) >>
           expect(
             user     = pi,
-            query    = updateFallbackEmail(pid, pi2, none),
-            expected = expectedFallbackEmail((pid, pi2, none)).asRight
+            query    = updatePreferredEmail(pid, pi2, none),
+            expected = expectedPreferredEmail((pid, pi2, none)).asRight
           )
 
   test("cannot update another pi's partner as a PI"):
@@ -672,6 +672,6 @@ class updateProgramUsers extends OdbSuite:
         linkUserAs(pi, mid, pi2.id) >>
         expect(
           user     = pi2,
-          query    = updateFallbackEmail(pid, pi2, GavriloPrincip.email),
-          expected = expectedFallbackEmail((pid, pi2, GavriloPrincip.email)).asRight
+          query    = updatePreferredEmail(pid, pi2, GavriloPrincip.email),
+          expected = expectedPreferredEmail((pid, pi2, GavriloPrincip.email)).asRight
         )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programUsers.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programUsers.scala
@@ -91,7 +91,7 @@ class programUsers extends OdbSuite:
   test("program user selection via id"):
     val lho = UserProfile("Lee".some, "Oswald".some, "Lee Harvey Oswald".some, "lee@oswald.co".some)
     createProgramAs(piJohn).flatMap: pid =>
-      addProgramUserAs(piJohn, pid, fallback = lho).flatMap: puid =>
+      addProgramUserAs(piJohn, pid, preferred = lho).flatMap: puid =>
         expect(
           user = staff,
           query = s"""
@@ -308,7 +308,7 @@ class programUsers extends OdbSuite:
           ) {
             matches {
               id
-              fallbackProfile { givenName }
+              preferredProfile { givenName }
             }
           }
         }
@@ -320,9 +320,9 @@ class programUsers extends OdbSuite:
 
     for
       pid  <- createProgramAs(pi2)
-      rid0 <- addProgramUserAs(pi2, pid, partnerLink = PartnerLink.HasPartner(Partner.CA), fallback = cg)
-      rid1 <- addProgramUserAs(pi2, pid, partnerLink = PartnerLink.HasPartner(Partner.UH), fallback = jwb)
-      rid2 <- addProgramUserAs(pi2, pid, partnerLink = PartnerLink.HasNonPartner, fallback = lc)
+      rid0 <- addProgramUserAs(pi2, pid, partnerLink = PartnerLink.HasPartner(Partner.CA), preferred = cg)
+      rid1 <- addProgramUserAs(pi2, pid, partnerLink = PartnerLink.HasPartner(Partner.UH), preferred = jwb)
+      rid2 <- addProgramUserAs(pi2, pid, partnerLink = PartnerLink.HasNonPartner, preferred = lc)
       _    <- linkUserAs(pi2, rid0, piCharles.id)
       _    <- linkUserAs(pi2, rid2, piLeon.id)
       _    <- expect(
@@ -335,7 +335,7 @@ class programUsers extends OdbSuite:
                        "matches": [
                          {
                            "id": $rid1,
-                           "fallbackProfile": { "givenName":  "John" }
+                           "preferredProfile": { "givenName":  "John" }
                          }
                        ]
                      }
@@ -353,15 +353,15 @@ class programUsers extends OdbSuite:
                        "matches": [
                          {
                            "id": $rid3,
-                           "fallbackProfile": { "givenName": null }
+                           "preferredProfile": { "givenName": null }
                          },
                          {
                            "id": $rid0,
-                           "fallbackProfile": { "givenName":  "Charles" }
+                           "preferredProfile": { "givenName":  "Charles" }
                          },
                          {
                            "id": $rid2,
-                           "fallbackProfile": { "givenName":  "Leon" }
+                           "preferredProfile": { "givenName":  "Leon" }
                          }
                        ]
                      }


### PR DESCRIPTION
Instead of being a fallback profile, the new idea is that the profile on the program user will override the profile on the User. Andy suggested we call it the `preferred` profile.

This PR doesn't really change any functionality, just the names of fields in the DB, code and schema.