### PR TITLE
Change chron table timestamp column type

### DIFF
--- a/modules/service/src/main/resources/db/migration/V1027__chron_table_timestamp.sql
+++ b/modules/service/src/main/resources/db/migration/V1027__chron_table_timestamp.sql
@@ -1,0 +1,55 @@
+-- ******************************
+-- t_chron_asterism_target_update
+-- ******************************
+
+ALTER TABLE t_chron_asterism_target_update
+  ALTER COLUMN c_timestamp TYPE timestamp USING c_timestamp AT TIME ZONE 'UTC';
+
+-- ************************
+-- t_chron_conditions_entry
+-- ************************
+
+DROP VIEW v_chron_conditions_entry;
+
+ALTER TABLE t_chron_conditions_entry
+  ALTER COLUMN c_timestamp TYPE timestamp USING c_timestamp AT TIME ZONE 'UTC';
+  
+CREATE OR REPLACE VIEW v_chron_conditions_entry AS
+  SELECT *,
+  CASE WHEN num_nulls(c_measurement_source, c_measurement_seeing, c_measurement_extinction_millimags, c_measurement_wavelength, c_measurement_azimuth, c_measurement_elevation) < 6 THEN c_chron_id END AS c_measurement_id,
+  CASE WHEN num_nulls(c_intuition_expectation, c_intuition_timespan, c_intuition_seeing_trend) < 3 THEN c_chron_id END AS c_intuition_id,
+  CASE WHEN num_nulls(c_intuition_expectation, c_intuition_timespan) < 2 THEN c_chron_id END AS c_expectation_id,
+  CASE WHEN c_measurement_wavelength IS NOT NULL THEN c_chron_id END AS c_wavelength_id,
+  CASE WHEN c_measurement_seeing IS NOT NULL THEN c_chron_id END AS c_measurement_seeing_id,
+  CASE WHEN c_measurement_azimuth IS NOT NULL THEN c_chron_id END AS c_measurement_pointing_id
+  FROM t_chron_conditions_entry;
+
+-- **********************
+-- t_chron_dataset_update
+-- **********************
+
+DROP VIEW v_chron_dataset_update;
+
+ALTER TABLE t_chron_dataset_update
+  ALTER COLUMN c_timestamp TYPE timestamp USING c_timestamp AT TIME ZONE 'UTC';
+
+CREATE OR REPLACE VIEW v_chron_dataset_update AS
+SELECT
+  u.*,
+
+  -- dataset interval from its constituent parts
+  (u.c_mod_start_time OR u.c_mod_end_time)     AS c_mod_interval,
+
+  COALESCE(u.c_new_start_time, d.c_start_time) AS c_coal_start_time,
+  COALESCE(u.c_new_end_time,   d.c_end_time)   AS c_coal_end_time
+FROM
+  t_chron_dataset_update u
+INNER JOIN
+  t_dataset d ON d.c_dataset_id = u.c_dataset_id;
+
+-- **********************
+-- t_chron_program_update
+-- **********************
+
+ALTER TABLE t_chron_program_update
+  ALTER COLUMN c_timestamp TYPE timestamp USING c_timestamp AT TIME ZONE 'UTC';

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/datasetChronicleEntries.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/datasetChronicleEntries.scala
@@ -6,7 +6,9 @@ package query
 
 import cats.effect.IO
 import cats.syntax.either.*
+import cats.syntax.order.*
 import cats.syntax.show.*
+import cats.syntax.traverse.*
 import eu.timepit.refined.types.numeric.PosInt
 import io.circe.Json
 import io.circe.literal.*
@@ -487,3 +489,32 @@ class datasetChronicleEntries extends OdbSuite with DatasetSetupOperations with 
           }
         """.asRight
       )
+
+  test("can read timestamp"):
+    currentTimestamp.flatMap: t =>
+      setup(8).flatMap: did =>
+        val timestamps = query(
+          staff,
+          s"""
+            query {
+              datasetChronicleEntries(WHERE: {
+                dataset: { EQ: "$did" }
+                modQaState: { EQ: true }
+              }) {
+                matches { timestamp }
+              }
+            }
+          """
+        ).flatMap: js =>
+          js.hcursor
+            .downFields("datasetChronicleEntries", "matches")
+            .values
+            .toList
+            .flatten
+            .traverse: js =>
+               js.hcursor.downField("timestamp").as[Timestamp]
+            .leftMap(f => new RuntimeException(f.message))
+            .liftTo[IO]
+            .map(_.map(_ > t)) // don't know the precise timestamp, but it should be readable and > than t
+
+        assertIO(timestamps, List(true))


### PR DESCRIPTION
* Changes the chron tables to use `timestamp` columns, since that is consistent with the `core_timestamp` and is used everywhere else.
* Fixes a bug wherein we attempt to read a dataset chronicle entry as a `core_timestamp` despite the fact that the column type was `timestamptz`.