### PR TITLE
Shortcut 6532: filter programs on cfp

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -16875,6 +16875,11 @@ input WhereProposal {
   """
   reference: WhereProposalReference
 
+  """
+  Matches on the CfP details (if any).
+  """
+  call: WhereCallForProposals
+
   #  """
   #  Matches the proposal TAC category.
   #  """

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereProposal.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereProposal.scala
@@ -9,16 +9,17 @@ import grackle.Predicate
 import grackle.Predicate.*
 import lucuma.odb.graphql.binding.*
 
-object WhereProposal {
+object WhereProposal:
 
-  def binding(path: Path): Matcher[Predicate] = {
+  def binding(path: Path): Matcher[Predicate] =
 
     val WhereTitleBinding             = WhereOptionString.binding(path / "title")
     val WhereProposalReferenceBinding = WhereProposalReference.binding(path / "reference")
+    val WhereCallForProposalsBinding  = WhereCallForProposals.binding(path / "call")
 
     lazy val WhereProposalBinding = binding(path)
 
-    ObjectFieldsBinding.rmap {
+    ObjectFieldsBinding.rmap:
       case List(
         BooleanBinding.Option("IS_NULL", rIsNull),
         WhereProposalBinding.List.Option("AND", rAND),
@@ -26,19 +27,16 @@ object WhereProposal {
         WhereProposalBinding.Option("NOT", rNOT),
         WhereTitleBinding.Option("title", rTitle),
         WhereProposalReferenceBinding.Option("reference", rRef),
+        WhereCallForProposalsBinding.Option("call", rCall)
       ) =>
-          (rIsNull, rAND, rOR, rNOT, rTitle, rRef).parMapN {
-            (isNull, AND, OR, NOT, title, ref) =>
+          (rIsNull, rAND, rOR, rNOT, rTitle, rRef, rCall).parMapN:
+            (isNull, AND, OR, NOT, title, ref, call) =>
               and(List(
                 isNull.map(IsNull(path / "program_id", _)),
                 AND.map(and),
                 OR.map(or),
                 NOT.map(Not(_)),
                 title,
-                ref
+                ref,
+                call
               ).flatten)
-        }
-    }
-  }
-
-}

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
@@ -135,18 +135,15 @@ object AccessControl:
   }
 
   /** Construct a `CheckedWithIds` (requires SuperUser access). */
-  @annotation.nowarn("msg=unused implicit parameter")
   def unchecked[A,B](SET: A, ids: List[B], enc: Encoder[B])(using SuperUserAccess): CheckedWithIds[A,B] =
     NonEmptyList.fromList(ids).fold(Checked.Empty): ids =>
       new Checked.NonEmptyWithIds(SET, ids, enc) {}
 
   /** Construct a `CheckedWithId` (requires SuperUser access). */
-  @annotation.nowarn("msg=unused implicit parameter")
   def unchecked[A,B](SET: A, id: B, enc: Encoder[B])(using SuperUserAccess): CheckedWithId[A,B] =
       new Checked.NonEmptyWithId(SET, id, enc) {}
 
   /** Construct a `Checked` (requires SuperUser access). */
-  @annotation.nowarn("msg=unused implicit parameter")
   def unchecked[A](SET: A, which: AppliedFragment)(using SuperUserAccess): Checked[A] =
     new Checked.NonEmpty(SET, which) {}
 
@@ -188,7 +185,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Select and return the ids of observations that are editable by the current user and meet
    * all the specified filters.
    */
-  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForObservationUpdateImpl(
     includeDeleted:      Option[Boolean],
     WHERE:               Option[Predicate],
@@ -210,7 +206,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Select and return the ids of observations that are clonable by the current user and meet
    * all the specified filters.
    */
-  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForObservationCloneImpl(
     includeDeleted:      Option[Boolean],
     WHERE:               Option[Predicate],
@@ -228,7 +223,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
                 Result.success(ids)
 
   /** Verify that `oid` is writable. */
-  @annotation.nowarn("msg=unused implicit parameter")
   private def verifyWritable(
     oid: Observation.Id
   )(using Services[F], NoTransaction[F]): F[Result[Unit]] =
@@ -257,7 +251,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Select and return the ids of programs that are editable by the current user and meet
    * all the specified filters.
    */
-  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForProgramUpdateImpl(
     includeDeleted: Option[Boolean],
     WHERE:          Option[Predicate]
@@ -279,7 +272,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
   /**
    * Compute the subset of `pids` that identify programs which are editable by the current user.
    */
-  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForProgramUpdateImpl(
     includeDeleted: Option[Boolean],
     pids:           List[Program.Id]
@@ -293,7 +285,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Select and return the ids of targets that are editable by the current user and meet
    * all the specified filters.
    */
-  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForTargetUpdateImpl(
     includeDeleted:      Option[Boolean],
     WHERE:               Option[Predicate],
@@ -320,7 +311,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Given an operation that defines a set of targets and a proposed edit, select and filter this
    * set based on access control policies and return a checked edit that is valid for execution.
    */
-  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: UpdateTargetsInput,
   )(using Services[F], NoTransaction[F]): F[Result[AccessControl.CheckedWithIds[TargetPropertiesInput.Edit, Target.Id]]] =
@@ -333,7 +323,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
         AccessControl.unchecked(input.SET, tids, target_id)
 
   /** Overload of `selectForObservationUpdateImpl` that takes a list of oids instead of a `Predicate`.  */
-  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForObservationUpdateImpl(
     includeDeleted:      Option[Boolean],
     oids:                List[Observation.Id],
@@ -351,7 +340,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Given an operation that defines a set of observations and a proposed edit, select and filter this
    * set based on access control policies and return a checked edit that is valid for execution.
    */
-  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: UpdateObservationsInput, 
     includeCalibrations: Boolean
@@ -393,7 +381,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Given an operation that defines a set of observations and a proposed edit, select and filter this
    * set based on access control policies and return a checked edit that is valid for execution.
    */
-  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: UpdateAsterismsInput,
     includeCalibrations: Boolean
@@ -413,7 +400,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Given an operation that defines a set of observations and a proposed edit, select and filter this
    * set based on access control policies and return a checked edit that is valid for execution.
    */
-  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: UpdateObservationsTimesInput,
     includeCalibrations: Boolean
@@ -433,7 +419,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
    * Given an operation that defines a set of observations and a proposed edit, select and filter this
    * set based on access control policies and return a checked edit that is valid for execution.
    */
-  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: SetGuideTargetNameInput,
     includeCalibrations: Boolean
@@ -647,7 +632,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
         Services.asSuperUser:
           Result(AccessControl.unchecked(input.SET, which)).pure[F]
 
-  @annotation.nowarn("msg=unused implicit parameter")
   private def selectForProgramNoteUpdateImpl(
     includeDeleted: Option[Boolean],
     WHERE:          Option[Predicate]
@@ -678,7 +662,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
              AccessControl.unchecked(input.SET, nids, program_note_id)
         })
 
-  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(
     input: CloneTargetInput
   )(using Services[F], NoTransaction[F]): F[Result[CheckedWithId[CloneTargetInput, Program.Id]]] =
@@ -729,7 +712,6 @@ trait AccessControl[F[_]] extends Predicates[F] {
       .value
 
 
-  @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(input: SetObservationWorkflowStateInput)(using Services[F], NoTransaction[F]): F[Result[CheckedWithId[(ObservationWorkflow, ObservationWorkflowState), Observation.Id]]] =
     verifyWritable(input.observationId) >>
     Services.asSuperUser:

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -690,7 +690,6 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
   private lazy val UpdateAsterisms: MutationField =
     MutationField("updateAsterisms", UpdateAsterismsInput.binding(Path.from(ObservationType))) { (input, child) =>
 
-      @annotation.nowarn("msg=unused implicit parameter")
       def selectObservations(using Services[F], NoTransaction[F]): F[Result[(AccessControl.CheckedWithIds[EditAsterismsPatchInput, Observation.Id], Query)]] =
         selectForUpdate(input, false /* exclude cals */).map { r =>
           r.flatMap { update =>

--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -243,13 +243,11 @@ object Generator {
           Md5Hash.unsafeFromByteArray(md5.digest())
         }
 
-        @annotation.nowarn("msg=unused implicit parameter")
         def checkCache(using NoTransaction[F]): EitherT[F, OdbError, Option[ExecutionDigest]] =
           EitherT.right(services.transactionally {
             executionDigestService.selectOne(oid, hash)
           })
 
-        @annotation.nowarn("msg=unused implicit parameter")
         def cache(digest: ExecutionDigest)(using NoTransaction[F]): EitherT[F, OdbError, Unit] =
           EitherT.right(services.transactionally {
             executionDigestService.insertOrUpdate(pid, oid, hash, digest)
@@ -258,7 +256,6 @@ object Generator {
 
       private object Context {
 
-        @annotation.nowarn("msg=unused implicit parameter")
         def lookup(
           pid: Program.Id,
           oid: Observation.Id
@@ -303,7 +300,6 @@ object Generator {
       )(using NoTransaction[F], Services.ServiceAccess): F[Either[OdbError, ExecutionDigest]] =
         digestWithParamsAndHash(pid, oid, when).map(_.map(_._1))
 
-      @annotation.nowarn("msg=unused implicit parameter")
       private def digestWithParamsAndHash(
         context: Context,
         when: Option[Timestamp]
@@ -332,7 +328,6 @@ object Generator {
       )(using NoTransaction[F], Services.ServiceAccess): F[Either[OdbError, ExecutionDigest]] =
         calcDigestThenCache(Context(pid, oid, asterismResults, params), when).value
 
-      @annotation.nowarn("msg=unused implicit parameter")
       private def calcDigestThenCache(
         ctx:  Context,
         when: Option[Timestamp]
@@ -401,7 +396,6 @@ object Generator {
           p <- protoExecutionConfig(ctx, g, srs, when)
         yield p
 
-      @annotation.nowarn("msg=unused implicit parameter")
       private def calcDigestFromContext(
         ctx:  Context,
         when: Option[Timestamp]
@@ -438,7 +432,6 @@ object Generator {
       )(using NoTransaction[F], Services.ServiceAccess): F[Either[OdbError, Stream[Pure, AtomDigest]]] =
         scienceAtomDigestsFromContext(Context(pid, oid, ast, params), when).value
 
-      @annotation.nowarn("msg=unused implicit parameter")
       private def scienceAtomDigestsFromContext(
         ctx:  Context,
         when: Option[Timestamp]
@@ -474,7 +467,6 @@ object Generator {
           x <- calcExecutionConfigFromContext(c, lim, when)
         } yield x).value
 
-      @annotation.nowarn("msg=unused implicit parameter")
       private def calcExecutionConfigFromContext(
         ctx:      Context,
         lim:      FutureLimit,

--- a/modules/service/src/main/scala/lucuma/odb/service/AttachmentFileService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AttachmentFileService.scala
@@ -117,7 +117,6 @@ object AttachmentFileService {
       EitherT.right(fa)
 
   extension [F[_]](svcs: Services[F])
-    @annotation.nowarn("msg=unused implicit parameter")
     def transactionallyEitherT[A](
       fa: (Transaction[F], Services[F]) ?=> EitherT[F, AttachmentException, A]
     )(using

--- a/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
@@ -302,7 +302,6 @@ object GuideService {
   )(using Services[F]): GuideService[F] =
     new GuideService[F] {
 
-      @annotation.nowarn("msg=unused implicit parameter")
       def getAsterism(pid: Program.Id, oid: Observation.Id)(using
         NoTransaction[F], SuperUserAccess
       ): F[Result[NonEmptyList[Target]]] =
@@ -316,7 +315,6 @@ object GuideService {
               .toResult(generalError(s"No targets have been defined for observation $oid.").asProblem)
           )
 
-      @annotation.nowarn("msg=unused implicit parameter")
       def getObservationInfo(oid: Observation.Id)(using
         NoTransaction[F]
       ): F[Result[ObservationInfo]] = {
@@ -330,7 +328,6 @@ object GuideService {
           )
       }
 
-      @annotation.nowarn("msg=unused implicit parameter")
       def getAvailabilityHash(pid: Program.Id, oid: Observation.Id)(using
         NoTransaction[F]
       ): F[Option[Md5Hash]] = {
@@ -350,7 +347,6 @@ object GuideService {
           .use(_.execute(af.argument).void)
       }
 
-      @annotation.nowarn("msg=unused implicit parameter")
       def getAvailabilityPeriods(pid: Program.Id, oid: Observation.Id)(using
         NoTransaction[F]
       ): F[List[AvailabilityPeriod]] = {
@@ -390,7 +386,6 @@ object GuideService {
           .use(_.option(af.argument))
           .map(_.fold(OdbError.InvalidObservation(oid).asFailure)(_.success))
 
-      @annotation.nowarn("msg=unused implicit parameter")
       def getFromCacheOrEmpty(pid: Program.Id, oid: Observation.Id, newHash: Md5Hash)(
         using NoTransaction[F]
       ): F[ContiguousTimestampMap[List[Angle]]] =

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -277,7 +277,6 @@ object ItcService {
         } yield r).value
 
       // Selects the parameters then selects the previously stored result set, if any.
-      @annotation.nowarn("msg=unused implicit parameter")
       private def attemptLookup(
         pid: Program.Id,
         oid: Observation.Id
@@ -372,7 +371,6 @@ object ItcService {
             go(lucuma.odb.sequence.flamingos2.MinAcquisitionExposureTime,
                lucuma.odb.sequence.flamingos2.MaxAcquisitionExposureTime)
 
-      @annotation.nowarn("msg=unused implicit parameter")
       private def callRemoteItc(
         targets: ItcInput
       )(using NoTransaction[F]): F[Either[OdbError, AsterismResults]] =

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -343,7 +343,6 @@ object ObservationWorkflowService {
                 }
             .toMap
 
-      @annotation.nowarn("msg=unused implicit parameter")
       // Computes the observation execution state if not cached
       private def executionStates(
         infos:      Map[Observation.Id, ObservationValidationInfo],
@@ -671,7 +670,6 @@ object ObservationWorkflowService {
           .flatMap: oids =>
             filterState(oids, states, commitHash, itcClient, ptc)
 
-      @annotation.nowarn("msg=unused implicit parameter")
       private def getObservationsForTargets(whichTargets: AppliedFragment)(using NoTransaction[F]): F[Map[Target.Id, List[Observation.Id]]] =
         services.transactionally:
           val af = Statements.selectObservationsForTargets(whichTargets)

--- a/modules/service/src/main/scala/lucuma/odb/service/Services.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/Services.scala
@@ -408,7 +408,6 @@ object Services:
 
     extension [F[_]: MonadCancelThrow, A](s: Resource[F, Services[F]])
 
-      @annotation.nowarn("msg=unused implicit parameter")
       def useTransactionally(fa: (Transaction[F], Services[F]) ?=> F[A])(
         using NoTransaction[F], NotGiven[Services[F]] // discourage nested calls
       ): F[A] =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programs.scala
@@ -319,4 +319,49 @@ class programs extends OdbSuite {
       }
     }
 
+  test("program selection via cfp"):
+    for
+      cid0 <- createCallForProposalsAs(staff)
+      cid1 <- createCallForProposalsAs(staff)
+      pid0 <- createProgramAs(pi, "CfP Test 0")
+      pid1 <- createProgramAs(pi, "CfP Test 1")
+      pid2 <- createProgramAs(pi, "CfP Test 2")
+      _    <- addProposal(pi, pid0, cid0.some)
+      _    <- addProposal(pi, pid1, cid1.some)
+      _    <- addProposal(pi, pid2, cid0.some)
+      _    <- expect(
+                user     = pi,
+                query    = s"""
+                  query {
+                    programs(
+                      WHERE: {
+                        proposal: {
+                          call: {
+                            id: { EQ: "$cid0" }
+                          }
+                        }
+                      }
+                    ) {
+                      matches { id }
+                    }
+                  }
+                """,
+                expected =
+                  json"""
+                    {
+                      "programs": {
+                        "matches": [
+                          {
+                            "id": ${pid0.asJson}
+                          },
+                          {
+                            "id": ${pid2.asJson}
+                          }
+                        ]
+                      }
+                    }
+                  """.asRight
+              )
+    yield ()
+
 }


### PR DESCRIPTION
Two unrelated items:

* Adds a `call` (for "call for proposals") field to `WhereProposal`
* Cleans up a bunch of left over warnings from the recent Scala update.