### PR TITLE
Shortcut 6531: Handle `null` instrument

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/VisitService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/VisitService.scala
@@ -102,7 +102,7 @@ object VisitService:
       ): ResultT[F, ObsDescription] =
         ResultT:
           session.option(Statements.SelectObsDescription)(observationId).map: od =>
-            Result.fromOption(od, OdbError.InvalidObservation(observationId, s"Observation '$observationId' not found.".some).asProblem)
+            Result.fromOption(od, OdbError.InvalidObservation(observationId, s"Observation '$observationId' not found or is not associated with any instrument.".some).asProblem)
 
 
       override def lookupOrInsert(
@@ -302,6 +302,7 @@ object VisitService:
                c_calibration_role
           FROM t_observation
          WHERE c_observation_id=$observation_id
+           AND c_instrument IS NOT NULL
       """.query(obs_description)
 
     val InsertVisit: Query[(Observation.Id, ObsDescription), Visit.Id] =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addSlewEvent.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addSlewEvent.scala
@@ -90,7 +90,7 @@ class addSlewEvent extends OdbSuite:
       """.asRight
     )
 
-  test("addSlewEvent - unknown visit"):
+  test("addSlewEvent - unknown observation"):
     def query: String =
       s"""
         mutation {
@@ -111,8 +111,16 @@ class addSlewEvent extends OdbSuite:
       ObservingModeType.GmosNorthLongSlit,
       service,
       _ => query,
-      _ => s"Observation 'o-42' not found.".asLeft
+      _ => s"Observation 'o-42' not found or is not associated with any instrument.".asLeft
     )
+
+  test("addSlewEvent - no instrument"):
+    for
+      pid <- createProgramAs(pi)
+      oid <- createObservationAs(pi, pid)
+      _   <- interceptGraphQL(s"Observation '$oid' not found or is not associated with any instrument."):
+               addSlewEventAs(service, oid, SlewStage.StartSlew)
+    yield ()
 
   def visits(o: Observation.Id): IO[List[(Visit.Id, ObservingNight)]] =
     query(


### PR DESCRIPTION
An exception in the production logs revealed that we do not try to prevent recording a visit for an observation that is not associated with any instrument (i.e., has no observing mode).  In order to collect data, an observing mode is necessary.  This PR will filter out observations that have no associated instrument.