### PR TITLE
Shortcut 6553: fix column type

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ProgramUserView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ProgramUserView.scala
@@ -23,7 +23,7 @@ trait ProgramUserView[F[_]] extends BaseMapping[F] {
     val Gender            = col("c_gender", gender.opt)
     val Affiliation       = col("c_affiliation", varchar_nonempty.opt)
     val HasDataAccess     = col("c_has_data_access", bool)
-    val DisplayName       = col("c_display_name", varchar.opt)
+    val DisplayName       = col("c_display_name", text.opt)
     val Email             = col("c_email", varchar.opt)
 
     object Preferred extends UserProfileTable[ColumnRef]:

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/programUsers.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/programUsers.scala
@@ -49,6 +49,7 @@ class programUsers extends OdbSuite:
   val piJohn  = TestUsers.Standard(
     11,
     StandardRole.Pi(Gid[StandardRole.Id].fromLong.getOption(11).get),
+    familyName = "Booth".some,
     email = "john@wilkes.net".some
   )
 
@@ -369,3 +370,33 @@ class programUsers extends OdbSuite:
                  """.asRight
              )
     yield ()
+
+  test("diplay name"):
+    expect(
+      user = staff,
+      query = s"""
+        query {
+          programUsers(
+              WHERE: {
+                user: { id: { EQ: "${piJohn.id}" } }
+              }
+          ) {
+            matches {
+              displayName
+            }
+          }
+        }
+      """,
+      expected =
+        json"""
+          {
+            "programUsers": {
+              "matches": [
+                {
+                  "displayName": "Booth"
+                }
+              ]
+            }
+          }
+        """.asRight
+      )


### PR DESCRIPTION
The `c_display_name` field of the `v_program_user` view was incorrectly identified as `varchar` instead of `text`.