### PR TITLE
Shortcut 6747: allow program ref in `setAllocations` input

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4458,10 +4458,14 @@ input ScienceRequirementsInput {
 
 """
 Describes the program allocations.  Each partner and band combination should
-appear at most once in the 'allocations' array.
+appear at most once in the 'allocations' array. One of programId,
+programReference or proposalReference is required. (If two or more are provided,
+they must refer to the same program.)
 """
 input SetAllocationsInput {
-  programId: ProgramId!
+  programId: ProgramId
+  proposalReference: ProposalReferenceLabel
+  programReference: ProgramReferenceLabel
   allocations: [AllocationInput!]!
 }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
@@ -594,16 +594,11 @@ trait AccessControl[F[_]] extends Predicates[F] {
     input: SetAllocationsInput
   )(using Services[F]): F[Result[AccessControl.CheckedWithId[List[AllocationInput], Program.Id]]] =
     requireStaffAccess:
-      programService(emailConfig, httpClient)
-        .resolvePid(input.programId, input.proposalReference, input.programReference)
-        .map: r =>
-          r.map: pid =>
-            Services.asSuperUser:
-              AccessControl.unchecked(input.allocations, pid, program_id)
-
-//    requireStaffAccess: // this is the only check
-//      Services.asSuperUser:
-//        Result(AccessControl.unchecked(input.allocations, input.programId, program_id)).pure[F]
+      ResultT(programService(emailConfig, httpClient).resolvePid(input.programId, input.proposalReference, input.programReference))
+        .map: pid =>
+          Services.asSuperUser:
+            AccessControl.unchecked(input.allocations, pid, program_id)
+        .value
 
   @annotation.nowarn("msg=unused implicit parameter")
   def selectForUpdate(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -645,11 +645,11 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
   private lazy val SetAllocations =
     MutationField("setAllocations", SetAllocationsInput.Binding): (input, child) =>
       services.useTransactionally:
-        selectForUpdate(input).flatMap: r =>
-          r.flatTraverse: checked =>
-            allocationService.setAllocations(checked).map: rpid =>
-              rpid.flatMap: pid =>
-                allocationResultSubquery(pid, child)
+        (for
+          c <- ResultT(selectForUpdate(input))
+          p <- ResultT(allocationService.setAllocations(c))
+          q <- ResultT.fromResult(allocationResultSubquery(p, child))
+        yield q).value
 
   private lazy val SetGuideTargetName = 
     MutationField("setGuideTargetName", SetGuideTargetNameInput.Binding): (input, child) =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -647,9 +647,9 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
       services.useTransactionally:
         selectForUpdate(input).flatMap: r =>
           r.flatTraverse: checked =>
-            allocationService.setAllocations(checked).map(_ *>
-              allocationResultSubquery(input.programId, child)
-            )
+            allocationService.setAllocations(checked).map: rpid =>
+              rpid.flatMap: pid =>
+                allocationResultSubquery(pid, child)
 
   private lazy val SetGuideTargetName = 
     MutationField("setGuideTargetName", SetGuideTargetNameInput.Binding): (input, child) =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setAllocations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setAllocations.scala
@@ -8,10 +8,13 @@ import cats.data.Ior
 import cats.effect.IO
 import cats.syntax.all.*
 import io.circe.literal.*
+import lucuma.core.enums.CallForProposalsType.DemoScience
 import lucuma.core.enums.Partner
 import lucuma.core.enums.ScienceBand
 import lucuma.core.enums.TimeAccountingCategory
 import lucuma.core.model.Observation
+import lucuma.core.model.ProgramReference
+import lucuma.core.model.Semester
 import lucuma.core.model.User
 import lucuma.core.syntax.timespan.*
 import lucuma.core.util.TimeSpan
@@ -237,5 +240,57 @@ class setAllocations extends OdbSuite {
     } yield ()
 
   }
+
+  test("set allocations with a proposal reference"):
+    val ref = for
+      cid <- createCallForProposalsAs(staff, DemoScience, Semester.unsafeFromString("2025A"))
+      pid <- createProgramWithUsPi(pi)
+      _   <- addDemoScienceProposal(pi, pid, cid)
+      _   <- submitProposal(pi, pid)
+      ref <- acceptProposal(staff, pid)
+    yield ref
+
+    def query(r: ProgramReference): String =
+      s"""
+          mutation {
+            setAllocations(input: {
+              programReference: "${r.label}"
+              allocations: [
+                {
+                  category: US
+                  scienceBand: BAND2
+                  duration: { hours: "1.23" }
+                }
+              ]
+            }) {
+              allocations {
+                category
+                scienceBand
+                duration { hours }
+              }
+            }
+          }
+      """
+
+    ref.flatMap: r =>
+      expect(
+        user    = staff,
+        query   = query(r.get),
+        expected = json"""
+          {
+            "setAllocations" : {
+              "allocations" : [
+                {
+                  "category" : "US",
+                  "scienceBand" : "BAND2",
+                  "duration" : {
+                    "hours" : 1.230000
+                  }
+                }
+              ]
+            }
+          }
+        """.asRight
+      )
 
 }


### PR DESCRIPTION
Per request, adds the option the use a program reference in the `setAllocations` input.