### PR TITLE
Shortcut 6589: cornucopia of steps issue

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/data/StepExecutionState.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/data/StepExecutionState.scala
@@ -36,4 +36,7 @@ enum StepExecutionState(val tag: String) derives Enumerated:
       case Aborted | Stopped | Abandoned => completedFailure
       case Completed                     => completedSuccess
 
+  def isTerminal: Boolean =
+    fold(false, true, true)
+
 end StepExecutionState

--- a/modules/service/src/main/resources/db/migration/V1035__no_abandoned_atoms.sql
+++ b/modules/service/src/main/resources/db/migration/V1035__no_abandoned_atoms.sql
@@ -1,0 +1,7 @@
+-- We are removing the idea that atoms are abandoned.  Atoms are complete when
+-- no more steps will be executed regardless of which steps may have once been
+-- prescribed for that atom.
+
+UPDATE t_atom_record
+   SET c_execution_state = 'completed'
+ WHERE c_execution_state = 'abandoned';

--- a/modules/service/src/main/scala/lucuma/odb/data/AtomExecutionState.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/AtomExecutionState.scala
@@ -18,8 +18,11 @@ enum AtomExecutionState(val tag: String) derives Enumerated:
   /** Atom events have arrived, but none are terminal. */
   case Ongoing     extends AtomExecutionState("ongoing")
 
-  /** The atom ended with END_ATOM. */
+  /** The atom ended and no more steps will be executed. */
   case Completed   extends AtomExecutionState("completed")
 
-  /** The atom execution was abandoned. */
+  /**
+   * The atom execution was abandoned.
+   * @deprecated("no longer used and will be removed")
+   */
   case Abandoned  extends AtomExecutionState("abandoned")

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
@@ -237,7 +237,7 @@ object ExecutionEventService {
               for
                 _ <- ResultT.liftF(services.sequenceService.setAtomExecutionState(aid, AtomStage.StartAtom))
                 _ <- ResultT.liftF(services.sequenceService.setStepExecutionState(input.stepId, input.stepStage, time))
-                _ <- ResultT.liftF(services.sequenceService.abandonOngoingStepsExcept(oid, aid, input.stepId))
+                _ <- ResultT.liftF(services.sequenceService.abandonOngoingStepsExcept(oid, aid, input.stepId.some))
                 _ <- ResultT.liftF(timeAccountingService.update(vid))
               yield eid
             else

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
@@ -9,6 +9,7 @@ import cats.syntax.applicativeError.*
 import cats.syntax.apply.*
 import cats.syntax.flatMap.*
 import cats.syntax.functor.*
+import cats.syntax.option.*
 import cats.syntax.show.*
 import fs2.Stream
 import grackle.Result
@@ -137,7 +138,7 @@ object ExecutionEventService {
         def invalidDataset: OdbError.InvalidDataset =
           OdbError.InvalidDataset(input.datasetId, Some(s"Dataset '${input.datasetId.show}' not found"))
 
-        val insert: F[Result[(Id, Timestamp, Visit.Id, Boolean)]] =
+        val insert: F[Result[(Id, Timestamp, Observation.Id, Visit.Id, Atom.Id, Step.Id, Boolean)]] =
           session
             .option(Statements.InsertDatasetEvent)(input)
             .map(_.toResult(invalidDataset.asProblem))
@@ -163,11 +164,11 @@ object ExecutionEventService {
             case _                        => ().pure
 
         ResultT(insert)
-          .flatMap: (eid, time, vid, wasInserted) =>
+          .flatMap: (eid, time, oid, vid, aid, sid, wasInserted) =>
             if wasInserted then
               ResultT.liftF:
-                services.sequenceService.abandonOngoingStepsExcept(oid, aid, sid.some)) *>
-                setDatasetTime(time)                                                    *>
+                services.sequenceService.abandonOngoingStepsExcept(oid, aid, sid.some) *>
+                setDatasetTime(time)                                                   *>
                 timeAccountingService.update(vid).as(eid)
             else
               ResultT.pure(eid)
@@ -193,7 +194,7 @@ object ExecutionEventService {
             if wasInserted then
               ResultT.liftF:
                 for
-                  _ <- sservices.sequenceService.abandonOngoingSteps(oid).whenA(input.command.isTerminal)
+                  _ <- services.sequenceService.abandonOngoingSteps(oid).whenA(input.command.isTerminal)
                   _ <- timeAccountingService.update(input.visitId)
                 yield eid
             else
@@ -328,7 +329,7 @@ object ExecutionEventService {
       """.query(execution_event_id *: observation_id *: visit_id *: bool)
          .contramap(in => (in.atomId, in.atomStage, in.clientId, in.atomId))
 
-    val InsertDatasetEvent: Query[AddDatasetEventInput, (Id, Timestamp, Visit.Id, Boolean)] =
+    val InsertDatasetEvent: Query[AddDatasetEventInput, (Id, Timestamp, Observation.Id, Visit.Id, Atom.Id, Step.Id, Boolean)] =
       sql"""
         INSERT INTO t_execution_event (
           c_event_type,
@@ -364,9 +365,12 @@ object ExecutionEventService {
         RETURNING
           c_execution_event_id,
           c_received,
+          c_observation_id,
           c_visit_id,
+          c_atom_id,
+          c_step_id,
           xmax = 0 AS inserted
-      """.query(execution_event_id *: core_timestamp *: visit_id *: bool)
+      """.query(execution_event_id *: core_timestamp *: observation_id *: visit_id *: atom_id *: step_id *: bool)
          .contramap(in => (in.datasetId, in.datasetStage, in.clientId, in.datasetId))
 
     val InsertSequenceEvent: Query[AddSequenceEventInput, (Id, Observation.Id, Boolean)] =

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
@@ -123,7 +123,7 @@ object ExecutionEventService {
               ResultT.liftF:
                 for
                   _ <- services.sequenceService.setAtomExecutionState(input.atomId, input.atomStage)
-                  _ <- services.sequenceService.abandonOngoingAtomsExcept(oid, input.atomId)
+                  _ <- services.sequenceService.abandonOngoingStepsExcept(oid, input.atomId, none)
                   _ <- timeAccountingService.update(vid)
                 yield eid
             else
@@ -166,7 +166,8 @@ object ExecutionEventService {
           .flatMap: (eid, time, vid, wasInserted) =>
             if wasInserted then
               ResultT.liftF:
-                setDatasetTime(time) *>
+                services.sequenceService.abandonOngoingStepsExcept(oid, aid, sid.some)) *>
+                setDatasetTime(time)                                                    *>
                 timeAccountingService.update(vid).as(eid)
             else
               ResultT.pure(eid)
@@ -192,7 +193,7 @@ object ExecutionEventService {
             if wasInserted then
               ResultT.liftF:
                 for
-                  _ <- services.sequenceService.abandonAtomsAndStepsForObservation(oid).whenA(input.command.isTerminal)
+                  _ <- sservices.sequenceService.abandonOngoingSteps(oid).whenA(input.command.isTerminal)
                   _ <- timeAccountingService.update(input.visitId)
                 yield eid
             else

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/6589.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/6589.scala
@@ -9,6 +9,7 @@ import cats.syntax.either.*
 import cats.syntax.eq.*
 import cats.syntax.traverse.*
 import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.enums.AtomStage
 import lucuma.core.enums.DatasetQaState
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.ObserveClass
@@ -114,11 +115,19 @@ class ShortCut_6589 extends ExecutionTestSupportForGmos:
       .flatMap: s =>
         assertIOBoolean(nextAtomId(s.o).map(_ =!= s.g))
 
-  test("... but not if there was a failed step."):
+  test("... but not if there was a failed step"):
     Setup
       .init(20)
       .flatMap: s =>
         setQaState(s.d, DatasetQaState.Usable) *>
+        assertIO(nextAtomId(s.o), s.g)
+
+  test("... even if there is an end atom event"):
+    Setup
+      .init(25)
+      .flatMap: s =>
+        addAtomEventAs(serviceUser, s.a, AtomStage.EndAtom) *>
+        setQaState(s.d, DatasetQaState.Usable)              *>
         assertIO(nextAtomId(s.o), s.g)
 
   def nextAtomStepTypes(o: Observation.Id): IO[List[StepType]] =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addAtomEvent.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addAtomEvent.scala
@@ -12,6 +12,7 @@ import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.AtomStage
 import lucuma.core.enums.ObservingModeType
+import lucuma.core.enums.SequenceCommand
 import lucuma.core.enums.StepStage
 import lucuma.core.model.Client
 import lucuma.core.model.Observation
@@ -31,12 +32,12 @@ class addAtomEvent extends OdbSuite with ExecutionState:
     mode: ObservingModeType,
     user: User
   ):IO[(Observation.Id, Atom.Id)] =
-    for {
+    for
       pid <- createProgramAs(user)
       oid <- createObservationAs(user, pid, mode.some)
       vid <- recordVisitAs(user, mode.instrument, oid)
       aid <- recordAtomAs(user, mode.instrument, vid)
-    } yield (oid, aid)
+    yield (oid, aid)
 
   private def addAtomEventTest(
     mode:     ObservingModeType,
@@ -44,11 +45,11 @@ class addAtomEvent extends OdbSuite with ExecutionState:
     query:    Atom.Id => String,
     expected: (Observation.Id, Atom.Id) => Either[String, Json]
   ): IO[Unit] =
-    for {
+    for
       ids <- recordAtom(mode, user)
       (oid, aid) = ids
       _   <- expect(user, query(aid), expected(oid, aid).leftMap(s => List(s)))
-    } yield ()
+    yield ()
 
   private def addAtomEventQuery(
     aid:   Atom.Id,
@@ -73,7 +74,7 @@ class addAtomEvent extends OdbSuite with ExecutionState:
       }
     """
 
-  test("addAtomEvent") {
+  test("addAtomEvent"):
     addAtomEventTest(
       ObservingModeType.GmosNorthLongSlit,
       service,
@@ -95,43 +96,21 @@ class addAtomEvent extends OdbSuite with ExecutionState:
       """.asRight
     )
 
-  }
-
-  test("addAtomEvent - unknown atom") {
+  test("addAtomEvent - unknown atom"):
     addAtomEventTest(
       ObservingModeType.GmosNorthLongSlit,
       service,
       _ => addAtomEventQuery(Atom.Id.parse("a-cfebc981-db7e-4c35-964d-6b19aa5ed2d7").get, AtomStage.StartAtom),
       (_, _) => s"Atom 'a-cfebc981-db7e-4c35-964d-6b19aa5ed2d7' not found".asLeft
     )
-  }
 
-  test("addAtomEvent - once terminal, state doesn't change") {
+  test("addAtomEvent - abandon atom"):
     val user = service
     val mode = ObservingModeType.GmosNorthLongSlit
 
     import AtomExecutionState.*
 
-    for {
-      pid  <- createProgramAs(user)
-      oid  <- createObservationAs(user, pid, mode.some)
-      vid  <- recordVisitAs(user, mode.instrument, oid)
-      aid0 <- recordAtomAs(user, mode.instrument, vid)
-      aid1 <- recordAtomAs(user, mode.instrument, vid)
-      _    <- addAtomEventAs(user, aid0, AtomStage.StartAtom)
-      _    <- addAtomEventAs(user, aid1, AtomStage.StartAtom)
-      _    <- addAtomEventAs(user, aid0, AtomStage.EndAtom)  // but remains abandoned
-      res  <- atomExecutionState(user, oid)
-    } yield assertEquals(res, List(Abandoned, Abandoned))
-  }
-
-  test("addAtomEvent - abandon atom") {
-    val user = service
-    val mode = ObservingModeType.GmosNorthLongSlit
-
-    import AtomExecutionState.*
-
-    for {
+    for
       pid  <- createProgramAs(user)
       oid  <- createObservationAs(user, pid, mode.some)
       vid  <- recordVisitAs(user, mode.instrument, oid)
@@ -139,18 +118,73 @@ class addAtomEvent extends OdbSuite with ExecutionState:
       aid1 <- recordAtomAs(user, mode.instrument, vid)
       aid2 <- recordAtomAs(user, mode.instrument, vid)
       _    <- addAtomEventAs(user, aid0, AtomStage.StartAtom) // 0 -> Ongoing
-      _    <- addAtomEventAs(user, aid1, AtomStage.StartAtom) // 0 -> Abandoned, 1 -> Ongoing
-      _    <- addAtomEventAs(user, aid1, AtomStage.EndAtom)   // 0 -> Abandoned, 1 -> Completed
-      _    <- addAtomEventAs(user, aid2, AtomStage.StartAtom) // 0 -> Abandoned, 1 -> Completed, 2 -> Ongoing
+      _    <- addAtomEventAs(user, aid1, AtomStage.StartAtom) // 0 -> Completed, 1 -> Ongoing
+      _    <- addAtomEventAs(user, aid1, AtomStage.EndAtom)   // 0 -> Completed, 1 -> Completed
+      _    <- addAtomEventAs(user, aid2, AtomStage.StartAtom) // 0 -> Completed, 1 -> Completed, 2 -> Ongoing
       res  <- atomExecutionState(user, oid)
-    } yield assertEquals(res, List(Abandoned, Completed, Ongoing))
-  }
+    yield assertEquals(res, List(Completed, Completed, Ongoing))
 
-  test("addAtomEvent - abandon step") {
+  test("start step starts atom without atom events"):
     val user = service
     val mode = ObservingModeType.GmosNorthLongSlit
 
-    for {
+    import AtomExecutionState.*
+
+    for
+      pid <- createProgramAs(user)
+      oid <- createObservationAs(user, pid, mode.some)
+      vid <- recordVisitAs(user, mode.instrument, oid)
+      aid <- recordAtomAs(user, mode.instrument, vid)
+      sid <- recordStepAs(user, mode.instrument, aid)
+      _   <- addStepEventAs(user, sid, StepStage.StartStep)
+      res <- atomExecutionState(user, oid)
+    yield assertEquals(res, List(Ongoing))
+
+  test("start step re-starts completed atom"):
+    val user = service
+    val mode = ObservingModeType.GmosNorthLongSlit
+
+    import AtomExecutionState.*
+
+    for
+      pid  <- createProgramAs(user)
+      oid  <- createObservationAs(user, pid, mode.some)
+      vid  <- recordVisitAs(user, mode.instrument, oid)
+      aid  <- recordAtomAs(user, mode.instrument, vid)
+      sid0 <- recordStepAs(user, mode.instrument, aid)
+      _    <- addStepEventAs(user, sid0, StepStage.StartStep)
+      _    <- addAtomEventAs(user, aid, AtomStage.EndAtom)
+      res0 <- atomExecutionState(user, oid)
+      sid1 <- recordStepAs(user, mode.instrument, aid)
+      _    <- addStepEventAs(user, sid1, StepStage.StartStep)
+      res1 <- atomExecutionState(user, oid)
+    yield
+      assertEquals(res0, List(Completed))
+      assertEquals(res1, List(Ongoing))
+
+  test("terminal sequence events complete atoms"):
+    val user = service
+    val mode = ObservingModeType.GmosNorthLongSlit
+
+    import AtomExecutionState.*
+
+    for
+      pid <- createProgramAs(user)
+      oid <- createObservationAs(user, pid, mode.some)
+      vid <- recordVisitAs(user, mode.instrument, oid)
+      aid <- recordAtomAs(user, mode.instrument, vid)
+      sid <- recordStepAs(user, mode.instrument, aid)
+      _   <- addStepEventAs(user, sid, StepStage.StartStep)
+      _   <- addSequenceEventAs(user, vid, SequenceCommand.Stop)
+      res <- atomExecutionState(user, oid)
+    yield
+      assertEquals(res, List(Completed))
+
+  test("addAtomEvent - abandon step"):
+    val user = service
+    val mode = ObservingModeType.GmosNorthLongSlit
+
+    for
       pid  <- createProgramAs(user)
       oid  <- createObservationAs(user, pid, mode.some)
       vid  <- recordVisitAs(user, mode.instrument, oid)
@@ -162,11 +196,9 @@ class addAtomEvent extends OdbSuite with ExecutionState:
       _    <- addAtomEventAs(user, aid1, AtomStage.StartAtom)
       resA <- atomExecutionState(user, oid)
       resS <- stepExecutionState(user, oid)
-    } yield {
-      assertEquals(resA, List(AtomExecutionState.Abandoned, AtomExecutionState.Ongoing))
+    yield
+      assertEquals(resA, List(AtomExecutionState.Completed, AtomExecutionState.Ongoing))
       assertEquals(resS, List(StepExecutionState.Abandoned))
-    }
-  }
 
   test("addAtomEvent - client id"):
     val user = service

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addSequenceEvent.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addSequenceEvent.scala
@@ -143,7 +143,7 @@ class addSequenceEvent extends OdbSuite with ExecutionState {
       resA <- atomExecutionState(user, oid)
       resS <- stepExecutionState(user, oid)
     } yield {
-      assertEquals(resA, List(AtomExecutionState.Completed, AtomExecutionState.Abandoned))
+      assertEquals(resA, List(AtomExecutionState.Completed, AtomExecutionState.Completed))
       assertEquals(resS, List(StepExecutionState.Completed, StepExecutionState.Abandoned))
     }
   }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addStepEvent.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/addStepEvent.scala
@@ -181,7 +181,7 @@ class addStepEvent extends OdbSuite with ExecutionState {
       resA <- atomExecutionState(user, oid)
       resS <- stepExecutionState(user, oid)
     } yield {
-      assertEquals(resA, List(AtomExecutionState.Abandoned, AtomExecutionState.Ongoing))
+      assertEquals(resA, List(AtomExecutionState.Completed, AtomExecutionState.Ongoing))
       assertEquals(resS, List(StepExecutionState.Abandoned, StepExecutionState.Ongoing))
     }
   }


### PR DESCRIPTION
Addresses the "cornucopia" issue (see shortcut description and diagnosis) by essentially deprecating the abandoned atom concept and making atom events optional.  Atoms are `NOT_STARTED`, `ONGOING` or `COMPLETED` but never `ABANDONED` (regardless of how many steps might be left on the table).  If we couple this with _simply no longer sending atom events_ it should solve the cornucopia issue.  The question for, I think, @rpiaggio is whether this is acceptable.

For now, the `ABANDONED` atom execution state will remain in the API but would be removed in a subsequent PR.  Atoms are only marked complete when an event associated with a _different_ atom arrives or a terminal sequence event for the observation arrives.  If neither of these occur, the atom remains `ONGOING`.  This has no impact on time accounting or sequence generation but might be an issue for the sequence displays in Explore and Observe?