### PR TITLE
Fix issues with group minimum and maximum intervals

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GroupPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GroupPropertiesInput.scala
@@ -75,7 +75,7 @@ object GroupPropertiesInput {
         (rName, rDescription, rMinimumRequired, rOrdered, rMinimumInterval, rMaximumInterval, rParentGroup, rParentGroupIndex, rExistence).parTupled.flatMap {
           (name, description, minimumRequired, ordered, minimumInterval, maximumInterval, parentGroup, parentGroupIndex, existence) =>
             (minimumInterval, maximumInterval) match
-              case (Some(min), Some(max)) if max <= min => Matcher.validationFailure("Minimum interval must be less than maximum interval.")
+              case (Some(min), Some(max)) if max < min => Matcher.validationFailure("Minimum interval must be less than or equal maximum interval.")
               case _ =>
                 Result(Create(
                   name, 
@@ -107,7 +107,7 @@ object GroupPropertiesInput {
         (rName, rDescription, rMinimumRequired, rOrdered, rMinimumInterval, rMaximumInterval, rParentGroup, rParentGroupIndex, rExistence).parTupled.flatMap {
           (name, description, minimumRequired, ordered, minimumInterval, maximumInterval, parentGroup, parentGroupIndex, existence) =>
             (minimumInterval.toOption, maximumInterval.toOption) match // Scala can't typecheck it if we match Nullable.NonNull for some reason :-\
-              case (Some(min), Some(max)) if max <= min => Matcher.validationFailure("Minimum interval must be less than maximum interval.")
+              case (Some(min), Some(max)) if max < min => Matcher.validationFailure("Minimum interval must be less than or equal maximum interval.")
               case _ =>
                 Result(Edit(
                   name, 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -1370,6 +1370,8 @@ trait DatabaseOperations { this: OdbSuite =>
     parentGroupId: Option[Group.Id] = None,
     parentIndex: Option[NonNegShort] = None,
     minRequired: Option[NonNegShort] = None,
+    minimumInterval: Option[TimeSpan] = None,
+    maximumInterval: Option[TimeSpan] = None,
     initialContents: Option[List[Either[Group.Id, Observation.Id]]] = None
   ): IO[Group.Id] =
     query(
@@ -1383,6 +1385,8 @@ trait DatabaseOperations { this: OdbSuite =>
                 parentGroup: ${parentGroupId.asJson.spaces2}
                 parentGroupIndex: ${parentIndex.map(_.value).asJson.spaces2}
                 minimumRequired: ${minRequired.map(_.value).asJson.spaces2}
+                ${minimumInterval.foldMap(ts => s"minimumInterval: { microseconds: \"${ts.toMicroseconds}\" }")}
+                ${maximumInterval.foldMap(ts => s"maximumInterval: { microseconds: \"${ts.toMicroseconds}\" }")}
               }
               ${
                 initialContents.foldMap: es =>


### PR DESCRIPTION
There were a few issues with the checks for the minimum and maximum intervals.

1. If the minimum and maximum were set in separate mutations, they could be set to the same value.
2. If they were set together in a single mutation, the GroupPropertiesInput required that the minimum be less than the maximum.
3. If only one of the values was set in an update which would result in the minimum being greater than the maximum, an uncaught exception would result in an Internal Error.

This PR updates the GroupPropertiesInput check to match the database constraint (minimum == maximum is allowed) and catches the constraint violation.