### PR TITLE
Don't run the legacy tests on every push, run them daily and on demand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          lfs: true
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
@@ -136,7 +135,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          lfs: true
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
@@ -192,7 +190,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          lfs: true
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1

--- a/.github/workflows/legacy-tests.yml
+++ b/.github/workflows/legacy-tests.yml
@@ -1,0 +1,53 @@
+name: Legacy Tests
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Daily at 2 AM UTC
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  legacy-tests:
+    name: ITC Legacy Tests
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'itc-legacy-tests')
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: ['17']
+        scala: ['3.7.3']
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+
+      - name: Cache sbt
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Run ITC Legacy Tests
+        run: sbt -v -J-Xmx6g itcLegacyTests/test
+        env:
+          RUN_LEGACY_TESTS: 'true'


### PR DESCRIPTION
Some changes for CI
* Don't run the itc legacy test, they are a bit slow and very seldom chang
* Instead run them daily and can be requested on demand with a label `itc-legacy-test`
* Don't request lfs for regular tests (Saves some money on lfs traffic)