### PR TITLE
Shortcut 8293: GHOST Observing Mode (Part 3)

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -11177,10 +11177,11 @@ type ItcResult {
 A discriminator for the types of ITC results.
 """
 enum ItcType {
-  SPECTROSCOPY,
-  IGRINS_2_SPECTROSCOPY,
+  GHOST_IFU,
   GMOS_NORTH_IMAGING,
-  GMOS_SOUTH_IMAGING
+  GMOS_SOUTH_IMAGING,
+  IGRINS_2_SPECTROSCOPY,
+  SPECTROSCOPY
 }
 
 """
@@ -11225,6 +11226,15 @@ interface Itc {
   "The type of the Itc results."
   itcType: ItcType!
 
+}
+
+"""
+GHOST IFU ITC results.  Each channel is paired with its result set.
+"""
+type ItcGhostIfu implements Itc {
+  itcType: ItcType!
+  red:     ItcResultSet!
+  blue:    ItcResultSet!
 }
 
 """

--- a/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
@@ -8,6 +8,7 @@ import cats.Order
 import cats.data.NonEmptyList
 import cats.data.NonEmptyMap
 import cats.syntax.all.*
+import eu.timepit.refined.cats.given
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.data.Zipper
 import lucuma.core.enums.GmosNorthFilter
@@ -55,10 +56,29 @@ object Itc:
 
   // ITC result type discriminator.
   enum Type(val tag: String) derives Enumerated:
+    case GhostIfu            extends Type("ghost_ifu")
     case GmosNorthImaging    extends Type("gmos_north_imaging")
     case GmosSouthImaging    extends Type("gmos_south_imaging")
-    case Spectroscopy        extends Type("spectroscopy")
     case Igrins2Spectroscopy extends Type("igrins_2_spectroscopy")
+    case Spectroscopy        extends Type("spectroscopy")
+
+  case class GhostIfu(
+    red:  Zipper[Result],
+    blue: Zipper[Result]
+  ) extends Itc:
+
+    override def dataType: Type =
+      Type.GhostIfu
+
+    override def scienceExposureCount: PosInt =
+      red.focus.value.exposureCount max blue.focus.value.exposureCount
+
+  object GhostIfu:
+    given Eq[GhostIfu] =
+      Eq.by(a => (a.red, a.blue))
+
+  val ghostIfu: Prism[Itc, GhostIfu] =
+    GenPrism[Itc, GhostIfu]
 
   /**
    * GMOS North imaging results.  There are results per-GMOS North filter.
@@ -153,10 +173,10 @@ object Itc:
     GenPrism[Itc, Igrins2Spectroscopy]
 
   given Eq[Itc] =
-    Eq.instance {
+    Eq.instance:
+      case (a: GhostIfu,            b: GhostIfu)            => a === b
       case (a: GmosNorthImaging,    b: GmosNorthImaging)    => a === b
       case (a: GmosSouthImaging,    b: GmosSouthImaging)    => a === b
-      case (a: Spectroscopy,        b: Spectroscopy)        => a === b
       case (a: Igrins2Spectroscopy, b: Igrins2Spectroscopy) => a === b
+      case (a: Spectroscopy,        b: Spectroscopy)        => a === b
       case _                                                => false
-    }

--- a/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
@@ -78,11 +78,22 @@ trait ItcCodec:
            yield filter -> results
          res.map(_.toNem)
 
+  given Decoder[Itc.GhostIfu] =
+    Decoder.instance: c =>
+      for
+        red  <- c.downField("red").as[Zipper[Itc.Result]]
+        blue <- c.downField("blue").as[Zipper[Itc.Result]]
+      yield Itc.GhostIfu(red, blue)
+
   given Decoder[Itc.GmosNorthImaging] =
     imagingScienceNemDecoder[GmosNorthFilter]("gmosNorthImagingScience").map(Itc.GmosNorthImaging.apply)
 
   given Decoder[Itc.GmosSouthImaging] =
     imagingScienceNemDecoder[GmosSouthFilter]("gmosSouthImagingScience").map(Itc.GmosSouthImaging.apply)
+
+  given Decoder[Itc.Igrins2Spectroscopy] =
+    Decoder.instance:
+      _.downField("spectroscopyScience").as[Zipper[Itc.Result]].map(Itc.Igrins2Spectroscopy.apply)
 
   given Decoder[Itc.Spectroscopy] =
     Decoder.instance: c =>
@@ -90,10 +101,6 @@ trait ItcCodec:
         acquisition <- c.downField("acquisition").as[Zipper[Itc.Result]]
         science     <- c.downField("spectroscopyScience").as[Zipper[Itc.Result]]
       yield Itc.Spectroscopy(acquisition, science)
-
-  given Decoder[Itc.Igrins2Spectroscopy] =
-    Decoder.instance:
-      _.downField("spectroscopyScience").as[Zipper[Itc.Result]].map(Itc.Igrins2Spectroscopy.apply)
 
   private def imagingScienceNemEncoder[A: Encoder](
     using Encoder[TimeSpan], Encoder[Wavelength]
@@ -105,6 +112,14 @@ trait ItcCodec:
             "filter"  -> filter.asJson,
             "results" -> results.asJson
           )
+
+  given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[Itc.GhostIfu] =
+    Encoder.instance: a =>
+      Json.obj(
+        "itcType" -> Itc.Type.GhostIfu.asJson,
+        "red"     -> a.red.asJson,
+        "blue"    -> a.blue.asJson
+      )
 
   given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[Itc.GmosNorthImaging] =
     Encoder.instance: a =>
@@ -120,6 +135,13 @@ trait ItcCodec:
         "gmosSouthImagingScience" -> a.science.asJson(using imagingScienceNemEncoder[GmosSouthFilter])
       )
 
+  given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[Itc.Igrins2Spectroscopy] =
+    Encoder.instance: a =>
+      Json.obj(
+        "itcType"             -> Itc.Type.Igrins2Spectroscopy.asJson,
+        "spectroscopyScience" -> a.science.asJson
+      )
+
   given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[Itc.Spectroscopy] =
     Encoder.instance: a =>
       Json.obj(
@@ -128,28 +150,23 @@ trait ItcCodec:
         "spectroscopyScience" -> a.science.asJson
       )
 
-  given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[Itc.Igrins2Spectroscopy] =
-    Encoder.instance: a =>
-      Json.obj(
-        "itcType"             -> Itc.Type.Igrins2Spectroscopy.asJson,
-        "spectroscopyScience" -> a.science.asJson
-      )
-
   given Decoder[Itc] =
     Decoder.instance: c =>
       c.downField("itcType")
        .as[Itc.Type]
        .flatMap:
+         case Itc.Type.GhostIfu            => Decoder[Itc.GhostIfu].apply(c)
          case Itc.Type.GmosNorthImaging    => Decoder[Itc.GmosNorthImaging].apply(c)
          case Itc.Type.GmosSouthImaging    => Decoder[Itc.GmosSouthImaging].apply(c)
-         case Itc.Type.Spectroscopy        => Decoder[Itc.Spectroscopy].apply(c)
          case Itc.Type.Igrins2Spectroscopy => Decoder[Itc.Igrins2Spectroscopy].apply(c)
+         case Itc.Type.Spectroscopy        => Decoder[Itc.Spectroscopy].apply(c)
 
   given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[Itc] =
     Encoder.instance:
+      case a @ Itc.GhostIfu(_, _)         => Encoder[Itc.GhostIfu].apply(a)
       case a @ Itc.GmosNorthImaging(_)    => Encoder[Itc.GmosNorthImaging].apply(a)
       case a @ Itc.GmosSouthImaging(_)    => Encoder[Itc.GmosSouthImaging].apply(a)
-      case a @ Itc.Spectroscopy(_, _)     => Encoder[Itc.Spectroscopy].apply(a)
       case a @ Itc.Igrins2Spectroscopy(_) => Encoder[Itc.Igrins2Spectroscopy].apply(a)
+      case a @ Itc.Spectroscopy(_, _)     => Encoder[Itc.Spectroscopy].apply(a)
 
 object itc extends ItcCodec

--- a/modules/schema/src/test/scala/lucuma/odb/data/arb/ArbItc.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/data/arb/ArbItc.scala
@@ -73,6 +73,17 @@ trait ArbItc:
     Cogen[(Target.Id, IntegrationTime, Option[SignalToNoiseAt])].contramap: a =>
       (a.targetId, a.value, a.signalToNoise)
 
+  given Arbitrary[Itc.GhostIfu] =
+    Arbitrary:
+      for
+        red  <- arbitrary[Zipper[Itc.Result]]
+        blue <- arbitrary[Zipper[Itc.Result]]
+      yield Itc.GhostIfu(red, blue)
+
+  given Cogen[Itc.GhostIfu] =
+    Cogen[(Zipper[Itc.Result], Zipper[Itc.Result])].contramap: a =>
+      (a.red, a.blue)
+
   given Arbitrary[Itc.GmosNorthImaging] =
     Arbitrary:
       for
@@ -118,18 +129,21 @@ trait ArbItc:
   given Arbitrary[Itc] =
     Arbitrary:
       Gen.oneOf(
+        arbitrary[Itc.GhostIfu],
         arbitrary[Itc.GmosNorthImaging],
         arbitrary[Itc.GmosSouthImaging],
-        arbitrary[Itc.Spectroscopy],
-        arbitrary[Itc.Igrins2Spectroscopy]
+        arbitrary[Itc.Igrins2Spectroscopy],
+        arbitrary[Itc.Spectroscopy]
       )
 
   given Cogen[Itc] =
     Cogen[
-      Either[Itc.Spectroscopy, Either[Itc.GmosNorthImaging, Either[Itc.GmosSouthImaging, Itc.Igrins2Spectroscopy]]]].contramap:
+      Either[Itc.Spectroscopy, Either[Itc.GmosNorthImaging, Either[Itc.GmosSouthImaging, Either[Itc.Igrins2Spectroscopy, Itc.GhostIfu]]]]
+    ].contramap:
       case a: Itc.Spectroscopy        => Left(a)
       case a: Itc.GmosNorthImaging    => Right(Left(a))
       case a: Itc.GmosSouthImaging    => Right(Right(Left(a)))
-      case a: Itc.Igrins2Spectroscopy => Right(Right(Right(a)))
+      case a: Itc.Igrins2Spectroscopy => Right(Right(Right(Left(a))))
+      case a: Itc.GhostIfu            => Right(Right(Right(Right(a))))
 
 object ArbItc extends ArbItc

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
@@ -102,9 +102,10 @@ object ItcInput:
         )
 
   /**
-    * ItcInput for igrins 2 spectroscopy, does not contain acquisition
+    * ItcInput for spectroscopy, for instruments where GPP does not manage
+    * acquisition (IGRINS2, GHOST).
     */
-  case class Igrins2Spectroscopy(
+  case class ScienceOnlySpectroscopy(
     science: SpectroscopyParameters,
     targets: NonEmptyList[TargetDefinition]
   ) extends ItcInput derives Eq:
@@ -112,9 +113,9 @@ object ItcInput:
     def scienceInput: SpectroscopyInput =
       SpectroscopyInput(science, targets.map(_.input))
 
-  object Igrins2Spectroscopy:
-    given HashBytes[Igrins2Spectroscopy] with
-      def hashBytes(a: Igrins2Spectroscopy): Array[Byte] =
+  object ScienceOnlySpectroscopy:
+    given HashBytes[ScienceOnlySpectroscopy] with
+      def hashBytes(a: ScienceOnlySpectroscopy): Array[Byte] =
         Array.concat(
           a.science.hashBytes,
           hashTargets(a.targets)
@@ -126,22 +127,22 @@ object ItcInput:
       case _                        => none
     }(identity)
 
-  val igrins2Spectroscopy: Prism[ItcInput, ItcInput.Igrins2Spectroscopy] =
-    Prism[ItcInput, ItcInput.Igrins2Spectroscopy] {
-      case s: ItcInput.Igrins2Spectroscopy => s.some
-      case _                               => none
+  val scienceOnlySpectroscopy: Prism[ItcInput, ItcInput.ScienceOnlySpectroscopy] =
+    Prism[ItcInput, ItcInput.ScienceOnlySpectroscopy] {
+      case s: ItcInput.ScienceOnlySpectroscopy => s.some
+      case _                                   => none
     }(identity)
 
   given Eq[ItcInput] =
     Eq.instance:
-      case (im0: Imaging,               im1: Imaging)                => im0 === im1
-      case (sp0: Spectroscopy,           sp1: Spectroscopy)          => sp0 === sp1
-      case (ig0: Igrins2Spectroscopy,    ig1: Igrins2Spectroscopy)   => ig0 === ig1
-      case _                                                         => false
+      case (n0: Imaging,                 n1: Imaging)                 => n0 === n1
+      case (n0: Spectroscopy,            n1: Spectroscopy)            => n0 === n1
+      case (n0: ScienceOnlySpectroscopy, n1: ScienceOnlySpectroscopy) => n0 === n1
+      case _                                                          => false
 
   given HashBytes[ItcInput] with
     def hashBytes(a: ItcInput): Array[Byte] =
       a match
-        case in @ Imaging(_, _)              => in.hashBytes
-        case in @ Spectroscopy(_, _, _, _)   => in.hashBytes
-        case in @ Igrins2Spectroscopy(_, _)  => in.hashBytes
+        case in @ Imaging(_, _)                  => in.hashBytes
+        case in @ Spectroscopy(_, _, _, _)       => in.hashBytes
+        case in @ ScienceOnlySpectroscopy(_, _)  => in.hashBytes

--- a/modules/sequence/src/test/scala/lucuma/odb/sequence/data/arb/ArbItcInput.scala
+++ b/modules/sequence/src/test/scala/lucuma/odb/sequence/data/arb/ArbItcInput.scala
@@ -55,13 +55,13 @@ trait ArbItcInput:
         bo
       )
 
-  given Arbitrary[ItcInput.Igrins2Spectroscopy] =
+  given Arbitrary[ItcInput.ScienceOnlySpectroscopy] =
     Arbitrary:
       for
         sci <- arbitrary[SpectroscopyParameters]
         ct  <- Gen.choose(1, 10)
         ts  <- List.range(1L, ct + 1L).traverse(genTargetDefinition)
-      yield ItcInput.Igrins2Spectroscopy(
+      yield ItcInput.ScienceOnlySpectroscopy(
         sci,
         NonEmptyList.fromListUnsafe(ts)
       )
@@ -71,7 +71,7 @@ trait ArbItcInput:
       Gen.oneOf(
         arbitrary[ItcInput.Imaging],
         arbitrary[ItcInput.Spectroscopy],
-        arbitrary[ItcInput.Igrins2Spectroscopy]
+        arbitrary[ItcInput.ScienceOnlySpectroscopy]
       )
 
 object ArbItcInput extends ArbItcInput

--- a/modules/service/src/main/scala/lucuma/odb/logic/GeneratorContext.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/GeneratorContext.scala
@@ -50,15 +50,18 @@ case class GeneratorContext(
     // ITC
     itcRes.foreach: itc =>
       itc match
-        case Itc.Spectroscopy(acq, sci)    =>
-          addResultSet(acq)
-          addResultSet(sci)
+        case Itc.GhostIfu(r, b)           =>
+          addResultSet(r)
+          addResultSet(b)
+        case Itc.GmosNorthImaging(m)      =>
+          m.toNel.toList.foreach(addImagingResultSet)
+        case Itc.GmosSouthImaging(m)      =>
+          m.toNel.toList.foreach(addImagingResultSet)
         case Itc.Igrins2Spectroscopy(sci) =>
           addResultSet(sci)
-        case Itc.GmosNorthImaging(m)   =>
-          m.toNel.toList.foreach(addImagingResultSet)
-        case Itc.GmosSouthImaging(m)   =>
-          m.toNel.toList.foreach(addImagingResultSet)
+        case Itc.Spectroscopy(acq, sci)   =>
+          addResultSet(acq)
+          addResultSet(sci)
 
     // Commit Hash
     md5.update(commitHash.hashBytes)

--- a/modules/service/src/main/scala/lucuma/odb/logic/GeneratorStreaming.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/GeneratorStreaming.scala
@@ -99,6 +99,22 @@ sealed trait GeneratorStreaming[F[_]]:
 
 object GeneratorStreaming:
 
+  def requireGhostItc(
+    oid: Observation.Id,
+    itc: Either[OdbError, Itc]
+  ): Either[OdbError, Itc.GhostIfu] =
+    itc.flatMap: i =>
+      Itc.ghostIfu.getOption(i).toRight:
+        OdbError.InvalidObservation(oid, s"Expecting a GHOST IFU result for this observation".some)
+
+  def requireIgrins2SpectroscopyItc(
+    oid: Observation.Id,
+    itc: Either[OdbError, Itc]
+  ): Either[OdbError, Itc.Igrins2Spectroscopy] =
+    itc.flatMap: i =>
+      Itc.igrins2Spectroscopy.getOption(i).toRight:
+        OdbError.InvalidObservation(oid, s"Expecting an IGRINS-2 spectroscopy ITC result for this observation".some)
+
   def requireImagingItc[A](
     name: String,
     oid:  Observation.Id,
@@ -116,14 +132,6 @@ object GeneratorStreaming:
     itc.flatMap: i =>
       Itc.spectroscopy.getOption(i).toRight:
         OdbError.InvalidObservation(oid, s"Expecting a spectroscopy ITC result for this observation".some)
-
-  def requireIgrins2SpectroscopyItc(
-    oid: Observation.Id,
-    itc: Either[OdbError, Itc]
-  ): Either[OdbError, Itc.Igrins2Spectroscopy] =
-    itc.flatMap: i =>
-      Itc.igrins2Spectroscopy.getOption(i).toRight:
-        OdbError.InvalidObservation(oid, s"Expecting an IGRINS-2 spectroscopy ITC result for this observation".some)
 
   def instantiate[F[_]: Async: Services](
     commitHash: CommitHash,

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -34,6 +34,7 @@ import lucuma.core.model.Target
 import lucuma.core.model.UnnormalizedSED
 import lucuma.core.model.User
 import lucuma.core.util.Timestamp
+import lucuma.itc.ItcGhostDetector
 import lucuma.itc.client.GmosFpu
 import lucuma.itc.client.ImagingParameters
 import lucuma.itc.client.InstrumentMode
@@ -97,6 +98,10 @@ object GeneratorParamsService {
     def format: String
 
   object Error:
+    case class MisconfiguredObservation(observationId: Observation.Id, msg: String) extends Error:
+      def format: String =
+        s"Observation '$observationId' is misconfigured: $msg."
+
     case class MissingObservation(programId: Program.Id, observationId: Observation.Id) extends Error:
       def format: String =
         s"Observation '$observationId' in program '$programId' not found."
@@ -111,10 +116,11 @@ object GeneratorParamsService {
     given Eq[Error] with
       def eqv(x: Error, y: Error): Boolean =
         (x, y) match
-          case (MissingObservation(p0, o0), MissingObservation(p1, o1)) => (p0 === p1) && (o0 === o1)
-          case (MissingData(p0), MissingData(p1))                       => p0 === p1
-          case (ConflictingData, ConflictingData)                       => true
-          case _                                                        => false
+          case (MisconfiguredObservation(o0, m0), MisconfiguredObservation(o1, m1)) => (o0 === o1) && (m0 === m1)
+          case (MissingObservation(p0, o0), MissingObservation(p1, o1))             => (p0 === p1) && (o0 === o1)
+          case (MissingData(p0), MissingData(p1))                                   => p0 === p1
+          case (ConflictingData, ConflictingData)                                   => true
+          case _                                                                    => false
 
   def instantiate[F[_]: Concurrent](using Services[F]): GeneratorParamsService[F] =
     new GeneratorParamsService[F] {
@@ -268,9 +274,32 @@ object GeneratorParamsService {
 
           GeneratorParams(itcInput, obsParams.scienceBand, obsMode, obsParams.calibrationRole, obsParams.declaredComplete, obsParams.executionState, obsParams.stepCount)
 
-        observingMode(obsParams.targets, config).map:
-          case gh @ ghost.ifu.Config(_, _, _, _, _) =>
-            throw new RuntimeException("GHOST TBD")
+        observingMode(obsParams.targets, config).flatMap:
+
+          case gh @ ghost.ifu.Config(resolutionMode, red, blue, _, _) =>
+            (
+              ExposureTimeMode.timeAndCount.getOption(red.value.exposureTimeMode),
+              ExposureTimeMode.timeAndCount.getOption(blue.value.exposureTimeMode)
+            )
+            .tupled
+            .toRight(Error.MisconfiguredObservation(obsParams.observationId, "GHOST requires TimeAndCount exposure time modes"))
+            .map: (redEtm, blueEtm) =>
+              val sciMode = InstrumentMode.GhostSpectroscopy(
+                resolutionMode,
+                ItcGhostDetector(redEtm, red.value.readMode, red.value.binning),
+                ItcGhostDetector(blueEtm, blue.value.readMode, blue.value.binning)
+              )
+              val consInput = obsParams.constraints.toInput
+              val science   = SpectroscopyParameters(consInput, sciMode)
+
+              val itcInput  =
+                obsParams.targets
+                  .traverse(itcTargetParams)
+                  .map(ItcInput.ScienceOnlySpectroscopy(science, _))
+                  .leftMap(MissingParamSet.fromParams)
+                  .toEither
+
+              GeneratorParams(itcInput, obsParams.scienceBand, gh, obsParams.calibrationRole, obsParams.declaredComplete, obsParams.executionState, obsParams.stepCount)
 
           case gn @ gmos.longslit.Config.GmosNorth(g, f, u, c, a) =>
             val sciMode = InstrumentMode.GmosNorthSpectroscopy(
@@ -290,7 +319,7 @@ object GeneratorParamsService {
                 ccdMode = sciMode.ccdMode
               ),
               sciMode  = sciMode
-            )
+            ).asRight
 
           case gs @ gmos.longslit.Config.GmosSouth(g, f, u, c, a) =>
             val sciMode = InstrumentMode.GmosSouthSpectroscopy(
@@ -310,7 +339,7 @@ object GeneratorParamsService {
                 ccdMode = sciMode.ccdMode
               ),
               sciMode  = sciMode
-            )
+            ).asRight
 
           case f2 @ flamingos2.longslit.Config(disperser, filter, fpu, sci, acq, _, _, _, _, _, _, _, _) =>
             val sciMode   = InstrumentMode.Flamingos2Spectroscopy(sci, disperser, filter, fpu)
@@ -321,7 +350,7 @@ object GeneratorParamsService {
                 acq.filter
               ),
               sciMode = sciMode
-            )
+            ).asRight
 
           case ig: igrins2.longslit.Config =>
             val sciMode   = InstrumentMode.Igrins2Spectroscopy(ig.scienceExposureTimeMode)
@@ -331,11 +360,11 @@ object GeneratorParamsService {
             val itcInput =
               obsParams.targets
                 .traverse(itcTargetParams)
-                .map(ItcInput.Igrins2Spectroscopy(science, _))
+                .map(ItcInput.ScienceOnlySpectroscopy(science, _))
                 .leftMap(MissingParamSet.fromParams)
                 .toEither
 
-            GeneratorParams(itcInput, obsParams.scienceBand, ig, obsParams.calibrationRole, obsParams.declaredComplete, obsParams.executionState, obsParams.stepCount)
+            GeneratorParams(itcInput, obsParams.scienceBand, ig, obsParams.calibrationRole, obsParams.declaredComplete, obsParams.executionState, obsParams.stepCount).asRight
 
           case gn @ gmos.imaging.Config.GmosNorth(_, fs, _) =>
             // An input per filter.
@@ -353,7 +382,7 @@ object GeneratorParamsService {
                 .leftMap(MissingParamSet.fromParams)
                 .toEither
 
-            GeneratorParams(itcInput, obsParams.scienceBand, gn, obsParams.calibrationRole, obsParams.declaredComplete, obsParams.executionState, obsParams.stepCount)
+            GeneratorParams(itcInput, obsParams.scienceBand, gn, obsParams.calibrationRole, obsParams.declaredComplete, obsParams.executionState, obsParams.stepCount).asRight
 
           case gs @ gmos.imaging.Config.GmosSouth(_, fs, _) =>
             // An input per filter.
@@ -371,7 +400,7 @@ object GeneratorParamsService {
                 .leftMap(MissingParamSet.fromParams)
                 .toEither
 
-            GeneratorParams(itcInput, obsParams.scienceBand, gs, obsParams.calibrationRole, obsParams.declaredComplete, obsParams.executionState, obsParams.stepCount)
+            GeneratorParams(itcInput, obsParams.scienceBand, gs, obsParams.calibrationRole, obsParams.declaredComplete, obsParams.executionState, obsParams.stepCount).asRight
 
       private def itcTargetParams(targetParams: TargetParams): ValidatedNel[MissingParam, ItcInput.TargetDefinition] = {
         // If emission line, SED not required, otherwhise must be defined

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -36,12 +36,14 @@ import lucuma.core.model.Target
 import lucuma.core.util.TimeSpan
 import lucuma.itc.AsterismIntegrationTimes
 import lucuma.itc.IntegrationTime
+import lucuma.itc.ItcGhostDetector
 import lucuma.itc.TargetIntegrationTime
 import lucuma.itc.client.ClientCalculationResult
 import lucuma.itc.client.ImagingInput
 import lucuma.itc.client.InstrumentMode
 import lucuma.itc.client.ItcClient
 import lucuma.itc.client.SpectroscopyInput
+import lucuma.itc.client.SpectroscopyParameters
 import lucuma.odb.data.Itc
 import lucuma.odb.data.Md5Hash
 import lucuma.odb.data.OdbError
@@ -385,6 +387,31 @@ object ItcService {
               .handleError: t =>
                 OdbError.RemoteServiceCallError(s"Error calling ITC service: ${t.getMessage}".some).asLeft
 
+        // A placeholder result for GHOST, at least for now.
+        //
+        // * The ITC accepts the red and blue exposure time mode data, but
+        //   only returns a single result set?  It isn't clear how to map this
+        //   back onto the red and blue channels.
+        //
+        // * The ITC only handles Time And Count mode and we don't use the S/N
+        //   value so we'll just short-circuit the call and make a fake result
+        //   that has the time and count we need per channel.
+        def ghost(
+          ghost:   InstrumentMode.GhostSpectroscopy,
+          targets: NonEmptyList[ItcInput.TargetDefinition]
+        ): EitherT[F, OdbError, Itc] =
+          def resultSet(d: ItcGhostDetector): Zipper[Itc.Result] =
+            Zipper.fromNel:
+              targets.map: t =>
+                val it = IntegrationTime(d.timeAndCount.time, d.timeAndCount.count)
+                Itc.Result(t.targetId, it, none)
+
+          EitherT.pure:
+            Itc.GhostIfu(
+              resultSet(ghost.redDetector),
+              resultSet(ghost.blueDetector)
+            )
+
         def imaging(im: ItcInput.Imaging): EitherT[F, OdbError, Itc] =
           im.science.head.mode match
             case InstrumentMode.GmosNorthImaging(_, _, _, _) =>
@@ -404,16 +431,23 @@ object ItcService {
             acq <- safeAcquisitionCall(oid, sp.acquisitionInput, sp.acquisitionTargets)
           yield Itc.Spectroscopy(acq, sci)
 
-        def igrins2Spectroscopy(sp: ItcInput.Igrins2Spectroscopy): EitherT[F, OdbError, Itc] =
+        def igrins2Spectroscopy(sp: ItcInput.ScienceOnlySpectroscopy): EitherT[F, OdbError, Itc] =
           for
             cr  <- callSpectroscopy(sp.scienceInput)
             sci <- EitherT.fromEither(toTargetResults(sp.targets, NonEmptyList.one(cr)).map(_.head))
           yield Itc.Igrins2Spectroscopy(sci)
 
         (input match
-          case im @ ItcInput.Imaging(_, _)             => imaging(im)
-          case sp @ ItcInput.Spectroscopy(_, _, _, _)  => spectroscopy(sp)
-          case ig @ ItcInput.Igrins2Spectroscopy(_, _) => igrins2Spectroscopy(ig)
+          case im @ ItcInput.Imaging(_, _) =>
+            imaging(im)
+          case sp @ ItcInput.Spectroscopy(_, _, _, _) =>
+            spectroscopy(sp)
+          case sp @ ItcInput.ScienceOnlySpectroscopy(SpectroscopyParameters(_, gh @ InstrumentMode.GhostSpectroscopy(_, _, _)), targets) =>
+            ghost(gh, targets)
+          case sp @ ItcInput.ScienceOnlySpectroscopy(SpectroscopyParameters(_, InstrumentMode.Igrins2Spectroscopy(_, _)), _) =>
+            igrins2Spectroscopy(sp)
+          case _ =>
+            EitherT.leftT(OdbError.InvalidObservation(oid, s"Unrecognized ItcInput: $input".some))
         ).value
 
       @annotation.nowarn("msg=unused implicit parameter")

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -477,4 +477,130 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
     } yield r
   }
 
+  test("ghost bypass"):
+    val mode = s"""
+      ghostIfu: {
+        resolutionMode: STANDARD
+        red: {
+          exposureTimeMode: {
+            timeAndCount: {
+              time: { seconds: 1.0 }
+              count: 1
+              at: { nanometers: 500 }
+            }
+          }
+        }
+        blue: {
+          exposureTimeMode: {
+            timeAndCount: {
+              time: { seconds: 2.0 }
+              count: 2
+              at: { nanometers: 500 }
+            }
+          }
+        }
+      }
+    """
+
+    def query(oid: Observation.Id) = s"""
+      query {
+        observation(observationId: "$oid") {
+          itc {
+            ... on ItcGhostIfu {
+              itcType
+              red {
+                selected {
+                  targetId
+                  exposureTime {
+                    seconds
+                  }
+                  exposureCount
+                  signalToNoiseAt {
+                    wavelength {
+                      picometers
+                    }
+                    single
+                    total
+                  }
+                }
+                all {
+                  targetId
+                }
+              }
+              blue {
+                selected {
+                  targetId
+                  exposureTime {
+                    seconds
+                  }
+                  exposureCount
+                  signalToNoiseAt {
+                    wavelength {
+                      picometers
+                    }
+                    single
+                    total
+                  }
+                }
+                all {
+                  targetId
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    def expected(t: Target.Id) = json"""
+      {
+        "observation": {
+          "itc": {
+            "itcType": "GHOST_IFU",
+            "red" : {
+              "selected" : {
+                "targetId" : ${t.asJson},
+                "exposureTime" : {
+                  "seconds" : 1.000000
+                },
+                "exposureCount" : 1,
+                "signalToNoiseAt" : null
+              },
+              "all" : [
+                {
+                  "targetId" : ${t.asJson}
+                }
+              ]
+            },
+            "blue" : {
+              "selected" : {
+                "targetId" : ${t.asJson},
+                "exposureTime" : {
+                  "seconds" : 2.000000
+                },
+                "exposureCount" : 2,
+                "signalToNoiseAt" : null
+              },
+              "all" : [
+                {
+                  "targetId" : ${t.asJson}
+                }
+              ]
+            }
+          }
+        }
+      }
+    """
+
+    for
+      p <- createProgram
+      t <- createTargetWithProfileAs(user, p)
+      o <- createObservationWithModeAs(user, p, List(t), mode)
+      _ <- expect(
+        user     = user,
+        query    = query(o),
+        expected = expected(t).asRight
+      )
+    yield ()
+
 }


### PR DESCRIPTION
Another piecemeal GHOST update.  This one is concerned with hooking up the ITC.

* Creates an `ItcGhostIfu` result type to manage ITC results for GHOST. 
* Updates the `GeneratorParamsService` to create a `ScienceOnlySpectroscopy` input (renamed from `Igrins2Spectroscopy` in order to also use it for GHOST).
* Updates `ItcService` to obtain ITC results for GHOST. Notably, it doesn't actually call the ITC.  Instead it just strips out the time and count and pairs from the input and lines them up with the proper channel.  I think the ITC needs to provide red and blue results before we can actually call it?