### PR TITLE
Add Resource web server project [sc-8674] [sc-8673]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
         run: sbt -v -J-Xmx6g +update
 
       - name: Build Docker images
-        run: 'sbt -v -J-Xmx6g ''++ ${{ matrix.scala }}'' clean ssoService/docker:publishLocal itcService/docker:publishLocal service/docker:publishLocal obscalc/docker:publishLocal calibrations/docker:publishLocal'
+        run: 'sbt -v -J-Xmx6g ''++ ${{ matrix.scala }}'' clean ssoService/docker:publishLocal itcService/docker:publishLocal service/docker:publishLocal obscalc/docker:publishLocal calibrations/docker:publishLocal resourceService/docker:publishLocal'
 
       - name: Push Docker images to Heroku
         run: |
@@ -284,12 +284,21 @@ jobs:
           docker push registry.heroku.com/${{ vars.HEROKU_ODB_APP_NAME || 'lucuma-postgres-odb' }}-production/calibration:${{ github.sha }}
           docker tag noirlab/calibrations-service registry.heroku.com/${{ vars.HEROKU_ODB_APP_NAME || 'lucuma-postgres-odb' }}-dev/calibration
           docker push registry.heroku.com/${{ vars.HEROKU_ODB_APP_NAME || 'lucuma-postgres-odb' }}-dev/calibration
+          docker tag noirlab/lucuma-resource-service registry.heroku.com/${{ vars.HEROKU_RESOURCE_APP_NAME || 'lucuma-resource' }}-dev/web:${{ github.sha }}
+          docker push registry.heroku.com/${{ vars.HEROKU_RESOURCE_APP_NAME || 'lucuma-resource' }}-dev/web:${{ github.sha }}
+          docker tag noirlab/lucuma-resource-service registry.heroku.com/${{ vars.HEROKU_RESOURCE_APP_NAME || 'lucuma-resource' }}-staging/web:${{ github.sha }}
+          docker push registry.heroku.com/${{ vars.HEROKU_RESOURCE_APP_NAME || 'lucuma-resource' }}-staging/web:${{ github.sha }}
+          docker tag noirlab/lucuma-resource-service registry.heroku.com/${{ vars.HEROKU_RESOURCE_APP_NAME || 'lucuma-resource' }}-production/web:${{ github.sha }}
+          docker push registry.heroku.com/${{ vars.HEROKU_RESOURCE_APP_NAME || 'lucuma-resource' }}-production/web:${{ github.sha }}
+          docker tag noirlab/lucuma-resource-service registry.heroku.com/${{ vars.HEROKU_RESOURCE_APP_NAME || 'lucuma-resource' }}-dev/web
+          docker push registry.heroku.com/${{ vars.HEROKU_RESOURCE_APP_NAME || 'lucuma-resource' }}-dev/web
 
       - name: Release dev app in Heroku
         run: |
           heroku container:release web -a ${{ vars.HEROKU_SSO_APP_NAME || 'lucuma-sso' }}-dev -v
           heroku container:release web -a ${{ vars.HEROKU_ITC_APP_NAME || 'itc' }}-dev -v
           heroku container:release web obscalc calibration -a ${{ vars.HEROKU_ODB_APP_NAME || 'lucuma-postgres-odb' }}-dev -v
+          heroku container:release web -a ${{ vars.HEROKU_RESOURCE_APP_NAME || 'lucuma-resource' }}-dev -v
 
       - name: Get Docker image SHA
         run: |
@@ -298,6 +307,7 @@ jobs:
           echo "DOCKER_IMAGE_SHA_ODB_WEB=$(docker inspect registry.heroku.com/${{ vars.HEROKU_ODB_APP_NAME || 'lucuma-postgres-odb' }}-dev/web:${{ github.sha }} --format={{.Id}})" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_SHA_ODB_OBSCALC=$(docker inspect registry.heroku.com/${{ vars.HEROKU_ODB_APP_NAME || 'lucuma-postgres-odb' }}-dev/obscalc:${{ github.sha }} --format={{.Id}})" >> $GITHUB_ENV
           echo "DOCKER_IMAGE_SHA_ODB_CALIBRATION=$(docker inspect registry.heroku.com/${{ vars.HEROKU_ODB_APP_NAME || 'lucuma-postgres-odb' }}-dev/calibration:${{ github.sha }} --format={{.Id}})" >> $GITHUB_ENV
+          echo "DOCKER_IMAGE_SHA_RESOURCE_WEB=$(docker inspect registry.heroku.com/${{ vars.HEROKU_RESOURCE_APP_NAME || 'lucuma-resource' }}-dev/web:${{ github.sha }} --format={{.Id}})" >> $GITHUB_ENV
 
       - name: Record deployment in GHA
         run: |
@@ -307,3 +317,5 @@ jobs:
           curl -s -X POST https://api.github.com/repos/${{ github.repository }}/deployments -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json" -d '{ "ref": "${{ github.sha }}", "environment": "development", "description": "ITC deployment to dev", "auto_merge": false, "required_contexts": [], "task": "deploy:ITC", "payload": { "docker_image_shas": { "web": "${{ env.DOCKER_IMAGE_SHA_ITC_WEB }}" } } }' 
           echo "Recording deployment ${{ github.sha }} for ODB to ${{ github.repository }}"
           curl -s -X POST https://api.github.com/repos/${{ github.repository }}/deployments -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json" -d '{ "ref": "${{ github.sha }}", "environment": "development", "description": "ODB deployment to dev", "auto_merge": false, "required_contexts": [], "task": "deploy:ODB", "payload": { "docker_image_shas": { "web": "${{ env.DOCKER_IMAGE_SHA_ODB_WEB }}", "obscalc": "${{ env.DOCKER_IMAGE_SHA_ODB_OBSCALC }}", "calibration": "${{ env.DOCKER_IMAGE_SHA_ODB_CALIBRATION }}" } } }' 
+          echo "Recording deployment ${{ github.sha }} for RESOURCE to ${{ github.repository }}"
+          curl -s -X POST https://api.github.com/repos/${{ github.repository }}/deployments -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json" -d '{ "ref": "${{ github.sha }}", "environment": "development", "description": "RESOURCE deployment to dev", "auto_merge": false, "required_contexts": [], "task": "deploy:RESOURCE", "payload": { "docker_image_shas": { "web": "${{ env.DOCKER_IMAGE_SHA_RESOURCE_WEB }}" } } }' 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -65,7 +65,7 @@ pull_request_rules:
       remove: []
 - name: Label model PRs
   conditions:
-  - files~=^itc/model/
+  - files~=^/
   actions:
     label:
       add:

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,2 +1,3 @@
 include ".scalafix-common.conf"
- OrganizeImports.removeUnused = false
+OrganizeImports.removeUnused = false
+OrganizeImports.targetDialect = Scala3

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,6 +4,7 @@ runner.dialect = scala3
 
 project.includePaths = [
   "glob:**/itc/**/*.scala"
+  "glob:**/resource/**/*.scala"
 ]
 
 project.excludePaths = [

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import NativePackagerHelper._
+import NativePackagerHelper.*
 
 // Please keep in alphabetical order
 val awsJavaSdkVersion            = "1.12.797"
@@ -184,28 +184,32 @@ lazy val sbtDockerPublishLocal =
       "itcService/docker:publishLocal",
       "service/docker:publishLocal",
       "obscalc/docker:publishLocal",
-      "calibrations/docker:publishLocal"
+      "calibrations/docker:publishLocal",
+      "resourceService/docker:publishLocal"
     ),
     name = Some("Build Docker images")
   )
 
-lazy val systems: List[String] = List("sso", "itc", "odb")
+lazy val systems: List[String] = List("sso", "itc", "odb", "resource")
 lazy val appNames: Map[String, String] = Map(
-  "sso" -> "${{ vars.HEROKU_SSO_APP_NAME || 'lucuma-sso' }}",
-  "itc" -> "${{ vars.HEROKU_ITC_APP_NAME || 'itc' }}",
-  "odb" -> "${{ vars.HEROKU_ODB_APP_NAME || 'lucuma-postgres-odb' }}"
+  "sso"      -> "${{ vars.HEROKU_SSO_APP_NAME || 'lucuma-sso' }}",
+  "itc"      -> "${{ vars.HEROKU_ITC_APP_NAME || 'itc' }}",
+  "odb"      -> "${{ vars.HEROKU_ODB_APP_NAME || 'lucuma-postgres-odb' }}",
+  "resource" -> "${{ vars.HEROKU_RESOURCE_APP_NAME || 'lucuma-resource' }}"
 )
 lazy val procTypes: Map[String, List[String]] = Map(
-  "sso" -> List("web"),
-  "itc" -> List("web"),
-  "odb" -> List("web", "obscalc", "calibration")
+  "sso"      -> List("web"),
+  "itc"      -> List("web"),
+  "odb"      -> List("web", "obscalc", "calibration"),
+  "resource" -> List("web")
 )
 lazy val procTypeImageNames: Map[(String, String), String] = Map(
-  ("sso", "web")           -> "lucuma-sso-service",
-  ("itc", "web")           -> "lucuma-itc-service",
-  ("odb", "web")           -> "lucuma-odb-service",
-  ("odb", "obscalc")       -> "obscalc-service",
-  ("odb", "calibration")   -> "calibrations-service"
+  ("sso", "web")         -> "lucuma-sso-service",
+  ("itc", "web")         -> "lucuma-itc-service",
+  ("odb", "web")         -> "lucuma-odb-service",
+  ("odb", "obscalc")     -> "obscalc-service",
+  ("odb", "calibration") -> "calibrations-service",
+  ("resource", "web")    -> "lucuma-resource-service"
 )
 lazy val environments: List[String] = List("dev", "staging", "production")
 lazy val systemProcTypes: List[(String, String, String)] =
@@ -317,6 +321,19 @@ lazy val graphqlInspectorItc =
     cond = Some("github.event_name == 'pull_request'")
   )
 
+lazy val graphqlInspectorResource =
+  WorkflowStep.Use(
+    UseRef.Public("kamilkisiela", "graphql-inspector", "master"),
+    name = Some("Validate Resource GraphQL schema changes"),
+    params =
+      Map(
+        "name"          -> "Validate Resource Public API",
+        "schema"        -> "main:resource/service/src/main/resources/graphql/resource.graphql",
+        "approve-label" -> "expected-breaking-change"
+      ),
+    cond = Some("github.event_name == 'pull_request'")
+  )
+
 // Don't do static checks repeatedly on each shard, instead create a separate task only for checks.
 ThisBuild / githubWorkflowAddedJobs ++= Seq(
   WorkflowJob(
@@ -326,6 +343,7 @@ ThisBuild / githubWorkflowAddedJobs ++= Seq(
       sbtStaticChecks ::
       graphqlInspectorOdb ::
       graphqlInspectorItc ::
+      // graphqlInspectorResource ::
       Nil,
     scalas = List(scalaVersion.value),
     javas = githubWorkflowJavaVersions.value.toList.take(1)
@@ -738,9 +756,12 @@ lazy val binding = project
     name := "lucuma-odb-binding",
     tlVersionIntroduced := Map("3" -> "0.19.3"),
     libraryDependencies ++= Seq(
+      "co.fs2"        %% "fs2-core"           % fs2Version,
+      "co.fs2"        %% "fs2-io"             % fs2Version,
       "edu.gemini"    %% "lucuma-core"        % lucumaCoreVersion,
       "org.typelevel" %% "grackle-core"       % grackleVersion,
       "org.scalameta" %% "munit"              % munitVersion           % Test,
+      "org.typelevel" %% "munit-cats-effect"  % munitCatsEffectVersion % Test
     )
   )
 
@@ -891,3 +912,69 @@ lazy val phase0 = project
 // Command aliases for starting/stopping all services
 addCommandAlias("allStart", ";service/reStart;obscalc/reStart;calibrations/reStart")
 addCommandAlias("allStop", ";service/reStop;obscalc/reStop;calibrations/reStop")
+
+// START RESOURCE
+
+lazy val resourceModel =
+  project
+    .in(file("resource/model"))
+    .enablePlugins(NoPublishPlugin)
+    .dependsOn(schema.jvm, otel)
+    .settings(resourceCommonSettings)
+    .settings(
+      name := "lucuma-resource-model",
+      libraryDependencies ++= Seq(
+        "edu.gemini"    %% "lucuma-core"  % lucumaCoreVersion,
+        "io.circe"      %% "circe-core"   % circeVersion,
+        "is.cir"        %% "ciris-http4s" % cirisVersion,
+        "is.cir"        %% "ciris"        % cirisVersion,
+        "org.http4s"    %% "http4s-core"  % http4sVersion,
+        "org.typelevel" %% "cats-core"    % catsVersion
+      )
+    )
+
+lazy val resourceService = project
+  .in(file("resource/service"))
+  .dependsOn(resourceModel, binding, otel, schema.jvm)
+  .enablePlugins(NoPublishPlugin, LucumaDockerPlugin, JavaAppPackaging, BuildInfoPlugin)
+  .settings(resourceCommonSettings, buildInfoSettings)
+  .settings(
+    name                        := "lucuma-resource-service",
+    description                 := "Lucuma Resource Service",
+    projectDependencyArtifacts  := (Compile / dependencyClasspathAsJars).value,
+    libraryDependencies ++= Seq(
+      "ch.qos.logback" % "logback-classic"                       % logbackVersion,
+      "co.fs2"        %% "fs2-core"                              % fs2Version,
+      "co.fs2"        %% "fs2-io"                                % fs2Version,
+      "edu.gemini"    %% "lucuma-graphql-routes"                 % lucumaGraphQLRoutesVersion,
+      "is.cir"        %% "ciris-http4s"                          % cirisVersion,
+      "is.cir"        %% "ciris"                                 % cirisVersion,
+      "org.flywaydb"   % "flyway-core"                           % flywayVersion,
+      "org.http4s"    %% "http4s-circe"                          % http4sVersion,
+      "org.http4s"    %% "http4s-dsl"                            % http4sVersion,
+      "org.http4s"    %% "http4s-ember-server"                   % http4sVersion,
+      "org.http4s"    %% "http4s-otel4s-middleware-metrics"      % http4sOtel4sVersion,
+      "org.http4s"    %% "http4s-otel4s-middleware-trace-server" % http4sOtel4sVersion,
+      "org.postgresql" % "postgresql"                            % postgresVersion,
+      "org.tpolecat"  %% "skunk-circe"                           % skunkVersion,
+      "org.tpolecat"  %% "skunk-core"                            % skunkVersion,
+      "org.typelevel" %% "cats-effect"                           % catsEffectVersion,
+      "org.typelevel" %% "grackle-skunk"                         % grackleVersion,
+      "org.typelevel" %% "log4cats-slf4j"                        % log4catsVersion,
+      "com.dimafeng"  %% "testcontainers-scala-munit"            % testcontainersScalaVersion   % Test,
+      "com.dimafeng"  %% "testcontainers-scala-postgresql"       % testcontainersScalaVersion   % Test,
+      "edu.gemini"    %% "lucuma-core-testkit"                   % lucumaCoreVersion            % Test,
+      "org.scalameta" %% "munit-scalacheck"                      % munitScalacheckVersion       % Test,
+      "org.scalameta" %% "munit"                                 % munitVersion                 % Test,
+      "org.typelevel" %% "munit-cats-effect"                     % munitCatsEffectVersion       % Test,
+      "org.typelevel" %% "scalacheck-effect-munit"               % scalacheckEffectMunitVersion % Test,
+      "org.http4s"    %% "http4s-jdk-http-client"                % http4sJdkHttpClientVersion   % Test,
+      "edu.gemini"    %% "clue-http4s"                           % clueVersion                  % Test
+    ),
+    reStart / envVars += "PORT" -> "8484",
+    executableScriptName        := "resource-service",
+    dockerExposedPorts ++= Seq(8484)
+  )
+
+lazy val resourceCommonSettings = lucumaGlobalSettings ++ Seq(
+)

--- a/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaSource.scala
+++ b/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaSource.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.schema
+
+import cats.effect.Sync
+import cats.syntax.eq.*
+import fs2.RaiseThrowable
+import fs2.Stream
+import fs2.io
+import fs2.io.file.Path
+import fs2.text
+
+trait SchemaSource[F[_]]:
+  def resolve(name: Path): Stream[F, String]
+
+object SchemaSource:
+  def fromResource[F[_]: Sync]: SchemaSource[F] = (name: Path) =>
+    Stream
+      .eval(Sync[F].blocking(Option(getClass.getClassLoader.getResourceAsStream(name.toString))))
+      .flatMap:
+        case Some(resource) =>
+          io.readInputStream(Sync[F].pure(resource), 8192)
+            .through(text.utf8.decode)
+            .through(text.lines)
+        case None           => Stream.raiseError[F](new io.IOException(s"Resource $name not found"))
+
+  def fromString[F[_]: RaiseThrowable](name: Path, content: String): SchemaSource[F] = (n: Path) =>
+    if (n === name) Stream.emit(content).through(text.lines)
+    else Stream.raiseError[F](new Error(s"Unknown source $n"))
+
+  def fromStringMap[F[_]: RaiseThrowable](m: Map[Path, String]): SchemaSource[F] = (name: Path) =>
+    m.get(name)
+      .fold(Stream.raiseError[F](new Error(s"Unknown source $name")))(x =>
+        Stream.emit(x).through(text.lines)
+      )

--- a/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaStitcher.scala
+++ b/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaStitcher.scala
@@ -1,0 +1,182 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.schema
+
+import cats.data.NonEmptySet
+import cats.effect.Sync
+import cats.parse.Parser
+import cats.parse.Parser.*
+import cats.parse.Rfc5234.alpha
+import cats.parse.Rfc5234.digit
+import cats.parse.Rfc5234.wsp
+import cats.syntax.all.*
+import eu.timepit.refined.cats.given
+import eu.timepit.refined.types.string.NonEmptyString
+import fs2.io.file.Path
+import grackle.*
+import org.tpolecat.sourcepos.SourcePos
+
+import scala.annotation.tailrec
+
+// SchemaStitcher can build a grackle Schema from schema files that contains import statements of the form:
+// #import <type list> from <schema file name>
+// <type list> is a coma separated list of the times to import, or * to import all of them
+trait SchemaStitcher[F[_]]:
+  def build(using SourcePos): F[Result[Schema]]
+
+object SchemaStitcher {
+
+  private case class SchemaStitcherImpl[F[_]: Sync](
+    root:   Path,
+    source: SchemaSource[F]
+  ) extends SchemaStitcher[F] {
+
+    // Process to build the schema:
+    // 1. Build a schema dependency tree starting with the root schema.
+    // 2. Recursively collapse the tree into a List, with dependencies first
+    // 3. Merge all elements referencing the same schema. Only the left-most one is left, and its type list is replaced
+    //    by the union of all the others
+    // 4. Build the final schema text joining the string representation of each schema. Only the used type are put in
+    //    the string.
+    // 5. Build the Schema instance
+    override def build(using SourcePos): F[Result[Schema]] = dependenciesTree(List.empty, root)
+      .map(x => collapseToList(AllElements, x))
+      .map(x => merge(x, List.empty))
+      .map(_.map(_.asString).mkString("\n"))
+      .map(Schema(_))
+
+    def dependenciesTree(pathToRoot: List[Path], schemaName: Path): F[DependencyNode] =
+      if pathToRoot.contains(schemaName) then
+        Sync[F].raiseError(
+          new Exception(s"Found circular reference when resolving schema $schemaName")
+        )
+      else
+        source
+          .resolve(schemaName)
+          .compile
+          .toList
+          .flatMap: ll =>
+            ll.map(importLineParser.parse)
+              .collect:
+                case Right((_, (els, path))) =>
+                  dependenciesTree(pathToRoot :+ schemaName, path).map((els, _))
+              .sequence
+              .map(DependencyNode(schemaName, ll, _))
+
+    def collapseToList(els: Elements, node: DependencyNode): List[SchemaNode] =
+      node.dependencies.flatMap { case (s, n) => collapseToList(s, n) } :+ SchemaNode(
+        node.v,
+        node.src.mkString("\n"),
+        els
+      )
+
+    @tailrec
+    final def merge(l: List[SchemaNode], acc: List[SchemaNode]): List[SchemaNode] =
+      l match
+        case Nil      => acc
+        case x :: Nil => acc :+ x
+        case x :: xx  =>
+          val (m, r) = xx.partition(_.name === x.name)
+          val s      = m.fold(x)((a, b) => SchemaNode(a.name, a.src, a.elements.union(b.elements)))
+          merge(r, acc :+ s)
+
+  }
+
+  sealed trait Elements
+  case object AllElements                                extends Elements
+  case class ElementList(l: NonEmptySet[NonEmptyString]) extends Elements
+
+  extension (el: Elements)
+    private def union(other: Elements): Elements = (el, other) match
+      case (ElementList(l1), ElementList(l2)) => ElementList(l1 ++ l2)
+      case _                                  => AllElements
+
+  private case class DependencyNode(
+    v:            Path,
+    src:          List[String],
+    dependencies: List[(Elements, DependencyNode)]
+  )
+
+  private case class SchemaNode(name: Path, src: String, elements: Elements) {
+    def asString: String = elements match {
+      case AllElements    => src
+      case ElementList(l) => asString(l)
+    }
+
+    def asString(l: NonEmptySet[NonEmptyString]): String =
+      Schema(src) match {
+        case Result.Success(b)    =>
+          resolveTypes(b.types,
+                       l.toList.flatMap(x => b.types.find(_.name === x.toString)),
+                       List.empty
+          )
+            .map(SchemaRenderer.renderTypeDefn)
+            .mkString("\n")
+        case Result.Warning(_, b) =>
+          resolveTypes(b.types,
+                       l.toList.flatMap(x => b.types.find(_.name === x.toString)),
+                       List.empty
+          )
+            .map(SchemaRenderer.renderTypeDefn)
+            .mkString("\n")
+        case _                    => ""
+      }
+
+    def resolveTypes(
+      types:    List[NamedType],
+      newNames: List[NamedType],
+      acc:      List[NamedType]
+    ): List[NamedType] =
+      if newNames.isEmpty then acc.distinct
+      else
+        val uniqueNews = newNames.distinct
+        val nextVals   = uniqueNews
+          .flatMap {
+            case fields: TypeWithFields                => fields.fields.flatMap(_.tpe.underlying.asNamed)
+            case UnionType(_, _, members, _)           => members
+            case InputObjectType(_, _, inputFields, _) =>
+              inputFields.flatMap(_.tpe.underlying.asNamed)
+            case _                                     => List.empty
+          }
+          .map(_.dealias)
+          .filter {
+            case u: ScalarType => !u.isBuiltIn
+            case v             => !acc.contains(v) && !uniqueNews.contains(v)
+          }
+        resolveTypes(types, nextVals, uniqueNews ++ acc)
+
+  }
+
+  private val allElementsParser: Parser[Elements]                        = char('*').as(AllElements)
+  private val firstCharInTypeParser: Parser[Char]                        = alpha | charIn('_')
+  private val otherCharsInTypeParser: Parser[Char]                       = firstCharInTypeParser | digit
+  private val elementNameParser: Parser[NonEmptyString]                  =
+    (firstCharInTypeParser ~ otherCharsInTypeParser.rep0).map { case (x, xx) =>
+      NonEmptyString.unsafeFrom((x +: xx).mkString(""))
+    }
+  private val elementNameListParser: Parser[NonEmptySet[NonEmptyString]] =
+    (elementNameParser ~ (wsp.rep0.with1 *> char(
+      ','
+    ) *> wsp.rep0 *> elementNameParser).backtrack.rep0)
+      .map { case (x, xx) => NonEmptySet.of(x, xx*) }
+  private val elementListParser: Parser[Elements]                        = elementNameListParser.map(ElementList.apply)
+  private val filenameCharParser: Parser[Char]                           =
+    digit | alpha | charIn('.', '_', System.getProperty("file.separator").headOption.getOrElse('/'))
+  private val schemaFilenameParser: Parser[Path]                         =
+    (Parser.char('\"') *> filenameCharParser.rep <* Parser.char('\"')).map(x =>
+      Path(x.toList.mkString(""))
+    )
+
+  // Left public to allow testing the parser
+  val importLineParser: Parser[(Elements, Path)] =
+    (wsp.rep0.with1 *> char('#') *> wsp.rep0 *> string(
+      "import"
+    ) *> wsp.rep *> (allElementsParser | elementListParser) <* wsp.rep)
+      ~ (string("from") *> wsp.rep *> schemaFilenameParser)
+
+  // The only way to build a SchemaStitcher
+  def apply[F[_]: Sync](root: Path, source: SchemaSource[F]): SchemaStitcher[F] =
+    SchemaStitcherImpl(root, source)
+
+}

--- a/modules/binding/src/test/scala/lucuma/odb/graphql/schema/SchemaStitcherTest.scala
+++ b/modules/binding/src/test/scala/lucuma/odb/graphql/schema/SchemaStitcherTest.scala
@@ -1,0 +1,131 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.schema
+
+import cats.effect.IO
+import fs2.io.file.Path
+import grackle.Result
+import grackle.Result.Success
+import grackle.Schema
+import munit.CatsEffectSuite
+
+class SchemaStitcherTest extends CatsEffectSuite {
+
+  import SchemaStitcherTest.*
+
+  test("SchemaStitcher should parse import statements") {
+    schemaResolver
+      .resolve(Path("baseSchema.graphql"))
+      .map(SchemaStitcher.importLineParser.parse)
+      .collect { case Right((_, (els, path))) =>
+        (els, path)
+      }
+      .compile
+      .toList
+      .map: a =>
+        assertEquals(a.length, 2)
+        a(0) match {
+          case (SchemaStitcher.AllElements, path) => assertEquals(path, Path("schema1.graphql"))
+          case other                              => fail(s"Unexpected parse result: $other")
+        }
+        a(1) match {
+          case (SchemaStitcher.ElementList(els), path) =>
+            assertEquals(els.toNonEmptyList.toList.map(_.value), List("TypeA", "TypeX"))
+            assertEquals(path, Path("schema2.graphql"))
+          case other                                   => fail(s"Unexpected parse result: $other")
+        }
+  }
+
+  test("SchemaStitcher should compose schema") {
+    SchemaStitcher[IO](Path("baseSchema.graphql"), schemaResolver).build.map { x =>
+      (x, expectedSchema) match {
+        case (Success(a), Success(b)) => assertEquals(a.toString, b.toString)
+        case _                        => fail("Error creating schema")
+      }
+    }
+  }
+
+}
+
+object SchemaStitcherTest {
+
+  val schema1: String = """
+    |#import TypeA from "schema2.graphql"
+    |
+    |type TypeB {
+    |  val1: TypeA!
+    |}
+  """.stripMargin
+
+  val schema2: String = """
+    |enum EnumX {
+    |  VAL0
+    |  VAL1
+    |}
+    |
+    |type TypeA {
+    |  attr0: [EnumX]!
+    |}
+    |
+    |type TypeB {
+    |  attr0: Boolean!
+    |  attr1: Float
+    |}
+    |
+    |type TypeX {
+    |  attr0: [TypeA]!
+    |}
+  """.stripMargin
+
+  val baseSchema: String = """
+    |#import * from "schema1.graphql"
+    |#import TypeA, TypeX from "schema2.graphql"
+    |
+    |type TypeC {
+    |  attr0: TypeB
+    |}
+    |
+    |type Query {
+    |  query1(par: TypeA!): TypeC!
+    |  query2(par: TypeX!): TypeC!
+    |}
+  """.stripMargin
+
+  val expectedSchema: Result[Schema] = Schema("""
+    |enum EnumX {
+    |  VAL0
+    |  VAL1
+    |}
+    |
+    |type TypeA {
+    |  attr0: [EnumX]!
+    |}
+    |
+    |type TypeX {
+    |  attr0: [TypeA]!
+    |}
+    |
+    |type TypeB {
+    |  val1: TypeA!
+    |}
+    |
+    |type TypeC {
+    |  attr0: TypeB
+    |}
+    |
+    |type Query {
+    |  query1(par: TypeA!): TypeC!
+    |  query2(par: TypeX!): TypeC!
+    |}
+    |""".stripMargin)
+
+  val schemaResolver: SchemaSource[IO] = SchemaSource.fromStringMap(
+    Map(
+      Path("baseSchema.graphql") -> baseSchema,
+      Path("schema1.graphql")    -> schema1,
+      Path("schema2.graphql")    -> schema2
+    )
+  )
+
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/introspection.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/introspection.scala
@@ -19,12 +19,15 @@ class introspection extends OdbSuite:
           __schema {
             queryType {
               name
+              kind
             }
             mutationType {
               name
+              kind
             }
             subscriptionType {
               name
+              kind
             }
             types {
               ...FullType
@@ -32,8 +35,9 @@ class introspection extends OdbSuite:
             directives {
               name
               description
+              isRepeatable
               locations
-              args {
+              args(includeDeprecated: true) {
                 ...InputValue
               }
             }
@@ -44,10 +48,12 @@ class introspection extends OdbSuite:
           kind
           name
           description
+          specifiedByURL
+          isOneOf
           fields(includeDeprecated: true) {
             name
             description
-            args {
+            args(includeDeprecated: true) {
               ...InputValue
             }
             type {
@@ -56,7 +62,7 @@ class introspection extends OdbSuite:
             isDeprecated
             deprecationReason
           }
-          inputFields {
+          inputFields(includeDeprecated: true) {
             ...InputValue
           }
           interfaces {
@@ -80,6 +86,8 @@ class introspection extends OdbSuite:
             ...TypeRef
           }
           defaultValue
+          isDeprecated
+          deprecationReason
         }
 
         fragment TypeRef on __Type {
@@ -106,6 +114,14 @@ class introspection extends OdbSuite:
                       ofType {
                         kind
                         name
+                        ofType {
+                          kind
+                          name
+                          ofType {
+                            kind
+                            name
+                          }
+                        }
                       }
                     }
                   }

--- a/resource-sparse-checkout
+++ b/resource-sparse-checkout
@@ -1,0 +1,11 @@
+/*
+!/*/
+/.github/
+/resource/
+/itc/model/
+/modules/binding/
+/modules/otel/
+/modules/schema/
+/modules/sso-backend-client/
+/modules/sso-frontend-client/
+/project/

--- a/resource/README.md
+++ b/resource/README.md
@@ -1,0 +1,20 @@
+# Resource
+
+The GPP resource service is a combination telescope calendar and configuration/resource manager (e.g. ICTD replacement).
+
+Declare a `DATABASE_URL` environment variable pointing to a Postgres database and run the service:
+
+```
+   sbt '~resourceService/reStart'
+```
+
+Then open the graphql playground at http://localhost:8484/resource/playground.html to interact with the API.
+
+## GraphQL Schema
+
+The schema is defined in `resource/service/src/main/resources/graphql/resource.graphql`. It uses imports from the [ODB schema](../modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql) and combines the two schemas at runtime using the `SchemaStitcher` in the `bindings` module.
+
+## OpenTelemetry (OTLP) Setup
+
+Services support exporting traces and metrics via OTLP.
+Telemetry is enabled when both `RESOURCE_OTEL_ENDPOINT` and `RESOURCE_OTEL_KEY` are set; otherwise it is a no-op.

--- a/resource/model/src/main/scala/resource/model/TelescopeAvailability.scala
+++ b/resource/model/src/main/scala/resource/model/TelescopeAvailability.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.model
+
+import lucuma.core.util.Enumerated
+
+enum TelescopeAvailability(val tag: String) derives Enumerated:
+  case Open   extends TelescopeAvailability("OPEN")
+  case Closed extends TelescopeAvailability("CLOSED")

--- a/resource/model/src/main/scala/resource/model/TelescopeAvailabilityStatus.scala
+++ b/resource/model/src/main/scala/resource/model/TelescopeAvailabilityStatus.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.model
+
+import io.circe.Encoder
+import lucuma.core.enums.Site
+import lucuma.core.util.TimestampInterval
+import lucuma.odb.json.time.query.given
+
+final case class TelescopeAvailabilityStatus(
+  interval:            TimestampInterval,
+  availability:        TelescopeAvailability,
+  reason:              Option[String],
+  plannedAvailability: Option[TelescopeAvailability],
+  site:                Site
+) derives Encoder.AsObject

--- a/resource/model/src/main/scala/resource/model/TelescopeMode.scala
+++ b/resource/model/src/main/scala/resource/model/TelescopeMode.scala
@@ -1,0 +1,9 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.model
+
+import io.circe.Encoder
+
+final case class TelescopeMode(`type`: TelescopeModeType, programReference: Option[String])
+    derives Encoder.AsObject

--- a/resource/model/src/main/scala/resource/model/TelescopeModeStatus.scala
+++ b/resource/model/src/main/scala/resource/model/TelescopeModeStatus.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.model
+
+import io.circe.Encoder
+import lucuma.core.enums.Site
+import lucuma.core.util.TimestampInterval
+import lucuma.odb.json.time.query.given
+
+final case class TelescopeModeStatus(interval: TimestampInterval, site: Site, mode: TelescopeMode)
+    derives Encoder.AsObject

--- a/resource/model/src/main/scala/resource/model/TelescopeModeType.scala
+++ b/resource/model/src/main/scala/resource/model/TelescopeModeType.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.model
+
+import lucuma.core.util.Enumerated
+
+enum TelescopeModeType(val tag: String) derives Enumerated:
+  case Queue           extends TelescopeModeType("QUEUE")
+  case Classical       extends TelescopeModeType("CLASSICAL")
+  case PriorityVisitor extends TelescopeModeType("PRIORITY_VISITOR")
+  case Engineering     extends TelescopeModeType("ENGINEERING")
+  case Commissioning   extends TelescopeModeType("COMMISSIONING")

--- a/resource/model/src/main/scala/resource/model/TelescopeNightTimeline.scala
+++ b/resource/model/src/main/scala/resource/model/TelescopeNightTimeline.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.model
+
+import io.circe.Encoder
+import lucuma.core.enums.Site
+import lucuma.core.util.TimestampInterval
+import lucuma.odb.json.time.query.given
+
+import java.time.LocalDate
+
+final case class TelescopeNightTimeline(
+  site:            Site,
+  observingNight:  LocalDate,
+  displayInterval: TimestampInterval,
+  availability:    List[TelescopeAvailabilityStatus],
+  tooStatus:       List[TelescopeTooStatus],
+  modes:           List[TelescopeModeStatus]
+) derives Encoder.AsObject

--- a/resource/model/src/main/scala/resource/model/TelescopeTooStatus.scala
+++ b/resource/model/src/main/scala/resource/model/TelescopeTooStatus.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.model
+
+import io.circe.Encoder
+import lucuma.core.enums.Site
+import lucuma.core.util.TimestampInterval
+import lucuma.odb.json.time.query.given
+
+final case class TelescopeTooStatus(interval: TimestampInterval, tooSupport: TooSupport, site: Site)
+    derives Encoder.AsObject

--- a/resource/model/src/main/scala/resource/model/TooSupport.scala
+++ b/resource/model/src/main/scala/resource/model/TooSupport.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.model
+
+import lucuma.core.util.Enumerated
+
+enum TooSupport(val tag: String) derives Enumerated:
+  case Standard  extends TooSupport("STANDARD")
+  case Interrupt extends TooSupport("INTERRUPT")
+  case Rapid     extends TooSupport("RAPID")
+  case None      extends TooSupport("NONE")

--- a/resource/model/src/main/scala/resource/model/config/DatabaseConfiguration.scala
+++ b/resource/model/src/main/scala/resource/model/config/DatabaseConfiguration.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.model.config
+
+import cats.Eq
+import cats.derived.*
+import cats.syntax.all.*
+import ciris.*
+import ciris.http4s.*
+import com.comcast.ip4s.Port
+import org.http4s.*
+import org.http4s.Uri.Host
+
+case class DatabaseConfiguration(
+  maxConnections: Int,
+  host:           Host,
+  port:           Port,
+  database:       String,
+  user:           String,
+  password:       String
+) derives Eq:
+  // We use Flyway (which uses JDBC) to perform schema migrations. Savor the irony.
+  def jdbcUrl: String = s"jdbc:postgresql://${host}:${port}/${database}?sslmode=require"
+
+object DatabaseConfiguration:
+  object Default:
+    val MaxConnections = Runtime.getRuntime.availableProcessors * 2 + 1
+
+  def fromDatabaseUrl(
+    maxConnections: Int,
+    uri:            Uri
+  ): Option[DatabaseConfiguration] =
+    for
+      userInfo <- uri.userInfo
+      user      = userInfo.username
+      password <- userInfo.password
+      host     <- uri.host
+      port     <- uri.port.flatMap(Port.fromInt)
+      database  = uri.path.renderString.stripPrefix("/")
+    yield DatabaseConfiguration(
+      maxConnections = maxConnections,
+      host = host,
+      port = port,
+      database = database,
+      user = user,
+      password = password
+    )
+
+  lazy val fromCiris: ConfigValue[Effect, DatabaseConfiguration] = (
+    env("MAX_CONNECTIONS").as[Int].default(Default.MaxConnections),
+    env("DATABASE_URL").as[Uri].redacted // passed by Heroku
+  ).parTupled.as[DatabaseConfiguration]
+
+  private given ConfigDecoder[(Int, Uri), DatabaseConfiguration] =
+    ConfigDecoder[(Int, Uri)].mapOption("DatabaseConfiguration")(fromDatabaseUrl)

--- a/resource/model/src/main/scala/resource/model/config/ExecutionEnvironment.scala
+++ b/resource/model/src/main/scala/resource/model/config/ExecutionEnvironment.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.model.config
+
+import cats.implicits.*
+import ciris.*
+
+enum ExecutionEnvironment:
+  case Local, Development, Staging, Production
+
+  def stringValue: String =
+    this match
+      case Local       => "local"
+      case Development => "development"
+      case Staging     => "staging"
+      case Production  => "production"
+
+given ConfigDecoder[String, ExecutionEnvironment] =
+  ConfigDecoder[String].map(_.toLowerCase).collect("Environment") {
+    case "local"       => ExecutionEnvironment.Local
+    case "development" => ExecutionEnvironment.Development
+    case "staging"     => ExecutionEnvironment.Staging
+    case "production"  => ExecutionEnvironment.Production
+  }

--- a/resource/model/src/main/scala/resource/model/config/ResourceConfiguration.scala
+++ b/resource/model/src/main/scala/resource/model/config/ResourceConfiguration.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.model.config
+
+import cats.Eq
+import cats.derived.*
+import cats.syntax.all.*
+import ciris.*
+import ciris.http4s.*
+import com.comcast.ip4s.*
+import lucuma.otel.OtelConfig
+
+final case class ResourceConfiguration(
+  database:    DatabaseConfiguration,
+  environment: ExecutionEnvironment,
+  port:        Port,
+  otel:        Option[OtelConfig]
+) derives Eq
+
+object ResourceConfiguration:
+
+  lazy val fromCiris: ConfigValue[Effect, ResourceConfiguration] = (
+    DatabaseConfiguration.fromCiris,
+    environment,
+    port,
+    otelConfig
+  ).parMapN(ResourceConfiguration.apply)
+
+  private lazy val environment =
+    val ee = env("RESOURCE_ENVIRONMENT").as[ExecutionEnvironment]
+    inHeroku.ifM(
+      ee,
+      ee.default(ExecutionEnvironment.Local)
+    )
+
+  private lazy val port = env("PORT").as[Port].default(port"8484")
+
+  private lazy val inHeroku: ConfigValue[Effect, Boolean] =
+    env("DYNO").option.map(_.isDefined)
+
+  private lazy val otelConfig: ConfigValue[Effect, Option[OtelConfig]] =
+    val otelEndpoint = env("RESOURCE_OTEL_ENDPOINT")
+    val otelKey      = env("RESOURCE_OTEL_KEY").redacted
+    // In Heroku, otel configuration is required
+    inHeroku.ifM(
+      (otelEndpoint, otelKey, environment).parMapN((endpoint, key, env) =>
+        OtelConfig(endpoint, key, env.stringValue).some
+      ),
+      (otelEndpoint.option, otelKey.option, environment).parTupled.map:
+        // Otherwise otel is optional
+        case (Some(endpoint), Some(key), env) if endpoint.trim.nonEmpty && key.trim.nonEmpty =>
+          OtelConfig(endpoint, key, env.stringValue).some
+        case _                                                                               =>
+          None
+    )

--- a/resource/service/src/main/resources/graphql/resource.graphql
+++ b/resource/service/src/main/resources/graphql/resource.graphql
@@ -1,0 +1,60 @@
+#import Timestamp, TimestampInterval, Site, Date from "lucuma/odb/graphql/OdbSchema.graphql"
+
+enum TelescopeAvailability {
+  OPEN
+  CLOSED
+}
+
+enum TooSupport {
+  STANDARD
+  INTERRUPT
+  RAPID
+  NONE
+}
+
+enum TelescopeModeType {
+  QUEUE
+  CLASSICAL
+  PRIORITY_VISITOR
+  ENGINEERING
+  COMMISSIONING
+}
+
+
+type TelescopeMode {
+  type: TelescopeModeType!
+  programReference: String
+}
+
+type TelescopeAvailabilityStatus {
+  interval: TimestampInterval!
+  availability: TelescopeAvailability!
+  reason: String
+  plannedAvailability: TelescopeAvailability
+  site: Site!
+}
+
+type TelescopeTooStatus {
+  interval: TimestampInterval!
+  tooSupport: TooSupport!
+  site: Site!
+}
+
+type TelescopeModeStatus {
+  interval: TimestampInterval!
+  site: Site!
+  mode: TelescopeMode!
+}
+
+type TelescopeNightTimeline {
+  site: Site!
+  observingNight: Date!
+  displayInterval: TimestampInterval!
+  availability: [TelescopeAvailabilityStatus!]!
+  tooStatus: [TelescopeTooStatus!]!
+  modes: [TelescopeModeStatus!]!
+}
+
+type Query {
+  telescopeNightTimeline(site: Site!, observingNight: Date!): TelescopeNightTimeline
+}

--- a/resource/service/src/main/resources/logback.xml
+++ b/resource/service/src/main/resources/logback.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Configuration of logging for development and local deployment.
+
+ File based logs are rotated daily up to 90 days.
+
+ It supports auto reloading scanning every 60s.
+-->
+<configuration scan="true" scanPeriod="60 seconds">
+    <logger name="resource" level="INFO" />
+    <logger name="org.http4s.server.middleware.Logger" level="WARN" />
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %-5level %logger{30} - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.netty" level="INFO">
+        <appender-ref ref="STDOUT" />
+    </logger>
+    <logger name="org.asynchttpclient.netty" level="INFO">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/resource/service/src/main/scala/resource/server/DummyData.scala
+++ b/resource/service/src/main/scala/resource/server/DummyData.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.server
+
+import cats.data.NonEmptyList
+import lucuma.core.enums.Site
+import lucuma.core.util.Timestamp
+import lucuma.core.util.TimestampInterval
+import resource.model.*
+
+import java.time.LocalDate
+
+object DummyData {
+
+  val mockTelescopeNightTimelines: NonEmptyList[TelescopeNightTimeline] = NonEmptyList.of(
+    TelescopeNightTimeline(
+      Site.GN,
+      LocalDate.parse("2026-08-01"),
+      TimestampInterval.between(
+        Timestamp.FromString.unsafeGet("2026-08-02T04:00:00Z"),
+        Timestamp.FromString.unsafeGet("2026-08-02T15:30:00Z")
+      ),
+      List(
+        TelescopeAvailabilityStatus(
+          TimestampInterval.between(
+            Timestamp.FromString.unsafeGet("2026-08-02T04:00:00Z"),
+            Timestamp.FromString.unsafeGet("2026-08-02T15:30:00Z")
+          ),
+          TelescopeAvailability.Open,
+          None,
+          None,
+          Site.GN
+        )
+      ),
+      List(
+        TelescopeTooStatus(
+          TimestampInterval.between(
+            Timestamp.FromString.unsafeGet("2026-08-02T04:00:00Z"),
+            Timestamp.FromString.unsafeGet("2026-08-02T10:00:00Z")
+          ),
+          TooSupport.Rapid,
+          Site.GN
+        ),
+        TelescopeTooStatus(
+          TimestampInterval.between(
+            Timestamp.FromString.unsafeGet("2026-08-02T10:00:00Z"),
+            Timestamp.FromString.unsafeGet("2026-08-02T15:30:00Z")
+          ),
+          TooSupport.Interrupt,
+          Site.GN
+        )
+      ),
+      List(
+        TelescopeModeStatus(
+          TimestampInterval.between(
+            Timestamp.FromString.unsafeGet("2026-08-02T04:00:00Z"),
+            Timestamp.FromString.unsafeGet("2026-08-02T15:30:00Z")
+          ),
+          Site.GN,
+          TelescopeMode(
+            TelescopeModeType.Queue,
+            None
+          )
+        )
+      )
+    )
+  )
+}

--- a/resource/service/src/main/scala/resource/server/graphql/BaseMapping.scala
+++ b/resource/service/src/main/scala/resource/server/graphql/BaseMapping.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.server.graphql
+
+import cats.Monoid
+import grackle.Env
+import grackle.Path
+import grackle.Query.Binding
+import grackle.QueryCompiler.Elab
+import grackle.Result
+import grackle.TypeRef
+import grackle.circe.CirceMappingLike
+import grackle.skunk.SkunkMapping
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+trait BaseMapping[F[_]] extends SkunkMapping[F] with CirceMappingLike[F]:
+  given Logger[F] = Slf4jLogger.getLogger[F]
+
+  type ElaboratorPF = PartialFunction[(TypeRef, String, List[Binding]), Elab[Unit]]
+  type ComputeF[A]  = (Path, Env) => F[Result[A]]
+
+  given Monoid[ElaboratorPF] with
+    def empty: ElaboratorPF                                     = PartialFunction.empty
+    def combine(x: ElaboratorPF, y: ElaboratorPF): ElaboratorPF = x.orElse(y)

--- a/resource/service/src/main/scala/resource/server/graphql/MutationMapping.scala
+++ b/resource/service/src/main/scala/resource/server/graphql/MutationMapping.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.server.graphql
+
+import cats.syntax.all.*
+import grackle.*
+import grackle.Query.Binding
+import grackle.QueryCompiler.Elab
+import grackle.Value.*
+import io.circe.Encoder
+
+trait MutationMapping[F[_]] extends BaseMapping[F] {
+  val MutationType: TypeRef = schema.ref("Mutation")
+
+  lazy val MutationMapping =
+    ObjectMapping(MutationType)(
+      RootEffect.computeEncodable[String]("sendHello")((_, env) => sendHello(env))
+    )
+
+  lazy val MutationElaborator: ElaboratorPF = List(
+    sendHelloElaborator
+  ).combineAll
+
+  def sendHello(env: Env): F[Result[String]] =
+    env
+      .getR[String]("name")
+      .map(name => s"Hello ${name}")
+      .pure[F]
+
+  def sendHelloElaborator: ElaboratorPF =
+    case (MutationType, "sendHello", List(Binding("name", StringValue(name)))) =>
+      Elab.env("name", name)
+
+}

--- a/resource/service/src/main/scala/resource/server/graphql/QueryMapping.scala
+++ b/resource/service/src/main/scala/resource/server/graphql/QueryMapping.scala
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.server.graphql
+
+import cats.effect.Sync
+import cats.syntax.all.*
+import grackle.QueryCompiler.Elab
+import grackle.Result
+import grackle.TypeRef
+import grackle.skunk.SkunkMapping
+import lucuma.core.enums.Site
+import lucuma.odb.graphql.binding.*
+import resource.model.*
+import resource.server.DummyData
+
+import java.time.LocalDate
+
+trait QueryMapping[F[_]: Sync] extends BaseMapping[F] {
+
+  private val SiteParam           = "site"
+  private val ObservingNightParam = "observingNight"
+
+  val QueryType: TypeRef = schema.ref("Query")
+
+  lazy val QueryMapping: ObjectMapping =
+    ObjectMapping(QueryType)(
+      RootEffect.computeEncodable("telescopeNightTimeline")(telescopeNightTimeline)
+    )
+
+  lazy val QueryElaborator: ElaboratorPF = List(
+    TelescopeNightTimelineE
+  ).combineAll
+
+  val telescopeNightTimeline: ComputeF[Option[TelescopeNightTimeline]] = (_, env) =>
+    (env.getR[Site](SiteParam), env.getR[LocalDate](ObservingNightParam))
+      .mapN: (site, observingNight) =>
+        DummyData.mockTelescopeNightTimelines
+          .find(t => t.site === site && t.observingNight.equals(observingNight))
+      .pure[F]
+
+  private lazy val TelescopeNightTimelineE: ElaboratorPF =
+    case (QueryType,
+          "telescopeNightTimeline",
+          List(
+            SiteBinding(SiteParam, rSite),
+            DateBinding(ObservingNightParam, rObservingNight)
+          )
+        ) =>
+      Elab
+        .liftR((rSite, rObservingNight).parTupled)
+        .flatMap: (site, observingNight) =>
+          Elab.env(
+            SiteParam           -> site,
+            ObservingNightParam -> observingNight
+          )
+
+}

--- a/resource/service/src/main/scala/resource/server/graphql/ResourceMapping.scala
+++ b/resource/service/src/main/scala/resource/server/graphql/ResourceMapping.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.server.graphql
+
+import _root_.skunk.Session
+import cats.effect.*
+import cats.syntax.all.*
+import grackle.*
+import grackle.QueryCompiler.SelectElaborator
+import grackle.skunk.SkunkMapping
+import grackle.skunk.SkunkMonitor
+
+class ResourceMapping[F[_]: Async](
+  pool:    Resource[F, Session[F]],
+  monitor: SkunkMonitor[F]
+)(override val schema: Schema)
+    extends SkunkMapping[F](pool, monitor)
+    with BaseMapping[F]
+    with QueryMapping[F]:
+  // with SubscriptionMapping[F]
+  // with MutationMapping[F]:
+
+  override val typeMappings: TypeMappings = TypeMappings(
+    List(
+      // MutationMapping,
+      QueryMapping
+      // SubscriptionMapping
+    )
+  )
+
+  override val selectElaborator: SelectElaborator =
+    SelectElaborator(
+      List(
+        // MutationElaborator,
+        QueryElaborator
+      ).combineAll
+    )

--- a/resource/service/src/main/scala/resource/server/graphql/SubscriptionMapping.scala
+++ b/resource/service/src/main/scala/resource/server/graphql/SubscriptionMapping.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.server.graphql
+
+import grackle.TypeRef
+
+trait SubscriptionMapping[F[_]] extends BaseMapping[F] {
+  val SubscriptionType: TypeRef = schema.ref("Subscription")
+
+  lazy val SubscriptionMapping =
+    ObjectMapping(SubscriptionType)(
+    )
+}

--- a/resource/service/src/main/scala/resource/server/http4s/GraphQlRoutes.scala
+++ b/resource/service/src/main/scala/resource/server/http4s/GraphQlRoutes.scala
@@ -1,0 +1,73 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.server.http4s
+
+import _root_.skunk.Session
+import cats.Show
+import cats.effect.*
+import cats.syntax.all.*
+import fs2.io.file.Path
+import grackle.*
+import grackle.Result.Failure
+import grackle.Result.Success
+import grackle.Result.Warning
+import grackle.skunk.SkunkMonitor
+import lucuma.graphql.routes.GraphQLService
+import lucuma.graphql.routes.Routes
+import lucuma.odb.graphql.schema.SchemaSource
+import lucuma.odb.graphql.schema.SchemaStitcher
+import org.http4s.HttpRoutes
+import org.http4s.dsl.Http4sDsl
+import org.http4s.server.websocket.WebSocketBuilder2
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.otel4s.trace.Tracer
+import resource.server.graphql.ResourceMapping
+
+class GraphQlRoutes[F[_]: {Async, Tracer}](
+) extends Http4sDsl[F] {
+
+  private given Logger[F] = Slf4jLogger.getLogger[F]
+
+  def service(
+    wsb:     WebSocketBuilder2[F],
+    pool:    Resource[F, Session[F]],
+    monitor: SkunkMonitor[F],
+    schema:  Schema
+  ): HttpRoutes[F] =
+    Routes.forService(
+      _ =>
+        GraphQLService[F](
+          ResourceMapping(
+            pool,
+            monitor
+          )(schema)
+        ).some.pure[F],
+      wsb
+    )
+}
+
+object GraphQlRoutes:
+  def loadSchema[F[_]: Sync: Logger]: F[Schema] =
+    given Show[Problem] = Show.fromToString
+    SchemaStitcher(Path("graphql/resource.graphql"), SchemaSource.fromResource).build
+      .flatMap:
+        case Result.Success(schema)           =>
+          Logger[F]
+            .info("Loaded GraphQL schema")
+            .as(schema)
+        case Result.Warning(problems, schema) =>
+          Logger[F]
+            .warn(s"Loaded schema with problems: ${problems.mkString_(",")}")
+            .as(schema)
+        case Result.Failure(problems)         =>
+          Sync[F].raiseError[Schema](
+            new Throwable(
+              s"Unable to load schema because: ${problems.mkString_(",")}"
+            )
+          )
+        case Result.InternalError(error)      =>
+          Sync[F].raiseError[Schema](
+            new Throwable(s"Unable to load schema because: ${error.getMessage}")
+          )

--- a/resource/service/src/main/scala/resource/server/http4s/ResourceMain.scala
+++ b/resource/service/src/main/scala/resource/server/http4s/ResourceMain.scala
@@ -1,0 +1,133 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.server.http4s
+
+import buildinfo.BuildInfo
+import cats.effect.*
+import cats.effect.std.Console
+import cats.effect.syntax.all.*
+import com.comcast.ip4s.*
+import fs2.*
+import fs2.compression.Compression
+import fs2.io.file.Files
+import fs2.io.net.*
+import grackle.Schema
+import grackle.skunk.SkunkMonitor
+import lucuma.otel.OtelSetup
+import natchez.Trace
+import org.http4s.*
+import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.server.*
+import org.http4s.server.websocket.WebSocketBuilder2
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.otel4s.metrics.MeterProvider
+import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
+import resource.model.config.*
+import skunk.*
+
+object ResourceMain extends IOApp.Simple {
+
+  override def run: IO[Unit] = webServer[IO].useForever
+
+  def webServer[F[_]: {Async, LiftIO, Compression, Console, Files, Network}]: Resource[F, Server] =
+    for
+      given Logger[F]         = Slf4jLogger.getLoggerFromName[F]("resource")
+      conf                   <- ResourceConfiguration.fromCiris.load[F].toResource
+      _                      <- printBanner(conf).toResource
+      otel                   <- OtelSetup.resource(
+                                  "lucuma-resource",
+                                  BuildInfo.gitHeadCommit.getOrElse("000000"),
+                                  conf.otel
+                                )
+      given Trace[F]          = otel.trace
+      given Tracer[F]         = otel.tracer
+      given TracerProvider[F] = otel.tracerProvider
+      given MeterProvider[F]  = otel.meterProvider
+      r                      <- routesResource[F](conf.database)
+      s                      <- server(conf, r)
+    yield s
+
+  def routes[F[_]: {Async, Files, Tracer}](
+    pool:    Resource[F, Session[F]],
+    monitor: SkunkMonitor[F],
+    schema:  Schema
+  )(wsb: WebSocketBuilder2[F]): HttpRoutes[F]         = Router[F](
+    "/"         -> new StaticRoutes().service,
+    "/resource" -> new GraphQlRoutes().service(wsb, pool, monitor, schema)
+  )
+
+  def routesResource[
+    F[_]: {Async, Trace, Tracer, TracerProvider, MeterProvider, Logger, Console, Network, Files,
+      Compression}
+  ](
+    databaseConfig: DatabaseConfiguration
+  ): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
+    for
+      pool       <- databasePool(databaseConfig)
+      schema     <- GraphQlRoutes.loadSchema[F].toResource
+      r           = routes(pool, SkunkMonitor.noopMonitor[F], schema)
+      middleware <- ServerMiddleware().toResource
+    yield wsb => middleware(r(wsb))
+
+  def server[F[_]: {Async, Network}](
+    conf: ResourceConfiguration,
+    app:  WebSocketBuilder2[F] => HttpRoutes[F]
+  ): Resource[F, Server] = EmberServerBuilder
+    .default[F]
+    .withHost(ipv4"0.0.0.0")
+    .withPort(conf.port)
+    .withHttpWebSocketApp(wsb => app(wsb).orNotFound)
+    .build
+
+  def databasePool[F[_]: {Temporal, Trace, Console, Network}](
+    config: DatabaseConfiguration
+  ): Resource[F, Resource[F, Session[F]]] =
+    Session.pooled[F](
+      host = config.host.renderString,
+      port = config.port.value,
+      user = config.user,
+      password = Some(config.password),
+      database = config.database,
+      ssl = SSL.Trusted.withFallback(true),
+      max = config.maxConnections
+    )
+
+  private def printBanner[F[_]: {Logger as L}](conf: ResourceConfiguration): F[Unit] = {
+    val runtime    = Runtime.getRuntime
+    val memorySize = java.lang.management.ManagementFactory
+      .getOperatingSystemMXBean()
+      .asInstanceOf[com.sun.management.OperatingSystemMXBean]
+      .getTotalMemorySize()
+
+    val banner = """
+▄▄▄▄▄▄▄                                             
+███▀▀███▄                                           
+███▄▄███▀ ▄█▀█▄ ▄█▀▀▀ ▄███▄ ██ ██ ████▄ ▄████ ▄█▀█▄ 
+███▀▀██▄  ██▄█▀ ▀███▄ ██ ██ ██ ██ ██ ▀▀ ██    ██▄█▀ 
+███  ▀███ ▀█▄▄▄ ▄▄▄█▀ ▀███▀ ▀██▀█ ██    ▀████ ▀█▄▄▄ 
+
+"""
+
+    val msg =
+      s"""Starting Resource Server
+          | environment          : ${conf.environment}
+          | port                 : ${conf.port}
+          | version (git commit) : ${BuildInfo.gitHeadCommit.getOrElse("----")}
+          | tracing              : ${conf.otel.fold("No-op (silent)")(c =>
+          s"OpenTelemetry (OTLP) endpoint=${c.endpoint} environment=${c.environment}"
+        )}
+          |
+          | cores                : ${runtime.availableProcessors()}
+          | current JVM memory   : ${runtime.totalMemory() / 1024 / 1024} MB
+          | maximum JVM memory   : ${runtime.maxMemory() / 1024 / 1024} MB
+          | total RAM            : ${memorySize / 1024 / 1024} MB
+          | java version         : ${System.getProperty("java.version")}
+          |""".stripMargin
+
+    L.info(banner + msg)
+  }
+
+}

--- a/resource/service/src/main/scala/resource/server/http4s/ServerMiddleware.scala
+++ b/resource/service/src/main/scala/resource/server/http4s/ServerMiddleware.scala
@@ -1,0 +1,77 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.server.http4s
+import cats.*
+import cats.data.Kleisli
+import cats.data.OptionT
+import cats.effect.*
+import cats.syntax.all.*
+import fs2.compression.Compression
+import org.http4s.HttpRoutes
+import org.http4s.Query
+import org.http4s.Uri
+import org.http4s.headers.Upgrade
+import org.http4s.metrics.MetricsOps
+import org.http4s.otel4s.middleware.metrics.OtelMetrics
+import org.http4s.otel4s.middleware.trace.redact
+import org.http4s.otel4s.middleware.trace.redact.PathRedactor
+import org.http4s.otel4s.middleware.trace.redact.QueryRedactor
+import org.http4s.otel4s.middleware.trace.server.ServerMiddleware as OtelServerMiddleware
+import org.http4s.otel4s.middleware.trace.server.ServerSpanDataProvider
+import org.http4s.server.middleware.ErrorAction
+import org.http4s.server.middleware.GZip
+import org.http4s.server.middleware.Logger as Http4sLogger
+import org.http4s.server.middleware.Metrics
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.otel4s.metrics.MeterProvider
+import org.typelevel.otel4s.trace.TracerProvider
+
+object ServerMiddleware {
+  type Middleware[F[_]] = Endo[HttpRoutes[F]]
+
+  /**
+   * Create a combined middleware to all server routes
+   */
+  def apply[F[_]: {Async, Compression, TracerProvider, MeterProvider}](): F[Middleware[F]] = {
+    given Logger[F] = Slf4jLogger.getLogger[F]
+
+    val logging = Http4sLogger.httpRoutes[F](
+      logHeaders = true,
+      logBody = false
+    )
+
+    val httpMetrics: MetricsOps[F] => Middleware[F] = metricsOps =>
+      routes =>
+        val withMetrics = Metrics[F](metricsOps)(routes)
+        Kleisli(req => if (req.headers.get[Upgrade].isDefined) routes(req) else withMetrics(req))
+
+    val errorReporting: Middleware[F] = routes =>
+      ErrorAction.httpRoutes.log(
+        httpRoutes = routes,
+        messageFailureLogAction = Logger[F].error(_)(_),
+        serviceErrorLogAction = Logger[F].error(_)(_)
+      )
+    val spanDataProvider              = ServerSpanDataProvider.openTelemetry(redactor)
+
+    (
+      OtelServerMiddleware.builder[F](spanDataProvider).build,
+      OtelMetrics.serverMetricsOps[F]()
+    ).mapN: (otel, metricsOps) =>
+      List[Middleware[F]](
+        logging,
+        httpMetrics(metricsOps),
+        otel.asHttpRoutesMiddleware,
+        errorReporting,
+        GZip(_)
+      ).reduce(_ andThen _) // N.B. the monoid for Endo uses `compose`
+  }
+
+  private object redactor extends PathRedactor with QueryRedactor:
+    def redactPath(path: Uri.Path): Uri.Path = path
+    def redactQuery(query: Query): Query     =
+      if (query.isEmpty) query
+      else Query(redact.REDACTED -> None)
+
+}

--- a/resource/service/src/main/scala/resource/server/http4s/StaticRoutes.scala
+++ b/resource/service/src/main/scala/resource/server/http4s/StaticRoutes.scala
@@ -1,0 +1,85 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.server.http4s
+
+import cats.data.NonEmptyList
+import cats.data.OptionT
+import cats.effect.Sync
+import cats.syntax.all.*
+import fs2.io.file.Files
+import fs2.io.file.Path
+import org.http4s.*
+import org.http4s.CacheDirective
+import org.http4s.CacheDirective.*
+import org.http4s.dsl.io.*
+import org.http4s.headers.`Cache-Control`
+
+import scala.concurrent.duration.*
+
+class StaticRoutes[F[_]: {Sync, Files}]:
+
+  private val AppDir: String = "app"
+
+  private val OneYear: FiniteDuration = 365.days
+
+  private val CacheHeaders: List[Header.ToRaw] = List(
+    `Cache-Control`(NonEmptyList.of(`max-age`(OneYear)))
+  )
+
+  // Cache index pages for a short time to avoid stale content
+  private val IndexCacheHeaders: List[Header.ToRaw] = List(
+    `Cache-Control`(NonEmptyList.of(`max-age`(6.hours), `must-revalidate`))
+  )
+
+  // /assets/* files are fingerprinted and can be cached for a long time
+  val immutable                                     = CacheDirective("immutable")
+  private val AssetCacheHeaders: List[Header.ToRaw] = List(
+    `Cache-Control`(NonEmptyList.of(`public`, `max-age`(OneYear), immutable))
+  )
+
+  def localFile(path: String, req: Request[F]): OptionT[F, Response[F]] =
+    OptionT
+      .liftF(baseDir)
+      .flatMap: dir =>
+        StaticFile.fromPath(
+          Path.fromNioPath(dir.resolve(AppDir).resolve(path.stripPrefix("/"))),
+          req.some
+        )
+
+  extension (req: Request[F])
+    def endsWith(exts: String*): Boolean = exts.exists(req.pathInfo.toString.endsWith)
+
+    def serve(path: String, headers: List[Header.ToRaw]): F[Response[F]] =
+      localFile(path, req)
+        .map(_.putHeaders(headers*))
+        .getOrElse(Response.notFound[F])
+
+  private val supportedExtension = List(
+    ".html",
+    ".js",
+    ".map",
+    ".css",
+    ".png",
+    ".eot",
+    ".svg",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".mp3",
+    ".ico",
+    ".webm",
+    ".json"
+  )
+
+  def service: HttpRoutes[F] =
+    HttpRoutes.of[F]:
+      case req @ GET -> Root                                                  =>
+        req.serve("/index.html", IndexCacheHeaders)
+      case req @ GET -> "assets" /: rest if req.endsWith(supportedExtension*) =>
+        req.serve(req.pathInfo.toString, AssetCacheHeaders)
+      case req if req.endsWith(supportedExtension*)                           =>
+        req.serve(req.pathInfo.toString, CacheHeaders)
+      // This maybe not desired in all cases but it helps to keep client side routing cleaner
+      case req if !req.pathInfo.toString.contains(".")                        =>
+        req.serve("/index.html", IndexCacheHeaders)

--- a/resource/service/src/main/scala/resource/server/http4s/package.scala
+++ b/resource/service/src/main/scala/resource/server/http4s/package.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package resource.server.http4s
+
+import cats.effect.Sync
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Calculates the base dir of the application.
+ */
+def baseDir[F[_]: Sync]: F[Path] = Sync[F].delay:
+  // https://stackoverflow.com/questions/320542/how-to-get-the-path-of-a-running-jar-file
+  val appPath =
+    Paths.get(this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI).getParent.getParent
+  if (Files.exists(appPath)) appPath else Paths.get(System.getProperty("user.home"))

--- a/resource/service/src/test/scala/lucuma/resource/ResourceBaseSuite.scala
+++ b/resource/service/src/test/scala/lucuma/resource/ResourceBaseSuite.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.resource
+
+import cats.effect.*
+import munit.CatsEffectSuite
+import munit.Location
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+trait ResourceBaseSuite:
+  this: CatsEffectSuite =>
+
+  given Logger[IO] = Slf4jLogger.getLogger
+
+  extension [A](opt: Option[A])
+    def value(using Location): A = opt.getOrElse(fail(s"Expected Some, but got $opt"))
+
+  extension [A](either: Either[?, A])
+    def value(using Location): A =
+      either.getOrElse(fail(s"Expected Right, but got $either"))
+
+  extension [A](either: Either[A, ?])
+    def leftValue(using Location): A =
+      either.left.getOrElse(fail(s"Expected Left, but got $either"))

--- a/resource/service/src/test/scala/lucuma/resource/graphql/query/TelescopeNightTimelineSuite.scala
+++ b/resource/service/src/test/scala/lucuma/resource/graphql/query/TelescopeNightTimelineSuite.scala
@@ -1,0 +1,142 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.resource.graphql.query
+
+import cats.syntax.all.*
+import io.circe.Json.*
+import io.circe.JsonObject
+import io.circe.syntax.*
+import lucuma.core.enums.Site
+import lucuma.resource.test.ResourceGraphQLSuite
+import resource.model.*
+
+class TelescopeNightTimelineSuite extends ResourceGraphQLSuite:
+
+  test("foo"):
+    expectSuccess(
+      query = """
+      |query TelescopeNightTimeline($site: Site!) {
+      |  telescopeNightTimeline(site: $site, observingNight: "2026-08-01") {
+      |    site
+      |    observingNight
+      |    displayInterval {
+      |      start
+      |      end
+      |      duration {
+      |        seconds
+      |      }
+      |    }
+      |    availability {
+      |      interval {
+      |        start
+      |        end
+      |        duration {
+      |          seconds
+      |        }
+      |      }
+      |      availability
+      |      reason
+      |      plannedAvailability
+      |      site
+      |    }
+      |    tooStatus {
+      |      interval {
+      |        start
+      |        end
+      |        duration {
+      |          seconds
+      |        }
+      |      }
+      |      tooSupport
+      |      site
+      |    }
+      |    modes {
+      |      interval {
+      |        start
+      |        end
+      |        duration {
+      |          seconds
+      |        }
+      |      }
+      |      site
+      |      mode {
+      |        type
+      |        programReference
+      |      }
+      |    }
+      |  }
+      |}
+      |""".stripMargin,
+      obj(
+        "telescopeNightTimeline" -> obj(
+          "site"            -> Site.GN.asJson,
+          "observingNight"  -> fromString("2026-08-01"),
+          "displayInterval" -> obj(
+            "start"    -> fromString("2026-08-02T04:00:00Z"),
+            "end"      -> fromString("2026-08-02T15:30:00Z"),
+            "duration" -> obj(
+              "seconds" -> fromBigDecimal(BigDecimal("41400.000000"))
+            )
+          ),
+          "availability"    -> arr(
+            obj(
+              "interval"            -> obj(
+                "start"    -> fromString("2026-08-02T04:00:00Z"),
+                "end"      -> fromString("2026-08-02T15:30:00Z"),
+                "duration" -> obj(
+                  "seconds" -> fromBigDecimal(BigDecimal("41400.000000"))
+                )
+              ),
+              "availability"        -> TelescopeAvailability.Open.asJson,
+              "reason"              -> Null,
+              "plannedAvailability" -> Null,
+              "site"                -> Site.GN.asJson
+            )
+          ),
+          "tooStatus"       -> arr(
+            obj(
+              "interval"   -> obj(
+                "start"    -> fromString("2026-08-02T04:00:00Z"),
+                "end"      -> fromString("2026-08-02T10:00:00Z"),
+                "duration" -> obj(
+                  "seconds" -> fromBigDecimal(BigDecimal("21600.000000"))
+                )
+              ),
+              "tooSupport" -> TooSupport.Rapid.asJson,
+              "site"       -> Site.GN.asJson
+            ),
+            obj(
+              "interval"   -> obj(
+                "start"    -> fromString("2026-08-02T10:00:00Z"),
+                "end"      -> fromString("2026-08-02T15:30:00Z"),
+                "duration" -> obj(
+                  "seconds" -> fromBigDecimal(BigDecimal("19800.000000"))
+                )
+              ),
+              "tooSupport" -> TooSupport.Interrupt.asJson,
+              "site"       -> Site.GN.asJson
+            )
+          ),
+          "modes"           -> arr(
+            obj(
+              "interval" -> obj(
+                "start"    -> fromString("2026-08-02T04:00:00Z"),
+                "end"      -> fromString("2026-08-02T15:30:00Z"),
+                "duration" -> obj(
+                  "seconds" -> fromBigDecimal(BigDecimal("41400.000000"))
+                )
+              ),
+              "site"     -> Site.GN.asJson,
+              "mode"     -> obj(
+                "type"             -> TelescopeModeType.Queue.asJson,
+                "programReference" -> Null
+              )
+            )
+          )
+        )
+      ),
+      JsonObject(
+        "site" -> Site.GN.asJson
+      ).some
+    )

--- a/resource/service/src/test/scala/lucuma/resource/test/ResourceGraphQLSuite.scala
+++ b/resource/service/src/test/scala/lucuma/resource/test/ResourceGraphQLSuite.scala
@@ -1,0 +1,112 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.resource.test
+
+import cats.effect.*
+import clue.FetchClient
+import clue.GraphQLOperation
+import clue.ResponseException
+import clue.http4s.Http4sHttpBackend
+import clue.http4s.Http4sHttpClient
+import clue.http4s.Http4sWebSocketBackend
+import clue.http4s.Http4sWebSocketClient
+import io.circe.Json
+import io.circe.JsonObject
+import lucuma.resource.test.ServerFixtures
+import munit.Location
+import org.http4s.*
+import org.http4s.jdkhttpclient.JdkHttpClient
+import org.http4s.jdkhttpclient.JdkWSClient
+import org.http4s.server.Server
+import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.Slf4jLogger
+
+trait ResourceGraphQLSuite extends ServerFixtures:
+
+  def expect(
+    query:     String,
+    expected:  Either[List[String], Json],
+    variables: Option[JsonObject] = None,
+    client:    ClientOption = ClientOption.Default
+  )(using Location): IO[Unit] = {
+    val op = this.query(query, variables, client)
+    expected.fold(
+      errors =>
+        op
+          .intercept[ResponseException[Any]]
+          .map(e => e.errors.toList.map(_.message))
+          .assertEquals(errors),
+      success =>
+        op.map(_.spaces2)
+          //        .flatTap(s => IO.println(s))
+          .assertEquals(success.spaces2) // by comparing strings we get more useful errors
+    )
+  }
+
+  /** Expect success. */
+  def expectSuccess(
+    query:     String,
+    expected:  Json,
+    variables: Option[JsonObject] = None,
+    client:    ClientOption = ClientOption.Default
+  )(using Location): IO[Unit] =
+    this
+      .query(query, variables, client)
+      .map(_.spaces2)
+      .assertEquals(expected.spaces2) // by comparing strings we get more useful errors
+
+  def query(
+    query:     String,
+    variables: Option[JsonObject] = None,
+    client:    ClientOption = ClientOption.Default
+  ): IO[Json] =
+    Resource
+      .eval(IO(serverFixture()))
+      .flatMap(client.connection)
+      .use:
+        conn =>
+          val req = conn.request(Operation(query))
+          val op  = variables.fold(req.apply)(req.withInput).raiseGraphQLErrors
+          op
+          // op.onError:
+          //   case ResponseException(es, _) =>
+          //     es.traverse_ : e =>
+
+          //       OdbError.fromGraphQLError(e) match
+          //         case Some(_) => IO.unit
+          //         case None    => IO.println(s"🐙 Not an OdbError: $e")
+          //   case _                        => IO.unit
+
+  private case class Operation(document: String)
+      extends GraphQLOperation.Typed[Nothing, JsonObject, Json]
+
+enum ClientOption:
+  case Http
+  case Ws
+
+  def connection(svr: Server): Resource[IO, FetchClient[IO, Nothing]] = this match
+    case ClientOption.Http => httpClient(svr)
+    case ClientOption.Ws   => streamingClient(svr)
+
+  private def httpClient(svr: Server): Resource[IO, FetchClient[IO, Nothing]] =
+    val uri = svr.baseUri / "resource" / "graphql"
+    for
+      given Http4sHttpBackend[IO] <- JdkHttpClient.simple[IO].map(Http4sHttpBackend[IO](_))
+      given Logger[IO]             = Slf4jLogger.getLogger[IO]
+      xc                          <- Resource.eval(Http4sHttpClient.of[IO, Nothing](uri))
+    yield xc
+
+  private def streamingClient(svr: Server): Resource[IO, FetchClient[IO, Nothing]] =
+    val uri =
+      (svr.baseUri / "resource" / "graphql").copy(scheme = Some(Uri.Scheme.unsafeFromString("ws")))
+    for {
+      given Http4sWebSocketBackend[IO] <- JdkWSClient.simple[IO].map(Http4sWebSocketBackend[IO](_))
+      given Logger[IO]                  = Slf4jLogger.getLogger[IO]
+      sc                               <- Resource.eval(Http4sWebSocketClient.of[IO, Nothing](uri))
+      // _  <- Resource.make(sc.connect(ps.pure[IO]))(_ => sc.disconnect())
+    } yield sc
+
+object ClientOption:
+  val Default: ClientOption   = Http
+  val All: List[ClientOption] = List(Http, Ws)

--- a/resource/service/src/test/scala/lucuma/resource/test/ServerFixtures.scala
+++ b/resource/service/src/test/scala/lucuma/resource/test/ServerFixtures.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.resource.test
+
+import cats.effect.*
+import cats.syntax.all.*
+import com.comcast.ip4s.*
+import lucuma.resource.ResourceBaseSuite
+import munit.catseffect.IOFixture
+import natchez.Trace
+import org.http4s.*
+import org.http4s.Uri.Host
+import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.server.Server
+import org.typelevel.otel4s.metrics.MeterProvider
+import org.typelevel.otel4s.trace.Tracer
+import org.typelevel.otel4s.trace.TracerProvider
+import resource.model.config.DatabaseConfiguration
+import resource.server.http4s.ResourceMain
+
+import scala.concurrent.duration.*
+
+trait ServerFixtures extends munit.CatsEffectSuite with ResourceBaseSuite:
+
+  given Trace[IO]          = Trace.Implicits.noop
+  given TracerProvider[IO] = TracerProvider.noop
+  given Tracer[IO]         = Tracer.Implicits.noop
+  given MeterProvider[IO]  = MeterProvider.noop
+
+  override def munitFixtures = super.munitFixtures ++ List(serverFixture)
+
+  lazy val serverFixture: IOFixture[Server] =
+    ResourceSuiteLocalFixture("server", server)
+
+  private lazy val server: Resource[IO, Server] =
+    for
+      a <- ResourceMain.routesResource[IO](databaseConfig).map(_.map(_.orNotFound))
+      s <- EmberServerBuilder
+             .default[IO]
+             .withHost(ipv4"0.0.0.0")
+             .withPort(port"0")
+             .withHttpWebSocketApp(a)
+             .withShutdownTimeout(2.seconds)
+             .build
+    yield s
+
+  protected lazy val databaseConfig: DatabaseConfiguration =
+    DatabaseConfiguration(
+      maxConnections = 10,
+      host = Host.unsafeFromString("localhost"),
+      port = port"5432",
+      user = "jimmy",
+      password = "banana",
+      database = "lucuma-odb"
+    )


### PR DESCRIPTION
Adds:
- resource/model - configuration and domain models
- resource/service - anything related to the web server, including GraphQL schema, skunk, http4s routes and server launcher.
- Resource graphql schema is implemented, though with static dummy data
- Deployment to Heroku

Adds a SchemaStitcher, mostly copied from navigate. To import types from base ODB schema. Could be used by other modules too (and possibly replace the schemaStitcher script)

TODO (most of them likely in later PRs):
- Add tests for the new modules (there's a lot of boilerplate to get things working, so it'll probably be relatively minor). Most likely in this PR
- DB migrations
- Authorization through SSO JWT verification
- README and docs updates


