### PR TITLE
Shortcut 8293: Validate ETM update for GHOST

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/ExposureTimeModeService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExposureTimeModeService.scala
@@ -166,7 +166,7 @@ object ExposureTimeModeService:
         oids:  List[Observation.Id],
         roles: ExposureTimeModeRole*
       )(using Transaction[F]): F[Map[Observation.Id, Map[ExposureTimeModeRole, NonEmptyList[ExposureTimeMode]]]] =
-        val af = Statements.Select(oids, roles.toList)
+        val af = Statements.select(oids, roles.toList)
 
         session.prepareR(af.fragment.query(observation_id *: exposure_time_mode_role *: exposure_time_mode)).use: pq =>
           pq.stream(af.argument, chunkSize = 1024)
@@ -356,7 +356,7 @@ object ExposureTimeModeService:
 
   object Statements:
 
-    def Select(
+    def select(
       oids:  List[Observation.Id],
       roles: List[ExposureTimeModeRole],
     ): AppliedFragment =

--- a/modules/service/src/main/scala/lucuma/odb/service/GhostIfuService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GhostIfuService.scala
@@ -3,10 +3,11 @@
 
 package lucuma.odb.service
 
+import cats.Order.catsKernelOrderingForOrder
 import cats.data.NonEmptyList
 import cats.effect.Concurrent
 import cats.syntax.applicative.*
-import cats.syntax.apply.*
+import cats.syntax.eq.*
 import cats.syntax.flatMap.*
 import cats.syntax.foldable.*
 import cats.syntax.functor.*
@@ -51,7 +52,7 @@ trait GhostIfuService[F[_]]:
   def update(
     SET:   GhostIfuInput.Edit,
     which: List[Observation.Id]
-  )(using Transaction[F]): F[Unit]
+  )(using Transaction[F]): F[Result[Unit]]
 
   def clone(
     originalId: Observation.Id,
@@ -63,23 +64,45 @@ object GhostIfuService:
   enum Channel:
     case Red, Blue
 
-  private def validateEtms(
-    requirementsEtm: Option[ExposureTimeMode],
-    scienceEtms:     Map[Channel, Option[ExposureTimeMode]]
-  ): Result[Unit] =
-    def validateEtm(c: Channel): Result[Unit] =
-      Result
-        .fromOption(
-          scienceEtms
-            .get(c)
-            .flatten
-            .orElse(requirementsEtm)
-            .flatMap(ExposureTimeMode.timeAndCount.getOption)
-            .void,
-          OdbError.InvalidArgument("GHOST observations require a TimeAndCount exposure time mode.".some).asProblem
+    def color: String =
+      this match
+        case Red  => "red"
+        case Blue => "blue"
+
+    def etmIdColumn: String =
+      s"c_${color}_exposure_time_mode_id"
+
+  private object validateEtms:
+    def errorMessage(oids: List[Observation.Id]): String =
+      val oidsString = oids match
+        case Nil => ""
+        case _   => s"${oids.sorted.mkString("(", ", ", ")")} "
+      s"GHOST observations ${oidsString}require red and blue channel TimeAndCount exposure time modes with equivalent wavelength values."
+
+    val error: OdbError = OdbError.InvalidArgument(errorMessage(Nil).some)
+
+    def checkAtEquals(a: ExposureTimeMode, b: ExposureTimeMode): Result[Unit] =
+      error.asFailure.unlessA(a.at === b.at)
+
+    def forCreate(
+      requirementsEtm: Option[ExposureTimeMode],
+      scienceEtmA:     Option[ExposureTimeMode],
+      scienceEtmB:     Option[ExposureTimeMode]
+    ): Result[Unit] =
+      def resolveAndValidate(e: Option[ExposureTimeMode]): Result[ExposureTimeMode] =
+        Result.fromOption(
+          e.orElse(requirementsEtm).flatMap(ExposureTimeMode.timeAndCount.getOption),
+          error.asProblem
         )
 
-    validateEtm(Channel.Red) *> validateEtm(Channel.Blue)
+      for
+        a <- resolveAndValidate(scienceEtmA)
+        b <- resolveAndValidate(scienceEtmB)
+        _ <- checkAtEquals(a, b)
+      yield ()
+
+    def forUpdate(a: ExposureTimeMode, b: ExposureTimeMode): Result[Unit] =
+      forCreate(none, a.some, b.some)
 
   def instantiate[F[_]: {Concurrent, Services}]: GhostIfuService[F] =
 
@@ -100,16 +123,15 @@ object GhostIfuService:
         reqEtm: Option[ExposureTimeMode],
         which:  List[Observation.Id]
       )(using Transaction[F]): F[Result[Unit]] =
-        val science = NonEmptyList.of(
-          Channel.Blue -> input.blue.flatMap(_.exposureTimeMode),
-          Channel.Red  -> input.red.flatMap(_.exposureTimeMode)
-        )
+        val redEtm  = input.red.flatMap(_.exposureTimeMode)
+        val blueEtm = input.blue.flatMap(_.exposureTimeMode)
+        val science = NonEmptyList.of(Channel.Red -> redEtm, Channel.Blue -> blueEtm)
 
         NonEmptyList
           .fromList(which)
           .fold(ResultT.unit[F]): nel =>
             for
-              _   <- ResultT.fromResult(validateEtms(reqEtm, science.toList.toMap))
+              _   <- ResultT.fromResult(validateEtms.forCreate(reqEtm, redEtm, blueEtm))
               r   <- ResultT(exposureTimeModeService.resolve("GHOST IFU", none, science, reqEtm, which))
               ids <- ResultT.liftF(exposureTimeModeService.insertResolvedAcquisitionAndScience(r))
               etms = nel.map: oid =>
@@ -127,12 +149,43 @@ object GhostIfuService:
       override def update(
         SET:   GhostIfuInput.Edit,
         which: List[Observation.Id]
-      )(using Transaction[F]): F[Unit] =
-        for
-          _ <- Statements.updateGhostIfu(SET, which).traverse_(session.exec)
-          _ <- SET.red.flatMap(_.exposureTimeMode).traverse_(etm => session.exec(Statements.updateEtm(which, etm, "red")))
-          _ <- SET.blue.flatMap(_.exposureTimeMode).traverse_(etm => session.exec(Statements.updateEtm(which, etm, "blue")))
-        yield ()
+      )(using Transaction[F]): F[Result[Unit]] =
+        def selectEtms(c: Channel): F[List[(Observation.Id, ExposureTimeMode)]] =
+          val af = Statements.selectGhostScienceExposureTimeModes(which, c)
+          session.prepareR(af.fragment.query(observation_id *: exposure_time_mode)).use: pq =>
+            pq.stream(af.argument, chunkSize = 1024)
+              .compile
+              .toList
+
+        def validateOne(
+          updatedEtm:     ExposureTimeMode,
+          lookupExisting: F[List[(Observation.Id, ExposureTimeMode)]]
+        ): ResultT[F, Unit] =
+          ResultT:
+            lookupExisting.map: lst =>
+              NonEmptyList
+                .fromList:
+                  lst.collect:
+                    case (oid, existingEtm) if !validateEtms.forUpdate(updatedEtm, existingEtm).hasValue => oid
+                .fold(Result.unit): oids =>
+                   OdbError.InvalidArgument(validateEtms.errorMessage(oids.toList).some).asFailure
+
+        val setRedEtm  = SET.red.flatMap(_.exposureTimeMode)
+        val setBlueEtm = SET.blue.flatMap(_.exposureTimeMode)
+
+        val validateEtmUpdate: ResultT[F, Unit] =
+          (setRedEtm, setBlueEtm) match
+            case (Some(r), Some(b)) => ResultT.fromResult(validateEtms.forUpdate(r, b))
+            case (None,    None)    => ResultT.unit
+            case (Some(r), None)    => validateOne(r, selectEtms(Channel.Blue))
+            case (None,    Some(b)) => validateOne(b, selectEtms(Channel.Red))
+
+        (for
+          _ <- ResultT.liftF(Statements.updateGhostIfu(SET, which).traverse_(session.exec))
+          _ <- validateEtmUpdate
+          _ <- ResultT.liftF(setRedEtm.traverse_(etm => session.exec(Statements.updateEtm(which, etm, Channel.Red))))
+          _ <- ResultT.liftF(setBlueEtm.traverse_(etm => session.exec(Statements.updateEtm(which, etm, Channel.Blue))))
+        yield ()).value
 
       override def clone(
         originalId: Observation.Id,
@@ -343,9 +396,9 @@ object GhostIfuService:
         WHERE src.c_observation_id = $observation_id"""(originalId)
 
     def updateEtm(
-      oids:   List[Observation.Id],
-      update: ExposureTimeMode,
-      color:  String
+      oids:    List[Observation.Id],
+      update:  ExposureTimeMode,
+      channel: Channel
     ): AppliedFragment =
       sql"""
         UPDATE t_exposure_time_mode e
@@ -355,8 +408,8 @@ object GhostIfuService:
             c_exposure_time      = ${time_span.opt},
             c_exposure_count     = ${int4_pos.opt}
         FROM t_ghost_ifu g
-        WHERE g.c_observation_id                  = e.c_observation_id
-          AND g.c_#${color}_exposure_time_mode_id = e.c_exposure_time_mode_id
+        WHERE g.c_observation_id        = e.c_observation_id
+          AND g.#${channel.etmIdColumn} = e.c_exposure_time_mode_id
           AND e.c_observation_id IN ${observation_id.list(oids.length).values}
       """.apply(
         update.modeType,
@@ -366,6 +419,23 @@ object GhostIfuService:
         update.exposureCount,
         oids
       )
+
+    def selectGhostScienceExposureTimeModes(
+      oids:    List[Observation.Id],
+      channel: Channel
+    ): AppliedFragment =
+      sql"""
+        SELECT
+          g.c_observation_id,
+          e.c_exposure_time_mode,
+          e.c_signal_to_noise_at,
+          e.c_signal_to_noise,
+          e.c_exposure_time,
+          e.c_exposure_count
+        FROM t_ghost_ifu g
+        JOIN t_exposure_time_mode e ON e.c_exposure_time_mode_id = g.#${channel.etmIdColumn}
+        WHERE g.c_observation_id IN ${observation_id.list(oids.length).values}
+      """.apply(oids.toList)
 
     def updateGhostIfu(
       SET:   GhostIfuInput.Edit,

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservingModeServices.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservingModeServices.scala
@@ -162,7 +162,7 @@ object ObservingModeServices:
       )(using Transaction[F], SuperUserAccess): F[Result[Unit]] =
         List(
           input.flamingos2LongSlit.map(m => flamingos2LongSlitService.update(m, which).map(_.success)),
-          input.ghostIfu.map(m => ghostIfuService.update(m, which).map(_.success)),
+          input.ghostIfu.map(m => ghostIfuService.update(m, which)),
           input.gmosNorthImaging.map(m => gmosImagingService.updateNorth(m, which)),
           input.gmosNorthLongSlit.map(m => gmosLongSlitService.updateNorth(m, which).map(_.success)),
           input.gmosSouthImaging.map(m => gmosImagingService.updateSouth(m, which)),

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GhostIfu.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GhostIfu.scala
@@ -275,7 +275,57 @@ class createObservation_GhostIfu extends OdbSuite:
               }
             """,
           expected = List(
-            "GHOST observations require a TimeAndCount exposure time mode."
+            "GHOST observations require red and blue channel TimeAndCount exposure time modes with equivalent wavelength values."
+          ).asLeft
+        )
+
+  test("cannot create GHOST IFU with time and count if the red and blue channel wavelengths differ"):
+    createProgramAs(pi).flatMap: pid =>
+      createTargetAs(pi, pid).flatMap: tid =>
+        expect(
+          user  = pi,
+          query =
+            // N.B. Using the F2 science requirements to get a S/N ETM
+            s"""
+              mutation {
+                createObservation(input: {
+                  programId: "$pid"
+                  SET: {
+                    targetEnvironment: {
+                      asterism: [ "$tid" ]
+                    }
+                    scienceRequirements: ${scienceRequirementsObject(Flamingos2LongSlit)}
+                    observingMode: {
+                      ghostIfu: {
+                        resolutionMode: STANDARD
+                        red: {
+                          exposureTimeMode: {
+                            timeAndCount: {
+                              time: { seconds: 1.0 }
+                              count: 1
+                              at: { nanometers: 500 }
+                            }
+                          }
+                        }
+                        blue: {
+                          exposureTimeMode: {
+                            timeAndCount: {
+                              time: { seconds: 2.0 }
+                              count: 2
+                              at: { nanometers: 501 }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }) {
+                  observation { id }
+                }
+              }
+            """,
+          expected = List(
+            "GHOST observations require red and blue channel TimeAndCount exposure time modes with equivalent wavelength values."
           ).asLeft
         )
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations_GhostIfu.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations_GhostIfu.scala
@@ -7,6 +7,7 @@ package mutation
 import cats.syntax.either.*
 import io.circe.Json
 import io.circe.literal.*
+import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.odb.graphql.query.ObservingModeSetupOperations
 
@@ -43,6 +44,32 @@ class updateObservations_GhostIfu extends OdbSuite with UpdateObservationsOps wi
     }
   """
 
+  val EtmQuery: String =
+    s"""
+      observations {
+        observingMode {
+          ghostIfu {
+            red {
+              exposureTimeMode {
+                timeAndCount {
+                  time { seconds }
+                  count
+                }
+              }
+            }
+            blue {
+              exposureTimeMode {
+                timeAndCount {
+                  time { seconds }
+                  count
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
   test("Update exposure time modes"):
     val update = """
       observingMode: {
@@ -62,31 +89,6 @@ class updateObservations_GhostIfu extends OdbSuite with UpdateObservationsOps wi
                 time: { seconds: 40.0 }
                 count: 40
                 at: { nanometers: 500 }
-              }
-            }
-          }
-        }
-      }
-    """
-
-    val query = """
-      observations {
-        observingMode {
-          ghostIfu {
-            red {
-              exposureTimeMode {
-                timeAndCount {
-                  time { seconds }
-                  count
-                }
-              }
-            }
-            blue {
-              exposureTimeMode {
-                timeAndCount {
-                  time { seconds }
-                  count
-                }
               }
             }
           }
@@ -129,7 +131,124 @@ class updateObservations_GhostIfu extends OdbSuite with UpdateObservationsOps wi
       p <- createProgramAs(pi)
       t <- createTargetWithProfileAs(pi, p)
       o <- createObservationWithModeAs(pi, p, List(t), GhostIfuInput)
-      _ <- updateObservation(pi, o, update, query, expected)
+      _ <- updateObservation(pi, o, update, EtmQuery, expected)
+    yield o
+
+  test("Cannot switch to S/N"):
+    val update = """
+      observingMode: {
+        ghostIfu: {
+          red: {
+            exposureTimeMode: {
+              signalToNoise: {
+                value: 100
+                at: { nanometers: 500 }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    def expected(o: Observation.Id): Either[String, Json] =
+     s"GHOST observations ($o) require red and blue channel TimeAndCount exposure time modes with equivalent wavelength values.".asLeft
+
+    for
+      p <- createProgramAs(pi)
+      t <- createTargetWithProfileAs(pi, p)
+      o <- createObservationWithModeAs(pi, p, List(t), GhostIfuInput)
+      _ <- updateObservation(pi, o, update, EtmQuery, expected(o))
+    yield o
+
+  test("Cannot use a different wavelength"):
+    val update = """
+      observingMode: {
+        ghostIfu: {
+          blue: {
+            exposureTimeMode: {
+              timeAndCount: {
+                time: { seconds: 10.0 }
+                count: 10
+                at: { nanometers: 501 }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    def expected(o: Observation.Id): Either[String, Json] =
+     s"GHOST observations ($o) require red and blue channel TimeAndCount exposure time modes with equivalent wavelength values.".asLeft
+
+    for
+      p <- createProgramAs(pi)
+      t <- createTargetWithProfileAs(pi, p)
+      o <- createObservationWithModeAs(pi, p, List(t), GhostIfuInput)
+      _ <- updateObservation(pi, o, update, EtmQuery, expected(o))
+    yield o
+
+  test("Can switch both"):
+    val update = """
+      observingMode: {
+        ghostIfu: {
+          red: {
+            exposureTimeMode: {
+              timeAndCount: {
+                time: { seconds: 10.0 }
+                count: 10
+                at: { nanometers: 501 }
+              }
+            }
+          }
+          blue: {
+            exposureTimeMode: {
+              timeAndCount: {
+                time: { seconds: 20.0 }
+                count: 20
+                at: { nanometers: 501 }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = json"""
+      {
+        "updateObservations": {
+          "observations": [
+            {
+              "observingMode": {
+                "ghostIfu": {
+                  "red": {
+                    "exposureTimeMode": {
+                      "timeAndCount": {
+                        "time": { "seconds": 10.000000 },
+                        "count": 10
+                      }
+                    }
+                  },
+                  "blue": {
+                    "exposureTimeMode": {
+                      "timeAndCount": {
+                        "time": { "seconds": 20.000000 },
+                        "count": 20
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    """.asRight
+
+    for
+      p <- createProgramAs(pi)
+      t <- createTargetWithProfileAs(pi, p)
+      o <- createObservationWithModeAs(pi, p, List(t), GhostIfuInput)
+      _ <- updateObservation(pi, o, update, EtmQuery, expected)
     yield o
 
   test("Update non-exposure time mode parameters"):

--- a/modules/service/src/test/scala/lucuma/odb/service/GhostIfuServiceSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/GhostIfuServiceSuite.scala
@@ -4,9 +4,10 @@
 package lucuma.odb.service
 
 import cats.effect.IO
+import cats.syntax.apply.*
 import cats.syntax.option.*
 import eu.timepit.refined.types.numeric.PosInt
-import grackle.Result
+import grackle.ResultT
 import lucuma.core.enums.GhostBinning
 import lucuma.core.enums.GhostIfu1FiberAgitator
 import lucuma.core.enums.GhostIfu2FiberAgitator
@@ -46,13 +47,17 @@ class GhostIfuServiceSuite extends ExecutionTestSupport:
     in:  GhostIfuInput.Create,
     etm: Option[ExposureTimeMode],
     oid: Observation.Id
-  ): IO[Result[Unit]] =
+  ): IO[Unit] =
     withServices(serviceUser): services =>
       services
         .transactionally:
           val setType  = services.session.execute(SetObservingMode)(Instrument.Ghost, ObservingModeType.GhostIfu, oid).void
           val doInsert = ghostIfuService.insert(in, etm, List(oid))
-          setType *> doInsert
+          (ResultT.liftF(setType) *> ResultT(doInsert)).value.flatMap: r =>
+            r.toEither match
+              case Right(_)        => IO.unit
+              case Left(Right(ps)) => IO.raiseError(Exception(ps.toString))
+              case Left(Left(e))   => IO.raiseError(e)
 
   private def select(
     oid: Observation.Id
@@ -108,7 +113,7 @@ class GhostIfuServiceSuite extends ExecutionTestSupport:
     val blueEtm = ExposureTimeMode.TimeAndCountMode(
       2.secondTimeSpan,
       PosInt.unsafeFrom(2),
-      Wavelength.unsafeFromIntPicometers(500002)
+      Wavelength.unsafeFromIntPicometers(500001)
     )
 
     val create = GhostIfuInput.Create(


### PR DESCRIPTION
Adds input validation for GHOST IFU mode updates.  When the ETM for a single channel (red or blue) is specified, but not the other, this requires performing a lookup to find the existing ETM for the other channel for comparison.  We now require that both ETMs be `TimeAndCount` and that the wavelength `at` is equivalent.