### PR TITLE
Ghost Central Wavelength

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -8919,6 +8919,11 @@ type GhostDynamic {
   blue: GhostDetector!
   ifu1FiberAgitator: GhostIfu1FiberAgitator!
   ifu2FiberAgitator: GhostIfu2FiberAgitator!
+
+  """
+  Central wavelength, which is fixed at 655 nm.
+  """
+  centralWavelength: Wavelength
 }
 
 """

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/ghost/shared.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/ghost/shared.scala
@@ -6,7 +6,7 @@ package lucuma.odb.sequence.ghost
 import lucuma.core.math.Wavelength
 
 /**
- * GHOST central wavelength, which seems to be fixed at 530 nm.
+ * GHOST central wavelength, which seems to be fixed at 655 nm.
  */
 val CentralWavelength: Wavelength =
-  Wavelength.unsafeFromIntPicometers(530000)
+  Wavelength.unsafeFromIntPicometers(655000)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GhostDynamicMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GhostDynamicMapping.scala
@@ -4,6 +4,10 @@
 package lucuma.odb.graphql
 package mapping
 
+import io.circe.syntax.given
+import lucuma.odb.json.wavelength.query.given
+import lucuma.odb.sequence.ghost.CentralWavelength
+
 import table.GhostDynamicTable
 
 trait GhostDynamicMapping[F[_]] extends GhostDynamicTable[F]:
@@ -23,7 +27,8 @@ trait GhostDynamicMapping[F[_]] extends GhostDynamicTable[F]:
       SqlObject("red"),
       SqlObject("blue"),
       SqlField("ifu1FiberAgitator", GhostDynamicTable.FiberAgitator.Ifu1),
-      SqlField("ifu2FiberAgitator", GhostDynamicTable.FiberAgitator.Ifu2)
+      SqlField("ifu2FiberAgitator", GhostDynamicTable.FiberAgitator.Ifu2),
+      CirceField("centralWavelength", CentralWavelength.asJson)
     )
 
   lazy val GhostDynamicMappings: List[TypeMapping] =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGhost.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGhost.scala
@@ -9,6 +9,8 @@ import io.circe.syntax.*
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.ghost.GhostDetector
 import lucuma.core.model.sequence.ghost.GhostDynamicConfig
+import lucuma.odb.sequence.ghost.CentralWavelength
+
 
 trait ExecutionTestSupportForGhost extends ExecutionTestSupport:
 
@@ -32,6 +34,7 @@ trait ExecutionTestSupportForGhost extends ExecutionTestSupport:
           }
           ifu1FiberAgitator
           ifu2FiberAgitator
+          centralWavelength { nanometers }
         }
         stepConfig {
           stepType
@@ -66,7 +69,10 @@ trait ExecutionTestSupportForGhost extends ExecutionTestSupport:
         "red": ${detector(c.red.value)},
         "blue": ${detector(c.blue.value)},
         "ifu1FiberAgitator": ${c.ifu1FiberAgitator.asJson},
-        "ifu2FiberAgitator": ${c.ifu2FiberAgitator.asJson}
+        "ifu2FiberAgitator": ${c.ifu2FiberAgitator.asJson},
+        "centralWavelength": {
+          "nanometers": ${CentralWavelength.toNanometers.value.value.asJson}
+        }
       }
     """
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGhostIfu.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGhostIfu.scala
@@ -155,6 +155,7 @@ class executionSciGhostIfu extends ExecutionTestSupportForGhost:
                               }
                               ifu1FiberAgitator
                               ifu2FiberAgitator
+                              centralWavelength { nanometers }
                             }
                           }
                         }


### PR DESCRIPTION
Adds a `centralWavelength` to the `GhostDynamicConfig` schema, which is just a fixed value.  This also changes said fixed value to 655 nm to match the `ocs`.  We were using the wavelength value as the AGS wavelength as well.  Is this correct?

If this seems acceptable I'll do a similar fix for IGRINS.