### PR TITLE
Only receive y-data for graphs from the ocs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ val slf4jVersion                 = "2.0.17"
 val testcontainersScalaVersion   = "0.44.1" // check test output if you attempt to update this
 val weaverVersion                = "0.8.4"
 
-ThisBuild / tlBaseVersion      := "0.67"
+ThisBuild / tlBaseVersion      := "0.68"
 ThisBuild / scalaVersion       := "3.8.3"
 ThisBuild / crossScalaVersions := Seq("3.8.3")
 ThisBuild / scalacOptions     ++= Seq("-Xmax-inlines", "50") // Hash derivation fails with default of 32

--- a/itc/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyTimeAndGraphResult.scala
+++ b/itc/client/shared/src/main/scala/lucuma/itc/client/SpectroscopyTimeAndGraphResult.scala
@@ -6,6 +6,7 @@ package lucuma.itc.client
 import cats.Eq
 import cats.Order
 import cats.data.NonEmptyChain
+import cats.data.NonEmptyList
 import cats.derived.*
 import cats.syntax.all.*
 import io.circe.Decoder
@@ -15,9 +16,10 @@ import lucuma.core.math.TotalSN
 import lucuma.core.util.NewType
 import lucuma.itc.Error
 import lucuma.itc.GraphType
-import lucuma.itc.ItcAxis
 import lucuma.itc.ItcCcd
 import lucuma.itc.ItcVersions
+import lucuma.itc.ItcXAxis
+import lucuma.itc.ItcYAxis
 import lucuma.itc.SeriesDataType
 import lucuma.itc.TargetIntegrationTime
 import lucuma.itc.client.json.decoders.given
@@ -27,9 +29,9 @@ import lucuma.itc.client.json.decoders.given
 case class SeriesResult(
   title:      String,
   seriesType: SeriesDataType,
-  dataY:      List[Double],
-  xAxis:      Option[ItcAxis],
-  yAxis:      Option[ItcAxis]
+  dataY:      NonEmptyList[Double],
+  xAxis:      ItcXAxis,
+  yAxis:      ItcYAxis
 ) derives Eq,
       Decoder
 

--- a/itc/client/shared/src/main/scala/lucuma/itc/client/queries.scala
+++ b/itc/client/shared/src/main/scala/lucuma/itc/client/queries.scala
@@ -246,15 +246,12 @@ object SpectroscopyIntegrationTimeAndGraphsQuery extends GraphQLOperation[Unit] 
                 start
                 end
                 count
-                min
-                max
               }
               yAxis {
-                start
-                end
-                count
                 min
+                indexOfMin
                 max
+                indexOfMax
               }
             }
           }

--- a/itc/model/src/main/scala/lucuma/itc/ItcGraph.scala
+++ b/itc/model/src/main/scala/lucuma/itc/ItcGraph.scala
@@ -5,6 +5,7 @@ package lucuma.itc
 
 import cats.Eq
 import cats.data.NonEmptyChain
+import cats.data.NonEmptyList
 import cats.derived.*
 import cats.syntax.all.*
 import io.circe.Decoder
@@ -32,43 +33,59 @@ enum GraphType(val tag: String) derives Enumerated:
   case SignalPixelGraph extends GraphType("signal_pixel_graph")
   case S2NGraph         extends GraphType("s2n_graph")
 
-case class ItcAxis(start: Double, end: Double, min: Double, max: Double, count: Int)
+// X-axis values are always wavelength in nanometers
+case class ItcXAxis(start: Double, end: Double, count: Int) derives Decoder, Encoder.AsObject:
+  assert(start >= 0, "Wavelength <= 0 received in ITC graph data.")
+
+  val step: Double = (end - start) / (count - 1)
+
+  def at(index: Int): Double                       = start + index * step
+  def wavelengthAt(index: Int): Option[Wavelength] =
+    Wavelength.intPicometers
+      .getOption((at(index) * 1000).toInt)
+
+  // Find the index for which the wavelength is at or just above the given wavelength. Return None if out of range.
+  // It might be more accurate to use 'round` instead of 'ceil' but 'ceil' matches previous behavior.
+  def indexOf(w: Double): Option[Int]     =
+    if (w < start || w > end) none
+    else ((w - start) / step).ceil.toInt.some
+  def indexOf(w: Wavelength): Option[Int] =
+    indexOf(w.toNanometers.value.value.toDouble)
+
+case class ItcYAxis(min: Double, indexOfMin: Int, max: Double, indexOfMax: Int)
     derives Decoder,
       Encoder.AsObject
+object ItcYAxis:
+  def fromData(data: NonEmptyList[Double]): ItcYAxis =
+    val (minTuple, maxTuple, _) = data.foldLeft(((Double.MaxValue, 0), (Double.MinValue, 0), 0)) {
+      case ((min, max, count), y) =>
+        val newMin = if (y < min._1) (y, count) else min
+        val newMax = if (y > max._1) (y, count) else max
+        (newMin, newMax, count + 1)
+    }
+    ItcYAxis(minTuple._1, minTuple._2, maxTuple._1, maxTuple._2)
 
-object ItcAxis:
-  // Calculate the values on the axis' range
-  def calcAxis(data: List[(Double, Double)], fun: ((Double, Double)) => Double): Option[ItcAxis] =
-    if (data.nonEmpty)
-      val (min, max, count) =
-        data.foldLeft((Double.MaxValue, Double.MinValue, 0)) { case ((max, min, count), current) =>
-          val x = fun(current)
-          (x.min(max), x.max(min), count + 1)
-        }
-      ItcAxis(fun(data.head), fun(data.last), min, max, count).some
-    else none
-
-case class ItcSeries private (
+case class ItcSeries(
   title:      String,
   seriesType: SeriesDataType,
-  data:       List[(Double, Double)],
-  dataX:      List[Double],
-  dataY:      List[Double],
-  xAxis:      Option[ItcAxis],
-  yAxis:      Option[ItcAxis]
-) derives Encoder.AsObject
+  dataY:      NonEmptyList[Double],
+  xAxis:      ItcXAxis,
+  yAxis:      ItcYAxis
+) derives Encoder.AsObject:
+  def wavelengthAtMaxAndMax: Option[(Wavelength, Double)] =
+    xAxis.wavelengthAt(yAxis.indexOfMax).tupleRight(yAxis.max)
+
+  def yValueAtWavelength(w: Wavelength): Option[Double] =
+    xAxis.indexOf(w).flatMap(i => dataY.toList.lift(i))
 
 object ItcSeries:
-  def apply(title: String, seriesType: SeriesDataType, data: List[(Double, Double)]): ItcSeries =
-    ItcSeries(
-      title,
-      seriesType,
-      data,
-      data.map(_._1),
-      data.map(_._2),
-      ItcAxis.calcAxis(data, _._1),
-      ItcAxis.calcAxis(data, _._2)
-    )
+  def apply(
+    title:      String,
+    seriesType: SeriesDataType,
+    dataY:      NonEmptyList[Double],
+    xAxis:      ItcXAxis
+  ): ItcSeries =
+    ItcSeries(title, seriesType, dataY, xAxis, ItcYAxis.fromData(dataY))
 
 case class ItcGraph(graphType: GraphType, series: List[ItcSeries]) derives Eq, Encoder.AsObject
 

--- a/itc/model/src/main/scala/lucuma/itc/SpectroscopyTimeAndGraphsResult.scala
+++ b/itc/model/src/main/scala/lucuma/itc/SpectroscopyTimeAndGraphsResult.scala
@@ -21,7 +21,6 @@ object SpectroscopyTimeAndGraphsResult:
         .obj(
           "versions"             -> r.versions.asJson,
           "targetTimesAndGraphs" -> r.targetOutcomes.value.asJson,
-          "targetTimes"          -> Json.Null, // This field is deprecated and should be removed in the future.
           "brightestIndex"       -> r.targetOutcomes.brightestIndex.asJson,
           "brightest"            -> r.targetOutcomes.brightest.asJson
         )

--- a/itc/service/ocslib/build-info.json
+++ b/itc/service/ocslib/build-info.json
@@ -1,7 +1,7 @@
 {
-  "ocs_git_hash": "1fa6a07877e1f58a8d655def7cb50062842c0b2d",
-  "ocs_git_branch": "main",
-  "ocs_git_describe": "v-48-g1fa6a0787",
-  "local": false,
-  "build_timestamp": "2026-04-30T18:24:59Z"
+  "ocs_git_hash": "2803ba316113a6fffdc8b260cded52404a28543f",
+  "ocs_git_branch": "gpp-ocs",
+  "ocs_git_describe": "v-50-g2803ba316-dirty",
+  "local": true,
+  "build_timestamp": "2026-05-05T20:07:27Z"
 }

--- a/itc/service/ocslib/edu-gemini-itc-shared_2.11-2026101.1.1.jar
+++ b/itc/service/ocslib/edu-gemini-itc-shared_2.11-2026101.1.1.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:537de8312594aae8caad308f7ef9bc1918f079ea94d64b05b8dccc488a6f09b9
-size 443687
+oid sha256:6558ca5ade503211173009217e850e52e587892dd88376de513ea5fd2fbfb866
+size 437232

--- a/itc/service/ocslib/edu-gemini-itc-web_2.11-2026101.1.1.jar
+++ b/itc/service/ocslib/edu-gemini-itc-web_2.11-2026101.1.1.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:97c9913968be62fd11719eeccfe436282aac22eeb888b2d3f955903dc7668f62
-size 682935
+oid sha256:3fbaee9d50ed8860f1afd8269de43ee85c783926f0134c1785ca85042a47a734
+size 699360

--- a/itc/service/ocslib/edu-gemini-itc_2.11-2026101.1.1.jar
+++ b/itc/service/ocslib/edu-gemini-itc_2.11-2026101.1.1.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:909dbde0e01fb6a22d97e2de7f1574c6317e04263d68cb133a37e9ad811d21a2
-size 352908682
+oid sha256:a9833a091615c973a6ffb74044e0239bb3a5594977ffafcb77118ca43b3b6d45
+size 352902185

--- a/itc/service/ocslib/edu-gemini-json_2.11-2026101.1.1.jar
+++ b/itc/service/ocslib/edu-gemini-json_2.11-2026101.1.1.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b540126caa955b57942ca9b1c5d2d614fd518ed0306e1b740f7650637c78ddf
-size 37978
+oid sha256:3929c2f45519d5041d8e0b88f096b39a73bc3d178bf519e906f3ce49bb7600f3
+size 37977

--- a/itc/service/ocslib/edu-gemini-pot_2.11-2026101.1.1.jar
+++ b/itc/service/ocslib/edu-gemini-pot_2.11-2026101.1.1.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b59010df3309dc3a68b2ef26f6483848eee583aaeb7ea05b1008c85468e6fa85
-size 4397463
+oid sha256:f5b573d49d1784c344fe4a5fc79b7e7ca305a39206a2df68049b3335c6d9a703
+size 4397455

--- a/itc/service/ocslib/edu-gemini-shared-skyobject_2.11-2026101.1.1.jar
+++ b/itc/service/ocslib/edu-gemini-shared-skyobject_2.11-2026101.1.1.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4cfd4a85045f8e903b03ffc821224d1e6a4f7b65fd511d783aaf7048b913c4e
-size 7347
+oid sha256:10cbb9b93dd95473794d83e3fcf766e96e7b7b17924721fb397aeb5db588923a
+size 7348

--- a/itc/service/ocslib/edu-gemini-shared-util_2.11-2026101.1.1.jar
+++ b/itc/service/ocslib/edu-gemini-shared-util_2.11-2026101.1.1.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5396b506c5fa52cd78cac1e5def325b98f4bedfb9ce7d5bf9f3fd1c78aa0cc97
-size 160966
+oid sha256:d24c92bf4761bfe16a0524894c7fec81938d10b359e41f6b16a30a809eafcbd2
+size 160965

--- a/itc/service/ocslib/edu-gemini-spmodel-core_2.11-2026101.1.1.jar
+++ b/itc/service/ocslib/edu-gemini-spmodel-core_2.11-2026101.1.1.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:add198d47b926fcd20cdf8253e9b5773926ad1d0c07a20cb20581815bd8e8c46
-size 932108
+oid sha256:ea4bc882add78681e79b265ce3e6dcff67eb5aad1dfca49b1d86cfbb6a6fe2f5
+size 932107

--- a/itc/service/ocslib/edu-gemini-spmodel-pio_2.11-2026101.1.1.jar
+++ b/itc/service/ocslib/edu-gemini-spmodel-pio_2.11-2026101.1.1.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:98fa0bda0e07d557594dadaacbbc74a1fd1711d3fa1c1fa4b7d41c110aa865e4
-size 317836
+oid sha256:712c37100029b016be6982aad869f34b0546268c6a1976f2d4c78bd78e536c91
+size 317835

--- a/itc/service/ocslib/edu-gemini-util-skycalc_2.11-2026101.1.1.jar
+++ b/itc/service/ocslib/edu-gemini-util-skycalc_2.11-2026101.1.1.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5fc9c2181bf0515ab4733d6bee72f4d06029540d0a83e8cc22c23f391ddf4f57
-size 231785
+oid sha256:7ba7b7ea945cdc79dc27eb635806b72197e70238495dde71eab3e06a800715dd
+size 231783

--- a/itc/service/src/main/resources/graphql/itc.graphql
+++ b/itc/service/src/main/resources/graphql/itc.graphql
@@ -1006,64 +1006,6 @@ enum GhostReadMode {
   FAST
 }
 
-enum GnirsGrating {
-  D10
-  D32
-  D111
-}
-
-enum GnirsFilter {
-  CROSS_DISPERSED
-  ORDER6
-  ORDER5
-  ORDER4
-  ORDER3
-  ORDER2
-  ORDER1
-  H2
-  H_ND100X
-  H2_ND100X
-  PAH
-  Y
-  J
-  K
-}
-
-enum GnirsCamera {
-  LONG_BLUE
-  LONG_RED
-  SHORT_BLUE
-  SHORT_RED
-}
-
-enum GnirsPrism {
-  MIRROR
-  SXD
-  LXD
-}
-
-enum GnirsReadMode {
-  VERY_BRIGHT
-  BRIGHT
-  FAINT
-  VERY_FAINT
-}
-
-enum GnirsFpuSlit {
-  LONG_SLIT_0_10
-  LONG_SLIT_0_15
-  LONG_SLIT_0_20
-  LONG_SLIT_0_30
-  LONG_SLIT_0_45
-  LONG_SLIT_0_675
-  LONG_SLIT_1_00
-}
-
-enum GnirsWellDepth {
-  SHALLOW
-  DEEP
-}
-
 """GMOS amp count"""
 enum GmosAmpCount {
   """GmosAmpCount Three"""
@@ -2193,6 +2135,12 @@ type SmartGcal implements StepConfig {
   stepType: StepType!
 }
 
+type Visitor {
+  mode: VisitorObservingModeType!
+  centralWavelength: Wavelength!
+  guideStarMinSep: Angle!
+}
+
 type SetAllocationsResult {
   allocations: [Allocation!]!
 }
@@ -3001,6 +2949,17 @@ enum ObservingModeType {
 
   """ObservingModeType Igrins2LongSlit"""
   IGRINS_2_LONG_SLIT
+}
+
+"""VisitorObservingModeType"""
+enum VisitorObservingModeType {
+  ALOPEKE_SPECKLE
+  ALOPEKE_WIDE_FIELD
+  MAROON_X
+  VISITOR_NORTH
+  VISITOR_SOUTH
+  ZORRO_SPECKLE
+  ZORRO_WIDE_FIELD
 }
 
 type ConstraintSet {
@@ -4235,6 +4194,9 @@ type GhostDynamic {
   blue: GhostDetector!
   ifu1FiberAgitator: GhostIfu1FiberAgitator!
   ifu2FiberAgitator: GhostIfu2FiberAgitator!
+
+  """Central wavelength, which is fixed at 655 nm."""
+  centralWavelength: Wavelength
 }
 
 """GHOST step with potential breakpoint."""
@@ -5601,6 +5563,13 @@ type Group {
   minimumInterval: TimeSpan
   maximumInterval: TimeSpan
 
+  """
+  If true, all observations in this group must be scheduled on the same night.
+  Mutually exclusive with `maximumInterval`.
+  Only valid for AND groups.
+  """
+  sameNight: Boolean!
+
   """Contained elements"""
   elements(includeDeleted: Boolean! = false): [GroupElement!]!
 
@@ -5771,8 +5740,11 @@ enum PortDisposition {
 
 """Instrument"""
 enum Instrument {
-  """Instrument AcqCam"""
-  ACQ_CAM
+  """Instrument AcqCam at Gemini North"""
+  ACQ_CAM_NORTH
+
+  """Instrument AcqCam at Gemini South"""
+  ACQ_CAM_SOUTH
 
   """Instrument Flamingos2"""
   FLAMINGOS2
@@ -5801,8 +5773,11 @@ enum Instrument {
   """Instrument Niri"""
   NIRI
 
-  """Instrument Visitor"""
-  VISITOR
+  """Visitor Instrument at Gemini North"""
+  VISITOR_NORTH
+
+  """Visitor Instrument at Gemini North"""
+  VISITOR_SOUTH
 
   """Instrument Scorpio"""
   SCORPIO
@@ -5812,6 +5787,9 @@ enum Instrument {
 
   """Instrument Zorro"""
   ZORRO
+
+  """Instrument MAROON-X"""
+  MAROON_X
 }
 
 """Describes an instrument configuration option for spectroscopy."""
@@ -5857,6 +5835,11 @@ type SpectroscopyConfigOption {
   instruments.
   """
   gmosSouth: SpectroscopyConfigOptionGmosSouth
+
+  """
+  For GNIRS options, the GNIRS configuration.  Null for other instruments.
+  """
+  gnirs: SpectroscopyConfigOptionGnirs
 }
 
 type SpectroscopyConfigOptionFlamingos2 {
@@ -5880,6 +5863,60 @@ type SpectroscopyConfigOptionGmosSouth {
   fpu: GmosSouthBuiltinFpu!
   grating: GmosSouthGrating!
   filter: GmosSouthFilter
+}
+
+type SpectroscopyConfigOptionGnirs {
+  grating: GnirsGrating!
+  filter: GnirsFilter!
+  fpu: GnirsFpuSlit!
+  prism: GnirsPrism!
+  camera: GnirsCamera!
+}
+
+enum GnirsPrism {
+  MIRROR
+  SXD
+  LXD
+}
+
+enum GnirsCamera {
+  LONG_BLUE
+  LONG_RED
+  SHORT_BLUE
+  SHORT_RED
+}
+
+enum GnirsGrating {
+  D10
+  D32
+  D111
+}
+
+enum GnirsFilter {
+  CROSS_DISPERSED
+  ORDER6
+  ORDER5
+  ORDER4
+  ORDER3
+  ORDER2
+  ORDER1
+  H2
+  H_ND100X
+  H2_ND100X
+  PAH
+  Y
+  J
+  K
+}
+
+enum GnirsFpuSlit {
+  LONG_SLIT_0_10
+  LONG_SLIT_0_15
+  LONG_SLIT_0_20
+  LONG_SLIT_0_30
+  LONG_SLIT_0_45
+  LONG_SLIT_0_675
+  LONG_SLIT_1_00
 }
 
 """
@@ -6317,6 +6354,12 @@ type ConfigurationObservingMode {
   gmosSouthImaging: ConfigurationGmosSouthImaging
   flamingos2LongSlit: ConfigurationFlamingos2LongSlit
   igrins2LongSlit: ConfigurationIgrins2LongSlit
+  visitor: ConfigurationVisitor
+}
+
+type ConfigurationVisitor {
+  mode: VisitorObservingModeType!
+  radius: Angle!
 }
 
 type ConfigurationGmosNorthLongSlit {
@@ -6910,6 +6953,7 @@ type ObservingMode {
 
   """IGRINS-2 Long Slit mode"""
   igrins2LongSlit: Igrins2LongSlit
+  visitor: Visitor
 }
 
 type ObservingModeGroup {
@@ -9065,38 +9109,6 @@ input GhostSpectroscopyInput {
   blueDetector: ItcGhostDetectorInput!
 }
 
-input GnirsSpectroscopyInput {
-  """Exposure time mode."""
-  timeAndCount: TimeAndCountExposureTimeModeInput!
-
-  """Central wavelength"""
-  centralWavelength: WavelengthInput!
-
-  """GNIRS filter"""
-  filter: GnirsFilter!
-
-  """GNIRS slit width"""
-  slitWidth: GnirsFpuSlit!
-
-  """GNIRS cross-disperser prism"""
-  prism: GnirsPrism!
-
-  """GNIRS grating"""
-  grating: GnirsGrating!
-
-  """GNIRS camera (determines pixel scale)"""
-  camera: GnirsCamera!
-
-  """GNIRS read mode"""
-  readMode: GnirsReadMode!
-
-  """GNIRS well depth"""
-  wellDepth: GnirsWellDepth!
-
-  """Instrument port disposition"""
-  port: PortDisposition = SIDE
-}
-
 """Params for instrument modes"""
 input InstrumentModesInput @oneOf {
   """Gmos North Spectroscopy"""
@@ -9122,9 +9134,6 @@ input InstrumentModesInput @oneOf {
 
   """GHOST Spectroscopy"""
   ghostSpectroscopy: GhostSpectroscopyInput
-
-  """Gnirs Longslit Spectroscopy"""
-  gnirsSpectroscopy: GnirsSpectroscopyInput
 }
 
 """Image quality input - specify either preset or exact arcsec value"""
@@ -9301,21 +9310,29 @@ enum ItcGraphType {
   S2N_GRAPH
 }
 
-type GraphAxis {
+type GraphXAxis {
   """First value of the axis"""
   start: Float!
 
   """Last value of the axis"""
   end: Float!
 
+  """How many values for the axis"""
+  count: PosInt!
+}
+
+type GraphYAxis {
   """Max value of the axis"""
   max: Float!
+
+  """Index of the max value on the x axis"""
+  indexOfMax: Int!
 
   """Min value of the axis"""
   min: Float!
 
-  """How many values for the axis"""
-  count: PosInt!
+  """Index of the min value on the x axis"""
+  indexOfMin: Int!
 }
 
 type ItcSeries {
@@ -9327,16 +9344,10 @@ type ItcSeries {
   seriesType: ItcSeriesType!
 
   """Values for the x axis"""
-  xAxis: GraphAxis
+  xAxis: GraphXAxis!
 
   """Values for the x axis"""
-  yAxis: GraphAxis
-
-  """Data series in the form of pairs (x, y)"""
-  data: [[Float!]!]!
-
-  """Data series for the X axis"""
-  dataX: [Float!]!
+  yAxis: GraphYAxis!
 
   """Data series for the Y axis"""
   dataY: [Float!]!
@@ -9410,11 +9421,6 @@ type SpectroscopyTimeAndGraphsResult {
 
   """ITC results for each target, in case all targets succeed"""
   targetTimesAndGraphs: [TargetTimeAndGraphsOutcome!]
-
-  """
-  In case of errors in integration times, we short cirtuit to the results from integration times
-  """
-  targetTimes: [TargetIntegrationTimeOutcome!] @deprecated(reason: "This field will always be null. The targetTimesAndGraphs field should be used instead.")
 
   """Index of the brightest target"""
   brightestIndex: NonNegInt

--- a/itc/service/src/main/resources/graphql/itc.graphql
+++ b/itc/service/src/main/resources/graphql/itc.graphql
@@ -5919,6 +5919,18 @@ enum GnirsFpuSlit {
   LONG_SLIT_1_00
 }
 
+enum GnirsReadMode {
+  VERY_BRIGHT
+  BRIGHT
+  FAINT
+  VERY_FAINT
+}
+
+enum GnirsWellDepth {
+  SHALLOW
+  DEEP
+}
+
 """
 A UUID provided by a client in order to prevent retrying a failed mutation from
 performing the action a second time when not necessary.  When a mutation is
@@ -9109,6 +9121,38 @@ input GhostSpectroscopyInput {
   blueDetector: ItcGhostDetectorInput!
 }
 
+input GnirsSpectroscopyInput {
+  """Exposure time mode."""
+  timeAndCount: TimeAndCountExposureTimeModeInput!
+
+  """Central wavelength"""
+  centralWavelength: WavelengthInput!
+
+  """GNIRS filter"""
+  filter: GnirsFilter!
+
+  """GNIRS slit width"""
+  slitWidth: GnirsFpuSlit!
+
+  """GNIRS cross-disperser prism"""
+  prism: GnirsPrism!
+
+  """GNIRS grating"""
+  grating: GnirsGrating!
+
+  """GNIRS camera (determines pixel scale)"""
+  camera: GnirsCamera!
+
+  """GNIRS read mode"""
+  readMode: GnirsReadMode!
+
+  """GNIRS well depth"""
+  wellDepth: GnirsWellDepth!
+
+  """Instrument port disposition"""
+  port: PortDisposition = SIDE
+}
+
 """Params for instrument modes"""
 input InstrumentModesInput @oneOf {
   """Gmos North Spectroscopy"""
@@ -9134,6 +9178,9 @@ input InstrumentModesInput @oneOf {
 
   """GHOST Spectroscopy"""
   ghostSpectroscopy: GhostSpectroscopyInput
+
+  """Gnirs Longslit Spectroscopy"""
+  gnirsSpectroscopy: GnirsSpectroscopyInput
 }
 
 """Image quality input - specify either preset or exact arcsec value"""

--- a/itc/service/src/main/resources/graphql/itc_base.graphql
+++ b/itc/service/src/main/resources/graphql/itc_base.graphql
@@ -394,21 +394,29 @@ enum ItcGraphType {
   S2N_GRAPH
 }
 
-type GraphAxis {
+type GraphXAxis {
   """First value of the axis"""
   start: Float!
 
   """Last value of the axis"""
   end: Float!
 
+  """How many values for the axis"""
+  count: PosInt!
+}
+
+type GraphYAxis {
   """Max value of the axis"""
   max: Float!
+
+  """Index of the max value on the x axis"""
+  indexOfMax: Int!
 
   """Min value of the axis"""
   min: Float!
 
-  """How many values for the axis"""
-  count: PosInt!
+  """Index of the min value on the x axis"""
+  indexOfMin: Int!
 }
 
 type ItcSeries {
@@ -418,16 +426,10 @@ type ItcSeries {
   seriesType: ItcSeriesType!
 
   """Values for the x axis"""
-  xAxis: GraphAxis
+  xAxis: GraphXAxis!
 
   """Values for the x axis"""
-  yAxis: GraphAxis
-
-  """Data series in the form of pairs (x, y)"""
-  data: [[Float!]!]!
-
-  """Data series for the X axis"""
-  dataX: [Float!]!
+  yAxis: GraphYAxis!
 
   """Data series for the Y axis"""
   dataY: [Float!]!
@@ -504,9 +506,6 @@ type SpectroscopyTimeAndGraphsResult {
 
   """ITC results for each target, in case all targets succeed"""
   targetTimesAndGraphs: [TargetTimeAndGraphsOutcome!]
-
-  """In case of errors in integration times, we short cirtuit to the results from integration times"""
-  targetTimes: [TargetIntegrationTimeOutcome!] @deprecated(reason: "This field will always be null. The targetTimesAndGraphs field should be used instead.")
 
   """Index of the brightest target"""
   brightestIndex: NonNegInt

--- a/itc/service/src/main/resources/graphql/itc_base.graphql
+++ b/itc/service/src/main/resources/graphql/itc_base.graphql
@@ -191,6 +191,38 @@ input GhostSpectroscopyInput {
   blueDetector: ItcGhostDetectorInput!
 }
 
+input GnirsSpectroscopyInput {
+  """Exposure time mode."""
+  timeAndCount: TimeAndCountExposureTimeModeInput!
+
+  """Central wavelength"""
+  centralWavelength: WavelengthInput!
+
+  """GNIRS filter"""
+  filter: GnirsFilter!
+
+  """GNIRS slit width"""
+  slitWidth: GnirsFpuSlit!
+
+  """GNIRS cross-disperser prism"""
+  prism: GnirsPrism!
+
+  """GNIRS grating"""
+  grating: GnirsGrating!
+
+  """GNIRS camera (determines pixel scale)"""
+  camera: GnirsCamera!
+
+  """GNIRS read mode"""
+  readMode: GnirsReadMode!
+
+  """GNIRS well depth"""
+  wellDepth: GnirsWellDepth!
+
+  """Instrument port disposition"""
+  port: PortDisposition = SIDE
+}
+
 """Params for instrument modes"""
 input InstrumentModesInput @oneOf {
   """Gmos North Spectroscopy"""
@@ -216,6 +248,9 @@ input InstrumentModesInput @oneOf {
 
   """GHOST Spectroscopy"""
   ghostSpectroscopy: GhostSpectroscopyInput
+
+  """Gnirs Longslit Spectroscopy"""
+  gnirsSpectroscopy: GnirsSpectroscopyInput
 }
 
 """Image quality input - specify either preset or exact arcsec value"""

--- a/itc/service/src/main/scala/lucuma/itc/legacy/codecs.scala
+++ b/itc/service/src/main/scala/lucuma/itc/legacy/codecs.scala
@@ -4,6 +4,7 @@
 package lucuma.itc.legacy
 
 import cats.data.NonEmptyChain
+import cats.data.NonEmptyList
 import cats.syntax.all.*
 import eu.timepit.refined.numeric.NonNegative
 import eu.timepit.refined.refineV
@@ -30,6 +31,7 @@ import lucuma.itc.ItcGhostDetector
 import lucuma.itc.ItcGraph
 import lucuma.itc.ItcGraphGroup
 import lucuma.itc.ItcSeries
+import lucuma.itc.ItcXAxis
 import lucuma.itc.SeriesDataType
 import lucuma.itc.legacy.syntax.all.*
 import lucuma.itc.service.ItcObservingConditions
@@ -526,14 +528,9 @@ private[legacy] object codecs:
     for
       title <- c.downField("title").as[String]
       dt    <- c.downField("dataType").as[SeriesDataType]
-      data  <- c.downField("data")
-                 .as[List[List[Double]]]
-                 .map { i =>
-                   (i.lift(0), i.lift(1)) match
-                     case (Some(a), Some(b)) if a.length === b.length => a.zip(b)
-                     case _                                           => List.empty
-                 }
-    yield ItcSeries(title, dt, data)
+      dataY <- c.downField("dataY").as[NonEmptyList[Double]]
+      xaxis <- c.downField("xAxis").as[ItcXAxis]
+    yield ItcSeries(title, dt, dataY, xaxis)
 
   given Decoder[ItcGraph] = (c: HCursor) =>
     for

--- a/itc/service/src/main/scala/lucuma/itc/package.scala
+++ b/itc/service/src/main/scala/lucuma/itc/package.scala
@@ -75,11 +75,7 @@ object Conversions:
       originalGraphs.map: graph =>
         graph.copy(graphs = graph.graphs.map: c =>
           c.copy(series = c.series.map: s =>
-            ItcSeries(
-              s.title,
-              s.seriesType,
-              s.data.collect { case (x, y) if !y.isNaN => (x.toDouble, y.toDouble) }
-            )))
+            s.copy(dataY = s.dataY.map(y => if y.isNaN then 0.0 else y))))
 
     // Find the wavelength that gives the maximum value for the given series data type
     // It returns one value per ccd, returns a pair of wavelength and value
@@ -89,22 +85,14 @@ object Conversions:
     ): List[(Wavelength, Double)] =
       graph.series
         .filter(_.seriesType === seriesDataType)
-        .zip(ccds.toList)
-        .map: (sn, _) =>
-          sn.data
-            .filter(_._1 > 0)
-            .maxByOption(_._2)
-            .flatMap((w, s) => Wavelength.intPicometers.getOption((w * 1000).toInt).tupleRight(s))
+        .map(_.wavelengthAtMaxAndMax)
         .flattenOption
 
+    // Find the SN of the first series that provides a value at the given wavelength
     def signalToNoiseAtWv(graph: ItcGraph, seriesDataType: SeriesDataType): Option[SignalToNoise] =
       graph.series
         .filter(_.seriesType === seriesDataType)
-        .zip(ccds.toList)
-        .map: (sn, _) =>
-          sn.data
-            .find(_._1 >= atWavelength.toNanometers.value.value)
-            .map(_._2)
+        .map(_.yValueAtWavelength(atWavelength))
         .flattenOption
         .headOption
         .flatMap(v => SignalToNoise.FromBigDecimalRounding.getOption(v))

--- a/itc/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -28,7 +28,7 @@ import scala.concurrent.duration.*
  */
 trait ItcCacheOrRemote extends Version:
   // Manual version to manually force a flush
-  private val ManualCacheVersion = 1
+  private val ManualCacheVersion = 2
   private val CacheRootPrefix    = "itc"
   val VersionKeyRoot: String     = "version"
 

--- a/itc/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/ItcCacheOrRemote.scala
@@ -27,8 +27,8 @@ import scala.concurrent.duration.*
  * in the cache
  */
 trait ItcCacheOrRemote extends Version:
-  // Manual version to manually force a flush
-  private val ManualCacheVersion = 2
+  // Manual version to manually force a flush. Not needed if the ocs jars have changed.
+  private val ManualCacheVersion = 1
   private val CacheRootPrefix    = "itc"
   val VersionKeyRoot: String     = "version"
 

--- a/itc/service/src/main/scala/lucuma/itc/service/redis/redis.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/redis/redis.scala
@@ -6,6 +6,7 @@ package lucuma.itc.service.redis
 import boopickle.DefaultBasic.*
 import cats.data.Chain
 import cats.data.NonEmptyChain
+import cats.data.NonEmptyList
 import cats.data.NonEmptyMap
 import eu.timepit.refined.*
 import eu.timepit.refined.api.*
@@ -45,14 +46,18 @@ given [A: Enumerated]: Pickler[A] =
 given [A: Pickler]: Pickler[NonEmptyChain[A]] =
   transformPickler(Chain.fromSeq[A].andThen(NonEmptyChain.fromChainUnsafe[A]))(_.toChain.toList)
 
+given picklerNonEmptyList[A: Pickler]: Pickler[NonEmptyList[A]] =
+  transformPickler(NonEmptyList.fromListUnsafe[A])(_.toList)
+
 given [K: Pickler: Ordering, V: Pickler]: Pickler[SortedMap[K, V]] =
   transformPickler((m: Map[K, V]) => SortedMap.from(m))(_.toMap)
 
 given [K: Pickler: Ordering, V: Pickler]: Pickler[NonEmptyMap[K, V]] =
   transformPickler(NonEmptyMap.fromMapUnsafe[K, V])(_.toSortedMap)
 
-given Pickler[ItcSeries]      =
-  transformPickler(Function.tupled(ItcSeries.apply))(x => (x.title, x.seriesType, x.data))
+given Pickler[ItcXAxis]       = generatePickler
+given Pickler[ItcYAxis]       = generatePickler
+given Pickler[ItcSeries]      = generatePickler
 given Pickler[FiniteDuration] =
   transformPickler(n => new FiniteDuration(n, NANOSECONDS))(_.toNanos)
 

--- a/itc/service/src/main/scala/lucuma/itc/service/syntax/ItcSyntax.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/syntax/ItcSyntax.scala
@@ -57,16 +57,11 @@ end ItcSyntax
 trait ItcGraphSyntax:
   extension (series: ItcSeries)
     def adjustSignificantFigures(figures: SignificantFigures): ItcSeries =
-      val data: List[(Double, Double)] =
-        series.data.map((x, y) =>
-          (figures.xAxis.fold(x)(xDigits => roundToSignificantFigures(x, xDigits.value)),
-           figures.yAxis.fold(y)(yDigits => roundToSignificantFigures(y, yDigits.value))
-          )
-        )
-      ItcSeries(series.title, series.seriesType, data)
-
-  extension (graph: ItcGraph)
-    def adjustSignificantFigures(figures: SignificantFigures): ItcGraph =
+      series.copy(dataY = figures.yAxis match
+        case Some(v) => series.dataY.map(y => roundToSignificantFigures(y, v.value))
+        case None    => series.dataY)
+  extension (graph:  ItcGraph)
+    def adjustSignificantFigures(figures: SignificantFigures): ItcGraph  =
       graph.copy(series = graph.series.map(_.adjustSignificantFigures(figures)))
 
   extension (sn: TotalSN)

--- a/itc/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
@@ -69,10 +69,11 @@ import lucuma.itc.CloudExtinctionInput
 import lucuma.itc.GraphType
 import lucuma.itc.ImageQualityInput
 import lucuma.itc.IntegrationTime
-import lucuma.itc.ItcAxis
 import lucuma.itc.ItcCcd
 import lucuma.itc.ItcGhostDetector
 import lucuma.itc.ItcVersions
+import lucuma.itc.ItcXAxis
+import lucuma.itc.ItcYAxis
 import lucuma.itc.SeriesDataType
 import lucuma.itc.SignalToNoiseAt
 import lucuma.itc.TargetIntegrationTime
@@ -308,9 +309,9 @@ class WiringSuite extends ClientSuite:
                         SeriesResult(
                           "title",
                           SeriesDataType.FinalS2NData,
-                          List(1000.0, 1001.0),
-                          ItcAxis(1, 2, 1, 2, 2).some,
-                          ItcAxis(1000.0, 1001.0, 1000, 1001, 2).some
+                          NonEmptyList.of(1000.0, 1001.0),
+                          ItcXAxis(1, 2, 2),
+                          ItcYAxis(1000.0, 0, 1001.0, 1)
                         )
                       )
                     )
@@ -511,9 +512,9 @@ class WiringSuite extends ClientSuite:
                           SeriesResult(
                             "title",
                             SeriesDataType.FinalS2NData,
-                            List(1000.0, 1001.0),
-                            ItcAxis(1, 2, 1, 2, 2).some,
-                            ItcAxis(1000.0, 1001.0, 1000, 1001, 2).some
+                            NonEmptyList.of(1000.0, 1001.0),
+                            ItcXAxis(1, 2, 2),
+                            ItcYAxis(1000.0, 0, 1001.0, 1)
                           )
                         )
                       )

--- a/itc/tests/src/test/scala/lucuma/itc/model/ItcXAxisSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/model/ItcXAxisSuite.scala
@@ -1,0 +1,55 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.itc.model
+
+import cats.syntax.all.*
+import lucuma.core.math.Wavelength
+import lucuma.itc.ItcXAxis
+import munit.FunSuite
+
+class ItcXAxisSuite extends FunSuite:
+  def toWv(i: Int): Wavelength =
+    Wavelength.intPicometers.getOption(i).get
+
+  test("ItcXAxis.at") {
+    val x = ItcXAxis(1, 5, 9)
+    assertEquals(x.at(0), 1.0)
+    assertEquals(x.at(1), 1.5)
+    assertEquals(x.at(2), 2.0)
+    assertEquals(x.at(8), 5.0)
+  }
+
+  test("ItcXAxis.wavelengthAt") {
+    val x = ItcXAxis(1, 5, 9)
+    assertEquals(x.wavelengthAt(0), toWv(1000).some)
+    assertEquals(x.wavelengthAt(1), toWv(1500).some)
+    assertEquals(x.wavelengthAt(2), toWv(2000).some)
+    assertEquals(x.wavelengthAt(8), toWv(5000).some)
+  }
+  test("ItcXAxis.indexOf") {
+    val x = ItcXAxis(1, 5, 9)
+    assertEquals(x.indexOf(0.9), none)
+    assertEquals(x.indexOf(1.0), 0.some)
+    assertEquals(x.indexOf(1.25), 1.some)
+    assertEquals(x.indexOf(1.5), 1.some)
+    assertEquals(x.indexOf(2.0), 2.some)
+    assertEquals(x.indexOf(2.75), 4.some)
+    assertEquals(x.indexOf(3.0), 4.some)
+    assertEquals(x.indexOf(3.01), 5.some)
+    assertEquals(x.indexOf(3.25), 5.some)
+    assertEquals(x.indexOf(5.0), 8.some)
+    assertEquals(x.indexOf(5.1), none)
+  }
+
+  test("ItcXAxis.indexOf(Wavelength)") {
+    val x = ItcXAxis(1, 5, 9)
+    assertEquals(x.indexOf(toWv(999)), none)
+    assertEquals(x.indexOf(toWv(1000)), 0.some)
+    assertEquals(x.indexOf(toWv(1250)), 1.some)
+    assertEquals(x.indexOf(toWv(1500)), 1.some)
+    assertEquals(x.indexOf(toWv(2000)), 2.some)
+    assertEquals(x.indexOf(toWv(3000)), 4.some)
+    assertEquals(x.indexOf(toWv(5000)), 8.some)
+    assertEquals(x.indexOf(toWv(5100)), none)
+  }

--- a/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyGraphSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyGraphSuite.scala
@@ -89,13 +89,16 @@ class spectroscopyGraphSuite extends GraphQLSuite {
                     series {
                       title
                       seriesType
-                      data
+                      dataY
                       xAxis {
                         start
                         end
                         count
                       }
-                      dataY
+                      yAxis {
+                        min
+                        max
+                      }
                     }
                   }
                 }
@@ -130,25 +133,19 @@ class spectroscopyGraphSuite extends GraphQLSuite {
                           {
                             "title": "title",
                             "seriesType": "FINAL_S2_NDATA",
-                            "data": [
-                              [
-                                1.0,
-                                1000.0
-                              ],
-                              [
-                                2.0,
+                            "dataY": [
+                                1000.0,
                                 1001.0
-                              ]
                             ],
                             "xAxis" : {
                               "start" : 1.0,
                               "end" : 2.0,
                               "count" : 2
                             },
-                            "dataY": [
-                              1000.0,
-                              1001.0
-                            ]
+                            "yAxis": { 
+                              "min": 1000.0,
+                              "max": 1001.0
+                             }
                           }
                         ]
                       }
@@ -237,13 +234,16 @@ class spectroscopyGraphSuite extends GraphQLSuite {
                     series {
                       title
                       seriesType
-                      data
+                      dataY
                       xAxis {
                         start
                         end
                         count
                       }
-                      dataY
+                      yAxis {
+                        min
+                        max
+                       }
                     }
                   }
                 }
@@ -278,25 +278,19 @@ class spectroscopyGraphSuite extends GraphQLSuite {
                           {
                             "title": "title",
                             "seriesType": "FINAL_S2_NDATA",
-                            "data": [
-                              [
-                                1.0,
-                                1000.0
-                              ],
-                              [
-                                2.0,
-                                1001.0
-                              ]
+                            "dataY": [
+                              1000.0,
+                              1001.0
                             ],
                             "xAxis" : {
                               "start" : 1.0,
                               "end" : 2.0,
                               "count" : 2
                             },
-                            "dataY": [
-                              1000.0,
-                              1001.0
-                            ]
+                            "yAxis": {
+                              "min": 1000.0,
+                              "max": 1001.0
+                            }
                           }
                         ]
                       }
@@ -410,13 +404,16 @@ class spectroscopyGraphSuite extends GraphQLSuite {
                     series {
                       title
                       seriesType
-                      data
+                      dataY
                       xAxis {
                         start
                         end
                         count
                       }
-                      dataY
+                      yAxis {
+                        min
+                        max
+                      }
                     }
                   }
                 }
@@ -451,25 +448,19 @@ class spectroscopyGraphSuite extends GraphQLSuite {
                           {
                             "title": "title",
                             "seriesType": "FINAL_S2_NDATA",
-                            "data": [
-                              [
-                                1.0,
-                                1000.0
-                              ],
-                              [
-                                2.0,
-                                1001.0
-                              ]
+                            "dataY": [
+                              1000.0,
+                              1001.0
                             ],
                             "xAxis" : {
                               "start" : 1.0,
                               "end" : 2.0,
                               "count" : 2
                             },
-                            "dataY": [
-                              1000.0,
-                              1001.0
-                            ]
+                            "yAxis": {
+                              "min": 1000.0,
+                              "max": 1001.0
+                            }
                           }
                         ]
                       }

--- a/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyTimeAndGraphSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyTimeAndGraphSuite.scala
@@ -93,13 +93,16 @@ class spectroscopyTimeAndGraphSuite extends GraphQLSuite {
                     series {
                       title
                       seriesType
-                      data
+                      dataY
                       xAxis {
                         start
                         end
                         count
                       }
-                      dataY
+                      yAxis {
+                        min
+                        max
+                       }
                     }
                   }
                 }
@@ -138,25 +141,19 @@ class spectroscopyTimeAndGraphSuite extends GraphQLSuite {
                           {
                             "title": "title",
                             "seriesType": "FINAL_S2_NDATA",
-                            "data": [
-                              [
-                                1.0,
-                                1000.0
-                              ],
-                              [
-                                2.0,
-                                1001.0
-                              ]
+                            "dataY": [
+                              1000.0,
+                              1001.0
                             ],
                             "xAxis" : {
                               "start" : 1.0,
                               "end" : 2.0,
                               "count" : 2
                             },
-                            "dataY": [
-                              1000.0,
-                              1001.0
-                            ]
+                            "yAxis": {
+                              "min": 1000.0,
+                              "max": 1001.0
+                            }
                           }
                         ]
                       }
@@ -249,13 +246,16 @@ class spectroscopyTimeAndGraphSuite extends GraphQLSuite {
                     series {
                       title
                       seriesType
-                      data
+                      dataY
                       xAxis {
                         start
                         end
                         count
                       }
-                      dataY
+                      yAxis {
+                        min
+                        max
+                      }
                     }
                   }
                 }
@@ -294,25 +294,19 @@ class spectroscopyTimeAndGraphSuite extends GraphQLSuite {
                           {
                             "title": "title",
                             "seriesType": "FINAL_S2_NDATA",
-                            "data": [
-                              [
-                                1.0,
-                                1000.0
-                              ],
-                              [
-                                2.0,
-                                1001.0
-                              ]
+                            "dataY": [
+                              1000.0,
+                              1001.0
                             ],
                             "xAxis" : {
                               "start" : 1.0,
                               "end" : 2.0,
                               "count" : 2
                             },
-                            "dataY": [
-                              1000.0,
-                              1001.0
-                            ]
+                            "yAxis": {
+                              "min": 1000.0,
+                              "max": 1001.0
+                            }
                           }
                         ]
                       }

--- a/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyTimeAndGraphSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyTimeAndGraphSuite.scala
@@ -254,7 +254,9 @@ class spectroscopyTimeAndGraphSuite extends GraphQLSuite {
                       }
                       yAxis {
                         min
+                        indexOfMin
                         max
+                        indexOfMax
                       }
                     }
                   }
@@ -305,7 +307,9 @@ class spectroscopyTimeAndGraphSuite extends GraphQLSuite {
                             },
                             "yAxis": {
                               "min": 1000.0,
-                              "max": 1001.0
+                              "indexOfMin": 0,
+                              "max": 1001.0,
+                              "indexOfMax": 1
                             }
                           }
                         ]
@@ -403,13 +407,16 @@ class spectroscopyTimeAndGraphSuite extends GraphQLSuite {
                     series {
                       title
                       seriesType
-                      data
+                      dataY
                       xAxis {
                         start
                         end
                         count
                       }
-                      dataY
+                      yAxis {
+                        min
+                        max
+                      }
                     }
                   }
                 }
@@ -448,25 +455,19 @@ class spectroscopyTimeAndGraphSuite extends GraphQLSuite {
                           {
                             "title": "title",
                             "seriesType": "FINAL_S2_NDATA",
-                            "data": [
-                              [
-                                1.0,
-                                1000.0
-                              ],
-                              [
-                                2.0,
-                                1001.0
-                              ]
+                            "dataY": [
+                              1000.0,
+                              1001.0
                             ],
                             "xAxis" : {
                               "start" : 1.0,
                               "end" : 2.0,
                               "count" : 2
                             },
-                            "dataY": [
-                              1000.0,
-                              1001.0
-                            ]
+                            "yAxis": {
+                              "min": 1000.0,
+                              "max": 1001.0
+                            }
                           }
                         ]
                       }

--- a/itc/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/tests/MockItc.scala
@@ -4,6 +4,7 @@
 package lucuma.itc.tests
 
 import cats.data.NonEmptyChain
+import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.syntax.applicative.*
 import cats.syntax.either.*
@@ -91,7 +92,12 @@ trait MockItcBase extends Itc[IO]:
           ItcGraph(
             GraphType.S2NGraph,
             List(
-              ItcSeries("title", SeriesDataType.FinalS2NData, List((1.0, 1000.0), (2.0, 1001.0)))
+              ItcSeries("title",
+                        SeriesDataType.FinalS2NData,
+                        NonEmptyList.of(1000.0, 1001.0),
+                        ItcXAxis(1, 2, 2),
+                        ItcYAxis(1000.0, 0, 1001.0, 1)
+              )
             )
           )
         ),

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -11429,6 +11429,18 @@ enum GnirsFpuSlit {
   LONG_SLIT_1_00
 }
 
+enum GnirsReadMode {
+  VERY_BRIGHT
+  BRIGHT
+  FAINT
+  VERY_FAINT
+}
+
+enum GnirsWellDepth {
+  SHALLOW
+  DEEP
+}
+
 """
 Edit or create imaging science requirements
 """

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -368,6 +368,8 @@ trait BaseMapping[F[_]]
   lazy val GnirsFpuSlitType                        = schema.ref("GnirsFpuSlit")
   lazy val GnirsPrismType                          = schema.ref("GnirsPrism")
   lazy val GnirsCameraType                         = schema.ref("GnirsCamera")
+  lazy val GnirsReadModeType                       = schema.ref("GnirsReadMode")
+  lazy val GnirsWellDepthType                      = schema.ref("GnirsWellDepth")
   lazy val SpectroscopyScienceRequirementsType     = schema.ref("SpectroscopyScienceRequirements")
   lazy val SpiralTelescopeConfigGeneratorType      = schema.ref("SpiralTelescopeConfigGenerator")
   lazy val StepConfigType                          = schema.ref("StepConfig")


### PR DESCRIPTION
Now only y data and x-axis information is being returned from the OCS. This should save significant time serializing and deserializing. In addition, the x data is never constructed on the server, and traversal of the y data is minimized.