### PR TITLE
Shortcut 8595: GHOST IFU `skyPosition` option

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -8775,6 +8775,14 @@ input GhostIfuInput {
   blue: GhostDetectorConfigInput
 
   """
+  Coordinates for taking sky images.  When specified, the observation is
+  considered to be a Target + Sky and is validated to ensure that only a single
+  target exists in its asterism.  If not specified, this will remain null.  May
+  be unset with a null value.
+  """
+  skyPosition: CoordinatesInput
+
+  """
   Slit viewing camera exposure time.  If not specified, this will remain null.
   May be unset with a null value.
   """
@@ -8860,6 +8868,11 @@ type GhostIfu {
   Blue detector config.
   """
   blue: GhostDetectorConfig!
+
+  """
+  Sky position, if any.
+  """
+  skyPosition: Coordinates
 
   """
   Slit viewing camera exposure time (if specified).

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/ghost/ifu/Config.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/ghost/ifu/Config.scala
@@ -6,11 +6,13 @@ package ifu
 
 import cats.Eq
 import cats.derived.*
+import cats.syntax.functor.*
 import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.GhostIfu1FiberAgitator
 import lucuma.core.enums.GhostIfu2FiberAgitator
 import lucuma.core.enums.GhostResolutionMode
+import lucuma.core.math.Coordinates
 import lucuma.core.util.TimeSpan
 
 import java.io.ByteArrayOutputStream
@@ -23,6 +25,7 @@ case class Config(
   resolutionMode:         GhostResolutionMode,
   red:                    DetectorConfig.Red,
   blue:                   DetectorConfig.Blue,
+  skyPosition:            Option[Coordinates],
   slitCameraExposureTime: Option[TimeSpan],
   explicitIfu1Agitator:   Option[GhostIfu1FiberAgitator],
   explicitIfu2Agitator:   Option[GhostIfu2FiberAgitator]
@@ -48,6 +51,11 @@ case class Config(
     out.writeChars(resolutionMode.tag)
     out.write(red.value.hashBytes)
     out.write(blue.value.hashBytes)
+    out.writeInt(skyPosition.as(1).getOrElse(0))
+    skyPosition.foreach: c =>
+      out.writeLong(c.ra.toAngle.toMicroarcseconds)
+      out.writeLong(c.dec.toAngle.toMicroarcseconds)
+    out.writeInt(slitCameraExposureTime.as(1).getOrElse(0))
     slitCameraExposureTime.foreach: t =>
       out.writeLong(t.toMicroseconds)
     out.writeChars(ifu1Agitator.tag)

--- a/modules/service/src/main/resources/db/migration/V1136__ghost.sql
+++ b/modules/service/src/main/resources/db/migration/V1136__ghost.sql
@@ -1,0 +1,16 @@
+-- Add (optional) sky coordinates
+ALTER TABLE t_ghost_ifu
+  ADD COLUMN c_sky_ra  d_angle_µas NULL DEFAULT NULL,
+  ADD COLUMN c_sky_dec d_angle_µas NULL DEFAULT NULL,
+  ADD CONSTRAINT ghost_ifu_sky_position_neither_or_both CHECK (
+    (c_sky_ra IS NULL) = (c_sky_dec IS NULL)
+  );
+
+DROP VIEW v_ghost_ifu;
+
+CREATE VIEW v_ghost_ifu AS
+SELECT
+  g.*,
+  CASE WHEN c_slit_viewing_camera_exposure_time IS NOT NULL THEN c_observation_id END AS c_slit_viewing_camera_id,
+  CASE WHEN c_sky_ra IS NOT NULL THEN c_observation_id END AS c_sky_id
+FROM t_ghost_ifu g;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/CoordinatesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/CoordinatesInput.scala
@@ -4,7 +4,7 @@
 package lucuma.odb.graphql
 package input
 
-import cats.syntax.parallel.*
+import cats.syntax.apply.*
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
 import lucuma.core.math.RightAscension
@@ -23,14 +23,17 @@ object CoordinatesInput {
   final case class Edit(
     ra:  Option[RightAscension],
     dec: Option[Declination]
-  )
+  ):
+    def toCoordinates: Option[Coordinates] =
+      (ra, dec).mapN(Coordinates(_, _))
+
   object Edit:
     val Binding: Matcher[Edit] =
       ObjectFieldsBinding.rmap {
         case List(
           RightAscensionInput.Binding.Option("ra", rRa),
           DeclinationInput.Binding.Option("dec", rDec)
-        ) => (rRa, rDec).parMapN(Edit(_, _))
+        ) => (rRa, rDec).mapN(Edit(_, _))
       }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GhostIfuInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GhostIfuInput.scala
@@ -12,6 +12,7 @@ import lucuma.core.enums.GhostIfu1FiberAgitator
 import lucuma.core.enums.GhostIfu2FiberAgitator
 import lucuma.core.enums.GhostResolutionMode
 import lucuma.core.enums.ObservingModeType
+import lucuma.core.math.Coordinates
 import lucuma.core.util.TimeSpan
 import lucuma.odb.data.Nullable
 import lucuma.odb.data.OdbError
@@ -27,6 +28,7 @@ object GhostIfuInput:
     resolutionMode:            GhostResolutionMode,
     red:                       Option[GhostDetectorConfigInput],
     blue:                      Option[GhostDetectorConfigInput],
+    skyPosition:               Option[Coordinates],
     slitCameraExposureTime:    Option[TimeSpan],
     explicitIfu1FiberAgitator: Option[GhostIfu1FiberAgitator],
     explicitIfu2FiberAgitator: Option[GhostIfu2FiberAgitator]
@@ -42,17 +44,19 @@ object GhostIfuInput:
           GhostResolutionModeBinding("resolutionMode", rResMode),
           GhostDetectorConfigInput.Binding.Option("red", rRed),
           GhostDetectorConfigInput.Binding.Option("blue", rBlue),
+          CoordinatesInput.Create.Binding.Option("skyPosition", rSky),
           TimeSpanInput.Binding.Option("slitViewingCameraExposureTime", rSlit),
           GhostIfu1FiberAgitatorBinding.Option("explicitIfu1Agitator", rIfu1),
           GhostIfu2FiberAgitatorBinding.Option("explicitIfu2Agitator", rIfu2)
-        ) => (rStepCount, rResMode, rRed, rBlue, rSlit, rIfu1, rIfu2).parMapN: (stepCount, resMode, red, blue, slit, ifu1, ifu2) =>
-          Create(stepCount.getOrElse(One), resMode, red, blue, slit, ifu1, ifu2)
+        ) => (rStepCount, rResMode, rRed, rBlue, rSky, rSlit, rIfu1, rIfu2).parMapN: (stepCount, resMode, red, blue, sky, slit, ifu1, ifu2) =>
+          Create(stepCount.getOrElse(One), resMode, red, blue, sky, slit, ifu1, ifu2)
 
   case class Edit(
     stepCount:                 Option[PosInt],
     resolutionMode:            Option[GhostResolutionMode],
     red:                       Option[GhostDetectorConfigInput],
     blue:                      Option[GhostDetectorConfigInput],
+    skyPosition:               Nullable[CoordinatesInput.Edit],
     slitCameraExposureTime:    Nullable[TimeSpan],
     explicitIfu1FiberAgitator: Nullable[GhostIfu1FiberAgitator],
     explicitIfu2FiberAgitator: Nullable[GhostIfu2FiberAgitator]
@@ -63,7 +67,7 @@ object GhostIfuInput:
     def toCreate: Result[Create] =
       Result
         .fromOption(resolutionMode, OdbError.InvalidArgument("A resolution mode must be supplied for GHOST IFU observations".some).asProblem)
-        .map(m => Create(stepCount.getOrElse(One), m, red, blue, slitCameraExposureTime.toOption, explicitIfu1FiberAgitator.toOption, explicitIfu2FiberAgitator.toOption))
+        .map(m => Create(stepCount.getOrElse(One), m, red, blue, skyPosition.toOption.flatMap(_.toCoordinates), slitCameraExposureTime.toOption, explicitIfu1FiberAgitator.toOption, explicitIfu2FiberAgitator.toOption))
 
   object Edit:
     val Binding: Matcher[Edit] =
@@ -73,8 +77,9 @@ object GhostIfuInput:
           GhostResolutionModeBinding.Option("resolutionMode", rResMode),
           GhostDetectorConfigInput.Binding.Option("red", rRed),
           GhostDetectorConfigInput.Binding.Option("blue", rBlue),
+          CoordinatesInput.Edit.Binding.Nullable("skyPosition", rSky),
           TimeSpanInput.Binding.Nullable("slitViewingCameraExposureTime", rSlit),
           GhostIfu1FiberAgitatorBinding.Nullable("explicitIfu1Agitator", rIfu1),
           GhostIfu2FiberAgitatorBinding.Nullable("explicitIfu2Agitator", rIfu2)
-        ) => (rStepCount, rResMode, rRed, rBlue, rSlit, rIfu1, rIfu2).parMapN: (stepCount, resMode, red, blue, slit, ifu1, ifu2) =>
-          Edit(stepCount, resMode, red, blue, slit, ifu1, ifu2)
+        ) => (rStepCount, rResMode, rRed, rBlue, rSky, rSlit, rIfu1, rIfu2).parMapN: (stepCount, resMode, red, blue, sky, slit, ifu1, ifu2) =>
+          Edit(stepCount, resMode, red, blue, sky, slit, ifu1, ifu2)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CoordinatesMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/CoordinatesMapping.scala
@@ -7,15 +7,19 @@ package mapping
 
 import grackle.skunk.SkunkMapping
 import lucuma.odb.graphql.table.ConfigurationRequestView
+import lucuma.odb.graphql.table.GhostIfuView
 
 import table.ObservationView
 
-trait CoordinatesMapping[F[_]] extends ObservationView[F] with ConfigurationRequestView[F] {
+trait CoordinatesMapping[F[_]] extends ObservationView[F]
+                                  with ConfigurationRequestView[F]
+                                  with GhostIfuView[F]:
 
   lazy val CoordinatesMappings =
     List(
       CoordinatesMapping,
       ConfigurationRequestReferenceCoordinatesMapping,
+      GhostIfuSkyPositionMapping
     )
 
   private lazy val CoordinatesMapping =
@@ -32,5 +36,9 @@ trait CoordinatesMapping[F[_]] extends ObservationView[F] with ConfigurationRequ
       SqlObject("dec")
     )
 
-}
-
+  private lazy val GhostIfuSkyPositionMapping =
+    ObjectMapping(GhostIfuType / "skyPosition")(
+      SqlField("synthetic-id", GhostIfuView.Sky.Id, key = true, hidden = true),
+      SqlObject("ra"),
+      SqlObject("dec")
+    )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/DeclinationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/DeclinationMapping.scala
@@ -10,6 +10,7 @@ import io.circe
 import lucuma.core.math.Declination
 import lucuma.odb.graphql.table.CallForProposalsView
 import lucuma.odb.graphql.table.ConfigurationRequestView
+import lucuma.odb.graphql.table.GhostIfuView
 import lucuma.odb.graphql.table.ObservationView
 import lucuma.odb.graphql.table.TargetView
 
@@ -17,6 +18,7 @@ import scala.reflect.ClassTag
 
 trait DeclinationMapping[F[_]] extends CallForProposalsView[F]
                                   with ConfigurationRequestView[F]
+                                  with GhostIfuView[F]
                                   with ObservationView[F]
                                   with TargetView[F] {
 
@@ -39,13 +41,14 @@ trait DeclinationMapping[F[_]] extends CallForProposalsView[F]
       declinationMappingAtPath(CallForProposalsType / "coordinateLimits" / "north" / "decEnd",   CallForProposalsView.Id, CallForProposalsView.coordinateLimits.north.DecEnd),
       declinationMappingAtPath(CallForProposalsType / "coordinateLimits" / "south" / "decStart", CallForProposalsView.Id, CallForProposalsView.coordinateLimits.south.DecStart),
       declinationMappingAtPath(CallForProposalsType / "coordinateLimits" / "south" / "decEnd",   CallForProposalsView.Id, CallForProposalsView.coordinateLimits.south.DecEnd),
-      declinationMappingAtPath(CoordinatesType / "dec", ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Dec),
-      declinationMappingAtPath(SiderealType / "dec", TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Dec),
       declinationMappingAtPath(ConfigurationTargetType / "coordinates" / "dec", ConfigurationRequestView.Target.ReferenceCoordinates.SyntheticId, ConfigurationRequestView.Target.ReferenceCoordinates.Dec),
       declinationMappingAtPath(ConfigurationTargetType / "region" / "declinationArc" / "start", ConfigurationRequestView.Target.Region.DeclinationArc.PartialSyntheticId, ConfigurationRequestView.Target.Region.DeclinationArc.Start),
       declinationMappingAtPath(ConfigurationTargetType / "region" / "declinationArc" / "end", ConfigurationRequestView.Target.Region.DeclinationArc.PartialSyntheticId, ConfigurationRequestView.Target.Region.DeclinationArc.End),
+      declinationMappingAtPath(CoordinatesType / "dec", ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Dec),
+      declinationMappingAtPath(GhostIfuType / "skyPosition" / "dec", GhostIfuView.Sky.Id, GhostIfuView.Sky.Dec),
       declinationMappingAtPath(OpportunityType / "region" / "declinationArc" / "start", TargetView.Opportunity.Region.DeclinationArc.StartEndSyntheticId, TargetView.Opportunity.Region.DeclinationArc.Start),
       declinationMappingAtPath(OpportunityType / "region" / "declinationArc" / "end", TargetView.Opportunity.Region.DeclinationArc.StartEndSyntheticId, TargetView.Opportunity.Region.DeclinationArc.End),
+      declinationMappingAtPath(SiderealType / "dec", TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Dec),
     )
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GhostIfuMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GhostIfuMapping.scala
@@ -55,6 +55,8 @@ trait GhostIfuMapping[F[_]]
       SqlObject("red"),
       SqlObject("blue"),
 
+      SqlObject("skyPosition"),
+
       SqlObject("slitViewingCameraExposureTime"),
 
       explicitOrElseDefault[GhostIfu1FiberAgitator]("ifu1Agitator", "explicitIfu1Agitator", "defaultIfu1Agitator"),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/RightAscensionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/RightAscensionMapping.scala
@@ -10,11 +10,13 @@ import io.circe
 import lucuma.core.math.RightAscension
 import lucuma.odb.graphql.table.CallForProposalsView
 import lucuma.odb.graphql.table.ConfigurationRequestView
+import lucuma.odb.graphql.table.GhostIfuView
 import lucuma.odb.graphql.table.ObservationView
 import lucuma.odb.graphql.table.TargetView
 
 trait RightAscensionMapping[F[_]] extends CallForProposalsView[F]
                                      with ConfigurationRequestView[F]
+                                     with GhostIfuView[F]
                                      with ObservationView[F]
                                      with TargetView[F] {
 
@@ -38,13 +40,14 @@ trait RightAscensionMapping[F[_]] extends CallForProposalsView[F]
       rightAscensionMappingAtPath(CallForProposalsType / "coordinateLimits" / "north" / "raEnd",   CallForProposalsView.Id, CallForProposalsView.coordinateLimits.north.RaEnd),
       rightAscensionMappingAtPath(CallForProposalsType / "coordinateLimits" / "south" / "raStart", CallForProposalsView.Id, CallForProposalsView.coordinateLimits.south.RaStart),
       rightAscensionMappingAtPath(CallForProposalsType / "coordinateLimits" / "south" / "raEnd",   CallForProposalsView.Id, CallForProposalsView.coordinateLimits.south.RaEnd),
-      rightAscensionMappingAtPath(CoordinatesType / "ra", ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Ra),
-      rightAscensionMappingAtPath(SiderealType / "ra", TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Ra),
       rightAscensionMappingAtPath(ConfigurationTargetType / "coordinates" / "ra", ConfigurationRequestView.Target.ReferenceCoordinates.SyntheticId, ConfigurationRequestView.Target.ReferenceCoordinates.Ra),
       rightAscensionMappingAtPath(ConfigurationTargetType / "region" / "rightAscensionArc" / "start", ConfigurationRequestView.Target.Region.RightAscensionArc.PartialSyntheticId, ConfigurationRequestView.Target.Region.RightAscensionArc.Start),
       rightAscensionMappingAtPath(ConfigurationTargetType / "region" / "rightAscensionArc" / "end", ConfigurationRequestView.Target.Region.RightAscensionArc.PartialSyntheticId, ConfigurationRequestView.Target.Region.RightAscensionArc.End),
+      rightAscensionMappingAtPath(CoordinatesType / "ra", ObservationView.TargetEnvironment.Coordinates.SyntheticId, ObservationView.TargetEnvironment.Coordinates.Ra),
+      rightAscensionMappingAtPath(GhostIfuType / "skyPosition" / "ra", GhostIfuView.Sky.Id, GhostIfuView.Sky.Ra),
       rightAscensionMappingAtPath(OpportunityType / "region" / "rightAscensionArc" / "start", TargetView.Opportunity.Region.RightAscensionArc.StartEndSyntheticId, TargetView.Opportunity.Region.RightAscensionArc.Start),
       rightAscensionMappingAtPath(OpportunityType / "region" / "rightAscensionArc" / "end", TargetView.Opportunity.Region.RightAscensionArc.StartEndSyntheticId, TargetView.Opportunity.Region.RightAscensionArc.End),
+      rightAscensionMappingAtPath(SiderealType / "ra", TargetView.Sidereal.SyntheticId, TargetView.Sidereal.Ra),
     )
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/GhostIfuView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/GhostIfuView.scala
@@ -27,6 +27,11 @@ trait GhostIfuView[F[_]] extends BaseMapping[F]:
     val Red: DetectorTable  = DetectorTable("red")
     val Blue: DetectorTable = DetectorTable("blue")
 
+    object Sky:
+      val Id: ColumnRef  = col("c_sky_id", observation_id.embedded)
+      val Ra: ColumnRef  = col("c_sky_ra", right_ascension.embedded)
+      val Dec: ColumnRef = col("c_sky_dec", declination.embedded)
+
     object SlitViewingCamera:
       val Id: ColumnRef           = col("c_slit_viewing_camera_id",            observation_id.embedded)
       val ExposureTime: ColumnRef = col("c_slit_viewing_camera_exposure_time", time_span.embedded)

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -278,7 +278,7 @@ object GeneratorParamsService {
 
         observingMode(obsParams.targets, config).flatMap:
 
-          case gh @ ghost.ifu.Config(_, resolutionMode, red, blue, _, _, _) =>
+          case gh @ ghost.ifu.Config(_, resolutionMode, red, blue, _, _, _, _) =>
             (
               ExposureTimeMode.timeAndCount.getOption(red.value.exposureTimeMode),
               ExposureTimeMode.timeAndCount.getOption(blue.value.exposureTimeMode)

--- a/modules/service/src/main/scala/lucuma/odb/service/GhostIfuService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GhostIfuService.scala
@@ -17,6 +17,7 @@ import grackle.ResultT
 import lucuma.core.enums.GhostBinning
 import lucuma.core.enums.GhostReadMode
 import lucuma.core.enums.GhostResolutionMode
+import lucuma.core.math.Coordinates
 import lucuma.core.model.ExposureTimeMode
 import lucuma.core.model.Observation
 import lucuma.odb.data.ExposureTimeModeId
@@ -229,6 +230,7 @@ object GhostIfuService:
         ghost_resolution_mode         *:
         ghost_detector_red            *:
         ghost_detector_blue           *:
+        (right_ascension *: declination).to[Coordinates].opt *:
         time_span.opt                 *:
         ghost_ifu1_fiber_agitator.opt *:
         ghost_ifu2_fiber_agitator.opt
@@ -245,6 +247,8 @@ object GhostIfuService:
 
     private val RemainingColumns: List[String] =
       List(
+        "c_sky_ra",
+        "c_sky_dec",
         "c_slit_viewing_camera_exposure_time",
         "c_ifu1_fiber_agitator",
         "c_ifu2_fiber_agitator"
@@ -316,6 +320,8 @@ object GhostIfuService:
             ${ghost_binning.opt},
             $ghost_read_mode,
             ${ghost_read_mode.opt},
+            ${right_ascension.opt},
+            ${declination.opt},
             ${time_span.opt},
             ${ghost_ifu1_fiber_agitator.opt},
             ${ghost_ifu2_fiber_agitator.opt}
@@ -333,6 +339,8 @@ object GhostIfuService:
             input.blue.flatMap(_.explicitBinning.toOption),
             GhostReadMode.Slow,
             input.blue.flatMap(_.explicitReadMode.toOption),
+            input.skyPosition.map(_.ra),
+            input.skyPosition.map(_.dec),
             input.slitCameraExposureTime,
             input.explicitIfu1FiberAgitator,
             input.explicitIfu2FiberAgitator
@@ -448,6 +456,8 @@ object GhostIfuService:
         val upRedReadMode    = sql"c_red_read_mode       = ${ghost_read_mode.opt}"
         val upBlueBinning    = sql"c_blue_binning        = ${ghost_binning.opt}"
         val upBlueReadMode   = sql"c_blue_read_mode      = ${ghost_read_mode.opt}"
+        val upSkyRa          = sql"c_sky_ra              = ${right_ascension.opt}"
+        val upSkyDec         = sql"c_sky_dec             = ${declination.opt}"
         val upSlitExpTime    = sql"c_slit_viewing_camera_exposure_time = ${time_span.opt}"
         val upIfu1Agitator   = sql"c_ifu1_fiber_agitator = ${ghost_ifu1_fiber_agitator.opt}"
         val upIfu2Agitator   = sql"c_ifu2_fiber_agitator = ${ghost_ifu2_fiber_agitator.opt}"
@@ -460,6 +470,8 @@ object GhostIfuService:
             SET.red.flatMap(_.explicitReadMode.toOptionOption).map(upRedReadMode),
             SET.blue.flatMap(_.explicitBinning.toOptionOption).map(upBlueBinning),
             SET.blue.flatMap(_.explicitReadMode.toOptionOption).map(upBlueReadMode),
+            SET.skyPosition.toOptionOption.map(_.flatMap(_.ra)).map(upSkyRa),
+            SET.skyPosition.toOptionOption.map(_.flatMap(_.dec)).map(upSkyDec),
             SET.slitCameraExposureTime.toOptionOption.map(upSlitExpTime),
             SET.explicitIfu1FiberAgitator.toOptionOption.map(upIfu1Agitator),
             SET.explicitIfu2FiberAgitator.toOptionOption.map(upIfu2Agitator)

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -157,6 +157,12 @@ object ObservationService {
       "explicitBase requires both ra and dec"
     )
 
+  val BothGhostIfuskyPositionConstraint: DatabaseConstraint =
+    DatabaseConstraint(
+      "ghost_ifu_sky_position_neither_or_both",
+      "skyPosition requires both ra and dec"
+    )
+
   def GenericConstraintViolationMessage(m: String): String =
     s"Database constraint violation produced by input: $m"
 
@@ -165,7 +171,8 @@ object ObservationService {
       MissingAirMassConstraint,
       MissingHourAngleConstraint,
       MissingScienceBandConstraint,
-      BothExplicitCoordinatesConstraint
+      BothExplicitCoordinatesConstraint,
+      BothGhostIfuskyPositionConstraint
     )
 
   def constraintViolationMessage(ex: PostgresErrorException): String =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GhostIfu.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GhostIfu.scala
@@ -509,6 +509,10 @@ class createObservation_GhostIfu extends OdbSuite:
                           defaultReadMode
                           explicitReadMode
                         }
+                        skyPosition {
+                          ra { hms }
+                          dec { dms }
+                        }
                         slitViewingCameraExposureTime { seconds }
                         ifu1Agitator
                         defaultIfu1Agitator
@@ -563,6 +567,7 @@ class createObservation_GhostIfu extends OdbSuite:
                           "defaultReadMode": "SLOW",
                           "explicitReadMode": null
                         },
+                        "skyPosition": null,
                         "slitViewingCameraExposureTime": null,
                         "ifu1Agitator": "DISABLED",
                         "defaultIfu1Agitator": "DISABLED",
@@ -570,6 +575,64 @@ class createObservation_GhostIfu extends OdbSuite:
                         "ifu2Agitator": "DISABLED",
                         "defaultIfu2Agitator": "DISABLED",
                         "explicitIfu2Agitator": null
+                      }
+                    }
+                  }
+                }
+              }
+            """.asRight
+        )
+
+  test("create GHOST IFU with sky position"):
+    createProgramAs(pi).flatMap: pid =>
+      createTargetAs(pi, pid).flatMap: tid =>
+        expect(
+          user  = pi,
+          query =
+            s"""
+              mutation {
+                createObservation(input: {
+                  programId: "$pid"
+                  SET: {
+                    targetEnvironment: {
+                      asterism: [ "$tid" ]
+                    }
+                    scienceRequirements: ${scienceRequirementsObject(GhostIfu)}
+                    observingMode: {
+                      ghostIfu: {
+                        resolutionMode: STANDARD
+                        skyPosition: {
+                          ra: { hours: 1.5 }
+                          dec: { degrees: 45.0 }
+                        }
+                      }
+                    }
+                  }
+                }) {
+                  observation {
+                    observingMode {
+                      ghostIfu {
+                        skyPosition {
+                          ra { hms }
+                          dec { dms }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            """,
+          expected =
+            json"""
+              {
+                "createObservation": {
+                  "observation": {
+                    "observingMode": {
+                      "ghostIfu": {
+                        "skyPosition": {
+                          "ra": { "hms": "01:30:00.000000" },
+                          "dec": { "dms": "+45:00:00.000000" }
+                        }
                       }
                     }
                   }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations_GhostIfu.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations_GhostIfu.scala
@@ -265,6 +265,10 @@ class updateObservations_GhostIfu extends OdbSuite with UpdateObservationsOps wi
             explicitBinning:  TWO_BY_EIGHT
             explicitReadMode: MEDIUM
           }
+          skyPosition: {
+            ra: { hours: 1.5 },
+            dec: { degrees: 45.0 }
+          }
           slitViewingCameraExposureTime: { seconds: 23.0 }
           explicitIfu1Agitator: DISABLED
           explicitIfu2Agitator: ENABLED
@@ -285,6 +289,10 @@ class updateObservations_GhostIfu extends OdbSuite with UpdateObservationsOps wi
             blue {
               explicitBinning
               explicitReadMode
+            }
+            skyPosition {
+              ra { hms }
+              dec { dms }
             }
             slitViewingCameraExposureTime { seconds }
             explicitIfu1Agitator
@@ -311,6 +319,10 @@ class updateObservations_GhostIfu extends OdbSuite with UpdateObservationsOps wi
                     "explicitBinning": "TWO_BY_EIGHT",
                     "explicitReadMode": "MEDIUM"
                   },
+                  "skyPosition": {
+                    "ra": { "hms": "01:30:00.000000" },
+                    "dec": { "dms": "+45:00:00.000000" }
+                  },
                   "slitViewingCameraExposureTime": {
                     "seconds": 23.000000
                   },
@@ -323,6 +335,39 @@ class updateObservations_GhostIfu extends OdbSuite with UpdateObservationsOps wi
         }
       }
     """.asRight
+
+    for
+      p <- createProgramAs(pi)
+      t <- createTargetWithProfileAs(pi, p)
+      o <- createObservationWithModeAs(pi, p, List(t), GhostIfuInput)
+      _ <- updateObservation(pi, o, update, query, expected)
+    yield o
+
+  test("Update only ra, but missing dec"):
+    val update = """
+      observingMode: {
+        ghostIfu: {
+          skyPosition: {
+            ra: { hours: 1.5 }
+          }
+        }
+      }
+    """
+
+    val query = """
+      observations {
+        observingMode {
+          ghostIfu {
+            skyPosition {
+              ra { hms }
+              dec { dms }
+            }
+          }
+        }
+      }
+    """
+
+    val expected = "skyPosition requires both ra and dec".asLeft
 
     for
       p <- createProgramAs(pi)

--- a/modules/service/src/test/scala/lucuma/odb/service/GhostIfuServiceSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/GhostIfuServiceSuite.scala
@@ -15,6 +15,7 @@ import lucuma.core.enums.GhostReadMode
 import lucuma.core.enums.GhostResolutionMode
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.ObservingModeType
+import lucuma.core.math.Coordinates
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ExposureTimeMode
 import lucuma.core.model.Observation
@@ -67,6 +68,7 @@ class GhostIfuServiceSuite extends ExecutionTestSupport:
       Nullable.NonNull(GhostBinning.FourByFour),
       Nullable.NonNull(GhostReadMode.Slow)
     ).some,
+    skyPosition               = Coordinates.fromHmsDms.getOption("17 57 48.49803 +04 41 36.2072"),
     slitCameraExposureTime    = TimeSpan.FromMicroseconds.getOption(1000L),
     explicitIfu1FiberAgitator = GhostIfu1FiberAgitator.Enabled.some,
     explicitIfu2FiberAgitator = GhostIfu2FiberAgitator.Disabled.some
@@ -134,6 +136,7 @@ class GhostIfuServiceSuite extends ExecutionTestSupport:
       resolutionMode         = in.resolutionMode,
       red                    = DetectorConfig.Red(expectedDetector(in.red, GhostReadMode.Medium)),
       blue                   = DetectorConfig.Blue(expectedDetector(in.blue, GhostReadMode.Slow)),
+      skyPosition            = in.skyPosition,
       slitCameraExposureTime = in.slitCameraExposureTime,
       explicitIfu1Agitator   = in.explicitIfu1FiberAgitator,
       explicitIfu2Agitator   = in.explicitIfu2FiberAgitator
@@ -160,6 +163,7 @@ class GhostIfuServiceSuite extends ExecutionTestSupport:
       resolutionMode            = GhostResolutionMode.Standard,
       red                       = none,
       blue                      = none,
+      skyPosition               = none,
       slitCameraExposureTime    = none,
       explicitIfu1FiberAgitator = none,
       explicitIfu2FiberAgitator = none


### PR DESCRIPTION
Adds an optional `skyPosition` coordinate to the GHOST observing mode.  At the moment this is unused but will be written to the `GhostStatic` configuration as part of the IFU mapping in a proximate PR.