### PR TITLE
Some improvements to speed up the build on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout current branch
-        uses: nschloe/action-cached-lfs-checkout@v1
+        uses: actions/checkout@v5
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
@@ -65,32 +65,8 @@ jobs:
       - name: Docker compose up
         run: docker compose up -d
 
-      - name: Validate ODB GraphQL schema changes
-        if: github.event_name == 'pull_request' && matrix.shard == '1'
-        uses: kamilkisiela/graphql-inspector@master
-        with:
-          name: Validate ODB Public API
-          schema: 'main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql'
-          approve-label: expected-breaking-change
-
-      - name: Validate ITC GraphQL schema changes
-        if: github.event_name == 'pull_request' && matrix.shard == '2'
-        uses: kamilkisiela/graphql-inspector@master
-        with:
-          name: Validate ITC Public API
-          schema: 'main:itc/service/src/main/resources/graphql/itc.graphql'
-          approve-label: expected-breaking-change
-
       - name: Check that workflows are up to date
         run: sbt -v -J-Xmx6g githubWorkflowCheck
-
-      - name: Check headers and formatting
-        if: matrix.java == 'temurin@25' && matrix.os == 'ubuntu-22.04' && matrix.shard == '0'
-        run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck lucumaScalafmtCheck lucumaScalafixCheck
-
-      - name: Check scalafix lints
-        if: matrix.java == 'temurin@25' && matrix.os == 'ubuntu-22.04' && matrix.shard == '0'
-        run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' 'scalafixAll --check'
 
       - name: Test
         env:
@@ -98,22 +74,23 @@ jobs:
           TEST_SHARD: ${{ matrix.shard }}
         run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' test
 
-      - name: Check binary compatibility
-        if: matrix.java == 'temurin@25' && matrix.os == 'ubuntu-22.04' && matrix.shard == '0'
-        run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' mimaReportBinaryIssues
-
-      - name: Generate API documentation
-        if: matrix.java == 'temurin@25' && matrix.os == 'ubuntu-22.04' && matrix.shard == '0'
-        run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' doc
-
-      - name: Aggregate coverage reports
-        run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' coverageReport coverageAggregate
-
-      - name: Upload code coverage data
-        uses: codecov/codecov-action@v6
-
       - name: Docker compose down
         run: docker compose down
+
+      - name: Make target directories
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
+        run: mkdir -p itc/testkit/.jvm/target itc/service/target modules/binding/target itc/model/.jvm/target modules/otel/target modules/sso-frontend-client/.jvm/target itc/testkit/.js/target itc/model/.js/target itc/client/jvm/target modules/schema/.js/target target itc/client/js/target modules/schema/.jvm/target modules/sso-frontend-client/.js/target modules/sso-backend-client/target project/target
+
+      - name: Compress target directories
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
+        run: tar cf targets.tar itc/testkit/.jvm/target itc/service/target modules/binding/target itc/model/.jvm/target modules/otel/target modules/sso-frontend-client/.jvm/target itc/testkit/.js/target itc/model/.js/target itc/client/jvm/target modules/schema/.js/target target itc/client/js/target modules/schema/.jvm/target modules/sso-frontend-client/.js/target modules/sso-backend-client/target project/target
+
+      - name: Upload target directories
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
+        uses: actions/upload-artifact@v5
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}-${{ matrix.shard }}
+          path: targets.tar
 
   publish:
     name: Publish Artifacts
@@ -126,7 +103,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch
-        uses: nschloe/action-cached-lfs-checkout@v1
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -145,6 +122,16 @@ jobs:
       - name: sbt update
         if: matrix.java == 'temurin@25' && steps.setup-java-temurin-25.outputs.cache-hit == 'false'
         run: sbt -v -J-Xmx6g +update
+
+      - name: Download target directories (3, 0)
+        uses: actions/download-artifact@v6
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3-0
+
+      - name: Inflate target directories (3, 0)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
 
       - name: Import signing key
         if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''
@@ -169,6 +156,55 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_CREDENTIAL_HOST: ${{ secrets.SONATYPE_CREDENTIAL_HOST }}
         run: sbt -v -J-Xmx6g tlCiRelease
+
+  checks:
+    name: Static checks and schema validation
+    strategy:
+      matrix:
+        os: [ubuntu-22.04]
+        scala: [3.8.3]
+        java: [temurin@25]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Setup Java (temurin@25)
+        id: setup-java-temurin-25
+        if: matrix.java == 'temurin@25'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@25' && steps.setup-java-temurin-25.outputs.cache-hit == 'false'
+        run: sbt -v -J-Xmx6g +update
+
+      - name: Static checks
+        run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck lucumaScalafmtCheck lucumaScalafixCheck 'scalafixAll --check' mimaReportBinaryIssues doc
+
+      - name: Validate ODB GraphQL schema changes
+        if: github.event_name == 'pull_request'
+        uses: kamilkisiela/graphql-inspector@master
+        with:
+          name: Validate ODB Public API
+          schema: 'main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql'
+          approve-label: expected-breaking-change
+
+      - name: Validate ITC GraphQL schema changes
+        if: github.event_name == 'pull_request'
+        uses: kamilkisiela/graphql-inspector@master
+        with:
+          name: Validate ITC Public API
+          schema: 'main:itc/service/src/main/resources/graphql/itc.graphql'
+          approve-label: expected-breaking-change
 
   deploy:
     name: Build and publish Docker images / Deploy to Heroku

--- a/.github/workflows/legacy-tests.yml
+++ b/.github/workflows/legacy-tests.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: nschloe/action-cached-lfs-checkout@v1
+        with:
+          fetch-depth: 1
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1

--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -26,9 +26,9 @@ jobs:
 
     steps:
       - name: Checkout current branch
-        uses: nschloe/action-cached-lfs-checkout@v1
+        uses: actions/checkout@v5
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup Java (temurin@17)
         uses: actions/setup-java@v4

--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,15 @@ ThisBuild / Test / parallelExecution := false
 
 ThisBuild / Test / testOptions += Tests.Argument(TestFrameworks.MUnit, "--log=debug")
 
+// Disable plugin-injected CI steps, they will be run in a the dedicated `checks` job
+// instead of being repeated for each shard
+ThisBuild / lucumaCoverage           := false
+ThisBuild / tlCiHeaderCheck          := false
+ThisBuild / tlCiScalafmtCheck        := false
+ThisBuild / tlCiScalafixCheck        := false
+ThisBuild / tlCiMimaBinaryIssueCheck := false
+ThisBuild / tlCiDocCheck             := false
+
 ThisBuild / watchOnTermination := { (action, cmd, times, state) =>
   val projNames = cmd
     .split(";")
@@ -101,44 +110,49 @@ ThisBuild / githubWorkflowBuildPreamble ~= { steps =>
 //    cond = Some("github.event_name == 'pull_request'  && matrix.shard == '1'")
 //  )
 
-ThisBuild / githubWorkflowBuildPreamble +=
-  WorkflowStep.Use(
-    UseRef.Public("kamilkisiela", "graphql-inspector", "master"),
-    name = Some("Validate ODB GraphQL schema changes"),
-    params =
-      Map(
-        "name"          -> "Validate ODB Public API",
-        "schema"        -> "main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql",
-        "approve-label" -> "expected-breaking-change"
-      ),
-    cond = Some("github.event_name == 'pull_request' && matrix.shard == '1'")
-  )
-
-ThisBuild / githubWorkflowBuildPreamble +=
-  WorkflowStep.Use(
-    UseRef.Public("kamilkisiela", "graphql-inspector", "master"),
-    name = Some("Validate ITC GraphQL schema changes"),
-    params =
-      Map(
-        "name"          -> "Validate ITC Public API",
-        "schema"        -> "main:itc/service/src/main/resources/graphql/itc.graphql",
-        "approve-label" -> "expected-breaking-change"
-      ),
-    cond = Some("github.event_name == 'pull_request' && matrix.shard == '2'")
-  )
-
 val nTestJobShards = 8
 
 ThisBuild / githubWorkflowBuildMatrixAdditions += (
   "shard" -> ((0 to (nTestJobShards - 1)).map(_.toString).toList)
 )
-ThisBuild / githubWorkflowBuild ~= (_.map(step =>
-  if (step.name.contains("Test"))
+ThisBuild / githubWorkflowBuild ~= (_.map {
+  case step if step.name.contains("Test") =>
     step.withEnv(
-      Map("TEST_SHARD_COUNT" -> nTestJobShards.toString(), "TEST_SHARD" -> "${{ matrix.shard }}")
+      Map(
+        "TEST_SHARD_COUNT" -> nTestJobShards.toString(),
+        "TEST_SHARD"       -> "${{ matrix.shard }}"
+      )
     )
-  else step
-))
+  case step => step
+})
+
+// Swap the test-shard checkout for a shallow no-LFS variant
+ThisBuild / githubWorkflowGeneratedCI ~= { jobs =>
+  jobs.map { job =>
+    if (job.id == "build")
+      job.withSteps(job.steps.map {
+        case s if s.name.contains("Checkout current branch") => CheckoutShallow
+        case s                                               => s
+      })
+    else job
+  }
+}
+
+// Shollow checkout and no lfs, used for test shards
+lazy val CheckoutShallow: WorkflowStep =
+  WorkflowStep.Use(
+    UseRef.Public("actions", "checkout", "v5"),
+    name = Some("Checkout current branch"),
+    params = Map("fetch-depth" -> "1")
+  )
+
+// checkout without lfs but full history
+lazy val CheckoutFull: WorkflowStep =
+  WorkflowStep.Use(
+    UseRef.Public("actions", "checkout", "v5"),
+    name = Some("Checkout current branch"),
+    params = Map("fetch-depth" -> "0")
+  )
 
 lazy val CheckoutFullWithLfs: WorkflowStep =
   WorkflowStep.Use(
@@ -148,7 +162,15 @@ lazy val CheckoutFullWithLfs: WorkflowStep =
   )
 
 ThisBuild / githubWorkflowJobSetup := {
-  List(CheckoutFullWithLfs) :::
+  List(CheckoutFull) :::
+    WorkflowStep.SetupSbt ::
+    WorkflowStep.SetupJava(githubWorkflowJavaVersions.value.toList) :::
+    githubWorkflowGeneratedCacheSteps.value.toList
+}
+
+// allow customizing the checkout style.
+def setupWith(checkout: WorkflowStep): Def.Initialize[List[WorkflowStep]] = Def.setting {
+  checkout ::
     WorkflowStep.SetupSbt ::
     WorkflowStep.SetupJava(githubWorkflowJavaVersions.value.toList) :::
     githubWorkflowGeneratedCacheSteps.value.toList
@@ -253,11 +275,65 @@ val mainCond                 = "github.ref == 'refs/heads/main'"
 val geminiRepoCond           = "startsWith(github.repository, 'gemini')"
 def allConds(conds: String*) = conds.mkString("(", " && ", ")")
 
+lazy val sbtStaticChecks =
+  WorkflowStep.Sbt(
+    List(
+      "headerCheckAll",
+      "scalafmtCheckAll",
+      "project /",
+      "scalafmtSbtCheck",
+      "lucumaScalafmtCheck",
+      "lucumaScalafixCheck",
+      "scalafixAll --check",
+      "mimaReportBinaryIssues",
+      "doc"
+    ),
+    name = Some("Static checks")
+  )
+
+lazy val graphqlInspectorOdb =
+  WorkflowStep.Use(
+    UseRef.Public("kamilkisiela", "graphql-inspector", "master"),
+    name = Some("Validate ODB GraphQL schema changes"),
+    params =
+      Map(
+        "name"          -> "Validate ODB Public API",
+        "schema"        -> "main:modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql",
+        "approve-label" -> "expected-breaking-change"
+      ),
+    cond = Some("github.event_name == 'pull_request'")
+  )
+
+lazy val graphqlInspectorItc =
+  WorkflowStep.Use(
+    UseRef.Public("kamilkisiela", "graphql-inspector", "master"),
+    name = Some("Validate ITC GraphQL schema changes"),
+    params =
+      Map(
+        "name"          -> "Validate ITC Public API",
+        "schema"        -> "main:itc/service/src/main/resources/graphql/itc.graphql",
+        "approve-label" -> "expected-breaking-change"
+      ),
+    cond = Some("github.event_name == 'pull_request'")
+  )
+
+// Don't do static checks repeatedly on each shard, instead create a separate task only for checks.
 ThisBuild / githubWorkflowAddedJobs ++= Seq(
+  WorkflowJob(
+    "checks",
+    "Static checks and schema validation",
+    githubWorkflowJobSetup.value.toList :::
+      sbtStaticChecks ::
+      graphqlInspectorOdb ::
+      graphqlInspectorItc ::
+      Nil,
+    scalas = List(scalaVersion.value),
+    javas = githubWorkflowJavaVersions.value.toList.take(1)
+  ),
   WorkflowJob(
     "deploy",
     "Build and publish Docker images / Deploy to Heroku",
-    githubWorkflowJobSetup.value.toList :::
+    setupWith(CheckoutFullWithLfs).value :::
       sbtDockerPublishLocal ::
       herokuPush ::
       herokuRelease ::


### PR DESCRIPTION
* Disable coverage
* We were doing static checks on each test shard, instead now we have a separate task to do it making shards only do the actual tests
* test shards were doing lfs checkout. I thought this would be fast as we are caching that, but sometimes it would do a full checkout in some of the shards making the whole process slower. Now we don checkout lfs as the shards don't run the legacy itc tests

CI has gone from about 17m to 13m on a few runs I did and it should be more deterministic.