### PR TITLE
Alopeke and zorro modes should not expand

### DIFF
--- a/modules/phase0/src/main/scala/lucuma/odb/phase0/ConfigurationRow.scala
+++ b/modules/phase0/src/main/scala/lucuma/odb/phase0/ConfigurationRow.scala
@@ -196,4 +196,19 @@ object ImagingRow extends RowParsers {
     }
   }
 
+  /**
+   * A single line in the .tsv file becomes exactly one row.
+   * Used for instruments that can't (yet) store details like filters (Alopeke, Zorro)
+   */
+  val singleRow: Parser[List[ImagingRow]] = (
+    (instrument        <* htab) ~
+    (arcsec            <* htab) ~
+    (string            <* htab) ~ // hold all filters
+    (ao                <* htab) ~
+    (imagingCapability <* htab) ~
+    site
+  ).map { case (((((inst, fov), filter), ao), capability), site) =>
+    List(ImagingRow(inst, fov, filter, ao, capability, site))
+  }
+
 }

--- a/modules/phase0/src/main/scala/lucuma/odb/phase0/FileReader.scala
+++ b/modules/phase0/src/main/scala/lucuma/odb/phase0/FileReader.scala
@@ -79,10 +79,10 @@ class FileReader[F[_]](fileName: String)(using ApplicativeError[F, Throwable]):
     read(Instrument.GmosSouth, GmosImagingRow.gmosSouth)
 
   val alopekeImaging: Pipe[F, Byte, (ImagingRow, PosInt)] =
-    read(Instrument.Alopeke, ImagingRow.rows)
+    read(Instrument.Alopeke, ImagingRow.singleRow)
 
   val zorroImaging: Pipe[F, Byte, (ImagingRow, PosInt)] =
-    read(Instrument.Zorro, ImagingRow.rows)
+    read(Instrument.Zorro, ImagingRow.singleRow)
 
   val gmosSouthSpectroscopy: Pipe[F, Byte, (GmosSpectroscopyRow.GmosSouth, PosInt)] =
     read(Instrument.GmosSouth, GmosSpectroscopyRow.gmosSouth)

--- a/modules/phase0/src/test/scala/lucuma/odb/phase0/Phase0LoaderSuite.scala
+++ b/modules/phase0/src/test/scala/lucuma/odb/phase0/Phase0LoaderSuite.scala
@@ -144,3 +144,37 @@ class Phase0LoaderSuite extends CatsEffectSuite:
       .toList
       .map: rows =>
         assertEquals(rows.length, 22)
+
+  test("load alopeke configurations"):
+    val rdr = FileReader[IO](imgFileName)
+    val inputStream = getClass.getResourceAsStream(imgFileName)
+    val stream =
+      fs2.io.readInputStream(
+        IO(inputStream),
+        chunkSize = 4096,
+        closeAfterUse = true
+      )
+
+    stream
+      .through(rdr.alopekeImaging)
+      .compile
+      .toList
+      .map: rows =>
+        assertEquals(rows.length, 2)
+
+  test("load zorro configurations"):
+    val rdr = FileReader[IO](imgFileName)
+    val inputStream = getClass.getResourceAsStream(imgFileName)
+    val stream =
+      fs2.io.readInputStream(
+        IO(inputStream),
+        chunkSize = 4096,
+        closeAfterUse = true
+      )
+
+    stream
+      .through(rdr.zorroImaging)
+      .compile
+      .toList
+      .map: rows =>
+        assertEquals(rows.length, 2)

--- a/modules/service/src/main/scala/db/migration/R__Phase0.scala
+++ b/modules/service/src/main/scala/db/migration/R__Phase0.scala
@@ -20,7 +20,7 @@ class R__Phase0 extends RepeatableMigration("Phase 0 Instrument Options") {
 
   val imagingFileName: String = "Phase0_Instrument_Matrix - Imaging.tsv"
 
-  override val importForcingVersion: Int = 7
+  override val importForcingVersion: Int = 8
 
   lazy val definitionFiles: NonEmptyList[(String, IO[InputStream])] =
     filesFromClasspath("phase0", NonEmptyList.of(spectroscopyFileName, imagingFileName))


### PR DESCRIPTION
Since we are not storing filter selection we may rather not show them as separate rows