### PR TITLE
Phantom groups

### DIFF
--- a/modules/service/src/main/resources/db/migration/V1143__cleanup_phantom_telluric_groups.sql
+++ b/modules/service/src/main/resources/db/migration/V1143__cleanup_phantom_telluric_groups.sql
@@ -1,0 +1,40 @@
+-- sc-8661: hide "phantom" system telluric groups whose parent science
+-- observatiann was moved out and/or deleted.
+--
+-- We soft-delete rather than DELETE to avoid having to update all references.
+-- Dev also has some obs with visits, we'll leave the phantom groups in that case.
+
+-- 1) Find phantom telluric groups whose tellurics can be safely hidden.
+CREATE TEMP TABLE tmp_phantom_telluric_groups AS
+SELECT g.c_group_id
+FROM   t_group g
+WHERE  g.c_system    = true                       -- system-managed group
+  AND  g.c_existence = 'present'                  -- not already hidden
+  AND  'telluric'    = ANY(g.c_calibration_roles) -- telluric group
+  AND  NOT EXISTS (                               -- no science obs (the buggy groups)
+    SELECT 1
+    FROM   t_observation s
+    WHERE  s.c_group_id          = g.c_group_id
+      AND  s.c_calibration_role IS NULL
+      AND  s.c_existence         = 'present'
+  )
+  AND  NOT EXISTS (                               -- and no telluric inside has visits or events
+    SELECT 1
+    FROM   t_observation t
+    WHERE  t.c_group_id = g.c_group_id
+      AND  ( EXISTS (SELECT 1 FROM t_visit           v WHERE v.c_observation_id = t.c_observation_id)
+          OR EXISTS (SELECT 1 FROM t_execution_event e WHERE e.c_observation_id = t.c_observation_id))
+  );
+
+-- 2) Soft delete the tellurics
+UPDATE t_observation
+SET    c_existence = 'deleted'
+WHERE  c_group_id IN (SELECT c_group_id FROM tmp_phantom_telluric_groups)
+  AND  c_existence = 'present';
+
+-- 3) Soft delte the groups
+UPDATE t_group
+SET    c_existence = 'deleted'
+WHERE  c_group_id IN (SELECT c_group_id FROM tmp_phantom_telluric_groups);
+
+DROP TABLE tmp_phantom_telluric_groups;

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -29,6 +29,7 @@ import lucuma.core.math.Declination
 import lucuma.core.math.RightAscension
 import lucuma.core.math.SignalToNoise
 import lucuma.core.math.Wavelength
+import lucuma.core.model.Access
 import lucuma.core.model.CloudExtinction
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ElevationRange
@@ -449,6 +450,27 @@ object ObservationService {
                   Services.asSuperUser:
                     allocationService.validateBand(band, pids)
 
+            // Observations in system groups (telluric, etc.) cannot be moved
+            // by non-service callers.
+            // doing so may introduce orphan groups, at least for tellurics.
+            val forbidSystemGroupMove: ResultT[F, Unit] =
+              val movingGroup = SET.group != Nullable.Absent || SET.groupIndex.isDefined
+
+              if !movingGroup || user.role.access == Access.Service then
+                ResultT.unit
+              else
+                val af = Statements.selectObservationsInSystemGroup(which)
+                ResultT:
+                  session.prepareR(af.fragment.query(observation_id))
+                    .use(_.stream(af.argument, 1024).compile.toList)
+                    .map:
+                      case Nil =>
+                        Result.unit
+                      case ids =>
+                        OdbError.InvalidArgument(
+                          s"Observations ${ids.map(_.show).mkString(", ")} cannot be moved out of their system group; move the group instead.".some
+                        ).asFailure
+
             val updates: ResultT[F, Map[Program.Id, List[Observation.Id]]] =
               for {
                 r <- ResultT(Statements.updateObservations(SET, which).traverse { af =>
@@ -481,17 +503,17 @@ object ObservationService {
                     }.map(_.sequence)))
             } yield g
 
-            for {
-              _ <- session.execute(sql"set constraints all deferred".command)
-              _ <- moveObservations(SET.group, SET.groupIndex, which)
-              r <- updates.value.recoverWith {
-                    case SqlState.CheckViolation(ex) =>
-                      OdbError.InvalidArgument(Some(constraintViolationMessage(ex))).asFailureF
-                    case SqlState.RaiseException(ex) =>
-                      OdbError.UpdateFailed(ex.message.some).asFailureF
-                  }
-              _ <- transaction.rollback.unlessA(r.hasValue) // rollback if something failed
-            } yield r
+            (for {
+              _ <- forbidSystemGroupMove
+              _ <- ResultT.liftF(session.execute(sql"set constraints all deferred".command))
+              _ <- ResultT.liftF(moveObservations(SET.group, SET.groupIndex, which))
+              r <- ResultT(updates.value.recoverWith {
+                     case SqlState.CheckViolation(ex) =>
+                       OdbError.InvalidArgument(Some(constraintViolationMessage(ex))).asFailureF
+                     case SqlState.RaiseException(ex) =>
+                       OdbError.UpdateFailed(ex.message.some).asFailureF
+                   })
+            } yield r).value.flatTap(r => transaction.rollback.unlessA(r.hasValue))
         }
 
       override def updateObservationsTimes(
@@ -1164,6 +1186,14 @@ object ObservationService {
         FROM t_observation
         WHERE c_observation_id IN (
       """.apply(gid, index) |+| which |+| void")"
+
+    def selectObservationsInSystemGroup(which: AppliedFragment): AppliedFragment =
+      void"""
+        SELECT o.c_observation_id
+        FROM   t_observation o
+        JOIN   t_group       g ON o.c_group_id = g.c_group_id
+        WHERE  g.c_system = true
+          AND  o.c_observation_id IN (""" |+| which |+| void")"
 
     // Brute force statements to delete a calibration observations
     def linkedTargets(oids: NonEmptyList[Observation.Id]): Query[List[Observation.Id], Target.Id] =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/8661.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/8661.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.issue.shortcut
+
+import cats.syntax.all.*
+import lucuma.core.enums.CalibrationRole
+import lucuma.odb.data.OdbError
+import lucuma.odb.graphql.feature.TelluricCalibrationsTestSupport
+import lucuma.odb.graphql.query.ExecutionTestSupportForFlamingos2
+
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+// A system telluric group could be left orphaned (a "phantom group")
+// when the parent science observation is moved out of the telluric group.
+//
+// It was reported that sometimes dragging and dropping created phantom
+// groups and that could explain how these groups were left without a science obs.
+class ShortCut_8661
+  extends ExecutionTestSupportForFlamingos2
+  with TelluricCalibrationsTestSupport:
+
+  private val when =
+    LocalDateTime.of(2024, 1, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
+
+  test("cannot move a science observation out of a telluric group"):
+    for {
+      pid       <- createProgramAs(pi)
+      tid       <- createTargetWithProfileAs(pi, pid)
+      oid       <- createFlamingos2LongSlitObservationAs(pi, pid, List(tid))
+      _         <- setExposureTime(oid, 120)
+      _         <- recalculateCalibrations(pid, when, oid)
+      obsBefore <- queryObservation(oid)
+      tellGid   = obsBefore.groupId.get
+      members   <- queryObservationsInGroup(tellGid)
+      // Try to move the the science into another group
+      newGid    <- createGroupAs(pi, pid, name = "Butterfly".some)
+      _         <- interceptOdbError(moveObservationAs(pi, oid, newGid.some)):
+                     case OdbError.InvalidArgument(Some(msg)) =>
+                       assertEquals(
+                         msg,
+                         s"Observations $oid cannot be moved out of their system group; move the group instead."
+                       )
+      // The science obs remains on the telluric group.
+      obsAfter  <- queryObservation(oid)
+    } yield
+      assert(members.exists(_.calibrationRole.contains(CalibrationRole.Telluric)))
+      assertEquals(obsAfter.groupId, tellGid.some)


### PR DESCRIPTION
The phantom groups are telluric groups that for some reason have lost their science observation but the group still exists.

The calibrations daemon is supposed to clean them up and it seems pretty tight to me. However user reports inidcate that some of these events maybe related to troubles in drag and dropping.

Moving a science obs out of a telluric group is allowed, and that combined with the dnd problem may explain this.

This PR closes that option, forbiding observations to be removed from system groups (except by the daemon itself)

A migration hides the existing telluric groups to avoid having to delete every reference.