### PR TITLE
Update basePosition to return fields appropriate for navigate tracking

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -15333,6 +15333,56 @@ type Region {
   declinationArc: DeclinationArc!
 }
 
+"""
+Discriminator for `BasePosition`.
+`SINGLE_TARGET` indicates the asterism has exactly one target (sideral/non-sidereal/too) with no explicit base override
+`ASTERISM` indicates a multi-target asterism whose base is the calculated center position at observation time;
+`EXPLICIT_BASE` indicates the base position has been explicitly overridden on the target environment.
+"""
+enum BasePositionType {
+  SINGLE_TARGET
+  ASTERISM
+  EXPLICIT_BASE
+}
+
+"""
+The base position used by navigate to slew and track the target.
+The display name can be the original name or a composite.
+`type` indicates which of the tracking types are returned.
+At most one of `sidereal` / `nonsidereal` / `coordinates` is non-null.
+"""
+type BasePosition {
+  """
+  Source of this base position: a single science target, the center
+  position of a multi-target asterism, or an explicit base override.
+  """
+  type: BasePositionType!
+
+  """
+  For single-target bases this is the target's name. For
+  multi-target asterisms this is a truncated comma-separated list of target names.
+  """
+  name: NonEmptyString!
+
+  """
+  Sidereal tracking record.
+  Populated only when the base is a single sidereal target with no explicit base override.
+  """
+  sidereal: Sidereal
+
+  """
+  Nonsidereal tracking record.
+  Populated only when the base is a single nonsidereal target with no explicit base override.
+  """
+  nonsidereal: Nonsidereal
+
+  """
+  Fixed base coordinates at observation time. Populated for multi-target
+  asterisms and for explicit base overrides.
+  """
+  coordinates: Coordinates
+}
+
 type TargetEnvironment {
   """
   All the observation's science targets, if any
@@ -15355,14 +15405,12 @@ type TargetEnvironment {
   ): Target
 
   """
-  Explicit (if defined) or computed base position at the specified time, if known.
+  The base position used by navigate to slew and track the target.
+  Uses the observation's stored observation time.
+  Returns a GraphQL error when the observation time is required
+  to compute the base but is not set on the observation.
   """
-  basePosition(
-    """
-    The time used for the base position calculations.
-    """
-    observationTime: Timestamp!
-  ): Coordinates
+  basePosition: BasePosition
 
   """
   The guide target(s) and related information.

--- a/modules/schema/src/main/scala/lucuma/odb/data/BasePosition.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/BasePosition.scala
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.data
+
+import cats.data.NonEmptyList
+import cats.syntax.foldable.*
+import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.core.math.Coordinates
+import lucuma.core.model.Target
+import lucuma.core.util.Enumerated
+
+// TODO: move to lucuma-core
+enum BasePositionType(val tag: String) derives Enumerated:
+  case SingleTarget extends BasePositionType("SingleTarget")
+  case Asterism     extends BasePositionType("Asterism")
+  case ExplicitBase extends BasePositionType("ExplicitBase")
+
+/**
+ * The base position toward which the telescope must point.
+ *
+ * Invariant: at most one of `sidereal` / `nonsidereal` / `coordinates` is populated.
+ * Opportunity targets have no meaningful base position; in that case the surrounding
+ * code returns `None` rather than constructing a `BasePosition`.
+ */
+case class BasePosition(
+  basePositionType: BasePositionType,
+  name:             NonEmptyString,
+  sidereal:         Option[Target.Sidereal],
+  nonsidereal:      Option[Target.Nonsidereal],
+  coordinates:      Option[Coordinates]
+)
+
+object BasePosition:
+
+  // Max length for the name, limited by epics
+  val MaxNameLength: Int = 48
+
+  private val Ellipsis = "..."
+
+  def truncate(s: NonEmptyString): NonEmptyString =
+    if s.value.length <= MaxNameLength then s
+    // truncated result is always non-empty
+    else NonEmptyString.unsafeFrom(s.value.take(MaxNameLength - Ellipsis.length) + Ellipsis)
+
+  /** Compose a display name from an asterism */
+  def composeName(targets: NonEmptyList[Target]): NonEmptyString =
+    // each target name is non empty thus the joined result is always non-empty
+    truncate(NonEmptyString.unsafeFrom(targets.map(_.name.value).mkString_(", ")))

--- a/modules/schema/src/main/scala/lucuma/odb/json/basePosition.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/basePosition.scala
@@ -1,0 +1,30 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.json
+
+import io.circe.Encoder
+import io.circe.Json
+import io.circe.refined.given
+import io.circe.syntax.*
+import lucuma.core.model.Target
+import lucuma.odb.data.BasePosition
+import lucuma.odb.json.coordinates.query.given
+import lucuma.odb.json.target.query.*
+
+trait BasePositionCodec:
+
+  given Encoder[BasePosition] =
+    given Encoder[Target.Sidereal]    = siderealDefinitionEncoder
+    given Encoder[Target.Nonsidereal] = nonsiderealDefinitionEncoder
+
+    Encoder.instance: bp =>
+      Json.obj(
+        "type"        -> bp.basePositionType.asJson,
+        "name"        -> bp.name.asJson,
+        "sidereal"    -> bp.sidereal.fold(Json.Null)(_.asJson),
+        "nonsidereal" -> bp.nonsidereal.fold(Json.Null)(_.asJson),
+        "coordinates" -> bp.coordinates.asJson
+      )
+
+object basePosition extends BasePositionCodec

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -37,6 +37,8 @@ trait BaseMapping[F[_]]
   lazy val AttachmentIdType                        = schema.ref("AttachmentId")
   lazy val AttachmentType                          = schema.ref("Attachment")
   lazy val AttachmentTypeType                      = schema.ref("AttachmentType")
+  lazy val BasePositionType                        = schema.ref("BasePosition")
+  lazy val BasePositionTypeType                    = schema.ref("BasePositionType")
   lazy val BiasType                                = schema.ref("Bias")
   lazy val BigDecimalType                          = schema.ref("BigDecimal")
   lazy val BlindOffsetTypeType                     = schema.ref("BlindOffsetType")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
@@ -19,15 +19,15 @@ import grackle.skunk.SkunkMapping
 import grackle.syntax.*
 import io.circe.refined.given
 import lucuma.catalog.clients.GaiaClient
-import lucuma.core.math.Coordinates
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.util.Timestamp
 import lucuma.core.util.TimestampInterval
 import lucuma.itc.client.ItcClient
+import lucuma.odb.data.BasePosition
 import lucuma.odb.graphql.predicate.Predicates
-import lucuma.odb.json.coordinates.query.given
+import lucuma.odb.json.basePosition.given
 import lucuma.odb.service.GuideService
 import lucuma.odb.service.Services
 import org.http4s.client.Client
@@ -47,7 +47,6 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
   def gaiaClient: GaiaClient[F]
   def services: Resource[F, Services[F]]
 
-  private val ObsTimeParam           = "observationTime"
   private val AvailabilityStartParam = "start"
   private val AvailabilityEndParam   = "end"
 
@@ -132,18 +131,13 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
   }
 
   def basePositionQueryHandler: EffectHandler[F] = {
-    val readEnv: Env => Result[Timestamp] = _.getR[Timestamp](ObsTimeParam)
+    val readEnv: Env => Result[Unit] = _ => ().success
 
-    val calculate: (Program.Id, Observation.Id, Timestamp) => F[Result[Option[Coordinates]]] =
-      (_, oid, obsTime) =>
-        services.use { implicit services =>
+    val calculate: (Program.Id, Observation.Id, Unit) => F[Result[Option[BasePosition]]] =
+      (_, oid, _) =>
+        services.use: s =>
           Services.asSuperUser:
-            services
-              .trackingService
-              .getCoordinatesSnapshotOrRegion(oid, obsTime, false)
-              .map: res =>
-                res.map(_.left.toOption.map(_.base)) // treat region as None
-        }
+            s.trackingService.getBasePosition(oid)
 
     effectHandler(readEnv, calculate)
   }

--- a/modules/service/src/main/scala/lucuma/odb/service/TrackingService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TrackingService.scala
@@ -37,6 +37,8 @@ import lucuma.core.model.Tracking
 import lucuma.core.util.Timestamp
 import lucuma.core.util.TimestampInterval
 import lucuma.horizons.HorizonsClient
+import lucuma.odb.data.BasePosition
+import lucuma.odb.data.BasePositionType
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.service.Services.SuperUserAccess
@@ -132,6 +134,13 @@ trait TrackingService[F[_]]:
   def deleteUserSuppliedEphemeris(
     key: Ephemeris.Key.UserSupplied
   )(using SuperUserAccess): F[Result[Unit]]
+
+  /**
+   * Compute the base position used by navigate for slewing.
+   */
+  def getBasePosition(
+    oid: Observation.Id
+  )(using SuperUserAccess): F[Result[Option[BasePosition]]]
 
 object TrackingService:
 
@@ -336,6 +345,69 @@ object TrackingService:
       )(using SuperUserAccess): F[Result[Unit]] =
         deleteEphemeris(key).value
 
+      def getBasePosition(
+        oid: Observation.Id
+      )(using SuperUserAccess): F[Result[Option[BasePosition]]] = {
+
+        def singleTargetResult(t: Target): Result[Option[BasePosition]] =
+          val name = BasePosition.truncate(t.name)
+          t match
+            case s: Sidereal    => Result.success(BasePosition(BasePositionType.SingleTarget, name, Some(s), None,    None).some)
+            case n: Nonsidereal => Result.success(BasePosition(BasePositionType.SingleTarget, name, None,    Some(n), None).some)
+            case _: Opportunity => Result.success(None)
+
+        def explicitBaseResult(
+          targets: NonEmptyList[Target],
+          coords:  Coordinates
+        ): Result[Option[BasePosition]] =
+          // for asterisms we return the composite name
+          val name =
+            if targets.size === 1 then BasePosition.truncate(targets.head.name)
+            else BasePosition.composeName(targets)
+
+          Result.success(BasePosition(BasePositionType.ExplicitBase, name, None, None, Some(coords)).some)
+
+        def asterismResult(
+          oid:     Observation.Id,
+          targets: NonEmptyList[Target],
+          obsTime: Option[Timestamp]
+        )(using SuperUserAccess): F[Result[Option[BasePosition]]] =
+          if targets.exists { case _: Opportunity => true; case _ => false } then
+            Result.success(Option.empty[BasePosition]).pure[F]
+          else obsTime match
+            case None    =>
+              OdbError.InvalidObservation(
+                oid,
+                Some(s"Observation time is required to compute the asterism base position in observation $oid.")
+              ).asFailure.pure
+            case Some(t) =>
+              getCoordinatesSnapshotOrRegion(oid, t, false).map: res =>
+                res.flatMap:
+                  case Left(snap) =>
+                    Result.success(BasePosition(BasePositionType.Asterism, BasePosition.composeName(targets), None, None, Some(snap.base)).some)
+                  case Right(_)   =>
+                    OdbError.InvalidObservation(
+                      oid, 
+                      Some(s"Unexpected opportunity target in asterism for $oid.")
+                    ).asFailure
+
+        for {
+          obsInfo            <- session.prepareR(Statements.SelectObsTimeExplicitBase).use(_.option(oid))
+          asterismMap        <- asterismService.getAsterisms(List(oid))
+          (obsTime, expBase)  = obsInfo.getOrElse((Option.empty[Timestamp], Option.empty[Coordinates]))
+          result             <- NonEmptyList.fromList(asterismMap.getOrElse(oid, Nil).map(_._2)) match
+                                  case None          =>
+                                    OdbError.InvalidObservation(oid, Some(s"No targets are defined for $oid.")).asFailure.pure
+                                  case Some(targets) =>
+                                    expBase match
+                                      case Some(coords) =>
+                                        explicitBaseResult(targets, coords).pure
+                                      case _            =>
+                                        if targets.size === 1 then singleTargetResult(targets.head).pure[F]
+                                        else asterismResult(oid, targets, obsTime)
+        } yield result
+      }
+
       private def getSiteAndExplicitBaseCoordinates(oids: List[Observation.Id], when: TimestampInterval): F[(Map[Observation.Id, Coordinates], Map[Observation.Id, Site])] =
         NonEmptyList.fromList(oids.distinct) match
           case None => (Map.empty, Map.empty).pure[F]
@@ -491,15 +563,22 @@ object TrackingService:
                       )
           .combineAll
 
+    val SelectObsTimeExplicitBase: Query[Observation.Id, (Option[Timestamp], Option[Coordinates])] =
+      sql"""
+        SELECT c_observation_time, c_explicit_ra, c_explicit_dec
+        FROM   t_observation
+        WHERE  c_observation_id = $observation_id
+      """.query(core_timestamp.opt *: coordinates.opt)
+
     def selectSiteAndExplicitBaseCoordinates(oids: NonEmptyList[Observation.Id], when: TimestampInterval, metadata: Metadata): Query[oids.type, (Observation.Id, Option[Site], Option[Coordinates])] =
       sql"""
         SELECT c_observation_id, c_instrument, c_explicit_ra, c_explicit_dec
         FROM t_observation
         WHERE c_observation_id IN (${observation_id.nel(oids)})
       """
-        .query(observation_id *: instrument.opt *: right_ascension.opt *: declination.opt)
+        .query(observation_id *: instrument.opt *: coordinates.opt)
         .map:
-          case (oid, oinst, ora, odec) =>
+          case (oid, oinst, ocoords) =>
 
             val osite: Option[Site] =
               oinst.flatMap: inst =>
@@ -507,7 +586,7 @@ object TrackingService:
                   .availability(inst)
                   .siteForRange(cats.collections.Range(when.start.toInstant, when.end.toInstant))
 
-            (oid, osite, (ora, odec).mapN(Coordinates.apply))
+            (oid, osite, ocoords)
 
     def storeEphemeris[A <: NonEmptyList[StorableEphemerisElement]](entries: A): Command[entries.type] = {
 

--- a/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/Codecs.scala
@@ -533,6 +533,9 @@ trait Codecs {
       RightAscension.fromAngleExact.reverseGet
     )
 
+  val coordinates: Codec[Coordinates] =
+    (right_ascension *: declination).imap(Coordinates.apply)(c => (c.ra, c.dec))
+
   val siderealTrackingDecoder: Decoder[SiderealTracking] =
     (right_ascension *: declination *: epoch *: proper_motion_ra.opt *: proper_motion_dec.opt *: radial_velocity.opt *: parallax.opt).emap {
       case (ra, dec, ep, pmRa, pmDec, rv, par) =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/perProgramPerConfigCalibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/perProgramPerConfigCalibrations.scala
@@ -113,8 +113,6 @@ class perProgramPerConfigCalibrations
       _ <- runObscalcUpdate(pid, oid)
     } yield ()
 
-
-
   val when = LocalDateTime.of(2024, 1, 1, 12, 0, 0).toInstant(ZoneOffset.UTC)
 
   // Utility classes used to decode group queries

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/basePosition.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/basePosition.scala
@@ -1,0 +1,377 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package query
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.syntax.all.*
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Declination
+import lucuma.core.math.RightAscension
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.Target
+import lucuma.core.model.User
+import lucuma.core.syntax.timespan.*
+import lucuma.core.util.TimeSpan
+import lucuma.core.util.Timestamp
+
+import java.time.LocalDateTime
+
+class basePosition extends OdbSuite:
+
+  val pi: User = TestUsers.Standard.pi(nextId, nextId)
+
+  override lazy val validUsers: List[User] = List(pi)
+
+  val when = LocalDateTime.of(2026, 5, 20, 12, 0, 0)
+
+  private val obsTime: Timestamp = Timestamp.fromLocalDateTime(when).get
+
+  private val duration: TimeSpan = 1.hourTimeSpan
+
+  private val explicitBaseUpdate = """
+    targetEnvironment: {
+      explicitBase: {
+        ra:  { hms: "1:00:00" },
+        dec: { dms: "2:00:00" }
+      }
+    }
+  """
+
+  private def query(oid: Observation.Id): String =
+    s"""
+      query {
+        observation(observationId: ${oid.asJson}) {
+          targetEnvironment {
+            basePosition {
+              type
+              name
+              sidereal {
+                ra  { hours }
+                dec { degrees }
+                epoch
+                properMotion {
+                  ra  { milliarcsecondsPerYear }
+                  dec { milliarcsecondsPerYear }
+                }
+                radialVelocity { kilometersPerSecond }
+                parallax       { milliarcseconds }
+              }
+              nonsidereal { keyType des key }
+              coordinates { ra { hours } dec { degrees } }
+            }
+          }
+        }
+      }
+    """
+
+  private def updateObservation(user: User, oid: Observation.Id, set: String): IO[Unit] =
+    expect(
+      user,
+      s"""
+        mutation {
+          updateObservations(input: {
+            SET: { $set }
+            WHERE: { id: { EQ: ${oid.asJson} } }
+          }) { observations { id } }
+        }
+      """,
+      json"""
+        {
+          "updateObservations": {
+            "observations": [
+              { "id": ${oid.asJson} }
+            ]
+          }
+        }
+      """.asRight
+    )
+
+  test("[baseposition] single sidereal target"):
+    val createWithTracking: Program.Id => String = pid => s"""
+      mutation {
+        createTarget(input: {
+          programId: ${pid.asJson}
+          SET: {
+            name: "M999"
+            sidereal: {
+              ra: { hours: "1.0" }
+              dec: { degrees: "2.0" }
+              epoch: "J2000.000"
+              properMotion: {
+                ra:  { milliarcsecondsPerYear: "10.5" }
+                dec: { milliarcsecondsPerYear: "-5.25" }
+              }
+              radialVelocity: { kilometersPerSecond: "42.0" }
+              parallax: { milliarcseconds: "7.5" }
+            }
+            sourceProfile: {
+              point: {
+                bandNormalized: {
+                  sed: { stellarLibrary: B5_III }
+                  brightnesses: []
+                }
+              }
+            }
+          }
+        }) { target { id } }
+      }
+    """
+
+    for
+      pid <- createProgramAs(pi)
+      tid <- query(pi, createWithTracking(pid)).map { js =>
+               js.hcursor
+                 .downFields("createTarget", "target", "id")
+                 .require[Target.Id]
+             }
+      oid <- createObservationAs(pi, pid, tid)
+      _   <- expect(pi, query(oid),
+        json"""
+          {
+            "observation": {
+              "targetEnvironment": {
+                "basePosition": {
+                  "type": "SINGLE_TARGET",
+                  "name": "M999",
+                  "sidereal": {
+                    "ra":  { "hours": 1.000000 },
+                    "dec": { "degrees": 2.0 },
+                    "epoch": "J2000.000",
+                    "properMotion": {
+                      "ra":  { "milliarcsecondsPerYear": 10.500 },
+                      "dec": { "milliarcsecondsPerYear": -5.250 }
+                    },
+                    "radialVelocity": { "kilometersPerSecond": 42.0000 },
+                    "parallax": { "milliarcseconds":    7.5 }
+                  },
+                  "nonsidereal": null,
+                  "coordinates": null
+                }
+              }
+            }
+          }
+        """.asRight)
+    yield ()
+
+  test("[baseposition] single nonsidereal target"):
+    for
+      pid <- createProgramAs(pi)
+      tid <- createNonsiderealTargetAs(pi, pid, "Halley")
+      oid <- createObservationAs(pi, pid, tid)
+      _   <- expect(pi, query(oid),
+        json"""
+          {
+            "observation": {
+              "targetEnvironment": {
+                "basePosition": {
+                  "type": "SINGLE_TARGET",
+                  "name": "Halley",
+                  "sidereal": null,
+                  "nonsidereal": {
+                    "keyType": "COMET",
+                    "des": "1P",
+                    "key": "Comet_1P"
+                  },
+                  "coordinates": null
+                }
+              }
+            }
+          }
+        """.asRight)
+    yield ()
+
+  test("[baseposition] single opportunity target"):
+    for
+      pid <- createProgramAs(pi)
+      tid <- createOpportunityTargetAs(pi, pid, "ToO")
+      oid <- createObservationAs(pi, pid, tid)
+      _   <- expect(pi, query(oid),
+        json"""
+          {
+            "observation": {
+              "targetEnvironment": {
+                "basePosition": null
+              }
+            }
+          }
+        """.asRight)
+    yield ()
+
+  test("[baseposition] single target with explicit base"):
+    for
+      pid <- createProgramAs(pi)
+      tid <- createTargetAs(pi, pid, "M999")
+      oid <- createObservationAs(pi, pid, tid)
+      _   <- updateObservation(pi, oid, explicitBaseUpdate)
+      _   <- expect(pi, query(oid),
+        json"""
+          {
+            "observation": {
+              "targetEnvironment": {
+                "basePosition": {
+                  "type": "EXPLICIT_BASE",
+                  "name": "M999",
+                  "sidereal": null,
+                  "nonsidereal": null,
+                  "coordinates": {
+                    "ra":  { "hours": 1.000000 },
+                    "dec": { "degrees": 2.0 }
+                  }
+                }
+              }
+            }
+          }
+        """.asRight)
+    yield ()
+
+  test("[baseposition] center coords of the asterism and obs time"):
+    def setCoords(tid: Target.Id, raDeg: String, decDeg: String): IO[Unit] =
+      query(
+        pi,
+        s"""
+          mutation {
+            updateTargets(input: {
+              SET: {
+                sidereal: {
+                  ra:  { degrees: "$raDeg" }
+                  dec: { degrees: "$decDeg" }
+                }
+              }
+              WHERE: { id: { EQ: "$tid" } }
+            }) { targets { id } }
+          }
+        """
+      ).void
+
+    val basePosQuery: Observation.Id => String = oid => s"""
+      query {
+        observation(observationId: ${oid.asJson}) {
+          targetEnvironment {
+            basePosition {
+              type
+              name
+              coordinates {
+                ra  { microseconds }
+                dec { microarcseconds }
+              }
+            }
+          }
+        }
+      }
+    """
+
+    def coords(raDeg: Double, decDeg: Double): Coordinates =
+      Coordinates(
+        RightAscension.fromDoubleDegrees(raDeg),
+        Declination.fromDoubleDegrees(decDeg).get
+      )
+
+    val cA = coords(14.999, 29.999)
+    val cB = coords(15.001, 30.000)
+    val cC = coords(15.000, 30.001)
+    val expected = Coordinates.centerOf(NonEmptyList.of(cA, cB, cC))
+
+    for
+      pid <- createProgramAs(pi)
+      t1  <- createTargetAs(pi, pid, "A")
+      t2  <- createTargetAs(pi, pid, "B")
+      t3  <- createTargetAs(pi, pid, "C")
+      _   <- setCoords(t1, "14.999", "29.999")
+      _   <- setCoords(t2, "15.001", "30.000")
+      _   <- setCoords(t3, "15.000", "30.001")
+      oid <- createObservationAs(pi, pid, t1, t2, t3)
+      _   <- setObservationTimeAndDuration(pi, oid, obsTime.some, duration.some)
+      js  <- query(pi, basePosQuery(oid))
+    yield
+      val bp = js.hcursor.downFields("observation", "targetEnvironment", "basePosition")
+      assertEquals(bp.downField("type").require[String], "ASTERISM")
+      assertEquals(bp.downField("name").require[String], "A, B, C")
+      val ra = bp.downFields("coordinates", "ra",  "microseconds").require[Long]
+      val dec = bp.downFields("coordinates", "dec", "microarcseconds").require[Long]
+      assertEquals(ra, expected.ra.toHourAngle.toMicroseconds)
+      assertEquals(dec, expected.dec.toAngle.toMicroarcseconds)
+
+  test("[baseposition] asterism with explicit base"):
+    for
+      pid <- createProgramAs(pi)
+      t1  <- createTargetAs(pi, pid, "A")
+      t2  <- createTargetAs(pi, pid, "B")
+      oid <- createObservationAs(pi, pid, t1, t2)
+      _   <- updateObservation(pi, oid, explicitBaseUpdate)
+      _   <- expect(pi, query(oid), json"""
+        {
+          "observation": {
+            "targetEnvironment": {
+              "basePosition": {
+                "type": "EXPLICIT_BASE",
+                "name": "A, B",
+                "sidereal": null,
+                "nonsidereal": null,
+                "coordinates": {
+                  "ra":  { "hours": 1.000000 },
+                  "dec": { "degrees": 2.0 }
+                }
+              }
+            }
+          }
+        }
+      """.asRight)
+    yield ()
+
+  test("[baseposition] asterism with no observation time"):
+    for
+      pid <- createProgramAs(pi)
+      t1  <- createTargetAs(pi, pid, "A")
+      t2  <- createTargetAs(pi, pid, "B")
+      oid <- createObservationAs(pi, pid, t1, t2)
+      _   <- expect(
+               pi,
+               query(oid),
+               List(s"Observation time is required to compute the asterism base position in observation $oid.").asLeft
+             )
+    yield ()
+
+  test("[baseposition] asterism containing an opportunity target"):
+    for
+      pid  <- createProgramAs(pi)
+      tSid <- createTargetAs(pi, pid, "Alpha")
+      tOpp <- createOpportunityTargetAs(pi, pid, "ToO")
+      oid  <- createObservationAs(pi, pid, tSid, tOpp)
+      _    <- setObservationTimeAndDuration(pi, oid, obsTime.some, duration.some)
+      _    <- expect(pi, query(oid), json"""
+        {
+          "observation": {
+            "targetEnvironment": {
+              "basePosition": null
+            }
+          }
+        }
+      """.asRight)
+    yield ()
+
+  test("[baseposition] name truncation"):
+    val targetA = "A" * 30
+    val targetB = "B" * 30
+
+    for
+      pid  <- createProgramAs(pi)
+      tA   <- createTargetAs(pi, pid, targetA)
+      tB   <- createTargetAs(pi, pid, targetB)
+      oid  <- createObservationAs(pi, pid, tA, tB)
+      _    <- setObservationTimeAndDuration(pi, oid, obsTime.some, duration.some)
+      name <- query(pi, query(oid)).map: js =>
+                js.hcursor
+                  .downFields("observation", "targetEnvironment", "basePosition", "name")
+                  .require[String]
+    yield
+      assertEquals(name.length, 48)
+      assert(name.endsWith("..."))
+      val expectedPrefix = (targetA + ", " + targetB).take(45)
+      assertEquals(name, expectedPrefix + "...")


### PR DESCRIPTION
This is a breaking change that changes `basePosition` such it can be used by navigate to slew and track targets that would be unfied for single/muti targets as well as supporting non-sidereals

I couldn't find any usages of the existing basePosition in `explore` so far.