### PR TITLE
Add macro to validate and stitch schema at compile-time

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,3 +1,3 @@
 include ".scalafix-common.conf"
-OrganizeImports.removeUnused = false
+OrganizeImports.removeUnused = true
 OrganizeImports.targetDialect = Scala3

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ val slf4jVersion                 = "2.0.18"
 val testcontainersScalaVersion   = "0.44.1" // check test output if you attempt to update this
 val weaverVersion                = "0.8.4"
 
-ThisBuild / tlBaseVersion      := "0.73"
+ThisBuild / tlBaseVersion      := "0.74"
 ThisBuild / scalaVersion       := "3.8.3"
 ThisBuild / crossScalaVersions := Seq("3.8.3")
 ThisBuild / scalacOptions     ++= Seq("-Xmax-inlines", "50") // Hash derivation fails with default of 32
@@ -749,6 +749,7 @@ lazy val binding = project
       "co.fs2"        %% "fs2-io"             % fs2Version,
       "edu.gemini"    %% "lucuma-core"        % lucumaCoreVersion,
       "org.typelevel" %% "grackle-core"       % grackleVersion,
+      "org.typelevel" %% "log4cats-core"      % log4catsVersion,
       "org.scalameta" %% "munit"              % munitVersion           % Test,
       "org.typelevel" %% "munit-cats-effect"  % munitCatsEffectVersion % Test
     )

--- a/itc/service/src/main/scala/lucuma/itc/service/ItcMapping.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/ItcMapping.scala
@@ -10,7 +10,6 @@ import cats.effect.*
 import cats.syntax.all.*
 import eu.timepit.refined.*
 import eu.timepit.refined.types.numeric.NonNegInt
-import fs2.io.file.Path
 import grackle.*
 import grackle.circe.CirceMapping
 import io.circe.syntax.*
@@ -23,7 +22,6 @@ import lucuma.itc.service.config.*
 import lucuma.itc.service.encoders.given
 import lucuma.itc.service.requests.*
 import lucuma.itc.service.syntax.all.*
-import lucuma.odb.graphql.schema.SchemaSource
 import lucuma.odb.graphql.schema.SchemaStitcher
 import org.typelevel.log4cats.Logger
 import org.typelevel.otel4s.trace.Tracer
@@ -32,25 +30,8 @@ import QueryCompiler.*
 
 object ItcMapping extends ItcCacheOrRemote with Version {
 
-  def loadSchema[F[_]: Sync: Logger]: F[Schema] =
-    SchemaStitcher[F](Path("graphql/itc.graphql"), SchemaSource.fromResource).build
-      .flatMap {
-        case Result.Success(schema)           => Logger[F].info("Loaded GraphQL schema").as(schema)
-        case Result.Warning(problems, schema) =>
-          Logger[F]
-            .warn(s"Loaded schema with problems: ${problems.map(_.message).toList.mkString(",")}")
-            .as(schema)
-        case Result.Failure(problems)         =>
-          Sync[F].raiseError[Schema](
-            new Throwable(
-              s"Unable to load schema because: ${problems.map(_.message).toList.mkString(",")}"
-            )
-          )
-        case Result.InternalError(error)      =>
-          Sync[F].raiseError[Schema](
-            new Throwable(s"Unable to load schema because: ${error.getMessage}")
-          )
-      }
+  def loadSchema[F[_]: ApplicativeThrow: Logger]: F[Schema] =
+    SchemaStitcher.load("graphql/itc.graphql")
 
   def versions[F[_]: Applicative](
     environment: ExecutionEnvironment

--- a/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaSource.scala
+++ b/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaSource.scala
@@ -3,34 +3,23 @@
 
 package lucuma.odb.graphql.schema
 
-import cats.effect.Sync
 import cats.syntax.eq.*
-import fs2.RaiseThrowable
-import fs2.Stream
-import fs2.io
 import fs2.io.file.Path
-import fs2.text
 
-trait SchemaSource[F[_]]:
-  def resolve(name: Path): Stream[F, String]
+import java.lang.System.lineSeparator
+import scala.io.Source
+
+trait SchemaSource:
+  def resolve(name: Path): List[String]
 
 object SchemaSource:
-  def fromResource[F[_]: Sync]: SchemaSource[F] = (name: Path) =>
-    Stream
-      .eval(Sync[F].blocking(Option(getClass.getClassLoader.getResourceAsStream(name.toString))))
-      .flatMap:
-        case Some(resource) =>
-          io.readInputStream(Sync[F].pure(resource), 8192)
-            .through(text.utf8.decode)
-            .through(text.lines)
-        case None           => Stream.raiseError[F](new io.IOException(s"Resource $name not found"))
+  def fromResource(classloader: ClassLoader): SchemaSource = (name: Path) =>
+    Source.fromResource(name.toString, classloader).getLines().toList
 
-  def fromString[F[_]: RaiseThrowable](name: Path, content: String): SchemaSource[F] = (n: Path) =>
-    if (n === name) Stream.emit(content).through(text.lines)
-    else Stream.raiseError[F](new Error(s"Unknown source $n"))
+  def fromString(name: Path, content: String): SchemaSource = (n: Path) =>
+    if (n === name) content.split(lineSeparator).toList
+    else throw new RuntimeException(s"Unknown source $n")
 
-  def fromStringMap[F[_]: RaiseThrowable](m: Map[Path, String]): SchemaSource[F] = (name: Path) =>
+  def fromStringMap(m: Map[Path, String]): SchemaSource = (name: Path) =>
     m.get(name)
-      .fold(Stream.raiseError[F](new Error(s"Unknown source $name")))(x =>
-        Stream.emit(x).through(text.lines)
-      )
+      .fold(throw new RuntimeException(s"Unknown source $name"))(_.split(lineSeparator).toList)

--- a/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaStitcher.scala
+++ b/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaStitcher.scala
@@ -3,8 +3,8 @@
 
 package lucuma.odb.graphql.schema
 
+import cats.ApplicativeThrow
 import cats.data.NonEmptySet
-import cats.effect.Sync
 import cats.parse.Parser
 import cats.parse.Parser.*
 import cats.parse.Rfc5234.alpha
@@ -16,137 +16,63 @@ import eu.timepit.refined.types.string.NonEmptyString
 import fs2.io.file.Path
 import grackle.*
 import org.tpolecat.sourcepos.SourcePos
+import org.typelevel.log4cats.Logger
 
-import scala.annotation.tailrec
+import java.lang.System.lineSeparator
 
 // SchemaStitcher can build a grackle Schema from schema files that contains import statements of the form:
 // #import <type list> from <schema file name>
 // <type list> is a coma separated list of the times to import, or * to import all of them
-trait SchemaStitcher[F[_]]:
-  def build(using SourcePos): F[Result[Schema]]
+trait SchemaStitcher:
+  def build(using SourcePos): Result[Schema]
 
-object SchemaStitcher {
+object SchemaStitcher:
+  def apply(root: Path, source: SchemaSource): SchemaStitcher =
+    SchemaStitcherImpl(root, source)
 
-  private case class SchemaStitcherImpl[F[_]: Sync](
-    root:   Path,
-    source: SchemaSource[F]
-  ) extends SchemaStitcher[F] {
+  /**
+   * Load a schema from the given resource path, log any results, and raise the `Result` to `F[_]`
+   */
+  inline def load[F[_]: ApplicativeThrow: Logger](location: String)(using SourcePos): F[Schema] =
+    SchemaStitcherMacros.fromResources(location).build match
+      case Result.Success(schema) =>
+        Logger[F]
+          .debug(s"Loaded GraphQL schema '${location}'")
+          .as(schema)
 
-    // Process to build the schema:
-    // 1. Build a schema dependency tree starting with the root schema.
-    // 2. Recursively collapse the tree into a List, with dependencies first
-    // 3. Merge all elements referencing the same schema. Only the left-most one is left, and its type list is replaced
-    //    by the union of all the others
-    // 4. Build the final schema text joining the string representation of each schema. Only the used type are put in
-    //    the string.
-    // 5. Build the Schema instance
-    override def build(using SourcePos): F[Result[Schema]] = dependenciesTree(List.empty, root)
-      .map(x => collapseToList(AllElements, x))
-      .map(x => merge(x, List.empty))
-      .map(_.map(_.asString).mkString("\n"))
-      .map(Schema(_))
+      case Result.Warning(problems, schema) =>
+        Logger[F]
+          .warn(
+            s"Loaded schema '${location}' with problems:${lineSeparator}${problems.map(_.toString).mkString_(lineSeparator).indent(4)}"
+          )
+          .as(schema)
 
-    def dependenciesTree(pathToRoot: List[Path], schemaName: Path): F[DependencyNode] =
-      if pathToRoot.contains(schemaName) then
-        Sync[F].raiseError(
-          new Exception(s"Found circular reference when resolving schema $schemaName")
+      case Result.Failure(problems) =>
+        ApplicativeThrow[F].raiseError(
+          new Throwable(
+            s"Unable to load schema '${location}':${lineSeparator}${problems.map(_.toString).mkString_(lineSeparator).indent(4)}"
+          )
         )
-      else
-        source
-          .resolve(schemaName)
-          .compile
-          .toList
-          .flatMap: ll =>
-            ll.map(importLineParser.parse)
-              .collect:
-                case Right((_, (els, path))) =>
-                  dependenciesTree(pathToRoot :+ schemaName, path).map((els, _))
-              .sequence
-              .map(DependencyNode(schemaName, ll, _))
 
-    def collapseToList(els: Elements, node: DependencyNode): List[SchemaNode] =
-      node.dependencies.flatMap { case (s, n) => collapseToList(s, n) } :+ SchemaNode(
-        node.v,
-        node.src.mkString("\n"),
-        els
-      )
+      case Result.InternalError(error) =>
+        ApplicativeThrow[F].raiseError(
+          new RuntimeException(s"Unable to load schema '${location}'", error)
+        )
 
-    @tailrec
-    final def merge(l: List[SchemaNode], acc: List[SchemaNode]): List[SchemaNode] =
-      l match
-        case Nil      => acc
-        case x :: Nil => acc :+ x
-        case x :: xx  =>
-          val (m, r) = xx.partition(_.name === x.name)
-          val s      = m.fold(x)((a, b) => SchemaNode(a.name, a.src, a.elements.union(b.elements)))
-          merge(r, acc :+ s)
-
-  }
+  /**
+   * SchemaStitcher without any stitching, only handles a single schema
+   */
+  def pure(text: String): SchemaStitcher = new SchemaStitcher:
+    def build(using SourcePos): Result[Schema] = Schema(text)
 
   sealed trait Elements
   case object AllElements                                extends Elements
   case class ElementList(l: NonEmptySet[NonEmptyString]) extends Elements
 
   extension (el: Elements)
-    private def union(other: Elements): Elements = (el, other) match
+    private[schema] def union(other: Elements): Elements = (el, other) match
       case (ElementList(l1), ElementList(l2)) => ElementList(l1 ++ l2)
       case _                                  => AllElements
-
-  private case class DependencyNode(
-    v:            Path,
-    src:          List[String],
-    dependencies: List[(Elements, DependencyNode)]
-  )
-
-  private case class SchemaNode(name: Path, src: String, elements: Elements) {
-    def asString: String = elements match {
-      case AllElements    => src
-      case ElementList(l) => asString(l)
-    }
-
-    def asString(l: NonEmptySet[NonEmptyString]): String =
-      Schema(src) match {
-        case Result.Success(b)    =>
-          resolveTypes(b.types,
-                       l.toList.flatMap(x => b.types.find(_.name === x.toString)),
-                       List.empty
-          )
-            .map(SchemaRenderer.renderTypeDefn)
-            .mkString("\n")
-        case Result.Warning(_, b) =>
-          resolveTypes(b.types,
-                       l.toList.flatMap(x => b.types.find(_.name === x.toString)),
-                       List.empty
-          )
-            .map(SchemaRenderer.renderTypeDefn)
-            .mkString("\n")
-        case _                    => ""
-      }
-
-    def resolveTypes(
-      types:    List[NamedType],
-      newNames: List[NamedType],
-      acc:      List[NamedType]
-    ): List[NamedType] =
-      if newNames.isEmpty then acc.distinct
-      else
-        val uniqueNews = newNames.distinct
-        val nextVals   = uniqueNews
-          .flatMap {
-            case fields: TypeWithFields                => fields.fields.flatMap(_.tpe.underlying.asNamed)
-            case UnionType(_, _, members, _)           => members
-            case InputObjectType(_, _, inputFields, _) =>
-              inputFields.flatMap(_.tpe.underlying.asNamed)
-            case _                                     => List.empty
-          }
-          .map(_.dealias)
-          .filter {
-            case u: ScalarType => !u.isBuiltIn
-            case v             => !acc.contains(v) && !uniqueNews.contains(v)
-          }
-        resolveTypes(types, nextVals, uniqueNews ++ acc)
-
-  }
 
   private val allElementsParser: Parser[Elements]                        = char('*').as(AllElements)
   private val firstCharInTypeParser: Parser[Char]                        = alpha | charIn('_')
@@ -174,9 +100,3 @@ object SchemaStitcher {
       "import"
     ) *> wsp.rep *> (allElementsParser | elementListParser) <* wsp.rep)
       ~ (string("from") *> wsp.rep *> schemaFilenameParser)
-
-  // The only way to build a SchemaStitcher
-  def apply[F[_]: Sync](root: Path, source: SchemaSource[F]): SchemaStitcher[F] =
-    SchemaStitcherImpl(root, source)
-
-}

--- a/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaStitcherImpl.scala
+++ b/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaStitcherImpl.scala
@@ -1,0 +1,126 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.schema
+
+import cats.data.NonEmptySet
+import cats.syntax.all.*
+import eu.timepit.refined.types.string.NonEmptyString
+import fs2.io.file.Path
+import grackle.*
+import org.tpolecat.sourcepos.SourcePos
+
+import java.lang.System.lineSeparator
+import scala.annotation.tailrec
+
+import SchemaStitcher.*
+
+private class SchemaStitcherImpl private[schema] (
+  root:   Path,
+  source: SchemaSource
+) extends SchemaStitcher {
+
+  // Process to build the schema:
+  // 1. Build a schema dependency tree starting with the root schema.
+  // 2. Recursively collapse the tree into a List, with dependencies first
+  // 3. Merge all elements referencing the same schema. Only the left-most one is left, and its type list is replaced
+  //    by the union of all the others
+  // 4. Build the final schema text joining the string representation of each schema. Only the used type are put in
+  //    the string.
+  // 5. Build the Schema instance
+  override def build(using SourcePos): Result[Schema] =
+    dependenciesTree(List.empty, root)
+      .map(x => collapseToList(AllElements, x))
+      .map(x => merge(x, List.empty))
+      .map(_.map(_.asString).mkString(lineSeparator))
+      .flatMap(Schema(_))
+
+  def dependenciesTree(pathToRoot: List[Path], schemaName: Path): Result[DependencyNode] =
+    if pathToRoot.contains(schemaName) then
+      Result.failure(s"Found circular reference when resolving schema $schemaName")
+    else
+      Result
+        .catchNonFatal(source.resolve(schemaName))
+        .flatMap: ll =>
+          ll
+            .map(importLineParser.parse)
+            .traverseCollect:
+              case Right((_, (els, path))) =>
+                dependenciesTree(pathToRoot :+ schemaName, path).map((els, _))
+            .map(DependencyNode(schemaName, ll, _))
+
+  def collapseToList(els: Elements, node: DependencyNode): List[SchemaNode] =
+    node.dependencies.flatMap { case (s, n) => collapseToList(s, n) } :+ SchemaNode(
+      node.v,
+      node.src.mkString(lineSeparator),
+      els
+    )
+
+  @tailrec
+  final def merge(l: List[SchemaNode], acc: List[SchemaNode]): List[SchemaNode] =
+    l match
+      case Nil      => acc
+      case x :: Nil => acc :+ x
+      case x :: xx  =>
+        val (m, r) = xx.partition(_.name === x.name)
+        val s      = m.fold(x)((a, b) => SchemaNode(a.name, a.src, a.elements.union(b.elements)))
+        merge(r, acc :+ s)
+
+}
+
+private case class DependencyNode(
+  v:            Path,
+  src:          List[String],
+  dependencies: List[(Elements, DependencyNode)]
+)
+
+private case class SchemaNode(name: Path, src: String, elements: Elements) {
+  def asString: String = elements match {
+    case AllElements    => src
+    case ElementList(l) => asString(l)
+  }
+
+  def asString(l: NonEmptySet[NonEmptyString]): String =
+    Schema(src) match {
+      case Result.Success(b)    =>
+        resolveTypes(
+          b.types,
+          l.toList.flatMap(x => b.types.find(_.name === x.toString)),
+          List.empty
+        )
+          .map(SchemaRenderer.renderTypeDefn)
+          .mkString(lineSeparator)
+      case Result.Warning(_, b) =>
+        resolveTypes(
+          b.types,
+          l.toList.flatMap(x => b.types.find(_.name === x.toString)),
+          List.empty
+        )
+          .map(SchemaRenderer.renderTypeDefn)
+          .mkString(lineSeparator)
+      case _                    => ""
+    }
+
+  def resolveTypes(
+    types:    List[NamedType],
+    newNames: List[NamedType],
+    acc:      List[NamedType]
+  ): List[NamedType] =
+    if newNames.isEmpty then acc.distinct
+    else
+      val uniqueNews = newNames.distinct
+      val nextVals   = uniqueNews
+        .flatMap {
+          case fields: TypeWithFields                => fields.fields.flatMap(_.tpe.underlying.asNamed)
+          case UnionType(_, _, members, _)           => members
+          case InputObjectType(_, _, inputFields, _) =>
+            inputFields.flatMap(_.tpe.underlying.asNamed)
+          case _                                     => List.empty
+        }
+        .map(_.dealias)
+        .filter {
+          case u: ScalarType => !u.isBuiltIn
+          case v             => !acc.contains(v) && !uniqueNews.contains(v)
+        }
+      resolveTypes(types, nextVals, uniqueNews ++ acc)
+}

--- a/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaStitcherMacros.scala
+++ b/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaStitcherMacros.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.schema
+
+import cats.syntax.all.*
+import fs2.io.file.Path
+import grackle.*
+import org.tpolecat.sourcepos.SourcePos
+
+import java.lang.System.lineSeparator
+
+private object SchemaStitcherMacros:
+  import scala.quoted.*
+  import scala.quoted.Quotes
+
+  inline def fromResources(name: String) =
+    ${ SchemaStitcherMacros.fromResourcesImpl('name) }
+
+  /**
+   * Macro to do some compile time checking for the schema. It will:
+   *   - Check that the resource exists
+   *   - Check that the schema can be loaded and stitched together without errors
+   *   - If the schema can be loaded, it will embed the final schema string in the code, so it
+   *     doesn't have to be loaded at runtime
+   */
+  def fromResourcesImpl(x: Expr[String])(using Quotes): Expr[SchemaStitcher] =
+    import quotes.reflect.report
+
+    val location = x.valueOrAbort
+    val cl       = this.getClass().getClassLoader()
+
+    SchemaStitcher(
+      Path(location),
+      SchemaSource.fromResource(cl)
+    ).build match
+      case Result.Success(schema) =>
+        val strSchema = Expr(schema.toString)
+        '{ SchemaStitcher.pure($strSchema) }
+
+      case Result.Warning(problems, schema) =>
+        report
+          .warning(
+            s"Loaded schema '${location}' with problems:${lineSeparator}${problems.map(_.toString).mkString_(lineSeparator).indent(4)}",
+            x
+          )
+        val strSchema = Expr(schema.toString)
+        '{ SchemaStitcher.pure($strSchema) }
+
+      case Result.Failure(problems) =>
+        report.errorAndAbort(
+          s"Unable to load schema '${location}':${lineSeparator}${problems.map(_.toString).mkString_(lineSeparator).indent(4)}",
+          x
+        )
+
+      case Result.InternalError(error) =>
+        report.errorAndAbort(s"Unable to load schema '${location}': ${error.getMessage}", x)

--- a/modules/binding/src/test/scala/lucuma/odb/graphql/schema/SchemaStitcherTest.scala
+++ b/modules/binding/src/test/scala/lucuma/odb/graphql/schema/SchemaStitcherTest.scala
@@ -3,46 +3,41 @@
 
 package lucuma.odb.graphql.schema
 
-import cats.effect.IO
 import fs2.io.file.Path
 import grackle.Result
 import grackle.Result.Success
 import grackle.Schema
-import munit.CatsEffectSuite
+import munit.FunSuite
 
-class SchemaStitcherTest extends CatsEffectSuite {
+class SchemaStitcherTest extends FunSuite {
 
   import SchemaStitcherTest.*
 
   test("SchemaStitcher should parse import statements") {
-    schemaResolver
+    val elements = schemaResolver
       .resolve(Path("baseSchema.graphql"))
       .map(SchemaStitcher.importLineParser.parse)
       .collect { case Right((_, (els, path))) =>
         (els, path)
       }
-      .compile
-      .toList
-      .map: a =>
-        assertEquals(a.length, 2)
-        a(0) match {
-          case (SchemaStitcher.AllElements, path) => assertEquals(path, Path("schema1.graphql"))
-          case other                              => fail(s"Unexpected parse result: $other")
-        }
-        a(1) match {
-          case (SchemaStitcher.ElementList(els), path) =>
-            assertEquals(els.toNonEmptyList.toList.map(_.value), List("TypeA", "TypeX"))
-            assertEquals(path, Path("schema2.graphql"))
-          case other                                   => fail(s"Unexpected parse result: $other")
-        }
+    assertEquals(elements.length, 2)
+    elements(0) match {
+      case (SchemaStitcher.AllElements, path) => assertEquals(path, Path("schema1.graphql"))
+      case other                              => fail(s"Unexpected parse result: $other")
+    }
+    elements(1) match {
+      case (SchemaStitcher.ElementList(els), path) =>
+        assertEquals(els.toNonEmptyList.toList.map(_.value), List("TypeA", "TypeX"))
+        assertEquals(path, Path("schema2.graphql"))
+      case other                                   => fail(s"Unexpected parse result: $other")
+    }
   }
 
   test("SchemaStitcher should compose schema") {
-    SchemaStitcher[IO](Path("baseSchema.graphql"), schemaResolver).build.map { x =>
-      (x, expectedSchema) match {
-        case (Success(a), Success(b)) => assertEquals(a.toString, b.toString)
-        case _                        => fail("Error creating schema")
-      }
+    val result = SchemaStitcher(Path("baseSchema.graphql"), schemaResolver).build
+    (result, expectedSchema) match {
+      case (Success(a), Success(b)) => assertEquals(a.toString, b.toString)
+      case _                        => fail("Error creating schema")
     }
   }
 
@@ -120,7 +115,7 @@ object SchemaStitcherTest {
     |}
     |""".stripMargin)
 
-  val schemaResolver: SchemaSource[IO] = SchemaSource.fromStringMap(
+  val schemaResolver: SchemaSource = SchemaSource.fromStringMap(
     Map(
       Path("baseSchema.graphql") -> baseSchema,
       Path("schema1.graphql")    -> schema1,

--- a/modules/sso-service/src/main/scala/graphql/SsoMapping.scala
+++ b/modules/sso-service/src/main/scala/graphql/SsoMapping.scala
@@ -6,11 +6,11 @@ package lucuma.sso.service.graphql
 import _root_.skunk.Channel
 import _root_.skunk.Session
 import _root_.skunk.implicits.*
+import cats.ApplicativeThrow
 import cats.effect.{Unique as _, *}
 import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.PosLong
 import fs2.Stream
-import fs2.io.file.Path
 import grackle.*
 import grackle.Predicate.*
 import grackle.Query.*
@@ -29,7 +29,6 @@ import lucuma.core.model.OrcidId
 import lucuma.core.model.StandardRole
 import lucuma.core.model.StandardUser
 import lucuma.core.model.User
-import lucuma.odb.graphql.schema.SchemaSource
 import lucuma.odb.graphql.schema.SchemaStitcher
 import lucuma.sso.service.database.Database
 import lucuma.sso.service.database.RoleRequest
@@ -52,25 +51,8 @@ object SsoMapping {
       }
   }
 
-  def loadSchema[F[_]: Sync: Logger]: F[Schema] =
-    SchemaStitcher[F](Path("Sso.graphql"), SchemaSource.fromResource).build
-      .flatMap {
-        case Result.Success(schema)           => Logger[F].info("Loaded GraphQL schema").as(schema)
-        case Result.Warning(problems, schema) =>
-          Logger[F]
-            .warn(s"Loaded schema with problems: ${problems.map(_.message).toList.mkString(",")}")
-            .as(schema)
-        case Result.Failure(problems)         =>
-          Sync[F].raiseError[Schema](
-            new Throwable(
-              s"Unable to load schema because: ${problems.map(_.message).toList.mkString(",")}"
-            )
-          )
-        case Result.InternalError(error)      =>
-          Sync[F].raiseError[Schema](
-            new Throwable(s"Unable to load schema because: ${error.getMessage}")
-          )
-      }
+  def loadSchema[F[_]: ApplicativeThrow: Logger]: F[Schema] =
+    SchemaStitcher.load("Sso.graphql")
 
   def apply[F[_]: Async: Trace](
     channels: Channels[F],

--- a/resource/service/src/main/scala/resource/server/http4s/GraphQlRoutes.scala
+++ b/resource/service/src/main/scala/resource/server/http4s/GraphQlRoutes.scala
@@ -4,10 +4,10 @@
 package resource.server.http4s
 
 import _root_.skunk.Session
+import cats.ApplicativeThrow
 import cats.Show
 import cats.effect.*
 import cats.syntax.all.*
-import fs2.io.file.Path
 import grackle.*
 import grackle.Result.Failure
 import grackle.Result.Success
@@ -15,7 +15,6 @@ import grackle.Result.Warning
 import grackle.skunk.SkunkMonitor
 import lucuma.graphql.routes.GraphQLService
 import lucuma.graphql.routes.Routes
-import lucuma.odb.graphql.schema.SchemaSource
 import lucuma.odb.graphql.schema.SchemaStitcher
 import org.http4s.HttpRoutes
 import org.http4s.dsl.Http4sDsl
@@ -49,25 +48,5 @@ class GraphQlRoutes[F[_]: {Async, Tracer}](
 }
 
 object GraphQlRoutes:
-  def loadSchema[F[_]: Sync: Logger]: F[Schema] =
-    given Show[Problem] = Show.fromToString
-    SchemaStitcher(Path("graphql/resource.graphql"), SchemaSource.fromResource).build
-      .flatMap:
-        case Result.Success(schema)           =>
-          Logger[F]
-            .info("Loaded GraphQL schema")
-            .as(schema)
-        case Result.Warning(problems, schema) =>
-          Logger[F]
-            .warn(s"Loaded schema with problems: ${problems.mkString_(",")}")
-            .as(schema)
-        case Result.Failure(problems)         =>
-          Sync[F].raiseError[Schema](
-            new Throwable(
-              s"Unable to load schema because: ${problems.mkString_(",")}"
-            )
-          )
-        case Result.InternalError(error)      =>
-          Sync[F].raiseError[Schema](
-            new Throwable(s"Unable to load schema because: ${error.getMessage}")
-          )
+  def loadSchema[F[_]: ApplicativeThrow: Logger]: F[Schema] =
+    SchemaStitcher.load("graphql/resource.graphql")


### PR DESCRIPTION
Adds a macro that validates the schema at compile time, checking that the resource exists, that it can be loaded and stitched together without errors, and if it can be loaded, it embeds the final schema string in the code, so it doesn't have to be stitched again at runtime.

Also adds a utility method to load a schema with logging and error handling.

Examples:

<img width="863" height="264" alt="image" src="https://github.com/user-attachments/assets/306a5b1c-159a-4f30-988b-a18bd45c9d18" />

<img width="943" height="275" alt="image" src="https://github.com/user-attachments/assets/2023f8b6-93d5-40f3-989a-eb699946d8e5" />
