### PR TITLE
Allow introspection without authorization

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -20,11 +20,13 @@ import io.laserdisc.pure.s3.tagless.S3AsyncClientOp
 import lucuma.catalog.clients.GaiaClient
 import lucuma.catalog.telluric.TelluricTargetsClient
 import lucuma.core.model.User
+import lucuma.graphql.routes.GraphQLService
 import lucuma.horizons.HorizonsClient
 import lucuma.itc.client.ItcClient
 import lucuma.odb.graphql.AttachmentRoutes
 import lucuma.odb.graphql.EmailWebhookRoutes
 import lucuma.odb.graphql.GraphQLRoutes
+import lucuma.odb.graphql.OdbMapping
 import lucuma.odb.graphql.SchedulerRoutes
 import lucuma.odb.graphql.enums.Enums
 import lucuma.odb.logic.TimeEstimateCalculatorImplementation
@@ -257,7 +259,8 @@ object FMain extends MainParams {
       middleware        <- ServerMiddleware(corsOverHttps, domain, ssoClient, userSvc)
       enums             <- Resource.eval(pool.use(Enums.load))
       ptc               <- Resource.eval(pool.use(TimeEstimateCalculatorImplementation.fromSession(_, enums)))
-      graphQLRoutes     <- GraphQLRoutes(gaiaClient, itcClient, commitHash, goaUsers, ssoClient, pool, SkunkMonitor.noopMonitor[F], GraphQLServiceTTL, userSvc, enums, ptc, httpClient, horizonsClient, emailConfig)
+      introspecService   = GraphQLService(OdbMapping.forIntrospection(pool, SkunkMonitor.noopMonitor[F], enums))
+      graphQLRoutes     <- GraphQLRoutes(gaiaClient, itcClient, commitHash, goaUsers, ssoClient, pool, SkunkMonitor.noopMonitor[F], GraphQLServiceTTL, userSvc, enums, ptc, httpClient, horizonsClient, emailConfig, introspecService)
       s3ClientOps       <- s3OpsResource
       s3Presigner       <- s3PresignerResource
       s3FileService      = S3FileService.fromS3ConfigAndClient(awsConfig, s3ClientOps, s3Presigner)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
@@ -55,20 +55,21 @@ object GraphQLRoutes {
    * based on the `Authorization` header and discarded when `ttl` expires.
    */
   def apply[F[_]: {Async, Parallel, Tracer as T, Logger as L, LoggerFactory, SecureRandom}](
-    gaiaClient:      GaiaClient[F],
-    itcClient:       ItcClient[F],
-    commitHash:      CommitHash,
-    goaUsers:        Set[User.Id],
-    ssoClient:       SsoClient[F, User],
-    pool:            Resource[F, Session[F]],
-    monitor:         SkunkMonitor[F],
-    ttl:             FiniteDuration,
-    userSvc:         UserService[F],
-    enums:           Enums,
-    ptc:             TimeEstimateCalculatorImplementation.ForInstrumentMode,
-    httpClient:      Client[F],
-    horizonsClient:  HorizonsClient[F],
-    emailConfig:     Config.Email
+    gaiaClient:           GaiaClient[F],
+    itcClient:            ItcClient[F],
+    commitHash:           CommitHash,
+    goaUsers:             Set[User.Id],
+    ssoClient:            SsoClient[F, User],
+    pool:                 Resource[F, Session[F]],
+    monitor:              SkunkMonitor[F],
+    ttl:                  FiniteDuration,
+    userSvc:              UserService[F],
+    enums:                Enums,
+    ptc:                  TimeEstimateCalculatorImplementation.ForInstrumentMode,
+    httpClient:           Client[F],
+    horizonsClient:       HorizonsClient[F],
+    emailConfig:          Config.Email,
+    introspectionService: GraphQLService[F]
   ): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
     OdbMapping.Topics(pool).flatMap { topics =>
 
@@ -92,7 +93,7 @@ object GraphQLRoutes {
       Cache.timed[F, Authorization, Option[GraphQLService[F]]](ttl).map { cache => wsb =>
         LucumaGraphQLRoutes.forService[F](
           {
-            case None    => none.pure[F]  // No auth, no service (for now)
+            case None    => introspectionService.some.pure[F] // only allow introspection
             case Some(a) =>
               cache.get(a).flatMap {
                 case Some(opt) =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -705,6 +705,43 @@ object OdbMapping {
         }
 
   /**
+    * A minimal read-only mapping that only knows how to return introspection metadata. Other queries will
+    * fail with errors.
+    */
+  def forIntrospection[F[_]: Async](
+    database: Resource[F, Session[F]],
+    monitor:  SkunkMonitor[F],
+    enums:    Enums,
+  ): Mapping[F] =
+    new SkunkMapping[F](database, monitor)
+      with LeafMappings[F]
+      with QueryMapping[F]
+    {
+
+      // These are unused for introspection metadata queries.
+      def user = sys.error("OdbMapping.forIntrospection: no user available")
+      def services = sys.error("OdbMapping.forIntrospection: no services available")
+      def itcClient = sys.error("OdbMapping.forIntrospection: no itcClient available")
+      def goaUsers = sys.error("OdbMapping.forIntrospection: no goaUsers available")
+
+      // Our schema
+      val schema: Schema =
+        unsafeLoadSchema("OdbSchema.graphql") |+| enums.schema
+
+      // Our combined type mappings
+      override val typeMappings: TypeMappings =
+        TypeMappings.unchecked(
+          List(
+            QueryMapping,
+          ) ++ LeafMappings
+        )
+
+      override val selectElaborator: SelectElaborator =
+        SelectElaborator(QueryElaborator)
+
+    }
+
+  /**
    * A reduced mapping for use with the Obscalc service.  Obscalc computes the
    * observation workflow, which makes a GraphQL call which in turn requires
    * a `Services` instance that has a mapping.  This mapping ignores

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -477,6 +477,13 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
         _   <- Resource.make(sc.connect(ps.pure[IO]))(_ => sc.disconnect())
       } yield sc
 
+  private def unauthenticatedClient(svr: Server): Resource[IO, FetchClient[IO, Nothing]] =
+    val uri = svr.baseUri / "odb"
+    for {
+      xbe <- JdkHttpClient.simple[IO].map(Http4sHttpBackend[IO](_))
+      xc  <- Resource.eval(Http4sHttpClient.of[IO, Nothing](uri)(using Async[IO], xbe, Logger[IO]))
+    } yield xc
+
   case class Operation(document: String) extends GraphQLOperation.Typed[Nothing, JsonObject, Json]
 
   private lazy val serverFixture: AnyFixture[Server] =
@@ -667,6 +674,23 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
         val op  = variables.fold(req.apply)(req.withInput)
         op.map(_.result)
       }
+
+  def unauthenticatedQuery(
+    query:     String,
+    variables: Option[JsonObject] = None
+  ): IO[Json] =
+    Resource.eval(IO(serverFixture()))
+      .flatMap(unauthenticatedClient)
+      .use: conn =>
+        val req = conn.request(Operation(query))
+        val op  = variables.fold(req.apply)(req.withInput).raiseGraphQLErrors
+        op.onError:
+          case ResponseException(es, _) =>
+            es.traverse_ : e =>
+              OdbError.fromGraphQLError(e) match
+                case Some(_) => IO.unit
+                case None    => IO.println(s"Not an OdbError: $e")
+          case _             => IO.unit
 
   def subscription(user: User, query: String, mutations: Either[List[(String, Option[JsonObject])], IO[Any]], variables: Option[JsonObject] = None): IO[List[Json]] =
     Supervisor[IO].use { sup =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/introspection.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/introspection.scala
@@ -134,3 +134,18 @@ class introspection extends OdbSuite:
     ).onError { case t =>
       fail("\n🐞🐞🐞\n🐞🐞🐞 Schema introspection failed!\n🐞🐞🐞\n", t)
     }
+
+  test("introspection query works without authentication"):
+    unauthenticatedQuery(
+      query = """
+        query IntrospectionQuery {
+          __schema {
+            queryType {
+              name
+            }
+          }
+        }
+      """
+    ).onError { case t =>
+      fail("Unauthenticated schema introspection failed!", t)
+    }


### PR DESCRIPTION
It turns out the metadata service was doing double duty for allowing introspection without authorization... 😢 

This creates an even more minimal service that only allows introspection. There may be a better way of doing this, but this is what I know how to do and it gets us back up and running for downloading the schema and using the playground.