### PR TITLE
Allow change observing mode even with an edited sequence

### DIFF
--- a/modules/service/src/main/resources/db/migration/V1152__clear_sequence_on_instrument_change.sql
+++ b/modules/service/src/main/resources/db/migration/V1152__clear_sequence_on_instrument_change.sql
@@ -1,0 +1,36 @@
+-- When an observation's instrument changes, the previously materialized
+-- sequence and any manually-defined atoms become invalid.
+
+-- Make the FK from t_atom back to t_observation deferrable so the trigger
+-- can run within the same transaction without a constraint violation.
+ALTER TABLE t_atom
+  DROP CONSTRAINT t_atom_c_observation_id_c_instrument_fkey,
+  ADD  CONSTRAINT t_atom_c_observation_id_c_instrument_fkey
+    FOREIGN KEY (c_observation_id, c_instrument)
+    REFERENCES t_observation(c_observation_id, c_instrument)
+    ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED;
+
+
+CREATE OR REPLACE FUNCTION clear_sequence_on_instrument_change()
+  RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM t_sequence_materialization
+   WHERE c_observation_id = OLD.c_observation_id;
+
+  -- Other foreign key constraints will prevent deletion of executed sequences.
+  DELETE FROM t_atom
+   WHERE c_observation_id = OLD.c_observation_id
+     AND c_instrument      = OLD.c_instrument;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER clear_sequence_on_instrument_change_trigger
+AFTER UPDATE OF c_instrument ON t_observation
+FOR EACH ROW
+WHEN (
+  OLD.c_instrument IS NOT NULL AND
+  OLD.c_instrument IS DISTINCT FROM NEW.c_instrument
+)
+EXECUTE FUNCTION clear_sequence_on_instrument_change();

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/8094.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/8094.scala
@@ -1,0 +1,143 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package issue.shortcut
+
+import cats.effect.IO
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.enums.GmosNorthFilter
+import lucuma.core.enums.Instrument
+import lucuma.core.enums.SequenceType
+import lucuma.core.model.Observation
+import lucuma.core.model.User
+import lucuma.odb.graphql.mutation.ReplaceSequenceOps
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
+
+// sc-8094: Error reverting configuration with edited sequence
+// The user should be able to revert a configuration or switch to a different observing mode
+// even if the sequence has been edited.
+class ShortCut_8094 extends ExecutionTestSupportForGmos with ReplaceSequenceOps: 
+
+  def removeMutation(oid: Observation.Id): String =
+    s"""
+      mutation {
+        updateObservations(input: {
+          SET: {
+            observingMode: null
+          }
+          WHERE: {
+            id: {
+              EQ: ${oid.asJson}
+            }
+          }
+        }) {
+          observations {
+            id
+            observingMode {
+              instrument
+            }
+          }
+        }
+      }
+    """
+
+  def removeObservingMode(user: User, oid: Observation.Id): IO[Unit] =
+    expect(
+      user = user,
+      query = removeMutation(oid),
+      expected = Right(
+        json"""
+          {
+            "updateObservations": {
+              "observations": [
+                {
+                  "id": $oid,
+                  "observingMode": null
+                }
+              ]
+            }
+          }
+        """
+      )
+    )
+
+  def updateToF2Mutation(oid: Observation.Id): String =
+    s"""
+      mutation {
+        updateObservations(input: {
+          SET: {
+            observingMode: {
+              flamingos2LongSlit: {
+                disperser: R1200_JH
+                filter: Y
+                fpu: LONG_SLIT_2
+                exposureTimeMode: {
+                  signalToNoise: {
+                    value: 30.0
+                    at: { nanometers: 345.67 }
+                  }
+                }
+              }
+            }
+          }
+          WHERE: {
+            id: {
+              EQ: ${oid.asJson}
+            }
+          }
+        }
+      ){
+        observations {
+          id
+          observingMode {
+            instrument
+          }
+        }
+      }
+    }
+    """
+
+  def updateToF2ObservingMode(user: User, oid: Observation.Id): IO[Unit] =
+    expect(
+      user = user,
+      query = updateToF2Mutation(oid),
+      expected = Right(
+        json"""
+          {
+            "updateObservations": {
+              "observations": [
+                {
+                  "id": $oid,
+                  "observingMode": {
+                    "instrument": "FLAMINGOS2"
+                  }
+                }
+              ]
+            }
+          }
+        """
+      )
+    )
+
+  test("Remove the observing mode for an observation with an edited sequence"):
+    for 
+      pid <- createProgramAs(pi)
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      in   = input(oid, SequenceType.Science, atomInput("a", stepInput(GmosNorthFilter.GPrime)))
+      _   <- query(user = pi, query = mutation(Instrument.GmosNorth, in))
+      _   <- removeObservingMode(pi, oid)
+    yield ()
+
+  test("Update to a different observing mode for an observation with an edited sequence"):
+    for 
+      pid <- createProgramAs(pi)
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      in   = input(oid, SequenceType.Science, atomInput("a", stepInput(GmosNorthFilter.GPrime)))
+      _   <- query(user = pi, query = mutation(Instrument.GmosNorth, in))
+      _   <- updateToF2ObservingMode(pi, oid)
+    yield ()
+  

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/replaceGmosNorthSequence.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/replaceGmosNorthSequence.scala
@@ -17,41 +17,6 @@ import lucuma.core.syntax.string.*
 
 class replaceGmosNorthSequence extends query.ExecutionTestSupportForGmos with ReplaceSequenceOps:
 
-  def stepInput(filter: GmosNorthFilter): String =
-    s"""
-          {
-            instrumentConfig: {
-              exposure: {
-                seconds: 20
-              }
-              readout: {
-                xBin: ONE
-                yBin: ONE
-                ampCount: TWELVE
-                ampGain: LOW
-                ampReadMode: SLOW
-              }
-              dtax: ZERO
-              roi: FULL_FRAME
-              gratingConfig: {
-                grating: R831_G5302
-                order: ZERO
-                wavelength: {
-                  nanometers: 500.0
-                }
-              }
-              filter: ${filter.tag.toScreamingSnakeCase}
-              fpu: {
-                builtin: LONG_SLIT_0_50
-              }
-            }
-            stepConfig: {
-              science: true
-            }
-            observeClass: SCIENCE
-          }
-    """
-
   def imagingStepInput(filter: GmosNorthFilter): String =
     s"""
           {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGmos.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGmos.scala
@@ -562,6 +562,41 @@ trait ExecutionTestSupportForGmos extends ExecutionTestSupport:
         .getOrElse(sys.error("Could not create observation"))
     }
 
+  def stepInput(filter: GmosNorthFilter): String =
+    s"""
+          {
+            instrumentConfig: {
+              exposure: {
+                seconds: 20
+              }
+              readout: {
+                xBin: ONE
+                yBin: ONE
+                ampCount: TWELVE
+                ampGain: LOW
+                ampReadMode: SLOW
+              }
+              dtax: ZERO
+              roi: FULL_FRAME
+              gratingConfig: {
+                grating: R831_G5302
+                order: ZERO
+                wavelength: {
+                  nanometers: 500.0
+                }
+              }
+              filter: ${filter.tag.toScreamingSnakeCase}
+              fpu: {
+                builtin: LONG_SLIT_0_50
+              }
+            }
+            stepConfig: {
+              science: true
+            }
+            observeClass: SCIENCE
+          }
+    """
+
   val createOngoingGmosNorthObservation: IO[Observation.Id] =
     for
       p <- createProgramAs(pi)


### PR DESCRIPTION
This addresses the explicit request in https://app.shortcut.com/lucuma/story/8094/error-reverting-configuration-with-edited-sequence?vc_group_by=day&ct_workflow=all&cf_workflow=500000071 of being able to revert a configuration even if the sequence has been edited, with the added bonus of allowing a different observing mode as long as it is a different instrument.

A caveat: Updating with the same instrument but different mode (spectroscopy vs imaging) will result in the new mode having a sequence for the old mode. Changes I am making in explore will prevent this, but it could still happen via the API. I figure we can address this if/when it becomes an issue.

@swalker2m I'm not really familiar with the edited sequence thing. Could you tell me if I'm missing something or doing something wrong?
