### PR TITLE
Add enum modes to the schema

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -6841,6 +6841,16 @@ ObservingMode
 """
 enum ObservingModeType {
   """
+  ObservingModeType AlopekeSpeckle
+  """
+  ALOPEKE_SPECKLE
+
+  """
+  ObservingModeType AlopekeWideField
+  """
+  ALOPEKE_WIDE_FIELD
+
+  """
   ObservingModeType Flamingos2LongSlit
   """
   FLAMINGOS_2_LONG_SLIT
@@ -6879,6 +6889,31 @@ enum ObservingModeType {
   ObservingModeType Igrins2LongSlit
   """
   IGRINS_2_LONG_SLIT
+
+  """
+  ObservingModeType MaroonX
+  """
+  MAROON_X
+
+  """
+  ObservingModeType VisitorNorth
+  """
+  VISITOR_NORTH
+
+  """
+  ObservingModeType VisitorSouth
+  """
+  VISITOR_SOUTH
+
+  """
+  ObservingModeType ZorroSpeckle
+  """
+  ZORRO_SPECKLE
+
+  """
+  ObservingModeType ZorroWideField
+  """
+  ZORRO_WIDE_FIELD
 }
 
 """

--- a/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/8802.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/issue/shortcut/8802.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package issue.shortcut
+
+import cats.syntax.all.*
+import io.circe.literal.*
+import lucuma.core.enums.VisitorObservingModeType
+import lucuma.core.model.StandardUser
+
+class ShortCut_8802 extends OdbSuite:
+
+  val pi: StandardUser = TestUsers.Standard.pi(nextId, nextId)
+
+  override val validUsers = List(pi)
+
+  test("ObservingMode.mode reports the visitor instrument value"):
+    createProgramAs(pi).flatMap: pid =>
+      createTargetAs(pi, pid).flatMap: tid =>
+        createVisitorModeObservationAs(pi, pid, VisitorObservingModeType.AlopekeSpeckle, tid).flatMap: oid =>
+          expect(
+            user  = pi,
+            query = s"""
+              query {
+                observation(observationId: "$oid") {
+                  observingMode {
+                    mode
+                    visitor {
+                      mode
+                    }
+                  }
+                }
+              }
+            """,
+            expected = json"""
+              {
+                "observation": {
+                  "observingMode": {
+                    "mode": "ALOPEKE_SPECKLE",
+                    "visitor": {
+                      "mode": "ALOPEKE_SPECKLE"
+                    }
+                  }
+                }
+              }
+            """.asRight
+          )


### PR DESCRIPTION
some enum values were not included in the schema, This doesn't break explore nor the odb itself as we know the enum values but affects python clients