### PR TITLE
Unify Gnirs with F2 logic for automatic ReadMode handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ val slf4jVersion                 = "2.0.18"
 val testcontainersScalaVersion   = "0.44.1" // check test output if you attempt to update this
 val weaverVersion                = "0.8.4"
 
-ThisBuild / tlBaseVersion      := "0.74"
+ThisBuild / tlBaseVersion      := "0.75"
 ThisBuild / scalaVersion       := "3.8.3"
 ThisBuild / crossScalaVersions := Seq("3.8.3")
 ThisBuild / scalacOptions     ++= Seq("-Xmax-inlines", "50") // Hash derivation fails with default of 32

--- a/modules/binding/src/main/scala/lucuma/odb/graphql/binding/GnirsObsReadModeBinding.scala
+++ b/modules/binding/src/main/scala/lucuma/odb/graphql/binding/GnirsObsReadModeBinding.scala
@@ -1,9 +1,0 @@
-// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
-// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
-
-package lucuma.odb.graphql.binding
-
-import lucuma.core.enums.GnirsObsReadMode
-
-val GnirsObsReadModeBinding: Matcher[GnirsObsReadMode] =
-  enumeratedBinding

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -9496,9 +9496,7 @@ type GnirsLongSlit {
   explicitDecker: GnirsDecker
   defaultDecker: GnirsDecker!
 
-  readMode: GnirsObsReadMode!
-  explicitReadMode: GnirsObsReadMode
-  defaultReadMode: GnirsObsReadMode!
+  explicitReadMode: GnirsReadMode
 
   wellDepth: GnirsWellDepth!
   explicitWellDepth: GnirsWellDepth
@@ -9579,7 +9577,7 @@ input GnirsLongSlitInput {
 
   explicitFocusMotorSteps: Int
 
-  explicitReadMode: GnirsObsReadMode
+  explicitReadMode: GnirsReadMode
 
   explicitWellDepth: GnirsWellDepth
 
@@ -11869,19 +11867,6 @@ enum GnirsFpuOther {
 }
 
 enum GnirsReadMode {
-  VERY_BRIGHT
-  BRIGHT
-  FAINT
-  VERY_FAINT
-}
-
-"""
-GNIRS observation-level read mode. Use `AUTOMATIC` to let the read mode be
-resolved per step from the step exposure time; otherwise fix the read mode
-for all steps.
-"""
-enum GnirsObsReadMode {
-  AUTOMATIC
   VERY_BRIGHT
   BRIGHT
   FAINT

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/longslit/Config.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/longslit/Config.scala
@@ -13,8 +13,8 @@ import lucuma.core.enums.GnirsDecker
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.enums.GnirsFpuSlit
 import lucuma.core.enums.GnirsGrating
-import lucuma.core.enums.GnirsObsReadMode
 import lucuma.core.enums.GnirsPrism
+import lucuma.core.enums.GnirsReadMode
 import lucuma.core.enums.GnirsWellDepth
 import lucuma.core.math.Offset
 import lucuma.core.math.Wavelength
@@ -61,7 +61,7 @@ case class Config(
   gratingWavelength:       Wavelength,
   camera:                  GnirsCamera,
   focus:                   GnirsFocus,
-  readMode:                GnirsObsReadMode,
+  explicitReadMode:        Option[GnirsReadMode],
   wellDepth:               GnirsWellDepth,
   exposureTimeMode:        ExposureTimeMode,
   coadds:                  PosInt,
@@ -85,7 +85,7 @@ case class Config(
       case GnirsFocus.Custom(qty)   =>
         out.writeByte(1)
         out.writeInt(qty.value.value.value)
-    out.writeChars(readMode.tag)
+    out.writeChars(explicitReadMode.fold("")(_.tag))
     out.writeChars(wellDepth.tag)
     out.write(exposureTimeMode.hashBytes)
     out.write(coadds.value.hashBytes)

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/longslit/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/longslit/Science.scala
@@ -12,6 +12,7 @@ import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.string.NonEmptyString
 import fs2.Pure
 import fs2.Stream
+import lucuma.core.enums.GnirsReadMode
 import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.SequenceType
 import lucuma.core.model.Observation
@@ -58,7 +59,7 @@ object Science:
       // Configure the dynamic config for a science step, then traverse the
       // telescope configs from the observing mode in order, producing one
       // science ProtoStep per offset.
-      val resolvedReadMode = config.readMode.resolveForStepExposureTime(time.exposureTime)
+      val resolvedReadMode = config.explicitReadMode.getOrElse(GnirsReadMode.forExposureTime(time.exposureTime))
       val acqMirror        = GnirsAcquisitionMirrorMode.Out(
         config.prism,
         config.grating,

--- a/modules/service/src/main/resources/db/migration/V1153__gnirs_auto_read_mode.sql
+++ b/modules/service/src/main/resources/db/migration/V1153__gnirs_auto_read_mode.sql
@@ -1,0 +1,88 @@
+-- GNIRS science read mode: switch from e_gnirs_obs_read_mode (which carried an
+-- 'Automatic' sentinel) to a nullable GnirsReadMode tag, mirroring Flamingos2.
+-- A NULL c_read_mode now means "Auto": the read mode is computed from the step
+-- exposure time at sequence-generation time. The four concrete read modes are
+-- stored as their tag, exactly like the materialized sequence's c_read_mode.
+
+-- Drop the view first; it expands ls.* at creation time so it pins both the
+-- c_read_mode column type and the c_read_mode_default expression.
+DROP VIEW v_gnirs_long_slit;
+
+-- Convert the explicit override column: the 'Automatic' sentinel collapses to
+-- NULL (i.e. no explicit override → compute from exposure time); the concrete
+-- read modes keep their tag in a d_tag column.
+ALTER TABLE t_gnirs_long_slit
+  ALTER COLUMN c_read_mode TYPE d_tag
+  USING (CASE WHEN c_read_mode = 'Automatic' THEN NULL ELSE c_read_mode::text END)::d_tag;
+
+-- Recreate v_gnirs_long_slit — body identical to V1150 except the now-removed
+-- c_read_mode_default column (there is no longer a stored default; the effective
+-- read mode is resolved in Scala from the exposure time, like Flamingos2).
+CREATE VIEW v_gnirs_long_slit AS
+  SELECT
+    ls.*,
+    -- decker pure default: mirrors GnirsDecker.forCameraAndReadMode(camera, effectivePrism)
+    -- ATTENTION: This logic is duplicated from lucuma-core GnirsDecker. Modify in sync.
+    (CASE
+      WHEN COALESCE(ls.c_prism, ls.c_initial_prism) = 'Mirror' THEN
+        CASE WHEN ls.c_camera IN ('ShortRed', 'ShortBlue') THEN 'ShortCamLongSlit'
+             ELSE 'LongCamLongSlit'
+        END
+      ELSE -- Sxd or Lxd
+        CASE WHEN ls.c_camera IN ('ShortRed', 'ShortBlue') THEN 'ShortCamCrossDispersed'
+             ELSE 'LongCamCrossDispersed'
+        END
+    END)::e_gnirs_decker AS c_decker_default,
+    -- grating wavelength default (computed once in lateral, referenced here and in effective)
+    d.c_grating_wavelength_default,
+    COALESCE(ls.c_grating_wavelength, d.c_grating_wavelength_default) AS c_grating_wavelength_effective,
+    -- well depth pure default: mirrors GnirsWellDepth.forCamera
+    (CASE
+      WHEN ls.c_camera IN ('ShortBlue', 'LongBlue') THEN 'Shallow'
+      WHEN ls.c_camera IN ('ShortRed',  'LongRed')  THEN 'Deep'
+    END)::e_gnirs_well_depth AS c_well_depth_default,
+    -- effective grating/prism: COALESCE(explicit, initial)
+    COALESCE(ls.c_grating, ls.c_initial_grating) AS c_grating_effective,
+    COALESCE(ls.c_prism,   ls.c_initial_prism)   AS c_prism_effective,
+    -- slit offset mode default (always nod_along_slit for GNIRS)
+    d.c_slit_offset_mode_default,
+    -- telescope configs default (computed once in lateral, referenced here and in effective)
+    d.c_telescope_configs_default,
+    -- effective = COALESCE(explicit, default)
+    COALESCE(ls.c_slit_offset_mode, d.c_slit_offset_mode_default) AS c_slit_offset_mode_effective,
+    COALESCE(ls.c_telescope_configs, d.c_telescope_configs_default) AS c_telescope_configs_effective
+  FROM t_gnirs_long_slit ls
+  CROSS JOIN LATERAL (
+    SELECT
+      -- slit offset mode default (always nod_along_slit for GNIRS)
+      'nod_along_slit'::varchar AS c_slit_offset_mode_default,
+      -- grating wavelength default: filter.optimalWavelength in pm
+      CASE ls.c_filter
+        WHEN 'Order6'   THEN 1100000
+        WHEN 'Order5'   THEN 1270000
+        WHEN 'Order4'   THEN 1645000
+        WHEN 'Order3'   THEN 2200000
+        WHEN 'Order2'   THEN 3500000
+        WHEN 'Order1'   THEN 4800000
+        ELSE 1650000
+      END AS c_grating_wavelength_default,
+      -- telescope configs default:
+      -- Cross-dispersed prisms → [-1", +2", +2", -1"] along slit
+      -- Short camera long slit  → [+2", -4", -4", +2"] along slit
+      -- Long camera, filter >= 2.5 µm (Order2/Order1/PAH) → [-3", +3", +3", -3"] along slit
+      -- Long camera, filter < 2.5 µm (all others)         → [-1", +5", +5", -1"] along slit
+      CASE
+        WHEN COALESCE(ls.c_prism, ls.c_initial_prism) IN ('Sxd', 'Lxd') THEN
+          '[{"q":{"microarcseconds":-1000000},"guiding":"ENABLED"},{"q":{"microarcseconds":2000000},"guiding":"ENABLED"},{"q":{"microarcseconds":2000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-1000000},"guiding":"ENABLED"}]'
+        WHEN ls.c_camera IN ('ShortBlue', 'ShortRed') THEN
+          '[{"q":{"microarcseconds":2000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-4000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-4000000},"guiding":"ENABLED"},{"q":{"microarcseconds":2000000},"guiding":"ENABLED"}]'
+        WHEN ls.c_filter IN ('Order2', 'Order1', 'PAH') THEN
+          '[{"q":{"microarcseconds":-3000000},"guiding":"ENABLED"},{"q":{"microarcseconds":3000000},"guiding":"ENABLED"},{"q":{"microarcseconds":3000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-3000000},"guiding":"ENABLED"}]'
+        ELSE
+          '[{"q":{"microarcseconds":-1000000},"guiding":"ENABLED"},{"q":{"microarcseconds":5000000},"guiding":"ENABLED"},{"q":{"microarcseconds":5000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-1000000},"guiding":"ENABLED"}]'
+      END AS c_telescope_configs_default
+  ) d;
+
+-- The 'Automatic' sentinel type is no longer used anywhere (the acquisition read
+-- mode was already replaced by e_gnirs_acquisition_type in V1150).
+DROP TYPE e_gnirs_obs_read_mode;

--- a/modules/service/src/main/scala/lucuma/odb/StartupDiagnostics.scala
+++ b/modules/service/src/main/scala/lucuma/odb/StartupDiagnostics.scala
@@ -70,7 +70,6 @@ object StartupDiagnostics:
           checkPostgresEnum(gcal_lamp_type),
           checkPostgresEnum(gnirs_acquisition_type),
           checkPostgresEnum(gnirs_decker),
-          checkPostgresEnum(gnirs_obs_read_mode),
           checkPostgresEnum(gnirs_well_depth),
           {
             // We'll skip this one.  There is a postgres enum, but it is tied

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -375,7 +375,6 @@ trait BaseMapping[F[_]]
   lazy val GnirsPrismType                          = schema.ref("GnirsPrism")
   lazy val GnirsCameraType                         = schema.ref("GnirsCamera")
   lazy val GnirsAcquisitionTypeType                = schema.ref("GnirsAcquisitionType")
-  lazy val GnirsObsReadModeType                    = schema.ref("GnirsObsReadMode")
   lazy val GnirsReadModeType                       = schema.ref("GnirsReadMode")
   lazy val GnirsWellDepthType                      = schema.ref("GnirsWellDepth")
   lazy val SpectroscopyScienceRequirementsType     = schema.ref("SpectroscopyScienceRequirements")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsLongSlitInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsLongSlitInput.scala
@@ -15,8 +15,8 @@ import lucuma.core.enums.GnirsDecker
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.enums.GnirsFpuSlit
 import lucuma.core.enums.GnirsGrating
-import lucuma.core.enums.GnirsObsReadMode
 import lucuma.core.enums.GnirsPrism
+import lucuma.core.enums.GnirsReadMode
 import lucuma.core.enums.GnirsWellDepth
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.enums.StepGuideState
@@ -92,7 +92,7 @@ object GnirsLongSlitInput:
     explicitGrating:              Option[GnirsGrating]             = None,
     explicitPrism:                Option[GnirsPrism]               = None,
     explicitFocusMotorSteps:      Option[Int]                      = None,
-    explicitReadMode:             Option[GnirsObsReadMode]         = None,
+    explicitReadMode:             Option[GnirsReadMode]            = None,
     explicitWellDepth:            Option[GnirsWellDepth]           = None,
     explicitTelescopeConfigs:     Option[SlitTelescopeConfigs]     = None,
     acquisition:                  Option[AcquisitionInput]         = None
@@ -118,7 +118,7 @@ object GnirsLongSlitInput:
           GnirsGratingBinding.Option("explicitGrating", rExplGrating),
           GnirsPrismBinding.Option("explicitPrism", rExplPrism),
           IntBinding.Option("explicitFocusMotorSteps", rFocus),
-          GnirsObsReadModeBinding.Option("explicitReadMode", rReadMode),
+          GnirsReadModeBinding.Option("explicitReadMode", rReadMode),
           GnirsWellDepthBinding.Option("explicitWellDepth", rWellDepth),
           SlitTelescopeConfigsInput.Binding.Option("explicitTelescopeConfigs", rExplTelescope),
           AcquisitionInput.Binding.Option("acquisition", rAcq)
@@ -146,7 +146,7 @@ object GnirsLongSlitInput:
     explicitGrating:           Nullable[GnirsGrating],
     explicitPrism:             Nullable[GnirsPrism],
     explicitFocusMotorSteps:   Nullable[Int],
-    explicitReadMode:          Nullable[GnirsObsReadMode],
+    explicitReadMode:          Nullable[GnirsReadMode],
     explicitWellDepth:         Nullable[GnirsWellDepth],
     explicitTelescopeConfigs:  Nullable[SlitTelescopeConfigs], // Nullable to allow clearing to default
     acquisition:               Option[AcquisitionInput]
@@ -192,7 +192,7 @@ object GnirsLongSlitInput:
           GnirsGratingBinding.Nullable("explicitGrating", rExplGrating),
           GnirsPrismBinding.Nullable("explicitPrism", rExplPrism),
           IntBinding.Nullable("explicitFocusMotorSteps", rFocus),
-          GnirsObsReadModeBinding.Nullable("explicitReadMode", rReadMode),
+          GnirsReadModeBinding.Nullable("explicitReadMode", rReadMode),
           GnirsWellDepthBinding.Nullable("explicitWellDepth", rWellDepth),
           SlitTelescopeConfigsInput.Binding.Nullable("explicitTelescopeConfigs", rExplTelescope),
           AcquisitionInput.Binding.Option("acquisition", rAcq)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GnirsLongSlitMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GnirsLongSlitMapping.scala
@@ -14,7 +14,6 @@ import grackle.skunk.SkunkMapping
 import io.circe.Json
 import io.circe.syntax.*
 import lucuma.core.enums.GnirsDecker
-import lucuma.core.enums.GnirsObsReadMode
 import lucuma.core.enums.GnirsWellDepth
 import lucuma.core.enums.SlitOffsetMode
 import lucuma.core.enums.StepGuideState
@@ -126,10 +125,9 @@ trait GnirsLongSlitMapping[F[_]]
       SqlField("explicitDecker", GnirsLongSlitView.ExplicitDecker),
       SqlField("defaultDecker",  GnirsLongSlitView.DefaultDecker),
 
-      // Read mode: explicit + default + effective
-      explicitOrElseDefault[GnirsObsReadMode]("readMode", "explicitReadMode", "defaultReadMode"),
+      // Read mode: explicit override only; when null the read mode is computed
+      // from the exposure time at sequence-generation time (mirrors Flamingos2).
       SqlField("explicitReadMode", GnirsLongSlitView.ExplicitReadMode),
-      SqlField("defaultReadMode",  GnirsLongSlitView.DefaultReadMode),
 
       // Well depth: explicit + default + effective
       explicitOrElseDefault[GnirsWellDepth]("wellDepth", "explicitWellDepth", "defaultWellDepth"),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
@@ -160,7 +160,6 @@ trait LeafMappings[F[_]] extends BaseMapping[F] {
       LeafMapping[GnirsFpuOther](GnirsFpuOtherType),
       LeafMapping[GnirsPrism](GnirsPrismType),
       LeafMapping[GnirsCamera](GnirsCameraType),
-      LeafMapping[GnirsObsReadMode](GnirsObsReadModeType),
       LeafMapping[GnirsReadMode](GnirsReadModeType),
       LeafMapping[GnirsWellDepth](GnirsWellDepthType),
       LeafMapping[Group.Id](GroupIdType),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/GnirsLongSlitView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/GnirsLongSlitView.scala
@@ -41,7 +41,7 @@ trait GnirsLongSlitView[F[_]] extends BaseMapping[F]:
     // Explicit overrides (nullable)
     val ExplicitDecker: ColumnRef   = col("c_decker", gnirs_decker.opt)
     val FocusMotorSteps: ColumnRef  = col("c_focus_motor_steps", int4.opt)
-    val ExplicitReadMode: ColumnRef = col("c_read_mode", gnirs_obs_read_mode.opt)
+    val ExplicitReadMode: ColumnRef = col("c_read_mode", gnirs_read_mode.opt)
     val ExplicitWellDepth: ColumnRef = col("c_well_depth", gnirs_well_depth.opt)
 
     // Slit telescope configs: explicit overrides (both nullable)
@@ -65,7 +65,6 @@ trait GnirsLongSlitView[F[_]] extends BaseMapping[F]:
     val DefaultDecker: ColumnRef    = col("c_decker_default", gnirs_decker)
     val DefaultGratingWavelength: ColumnRef    = col("c_grating_wavelength_default", wavelength_pm)
     val GratingWavelengthEffective: ColumnRef  = col("c_grating_wavelength_effective", wavelength_pm)
-    val DefaultReadMode: ColumnRef  = col("c_read_mode_default", gnirs_obs_read_mode)
     val DefaultWellDepth: ColumnRef = col("c_well_depth_default", gnirs_well_depth)
 
     // Effective grating/prism: COALESCE(explicit, initial)

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -24,6 +24,7 @@ import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.DeclaredExecutionState
 import lucuma.core.enums.ExecutionState
 import lucuma.core.enums.Flamingos2ReadMode
+import lucuma.core.enums.GnirsReadMode
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.enums.ScienceBand
 import lucuma.core.math.RadialVelocity
@@ -426,7 +427,7 @@ object GeneratorParamsService {
                   prism             = gn.prism,
                   grating           = gn.grating,
                   camera            = gn.camera,
-                  readMode          = gn.readMode.resolveForStepExposureTime(etm.time),
+                  readMode          = gn.explicitReadMode.getOrElse(GnirsReadMode.forExposureTime(etm.time)),
                   wellDepth         = gn.wellDepth
                 )
                 val consInput = obsParams.constraints.toInput

--- a/modules/service/src/main/scala/lucuma/odb/service/GnirsLongSlitService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GnirsLongSlitService.scala
@@ -16,8 +16,8 @@ import lucuma.core.enums.GnirsDecker
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.enums.GnirsFpuSlit
 import lucuma.core.enums.GnirsGrating
-import lucuma.core.enums.GnirsObsReadMode
 import lucuma.core.enums.GnirsPrism
+import lucuma.core.enums.GnirsReadMode
 import lucuma.core.enums.GnirsWellDepth
 import lucuma.core.enums.SlitOffsetMode
 import lucuma.core.math.Angle
@@ -85,9 +85,8 @@ object GnirsLongSlitService:
         // Decker default + explicit
         gnirs_decker                     *: // c_decker_default
         gnirs_decker.opt                 *: // c_decker (explicit)
-        // Read mode default + explicit
-        gnirs_obs_read_mode              *: // c_read_mode_default
-        gnirs_obs_read_mode.opt          *: // c_read_mode (explicit)
+        // Read mode explicit override (None => compute from exposure time)
+        gnirs_read_mode.opt              *: // c_read_mode (explicit)
         // Well depth default + explicit
         gnirs_well_depth                 *: // c_well_depth_default
         gnirs_well_depth.opt             *: // c_well_depth (explicit)
@@ -109,7 +108,7 @@ object GnirsLongSlitService:
         case (sciEtm *: gratingEff *: prismEff *: gratingWavEff *:
               camera *: fpu *: filter *: coadds *:
               deckerDef *: deckerExp *:
-              readModeDef *: readModeExp *:
+              readModeExp *:
               wellDepthDef *: wellDepthExp *:
               focusMotorSteps *:
               slitOffsetModeExp *: tcExp *: slitOffsetModeDef *: tcDef *:
@@ -145,7 +144,7 @@ object GnirsLongSlitService:
                           gratingWavEff,
                           camera,
                           focus,
-                          readModeExp.getOrElse(readModeDef),
+                          readModeExp,
                           wellDepthExp.getOrElse(wellDepthDef),
                           sciEtm,
                           coaddsP,
@@ -234,7 +233,6 @@ object GnirsLongSlitService:
           ls.c_coadds,
           ls.c_decker_default,
           ls.c_decker,
-          ls.c_read_mode_default,
           ls.c_read_mode,
           ls.c_well_depth_default,
           ls.c_well_depth,
@@ -288,7 +286,7 @@ object GnirsLongSlitService:
       Option[GnirsGrating],   // explicit grating
       Option[GnirsPrism],     // explicit prism
       Option[Int],            // focus_motor_steps
-      Option[GnirsObsReadMode],
+      Option[GnirsReadMode],
       Option[GnirsWellDepth],
       // telescope configs (nullable = use default)
       Option[SlitOffsetMode],
@@ -345,7 +343,7 @@ object GnirsLongSlitService:
           ${gnirs_grating.opt},
           ${gnirs_prism.opt},
           ${int4.opt},
-          ${gnirs_obs_read_mode.opt},
+          ${gnirs_read_mode.opt},
           ${gnirs_well_depth.opt},
           ${slit_offset_mode.opt},
           ${text.opt},
@@ -412,7 +410,7 @@ object GnirsLongSlitService:
       val upDecker       = sql"c_decker             = ${gnirs_decker.opt}"
       val upGratingWav   = sql"c_grating_wavelength = ${wavelength_pm.opt}"
       val upFocus        = sql"c_focus_motor_steps  = ${int4.opt}"
-      val upReadMode     = sql"c_read_mode          = ${gnirs_obs_read_mode.opt}"
+      val upReadMode     = sql"c_read_mode          = ${gnirs_read_mode.opt}"
       val upWellDepth    = sql"c_well_depth         = ${gnirs_well_depth.opt}"
       val upGrating      = sql"c_grating            = ${gnirs_grating.opt}"
       val upPrism        = sql"c_prism              = ${gnirs_prism.opt}"

--- a/modules/service/src/main/scala/lucuma/odb/util/GnirsCodecs.scala
+++ b/modules/service/src/main/scala/lucuma/odb/util/GnirsCodecs.scala
@@ -13,7 +13,6 @@ import lucuma.core.enums.GnirsFilter
 import lucuma.core.enums.GnirsFpuOther
 import lucuma.core.enums.GnirsFpuSlit
 import lucuma.core.enums.GnirsGrating
-import lucuma.core.enums.GnirsObsReadMode
 import lucuma.core.enums.GnirsPrism
 import lucuma.core.enums.GnirsReadMode
 import lucuma.core.enums.GnirsWellDepth
@@ -61,9 +60,6 @@ trait GnirsCodecs:
 
   val gnirs_acquisition_type: Codec[GnirsAcquisitionType] =
     enumerated(Type("e_gnirs_acquisition_type"))
-
-  val gnirs_obs_read_mode: Codec[GnirsObsReadMode] =
-    enumerated(Type("e_gnirs_obs_read_mode"))
 
   val gnirs_well_depth: Codec[GnirsWellDepth] =
     enumerated(Type("e_gnirs_well_depth"))

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GnirsLongSlit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GnirsLongSlit.scala
@@ -76,8 +76,6 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         gratingWavelength { nanometers }
                         defaultGratingWavelength { nanometers }
                         explicitGratingWavelength { nanometers }
-                        readMode
-                        defaultReadMode
                         explicitReadMode
                         wellDepth
                         defaultWellDepth
@@ -132,8 +130,6 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                       "gratingWavelength": { "nanometers": 2200.000 },
                       "defaultGratingWavelength": { "nanometers": 2200.000 },
                       "explicitGratingWavelength": null,
-                      "readMode": "AUTOMATIC",
-                      "defaultReadMode": "AUTOMATIC",
                       "explicitReadMode": null,
                       "wellDepth": "SHALLOW",
                       "defaultWellDepth": "SHALLOW",
@@ -237,8 +233,6 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         gratingWavelength { nanometers }
                         defaultGratingWavelength { nanometers }
                         explicitGratingWavelength { nanometers }
-                        readMode
-                        defaultReadMode
                         explicitReadMode
                         wellDepth
                         defaultWellDepth
@@ -268,8 +262,6 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                       "gratingWavelength": { "nanometers": 2100.000 },
                       "defaultGratingWavelength": { "nanometers": 2200.000 },
                       "explicitGratingWavelength": { "nanometers": 2100.000 },
-                      "readMode": "BRIGHT",
-                      "defaultReadMode": "AUTOMATIC",
                       "explicitReadMode": "BRIGHT",
                       "wellDepth": "SHALLOW",
                       "defaultWellDepth": "DEEP",


### PR DESCRIPTION
I had implemented an extra enum that just added `Automatic` option, but that isn't necessary if we follow the F2 path, making the logic consistent in both instruments.