### PR TITLE
Gnirs acquisition sky offset

### DIFF
--- a/modules/CLAUDE.md
+++ b/modules/CLAUDE.md
@@ -245,12 +245,12 @@ When writing a `Fragment` / `encoder` for an INSERT that maps to a table with `c
 
 ## ETM (ExposureTimeMode) Convention
 
-"Acquisition config" means the non-ETM acquisition fields (filter, read mode, coadds, P/Q offsets). "Acquisition ETM" is the exposure time + count row in `t_exposure_time_mode`. The two are independent: a mode can store acquisition config inline in its own table and still keep the acquisition ETM in `t_exposure_time_mode`.
+"Acquisition config" means the non-ETM acquisition fields (filter, read mode, coadds, sky offset). "Acquisition ETM" is the exposure time + count row in `t_exposure_time_mode`. The two are independent: a mode can store acquisition config inline in its own table and still keep the acquisition ETM in `t_exposure_time_mode`.
 
 | Mode | Acquisition config | Acquisition ETM | Science ETM |
 |---|---|---|---|
 | GMOS North/South LongSlit, Flamingos-2 LongSlit | (none inline; comes from observation/defaults) | `t_exposure_time_mode` (role=acquisition) | `t_exposure_time_mode` (role=science) |
-| GNIRS LongSlit | Inline columns in `t_gnirs_long_slit`: `c_acq_type`, `c_acq_coadds`, `c_acq_filter`, `c_acq_offset_p`, `c_acq_offset_q` | `t_exposure_time_mode` (role=acquisition) | `t_exposure_time_mode` (role=science) |
+| GNIRS LongSlit | Inline columns in `t_gnirs_long_slit`: `c_acq_type`, `c_acq_coadds`, `c_acq_filter`, `c_acq_sky_offset_p`, `c_acq_sky_offset_q` (the two components together form a single `Option[Offset]` sky offset, enforced by a both-or-neither CHECK) | `t_exposure_time_mode` (role=acquisition) | `t_exposure_time_mode` (role=science) |
 | IGRINS-2 LongSlit | (no acquisition sequence) | — | `t_exposure_time_mode` (role=science) |
 | GHOST IFU | — | — | Two rows (red + blue) in `t_exposure_time_mode` |
 

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -9464,7 +9464,7 @@ type GnirsLongSlitAcquisition {
   acquisitionType: GnirsAcquisitionType!
   coadds: PosInt!
   filter: GnirsFilter!
-  offset: Offset
+  skyOffset: Offset
   exposureTimeMode: ExposureTimeMode!
 }
 
@@ -9522,7 +9522,7 @@ input GnirsLongSlitAcquisitionInput {
   filter: GnirsFilter
   acquisitionType: GnirsAcquisitionType
   coadds: PosInt
-  offset: OffsetInput
+  skyOffset: OffsetInput
   exposureTimeMode: ExposureTimeModeInput
 }
 

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/longslit/Config.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/longslit/Config.scala
@@ -28,11 +28,11 @@ import java.io.DataOutputStream
 
 case class AcquisitionConfig(
   acqType:          GnirsAcquisitionType,
-  coadds:           PosInt,
   filter:           GnirsFilter,
   offsetP:          Option[Offset.P],
   offsetQ:          Option[Offset.Q],
-  exposureTimeMode: ExposureTimeMode
+  exposureTimeMode: ExposureTimeMode,
+  coadds:           PosInt,
 ):
 
   def hashBytes: Array[Byte] =

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/longslit/Config.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/longslit/Config.scala
@@ -29,8 +29,7 @@ import java.io.DataOutputStream
 case class AcquisitionConfig(
   acqType:          GnirsAcquisitionType,
   filter:           GnirsFilter,
-  offsetP:          Option[Offset.P],
-  offsetQ:          Option[Offset.Q],
+  skyOffset:        Option[Offset],
   exposureTimeMode: ExposureTimeMode,
   coadds:           PosInt,
 ):
@@ -41,8 +40,7 @@ case class AcquisitionConfig(
     out.writeChars(acqType.tag)
     out.write(coadds.value.hashBytes)
     out.writeChars(filter.tag)
-    out.write(offsetP.map(_.hashBytes).getOrElse(Array.emptyByteArray))
-    out.write(offsetQ.map(_.hashBytes).getOrElse(Array.emptyByteArray))
+    out.write(skyOffset.map(_.hashBytes).getOrElse(Array.emptyByteArray))
     out.write(exposureTimeMode.hashBytes)
     out.close()
     bao.toByteArray
@@ -50,7 +48,7 @@ case class AcquisitionConfig(
 object AcquisitionConfig:
   given Eq[AcquisitionConfig] =
     Eq.by: a =>
-      (a.acqType, a.coadds.value, a.filter, a.offsetP.map(_.toAngle), a.offsetQ.map(_.toAngle), a.exposureTimeMode)
+      (a.acqType, a.coadds.value, a.filter, a.skyOffset, a.exposureTimeMode)
 
 case class Config(
   filter:                  GnirsFilter,

--- a/modules/service/src/main/resources/db/migration/V1154__gnirs_sky_offset.sql
+++ b/modules/service/src/main/resources/db/migration/V1154__gnirs_sky_offset.sql
@@ -1,0 +1,86 @@
+-- GNIRS acquisition offset: replace the separate c_acq_offset_p / c_acq_offset_q
+-- columns with a single conceptual "sky offset" exposed in the model/API as one
+-- Option[Offset]. The two angle components are still stored as two d_angle_µas
+-- columns (the idiomatic per-component storage), just renamed to c_acq_sky_offset_p
+-- and c_acq_sky_offset_q.
+
+-- Drop the view first; it expands ls.* at creation time so it pins the
+-- c_acq_offset_p / c_acq_offset_q column names.
+DROP VIEW v_gnirs_long_slit;
+
+-- Rename the columns on the underlying table.
+ALTER TABLE t_gnirs_long_slit RENAME COLUMN c_acq_offset_p TO c_acq_sky_offset_p;
+ALTER TABLE t_gnirs_long_slit RENAME COLUMN c_acq_offset_q TO c_acq_sky_offset_q;
+
+-- The two components together form a single Option[Offset]: either both are set
+-- (the offset is present) or both are NULL (no offset). Disallow a half-set state.
+ALTER TABLE t_gnirs_long_slit
+  ADD CONSTRAINT c_acq_sky_offset_both_or_neither
+  CHECK ((c_acq_sky_offset_p IS NULL) = (c_acq_sky_offset_q IS NULL));
+
+-- Recreate v_gnirs_long_slit — body identical to V1153; ls.* now carries the
+-- renamed c_acq_sky_offset_p / c_acq_sky_offset_q columns.
+CREATE VIEW v_gnirs_long_slit AS
+  SELECT
+    ls.*,
+    -- decker pure default: mirrors GnirsDecker.forCameraAndReadMode(camera, effectivePrism)
+    -- ATTENTION: This logic is duplicated from lucuma-core GnirsDecker. Modify in sync.
+    (CASE
+      WHEN COALESCE(ls.c_prism, ls.c_initial_prism) = 'Mirror' THEN
+        CASE WHEN ls.c_camera IN ('ShortRed', 'ShortBlue') THEN 'ShortCamLongSlit'
+             ELSE 'LongCamLongSlit'
+        END
+      ELSE -- Sxd or Lxd
+        CASE WHEN ls.c_camera IN ('ShortRed', 'ShortBlue') THEN 'ShortCamCrossDispersed'
+             ELSE 'LongCamCrossDispersed'
+        END
+    END)::e_gnirs_decker AS c_decker_default,
+    -- grating wavelength default (computed once in lateral, referenced here and in effective)
+    d.c_grating_wavelength_default,
+    COALESCE(ls.c_grating_wavelength, d.c_grating_wavelength_default) AS c_grating_wavelength_effective,
+    -- well depth pure default: mirrors GnirsWellDepth.forCamera
+    (CASE
+      WHEN ls.c_camera IN ('ShortBlue', 'LongBlue') THEN 'Shallow'
+      WHEN ls.c_camera IN ('ShortRed',  'LongRed')  THEN 'Deep'
+    END)::e_gnirs_well_depth AS c_well_depth_default,
+    -- effective grating/prism: COALESCE(explicit, initial)
+    COALESCE(ls.c_grating, ls.c_initial_grating) AS c_grating_effective,
+    COALESCE(ls.c_prism,   ls.c_initial_prism)   AS c_prism_effective,
+    -- slit offset mode default (always nod_along_slit for GNIRS)
+    d.c_slit_offset_mode_default,
+    -- telescope configs default (computed once in lateral, referenced here and in effective)
+    d.c_telescope_configs_default,
+    -- effective = COALESCE(explicit, default)
+    COALESCE(ls.c_slit_offset_mode, d.c_slit_offset_mode_default) AS c_slit_offset_mode_effective,
+    COALESCE(ls.c_telescope_configs, d.c_telescope_configs_default) AS c_telescope_configs_effective
+  FROM t_gnirs_long_slit ls
+  CROSS JOIN LATERAL (
+    SELECT
+      -- slit offset mode default (always nod_along_slit for GNIRS)
+      'nod_along_slit'::varchar AS c_slit_offset_mode_default,
+      -- grating wavelength default: filter.optimalWavelength in pm
+      CASE ls.c_filter
+        WHEN 'Order6'   THEN 1100000
+        WHEN 'Order5'   THEN 1270000
+        WHEN 'Order4'   THEN 1645000
+        WHEN 'Order3'   THEN 2200000
+        WHEN 'Order2'   THEN 3500000
+        WHEN 'Order1'   THEN 4800000
+        ELSE 1650000
+      END AS c_grating_wavelength_default,
+      -- telescope configs default:
+      -- Cross-dispersed prisms → [-1", +2", +2", -1"] along slit
+      -- Short camera long slit  → [+2", -4", -4", +2"] along slit
+      -- Long camera, filter >= 2.5 µm (Order2/Order1/PAH) → [-3", +3", +3", -3"] along slit
+      -- Long camera, filter < 2.5 µm (all others)         → [-1", +5", +5", -1"] along slit
+      CASE
+        WHEN COALESCE(ls.c_prism, ls.c_initial_prism) IN ('Sxd', 'Lxd') THEN
+          '[{"q":{"microarcseconds":-1000000},"guiding":"ENABLED"},{"q":{"microarcseconds":2000000},"guiding":"ENABLED"},{"q":{"microarcseconds":2000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-1000000},"guiding":"ENABLED"}]'
+        WHEN ls.c_camera IN ('ShortBlue', 'ShortRed') THEN
+          '[{"q":{"microarcseconds":2000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-4000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-4000000},"guiding":"ENABLED"},{"q":{"microarcseconds":2000000},"guiding":"ENABLED"}]'
+        WHEN ls.c_filter IN ('Order2', 'Order1', 'PAH') THEN
+          '[{"q":{"microarcseconds":-3000000},"guiding":"ENABLED"},{"q":{"microarcseconds":3000000},"guiding":"ENABLED"},{"q":{"microarcseconds":3000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-3000000},"guiding":"ENABLED"}]'
+        ELSE
+          '[{"q":{"microarcseconds":-1000000},"guiding":"ENABLED"},{"q":{"microarcseconds":5000000},"guiding":"ENABLED"},{"q":{"microarcseconds":5000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-1000000},"guiding":"ENABLED"}]'
+      END AS c_telescope_configs_default
+  ) d;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsLongSlitInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsLongSlitInput.scala
@@ -63,7 +63,7 @@ object GnirsLongSlitInput:
     filter:           Option[GnirsFilter],
     acqType:          Option[GnirsAcquisitionType],
     coadds:           Option[PosInt],
-    offset:           Option[Offset],
+    skyOffset:        Option[Offset],
     exposureTimeMode: Option[ExposureTimeMode]
   )
 
@@ -74,10 +74,10 @@ object GnirsLongSlitInput:
           GnirsFilterBinding.Option("filter", rFilter),
           GnirsAcquisitionTypeBinding.Option("acquisitionType", rAcqType),
           PosIntBinding.Option("coadds", rCoadds),
-          OffsetInput.Binding.Option("offset", rOffset),
+          OffsetInput.Binding.Option("skyOffset", rSkyOffset),
           ExposureTimeModeInput.Binding.Option("exposureTimeMode", rEtm)
         ) =>
-          (rFilter, rAcqType, rCoadds, rOffset, rEtm).parMapN(AcquisitionInput.apply)
+          (rFilter, rAcqType, rCoadds, rSkyOffset, rEtm).parMapN(AcquisitionInput.apply)
 
   case class Create(
     exposureTimeMode: Option[ExposureTimeMode],

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GnirsLongSlitMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GnirsLongSlitMapping.scala
@@ -71,19 +71,19 @@ trait GnirsLongSlitMapping[F[_]]
       SqlField("coadds",    GnirsLongSlitView.AcqCoadds),
       SqlField("filter",    GnirsLongSlitView.AcqFilter),
 
-      SqlField("acqOffPRaw", GnirsLongSlitView.AcqOffsetP, hidden = true),
-      SqlField("acqOffQRaw", GnirsLongSlitView.AcqOffsetQ, hidden = true),
+      SqlField("acqSkyOffPRaw", GnirsLongSlitView.AcqSkyOffsetP, hidden = true),
+      SqlField("acqSkyOffQRaw", GnirsLongSlitView.AcqSkyOffsetQ, hidden = true),
 
-      CursorFieldJson("offset",
+      CursorFieldJson("skyOffset",
         cursor =>
           for
-            p <- cursor.field("acqOffPRaw", None).flatMap(_.as[Option[Angle]])
-            q <- cursor.field("acqOffQRaw", None).flatMap(_.as[Option[Angle]])
+            p <- cursor.field("acqSkyOffPRaw", None).flatMap(_.as[Option[Angle]])
+            q <- cursor.field("acqSkyOffQRaw", None).flatMap(_.as[Option[Angle]])
           yield (p, q) match
             case (Some(pa), Some(qa)) =>
               Offset(Offset.P(pa), Offset.Q(qa)).asJson
             case _ => Json.Null,
-        List("acqOffPRaw", "acqOffQRaw")
+        List("acqSkyOffPRaw", "acqSkyOffQRaw")
       ),
 
       SqlObject("exposureTimeMode", Join(GnirsLongSlitView.ObservationId, ExposureTimeModeView.ObservationId)),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/GnirsLongSlitView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/GnirsLongSlitView.scala
@@ -58,8 +58,8 @@ trait GnirsLongSlitView[F[_]] extends BaseMapping[F]:
     val AcqType: ColumnRef          = col("c_acq_type", gnirs_acquisition_type)
     val AcqCoadds: ColumnRef        = col("c_acq_coadds", int4_pos)
     val AcqFilter: ColumnRef        = col("c_acq_filter", gnirs_filter)
-    val AcqOffsetP: ColumnRef       = col("c_acq_offset_p", angle_µas.opt)
-    val AcqOffsetQ: ColumnRef       = col("c_acq_offset_q", angle_µas.opt)
+    val AcqSkyOffsetP: ColumnRef    = col("c_acq_sky_offset_p", angle_µas.opt)
+    val AcqSkyOffsetQ: ColumnRef    = col("c_acq_sky_offset_q", angle_µas.opt)
 
     // View-computed defaults
     val DefaultDecker: ColumnRef    = col("c_decker_default", gnirs_decker)

--- a/modules/service/src/main/scala/lucuma/odb/service/GnirsLongSlitService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GnirsLongSlitService.scala
@@ -101,8 +101,8 @@ object GnirsLongSlitService:
         gnirs_acquisition_type           *: // c_acq_type
         int4                             *: // c_acq_coadds
         gnirs_filter                     *: // c_acq_filter
-        angle_µas.opt                    *: // c_acq_offset_p
-        angle_µas.opt                    *: // c_acq_offset_q
+        angle_µas.opt                    *: // c_acq_sky_offset_p
+        angle_µas.opt                    *: // c_acq_sky_offset_q
         exposure_time_mode                  // acquisition ETM
       ).emap:
         case (sciEtm *: gratingEff *: prismEff *: gratingWavEff *:
@@ -112,7 +112,7 @@ object GnirsLongSlitService:
               wellDepthDef *: wellDepthExp *:
               focusMotorSteps *:
               slitOffsetModeExp *: tcExp *: slitOffsetModeDef *: tcDef *:
-              acqType *: acqCoadds *: acqFilter *: acqOffP *: acqOffQ *:
+              acqType *: acqCoadds *: acqFilter *: acqSkyOffP *: acqSkyOffQ *:
               acqEtm *: EmptyTuple) =>
           SlitTelescopeConfigsFormat.getOption((slitOffsetModeDef, tcDef))
             .toRight(s"Could not parse default telescope configs from '$tcDef'")
@@ -129,8 +129,7 @@ object GnirsLongSlitService:
                       .map: acqCoaddsP =>
                         val acq = AcquisitionConfig(
                           acqType, acqFilter,
-                          acqOffP.map(a => Offset.P(a)),
-                          acqOffQ.map(a => Offset.Q(a)),
+                          (acqSkyOffP, acqSkyOffQ).mapN((p, q) => Offset(Offset.P(p), Offset.Q(q))),
                           acqEtm, acqCoaddsP
                         )
                         val focus = focusMotorSteps.fold(GnirsFocus.Best): n =>
@@ -244,8 +243,8 @@ object GnirsLongSlitService:
           ls.c_acq_type,
           ls.c_acq_coadds,
           ls.c_acq_filter,
-          ls.c_acq_offset_p,
-          ls.c_acq_offset_q,
+          ls.c_acq_sky_offset_p,
+          ls.c_acq_sky_offset_q,
           acq.c_exposure_time_mode,
           acq.c_signal_to_noise_at,
           acq.c_signal_to_noise,
@@ -295,8 +294,8 @@ object GnirsLongSlitService:
       GnirsAcquisitionType,
       Int,
       GnirsFilter,
-      Option[Long],           // acq_offset_p in µas
-      Option[Long]            // acq_offset_q in µas
+      Option[Long],           // acq_sky_offset_p in µas
+      Option[Long]            // acq_sky_offset_q in µas
     )] =
       sql"""
         INSERT INTO t_gnirs_long_slit (
@@ -323,8 +322,8 @@ object GnirsLongSlitService:
           c_acq_type,
           c_acq_coadds,
           c_acq_filter,
-          c_acq_offset_p,
-          c_acq_offset_q
+          c_acq_sky_offset_p,
+          c_acq_sky_offset_q
         )
         SELECT
           $observation_id,
@@ -358,12 +357,12 @@ object GnirsLongSlitService:
         (oid, initGrating, initPrism, camera, fpu, filter, coadds,
          decker, gratingWav, explGrating, explPrism, focus,
          readMode, wellDepth, slitMode, offsets,
-         acqType, acqCoadds, acqFilter, acqOffP, acqOffQ) =>
+         acqType, acqCoadds, acqFilter, acqSkyOffP, acqSkyOffQ) =>
           (oid, initGrating, initPrism, camera, camera, fpu, fpu,
            filter, filter, coadds, decker, gratingWav,
            explGrating, explPrism, focus, readMode, wellDepth,
            slitMode, offsets,
-           acqType, acqCoadds, acqFilter, acqOffP, acqOffQ, oid)
+           acqType, acqCoadds, acqFilter, acqSkyOffP, acqSkyOffQ, oid)
       }
 
     def insertGnirsLongSlit(
@@ -371,8 +370,8 @@ object GnirsLongSlitService:
       input:         GnirsLongSlitInput.Create
     ): AppliedFragment =
       val explicitTC = input.explicitTelescopeConfigs.map(SlitTelescopeConfigsFormat.reverseGet)
-      val acqOffP = input.acquisition.flatMap(_.offset).map(o => Angle.microarcseconds.get(o.p.toAngle))
-      val acqOffQ = input.acquisition.flatMap(_.offset).map(o => Angle.microarcseconds.get(o.q.toAngle))
+      val acqSkyOffP = input.acquisition.flatMap(_.skyOffset).map(o => Angle.microarcseconds.get(o.p.toAngle))
+      val acqSkyOffQ = input.acquisition.flatMap(_.skyOffset).map(o => Angle.microarcseconds.get(o.q.toAngle))
       InsertGnirsLongSlit.apply(
         observationId,
         input.grating,
@@ -393,8 +392,8 @@ object GnirsLongSlitService:
         defaultAcqType(input),
         input.acquisition.flatMap(_.coadds).map(_.value).getOrElse(1),
         defaultAcqFilter(input),
-        acqOffP,
-        acqOffQ
+        acqSkyOffP,
+        acqSkyOffQ
       )
 
     def deleteGnirs(which: List[Observation.Id]): Option[AppliedFragment] =
@@ -421,8 +420,8 @@ object GnirsLongSlitService:
       val upAcqType      = sql"c_acq_type = $gnirs_acquisition_type"
       val upAcqCoadds    = sql"c_acq_coadds    = $int4_pos"
       val upAcqFilter    = sql"c_acq_filter    = $gnirs_filter"
-      val upAcqOffsetP   = sql"c_acq_offset_p  = ${int8.opt}"
-      val upAcqOffsetQ   = sql"c_acq_offset_q  = ${int8.opt}"
+      val upAcqSkyOffP   = sql"c_acq_sky_offset_p  = ${int8.opt}"
+      val upAcqSkyOffQ   = sql"c_acq_sky_offset_q  = ${int8.opt}"
 
       val upTelescope: Option[List[AppliedFragment]] =
         SET.explicitTelescopeConfigs.toOptionOption.map:
@@ -437,10 +436,10 @@ object GnirsLongSlitService:
       val acqUpdates: List[AppliedFragment] =
         SET.acquisition.toList.flatMap: acq =>
           val offUpdates: List[AppliedFragment] =
-            acq.offset.toList.flatMap: o =>
+            acq.skyOffset.toList.flatMap: o =>
               List(
-                upAcqOffsetP(Some(Angle.microarcseconds.get(o.p.toAngle))),
-                upAcqOffsetQ(Some(Angle.microarcseconds.get(o.q.toAngle)))
+                upAcqSkyOffP(Some(Angle.microarcseconds.get(o.p.toAngle))),
+                upAcqSkyOffQ(Some(Angle.microarcseconds.get(o.q.toAngle)))
               )
           List(
             acq.acqType.map(upAcqType),
@@ -488,7 +487,7 @@ object GnirsLongSlitService:
           c_coadds, c_decker, c_focus_motor_steps, c_read_mode, c_well_depth,
           c_slit_offset_mode, c_telescope_configs,
           c_acq_type, c_acq_coadds, c_acq_filter,
-          c_acq_offset_p, c_acq_offset_q
+          c_acq_sky_offset_p, c_acq_sky_offset_q
         )
         SELECT
           $observation_id,
@@ -502,7 +501,7 @@ object GnirsLongSlitService:
           c_coadds, c_decker, c_focus_motor_steps, c_read_mode, c_well_depth,
           c_slit_offset_mode, c_telescope_configs,
           c_acq_type, c_acq_coadds, c_acq_filter,
-          c_acq_offset_p, c_acq_offset_q
+          c_acq_sky_offset_p, c_acq_sky_offset_q
         FROM t_gnirs_long_slit
         WHERE c_observation_id = $observation_id
       """.apply(newId, newId, originalId)

--- a/modules/service/src/main/scala/lucuma/odb/service/GnirsLongSlitService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GnirsLongSlitService.scala
@@ -128,10 +128,10 @@ object GnirsLongSlitService:
                       .leftMap(e => s"Invalid acq coadds $acqCoadds: $e")
                       .map: acqCoaddsP =>
                         val acq = AcquisitionConfig(
-                          acqType, acqCoaddsP, acqFilter,
+                          acqType, acqFilter,
                           acqOffP.map(a => Offset.P(a)),
                           acqOffQ.map(a => Offset.Q(a)),
-                          acqEtm
+                          acqEtm, acqCoaddsP
                         )
                         val focus = focusMotorSteps.fold(GnirsFocus.Best): n =>
                           GnirsFocus.Custom(GnirsFocusMotorStepsValue.unsafeFrom(n).withUnit[GnirsFocusMotorStep])

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GnirsLongSlit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GnirsLongSlit.scala
@@ -93,7 +93,7 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                           acquisitionType
                           coadds
                           filter
-                          offset { p { arcseconds } q { arcseconds } }
+                          skyOffset { p { arcseconds } q { arcseconds } }
                           exposureTimeMode {
                             signalToNoise { value at { nanometers } }
                             timeAndCount { time { seconds } count at { nanometers } }
@@ -156,7 +156,7 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         "acquisitionType": "FAINT",
                         "coadds": 1,
                         "filter": "ORDER3",
-                        "offset": null,
+                        "skyOffset": null,
                         "exposureTimeMode": {
                           "signalToNoise": {
                             "value": 10.000,
@@ -172,6 +172,143 @@ class createObservation_GnirsLongSlit extends OdbSuite:
             }
           """)
         )
+
+  test("create GNIRS Long Slit with acquisition skyOffset — round-trips"):
+    createProgramAs(pi).flatMap: pid =>
+      createTargetAs(pi, pid).flatMap: tid =>
+        expect(
+          user  = pi,
+          query =
+            s"""
+              mutation {
+                createObservation(input: {
+                  programId: "$pid"
+                  SET: {
+                    targetEnvironment: { asterism: [ "$tid" ] }
+                    scienceRequirements: {
+                      spectroscopy: {
+                        wavelength: { nanometers: 2200 }
+                        resolution: 1000
+                        wavelengthCoverage: { nanometers: 200 }
+                        focalPlane: SINGLE_SLIT
+                        focalPlaneAngle: { microarcseconds: 0 }
+                      }
+                    }
+                    observingMode: {
+                      gnirsLongSlit: {
+                        grating: D111
+                        prism: MIRROR
+                        camera: SHORT_BLUE
+                        fpu: LONG_SLIT_0_30
+                        filter: ORDER3
+                        exposureTimeMode: {
+                          timeAndCount: {
+                            time: { seconds: 30.0 }
+                            count: 3
+                            at: { nanometers: 2200 }
+                          }
+                        }
+                        acquisition: {
+                          skyOffset: {
+                            p: { arcseconds: 1.5 }
+                            q: { arcseconds: -2.5 }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }) {
+                  observation {
+                    observingMode {
+                      gnirsLongSlit {
+                        acquisition {
+                          skyOffset { p { arcseconds } q { arcseconds } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            """,
+          expected = Right(json"""
+            {
+              "createObservation": {
+                "observation": {
+                  "observingMode": {
+                    "gnirsLongSlit": {
+                      "acquisition": {
+                        "skyOffset": {
+                          "p": { "arcseconds": 1.500000 },
+                          "q": { "arcseconds": -2.500000 }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          """)
+        )
+
+  test("update GNIRS Long Slit — set acquisition skyOffset"):
+    createProgramAs(pi).flatMap: pid =>
+      createTargetAs(pi, pid).flatMap: tid =>
+        for
+          oid <- createGnirsLongSlitObservationAs(pi, pid, tid)
+          _   <- expect(
+            user  = pi,
+            query =
+              s"""
+                mutation {
+                  updateObservations(input: {
+                    SET: {
+                      observingMode: {
+                        gnirsLongSlit: {
+                          acquisition: {
+                            skyOffset: {
+                              p: { arcseconds: 3.0 }
+                              q: { arcseconds: 4.0 }
+                            }
+                          }
+                        }
+                      }
+                    }
+                    WHERE: { id: { EQ: "$oid" } }
+                  }) {
+                    observations {
+                      observingMode {
+                        gnirsLongSlit {
+                          acquisition {
+                            skyOffset { p { arcseconds } q { arcseconds } }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              """,
+            expected = Right(json"""
+              {
+                "updateObservations": {
+                  "observations": [
+                    {
+                      "observingMode": {
+                        "gnirsLongSlit": {
+                          "acquisition": {
+                            "skyOffset": {
+                              "p": { "arcseconds": 3.000000 },
+                              "q": { "arcseconds": 4.000000 }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            """)
+          )
+        yield ()
 
   test("create GNIRS Long Slit with explicit overrides"):
     createProgramAs(staff).flatMap: pid =>


### PR DESCRIPTION
Remodel the Gnirs acquisition sky offset as a single attribute, renames and adds db checks to ensure both axes are set or neither. Also, more tests.