### PR TITLE
Gnirs preliminary acquisition sequence generation

### DIFF
--- a/ITC-README.md
+++ b/ITC-README.md
@@ -1,6 +1,5 @@
 # lucuma-itc
 
-
 This is a graphql server acting as a proxy for the old ocs2-based itc server
 
 # Run
@@ -8,19 +7,18 @@ This is a graphql server acting as a proxy for the old ocs2-based itc server
 It is possible to run locally using sbt
 
 ```
-   sbt ~service/reStart
+   sbt ~itcService/reStart
 ```
 
 When using sbtn there is no output (see https://github.com/spray/sbt-revolver/issues/99).
 
 Note, it is important to have [`git lfs`](https://git-lfs.com) installed in
-order to obtain the necessary classes for running the ITC.  See (`git lfs` and
+order to obtain the necessary classes for running the ITC. See (`git lfs` and
 Legacy ITC Code below).
 
 You can then open the playground to work with the API by pointing your browser to
 
 http://localhost:6060/playground.html
-
 
 ## Env
 
@@ -40,9 +38,9 @@ The keys are stored as `itc:prefix:hash` where hash is just the hash of the para
 
 A few diferent encodings were tested to reduce size. Here are some measurement
 
-* Plain json: 1441864
-* Compressed json: 589896
-* Boopickle: 262216
+- Plain json: 1441864
+- Compressed json: 589896
+- Boopickle: 262216
 
 Make sure Redis is configured to use the `volatile-lru` eviction policy. This allows us to use it as a cache
 for keys stored with a TTL, which is what we do here, while keeping a permanent entry for the version key.
@@ -61,15 +59,15 @@ The only reason for the remote values to be stale is if the old ITC changes (hap
 ## `git lfs` and Legacy ITC Code
 
 The itc calculations are mostly done in java and scala using legacy technologies,
-in particular libraries like scala 2.11, scalaz, argonaut.  We were wrapping this
+in particular libraries like scala 2.11, scalaz, argonaut. We were wrapping this
 code in an http server but that incurred considerable overhead especially when
-the graph data was needed.  As an alternative we can now directly call the java
+the graph data was needed. As an alternative we can now directly call the java
 code but given the use of legacy libraries this requires the jar files to be
 loaded dynamically by the application and be called via reflection with a custom
 classloader
 
 In case the code in ocs2 changes we need to update the jar files using the
-`itc/update_itc_jars.sh` script.  The jar files are fairly large (they contain the data files
+`itc/update_itc_jars.sh` script. The jar files are fairly large (they contain the data files
 used to calculate the itc results). Given github limitations these need to be
 stored in `git lfs`.
 
@@ -82,11 +80,13 @@ When the OCS ITC code changes, update the JAR files by running:
 ```
 
 For example:
+
 ```bash
 ./itc/update_itc_jars.sh ../ocs/app/itc/target/itc/2026A-test.1.1.1/Test/itc/bundle
 ```
 
 The script will:
+
 - Find the OCS git repository from the bundle directory
 - Capture git metadata (commit hash, branch, etc.)
   - ocs git repo bust be clean
@@ -100,11 +100,13 @@ The itc schema uses many types defined on the odb schema. Types are imported usi
 ## Benchmarking
 
 ### Simple Performance Test
+
 ```
 sbt "benchmark/runMain lucuma.itc.benchmarks.ItcPerformanceHarness"
 ```
 
 ### Using jmh
+
 ```
 benchmark/Jmh/run lucuma.itc.benchmarks.ItcCoreBenchmark
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ val slf4jVersion                 = "2.0.18"
 val testcontainersScalaVersion   = "0.44.1" // check test output if you attempt to update this
 val weaverVersion                = "0.8.4"
 
-ThisBuild / tlBaseVersion      := "0.76"
+ThisBuild / tlBaseVersion      := "0.77"
 ThisBuild / scalaVersion       := "3.8.3"
 ThisBuild / crossScalaVersions := Seq("3.8.3")
 ThisBuild / scalacOptions     ++= Seq("-Xmax-inlines", "50") // Hash derivation fails with default of 32

--- a/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
@@ -59,7 +59,6 @@ object Itc:
     case GhostIfu            extends Type("ghost_ifu")
     case GmosNorthImaging    extends Type("gmos_north_imaging")
     case GmosSouthImaging    extends Type("gmos_south_imaging")
-    case GnirsSpectroscopy   extends Type("gnirs_spectroscopy")
     case Igrins2Spectroscopy extends Type("igrins_2_spectroscopy")
     case Spectroscopy        extends Type("spectroscopy")
 
@@ -173,33 +172,11 @@ object Itc:
   val igrins2Spectroscopy: Prism[Itc, Igrins2Spectroscopy] =
     GenPrism[Itc, Igrins2Spectroscopy]
 
-  /**
-   * Spectroscopy science results for GNIRS. Acquisition is configured inline
-   * in the observing mode but the acquisition ITC call is not yet performed.
-   */
-  case class GnirsSpectroscopy(
-    science: Zipper[Result]
-  ) extends Itc:
-
-    override def dataType: Type =
-      Type.GnirsSpectroscopy
-
-    override def scienceExposureCount: PosInt =
-      science.focus.value.exposureCount
-
-  object GnirsSpectroscopy:
-    given Eq[GnirsSpectroscopy] =
-      Eq.by(_.science)
-
-  val gnirsSpectroscopy: Prism[Itc, GnirsSpectroscopy] =
-    GenPrism[Itc, GnirsSpectroscopy]
-
   given Eq[Itc] =
     Eq.instance:
       case (a: GhostIfu,            b: GhostIfu)            => a === b
       case (a: GmosNorthImaging,    b: GmosNorthImaging)    => a === b
       case (a: GmosSouthImaging,    b: GmosSouthImaging)    => a === b
-      case (a: GnirsSpectroscopy,   b: GnirsSpectroscopy)   => a === b
       case (a: Igrins2Spectroscopy, b: Igrins2Spectroscopy) => a === b
       case (a: Spectroscopy,        b: Spectroscopy)        => a === b
       case _                                                => false

--- a/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
@@ -91,10 +91,6 @@ trait ItcCodec:
   given Decoder[Itc.GmosSouthImaging] =
     imagingScienceNemDecoder[GmosSouthFilter]("gmosSouthImagingScience").map(Itc.GmosSouthImaging.apply)
 
-  given Decoder[Itc.GnirsSpectroscopy] =
-    Decoder.instance:
-      _.downField("spectroscopyScience").as[Zipper[Itc.Result]].map(Itc.GnirsSpectroscopy.apply)
-
   given Decoder[Itc.Igrins2Spectroscopy] =
     Decoder.instance:
       _.downField("spectroscopyScience").as[Zipper[Itc.Result]].map(Itc.Igrins2Spectroscopy.apply)
@@ -139,13 +135,6 @@ trait ItcCodec:
         "gmosSouthImagingScience" -> a.science.asJson(using imagingScienceNemEncoder[GmosSouthFilter])
       )
 
-  given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[Itc.GnirsSpectroscopy] =
-    Encoder.instance: a =>
-      Json.obj(
-        "itcType"             -> Itc.Type.GnirsSpectroscopy.asJson,
-        "spectroscopyScience" -> a.science.asJson
-      )
-
   given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[Itc.Igrins2Spectroscopy] =
     Encoder.instance: a =>
       Json.obj(
@@ -169,7 +158,6 @@ trait ItcCodec:
          case Itc.Type.GhostIfu            => Decoder[Itc.GhostIfu].apply(c)
          case Itc.Type.GmosNorthImaging    => Decoder[Itc.GmosNorthImaging].apply(c)
          case Itc.Type.GmosSouthImaging    => Decoder[Itc.GmosSouthImaging].apply(c)
-         case Itc.Type.GnirsSpectroscopy   => Decoder[Itc.GnirsSpectroscopy].apply(c)
          case Itc.Type.Igrins2Spectroscopy => Decoder[Itc.Igrins2Spectroscopy].apply(c)
          case Itc.Type.Spectroscopy        => Decoder[Itc.Spectroscopy].apply(c)
 
@@ -178,7 +166,6 @@ trait ItcCodec:
       case a @ Itc.GhostIfu(_, _)         => Encoder[Itc.GhostIfu].apply(a)
       case a @ Itc.GmosNorthImaging(_)    => Encoder[Itc.GmosNorthImaging].apply(a)
       case a @ Itc.GmosSouthImaging(_)    => Encoder[Itc.GmosSouthImaging].apply(a)
-      case a @ Itc.GnirsSpectroscopy(_)   => Encoder[Itc.GnirsSpectroscopy].apply(a)
       case a @ Itc.Igrins2Spectroscopy(_) => Encoder[Itc.Igrins2Spectroscopy].apply(a)
       case a @ Itc.Spectroscopy(_, _)     => Encoder[Itc.Spectroscopy].apply(a)
 

--- a/modules/schema/src/test/scala/lucuma/odb/data/arb/ArbItc.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/data/arb/ArbItc.scala
@@ -126,33 +126,24 @@ trait ArbItc:
   given Cogen[Itc.Igrins2Spectroscopy] =
     Cogen[Zipper[Itc.Result]].contramap(_.science)
 
-  given Arbitrary[Itc.GnirsSpectroscopy] =
-    Arbitrary:
-      arbitrary[Zipper[Itc.Result]].map(Itc.GnirsSpectroscopy.apply)
-
-  given Cogen[Itc.GnirsSpectroscopy] =
-    Cogen[Zipper[Itc.Result]].contramap(_.science)
-
   given Arbitrary[Itc] =
     Arbitrary:
       Gen.oneOf(
         arbitrary[Itc.GhostIfu],
         arbitrary[Itc.GmosNorthImaging],
         arbitrary[Itc.GmosSouthImaging],
-        arbitrary[Itc.GnirsSpectroscopy],
         arbitrary[Itc.Igrins2Spectroscopy],
         arbitrary[Itc.Spectroscopy]
       )
 
   given Cogen[Itc] =
     Cogen[
-      Either[Itc.Spectroscopy, Either[Itc.GmosNorthImaging, Either[Itc.GmosSouthImaging, Either[Itc.GnirsSpectroscopy, Either[Itc.Igrins2Spectroscopy, Itc.GhostIfu]]]]]
+      Either[Itc.Spectroscopy, Either[Itc.GmosNorthImaging, Either[Itc.GmosSouthImaging, Either[Itc.Igrins2Spectroscopy, Itc.GhostIfu]]]]
     ].contramap:
       case a: Itc.Spectroscopy        => Left(a)
       case a: Itc.GmosNorthImaging    => Right(Left(a))
       case a: Itc.GmosSouthImaging    => Right(Right(Left(a)))
-      case a: Itc.GnirsSpectroscopy   => Right(Right(Right(Left(a))))
-      case a: Itc.Igrins2Spectroscopy => Right(Right(Right(Right(Left(a)))))
-      case a: Itc.GhostIfu            => Right(Right(Right(Right(Right(a)))))
+      case a: Itc.Igrins2Spectroscopy => Right(Right(Right(Left(a))))
+      case a: Itc.GhostIfu            => Right(Right(Right(Right(a))))
 
 object ArbItc extends ArbItc

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/longslit/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/longslit/Acquisition.scala
@@ -1,0 +1,152 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence
+package gnirs
+package longslit
+
+import cats.data.NonEmptyList
+import cats.data.State
+import cats.syntax.eq.*
+import cats.syntax.option.*
+import cats.syntax.traverse.*
+import eu.timepit.refined.types.string.NonEmptyString
+import fs2.Pure
+import fs2.Stream
+import lucuma.core.enums.GnirsAcquisitionType
+import lucuma.core.enums.GnirsDecker
+import lucuma.core.enums.GnirsFpuOther
+import lucuma.core.enums.GnirsPrism
+import lucuma.core.enums.GnirsReadMode
+import lucuma.core.enums.ObserveClass
+import lucuma.core.enums.SequenceType
+import lucuma.core.enums.StepGuideState.Disabled
+import lucuma.core.enums.StepGuideState.Enabled
+import lucuma.core.math.Offset
+import lucuma.core.math.syntax.int.*
+import lucuma.core.model.Observation
+import lucuma.core.model.sequence.Atom
+import lucuma.core.model.sequence.TelescopeConfig
+import lucuma.core.model.sequence.gnirs.GnirsAcquisitionMirrorMode
+import lucuma.core.model.sequence.gnirs.GnirsDynamicConfig
+import lucuma.core.model.sequence.gnirs.GnirsStaticConfig
+import lucuma.itc.IntegrationTime
+import lucuma.odb.data.OdbError
+import lucuma.odb.sequence.data.ProtoStep
+import lucuma.odb.sequence.util.AtomBuilder
+
+import java.util.UUID
+
+/**
+ * GNIRS long slit acquisition sequence generation.
+ */
+object Acquisition:
+
+  val RepeatingAtomCount: Int = 10
+
+  case class Steps(
+    slitImage:      ProtoStep[GnirsDynamicConfig],
+    field:          ProtoStep[GnirsDynamicConfig],
+    fieldSky:       Option[ProtoStep[GnirsDynamicConfig]],
+    throughSlit:    ProtoStep[GnirsDynamicConfig],
+    throughSlitSky: Option[ProtoStep[GnirsDynamicConfig]]
+  ):
+    private val hasSky = fieldSky.isDefined
+
+    val initialAtom: NonEmptyList[ProtoStep[GnirsDynamicConfig]] =
+      if hasSky then
+        NonEmptyList.of(
+          slitImage,
+          fieldSky.get,
+          field,
+          throughSlitSky.get,
+          throughSlit.withBreakpoint
+        )
+      else
+        NonEmptyList.of(slitImage, field, throughSlit.withBreakpoint)
+
+    val repeatingAtom: NonEmptyList[ProtoStep[GnirsDynamicConfig]] =
+      NonEmptyList.of(throughSlit)
+
+  private object StepComputer extends GnirsSequenceState:
+
+    def compute(config: Config, time: IntegrationTime): Steps =
+      val acqExposureTime = time.exposureTime
+      val readMode        = GnirsReadMode.forExposureTime(acqExposureTime)
+      val acqType         = config.acquisition.explicitAcqType.getOrElse:
+        GnirsAcquisitionType.forAcquisitionExposureTime(acqExposureTime)
+      val slitDecker      = GnirsDecker.forCameraAndReadMode(config.camera, GnirsPrism.Mirror)
+      val applySky        = acqType === GnirsAcquisitionType.Faint
+
+      eval:
+        for
+          _ <- State.modify[GnirsDynamicConfig]: dyn =>
+                 dyn.copy(
+                   exposure          = acqExposureTime,
+                   coadds            = config.acquisition.coadds,
+                   filter            = config.acquisition.filter,
+                   acquisitionMirror = GnirsAcquisitionMirrorMode.In,
+                   camera            = config.camera,
+                   focus             = config.focus,
+                   readMode          = readMode,
+                   decker            = slitDecker,
+                   fpu               = Left(config.fpu)
+                 )
+          slitImage      <- scienceStep(
+                              TelescopeConfig(
+                                Offset(Offset.P(10.arcsec), Offset.Q(0.arcsec)),
+                                Disabled
+                              ),
+                              ObserveClass.Acquisition
+                            )
+          _              <- State.modify[GnirsDynamicConfig]:
+                              _.copy(decker = GnirsDecker.Acquisition, fpu = Right(GnirsFpuOther.Acquisition))
+          fieldSkyOpt    <- config.acquisition.skyOffset.traverse: sky =>
+                              scienceStep(TelescopeConfig(sky, Enabled), ObserveClass.Acquisition)
+          field          <- scienceStep(0.arcsec, 0.arcsec, ObserveClass.Acquisition)
+          _              <- State.modify[GnirsDynamicConfig]:
+                              _.copy(decker = slitDecker, fpu = Left(config.fpu))
+          tSlitSkyOpt    <- config.acquisition.skyOffset.traverse: sky =>
+                              scienceStep(TelescopeConfig(sky, Enabled), ObserveClass.Acquisition)
+          throughSlit    <- scienceStep(0.arcsec, 0.arcsec, ObserveClass.Acquisition)
+        yield Steps(
+          slitImage      = slitImage,
+          field          = field,
+          fieldSky       = if applySky then fieldSkyOpt else none,
+          throughSlit    = throughSlit,
+          throughSlitSky = if applySky then tSlitSkyOpt else none
+        )
+
+  private class Generator(
+    builder: AtomBuilder[GnirsDynamicConfig],
+    steps:   Steps
+  ) extends SequenceGenerator[GnirsDynamicConfig]:
+
+    override val generate: Stream[Pure, Atom[GnirsDynamicConfig]] =
+      (for
+        a0 <- builder.build(NonEmptyString.unapply("Initial Acquisition"), 0, 0, steps.initialAtom)
+        as <- (1 to RepeatingAtomCount).toList.traverse: aix =>
+                builder.build(NonEmptyString.unapply("Fine Adjustments"), aix, 0, steps.repeatingAtom)
+      yield Stream.emits(a0 :: as)).runA(StepTimeEstimateCalculator.Last.empty[GnirsDynamicConfig]).value
+
+  def instantiate(
+    observationId: Observation.Id,
+    estimator:     StepTimeEstimateCalculator[GnirsStaticConfig, GnirsDynamicConfig],
+    static:        GnirsStaticConfig,
+    namespace:     UUID,
+    config:        Config,
+    time:          Either[OdbError, IntegrationTime]
+  ): Either[OdbError, SequenceGenerator[GnirsDynamicConfig]] =
+    time
+      .filterOrElse(
+        _.exposureTime.toNonNegMicroseconds.value > 0,
+        OdbError.SequenceUnavailable(
+          observationId,
+          s"Could not generate a sequence for $observationId: GNIRS Long Slit requires a positive acquisition exposure time.".some
+        )
+      )
+      .map: t =>
+        new Generator(
+          AtomBuilder.instantiate(estimator, static, namespace, SequenceType.Acquisition),
+          StepComputer.compute(config, t)
+        )

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/longslit/LongSlit.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/longslit/LongSlit.scala
@@ -5,7 +5,6 @@ package lucuma.odb.sequence
 package gnirs.longslit
 
 import fs2.Pure
-import fs2.Stream
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.gnirs.GnirsDynamicConfig
 import lucuma.core.model.sequence.gnirs.GnirsStaticConfig
@@ -26,10 +25,16 @@ object LongSlit:
     estimator:     StepTimeEstimateCalculator[GnirsStaticConfig, GnirsDynamicConfig],
     namespace:     UUID,
     config:        Config,
-    itc:           Either[OdbError, Itc.GnirsSpectroscopy]
+    itc:           Either[OdbError, Itc.Spectroscopy]
   ): Either[OdbError, StreamingExecutionConfig[Pure, GnirsStaticConfig, GnirsDynamicConfig]] =
     val static = staticFrom(config)
-    Science.instantiate(
-      observationId, estimator, static, namespace, config,
-      itc.map(_.science.focus.value)
-    ).map(s => StreamingExecutionConfig(static, Stream.empty, s.generate))
+    for
+      a <- Acquisition.instantiate(
+             observationId, estimator, static, namespace, config,
+             itc.map(_.acquisition.focus.value)
+           )
+      s <- Science.instantiate(
+             observationId, estimator, static, namespace, config,
+             itc.map(_.science.focus.value)
+           )
+    yield StreamingExecutionConfig(static, a.generate, s.generate)

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/shared.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/shared.scala
@@ -1,0 +1,11 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence.gnirs
+
+import lucuma.core.syntax.timespan.*
+import lucuma.core.util.TimeSpan
+
+// Definitions that are shared across GNIRS modes.
+val MinAcquisitionExposureTime: TimeSpan = 100.msTimeSpan  // 0.1 s; actually determined by the read mode, but this is a reasonable lower bound for all modes.
+val MaxAcquisitionExposureTime: TimeSpan = 60.secondTimeSpan

--- a/modules/service/src/main/scala/lucuma/odb/logic/GeneratorContext.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/GeneratorContext.scala
@@ -57,8 +57,6 @@ case class GeneratorContext(
           m.toNel.toList.foreach(addImagingResultSet)
         case Itc.GmosSouthImaging(m)      =>
           m.toNel.toList.foreach(addImagingResultSet)
-        case Itc.GnirsSpectroscopy(sci)   =>
-          addResultSet(sci)
         case Itc.Igrins2Spectroscopy(sci) =>
           addResultSet(sci)
         case Itc.Spectroscopy(acq, sci)   =>

--- a/modules/service/src/main/scala/lucuma/odb/logic/GeneratorStreaming.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/GeneratorStreaming.scala
@@ -134,14 +134,6 @@ object GeneratorStreaming:
       Itc.igrins2Spectroscopy.getOption(i).toRight:
         OdbError.InvalidObservation(oid, s"Expecting an IGRINS-2 spectroscopy ITC result for this observation".some)
 
-  def requireGnirsSpectroscopyItc(
-    oid: Observation.Id,
-    itc: Either[OdbError, Itc]
-  ): Either[OdbError, Itc.GnirsSpectroscopy] =
-    itc.flatMap: i =>
-      Itc.gnirsSpectroscopy.getOption(i).toRight:
-        OdbError.InvalidObservation(oid, s"Expecting a GNIRS spectroscopy ITC result for this observation".some)
-
   def requireImagingItc[A](
     name: String,
     oid:  Observation.Id,
@@ -289,7 +281,7 @@ object GeneratorStreaming:
         import lucuma.odb.sequence.gnirs.longslit.LongSlit
         (for
           cfg <- extractMode(ObservingMode.GnirsLongSlitName, context)(_.asGnirsLongSlit)
-          itc  = requireGnirsSpectroscopyItc(context.oid, context.itcRes)
+          itc  = requireSpectroscopyItc(context.oid, context.itcRes)
           gen <- EitherT.fromEither(LongSlit.instantiate(context.oid, calculator.gnirsStep, context.namespace, cfg, itc))
         yield gen.covary[F]).value
 

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -430,15 +430,17 @@ object GeneratorParamsService {
                   readMode          = gn.explicitReadMode.getOrElse(GnirsReadMode.forExposureTime(etm.time)),
                   wellDepth         = gn.wellDepth
                 )
-                val consInput = obsParams.constraints.toInput
-                val science   = SpectroscopyParameters(consInput, sciMode)
-                val itcInput  =
-                  obsParams.targets
-                    .traverse(itcTargetParams)
-                    .map(ItcInput.ScienceOnlySpectroscopy(science, _))
-                    .leftMap(MissingParamSet.fromParams)
-                    .toEither
-                GeneratorParams(itcInput, obsParams.scienceBand, gn, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount)
+                spectroscopyGeneratorParams(
+                  obsMode = gn,
+                  acqMode = InstrumentMode.GnirsImaging(
+                    exposureTimeMode = gn.acquisition.exposureTimeMode,
+                    filter           = gn.acquisition.filter,
+                    camera           = gn.camera,
+                    readMode         = GnirsReadMode.Bright,
+                    wellDepth        = gn.wellDepth
+                  ),
+                  sciMode = sciMode
+                )
 
           // Visitor Modes
           case vis: visitor.Config =>

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -294,6 +294,9 @@ object ItcService {
           case InstrumentMode.Flamingos2Imaging(_, _, _, _) =>
             go(lucuma.odb.sequence.flamingos2.MinAcquisitionExposureTime,
                lucuma.odb.sequence.flamingos2.MaxAcquisitionExposureTime)
+          case InstrumentMode.GnirsImaging(_, _, _, _, _, _) =>
+            go(lucuma.odb.sequence.gnirs.MinAcquisitionExposureTime,
+               lucuma.odb.sequence.gnirs.MaxAcquisitionExposureTime)
           case m                                                      =>
             EitherT.leftT:
               OdbError.InvalidObservation(oid, s"Acquisition is not supported for ${m.displayName}".some)
@@ -437,12 +440,6 @@ object ItcService {
             sci <- EitherT.fromEither(toTargetResults(sp.targets, NonEmptyList.one(cr)).map(_.head))
           yield Itc.Igrins2Spectroscopy(sci)
 
-        def gnirsSpectroscopy(sp: ItcInput.ScienceOnlySpectroscopy): EitherT[F, OdbError, Itc] =
-          for
-            cr  <- callSpectroscopy(sp.scienceInput)
-            sci <- EitherT.fromEither(toTargetResults(sp.targets, NonEmptyList.one(cr)).map(_.head))
-          yield Itc.GnirsSpectroscopy(sci)
-
         (input match
           case im @ ItcInput.Imaging(_, _) =>
             imaging(im)
@@ -452,8 +449,6 @@ object ItcService {
             ghost(gh, targets)
           case sp @ ItcInput.ScienceOnlySpectroscopy(SpectroscopyParameters(_, InstrumentMode.Igrins2Spectroscopy(_, _)), _) =>
             igrins2Spectroscopy(sp)
-          case sp @ ItcInput.ScienceOnlySpectroscopy(SpectroscopyParameters(_, _: InstrumentMode.GnirsSpectroscopy), _) =>
-            gnirsSpectroscopy(sp)
           case _ =>
             EitherT.leftT(OdbError.InvalidObservation(oid, s"Unrecognized ItcInput: $input".some))
         ).value

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGnirs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGnirs.scala
@@ -130,8 +130,116 @@ trait ExecutionTestSupportForGnirs extends ExecutionTestSupport:
       }
     """
 
+  def gnirsAcquisitionQuery(oid: Observation.Id, futureLimit: Option[Int] = None): String =
+    executionConfigQuery(oid, "gnirs", "acquisition", GnirsAtomQuery, futureLimit)
+
   def gnirsScienceQuery(oid: Observation.Id, futureLimit: Option[Int] = None): String =
     executionConfigQuery(oid, "gnirs", "science", GnirsAtomQuery, futureLimit)
+
+  /** Set the acquisition T+C ETM on a GNIRS LongSlit observation. */
+  def setAcquisitionTimeAndCount(oid: Observation.Id, seconds: BigDecimal, count: Int, atNm: BigDecimal): IO[Unit] =
+    query(
+      pi,
+      s"""
+        mutation {
+          updateObservations(input: {
+            SET: {
+              observingMode: {
+                gnirsLongSlit: {
+                  acquisition: {
+                    exposureTimeMode: {
+                      timeAndCount: {
+                        time:  { seconds: $seconds }
+                        count: $count
+                        at:    { nanometers: $atNm }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            WHERE: { id: { EQ: "$oid" } }
+          }) {
+            observations { id }
+          }
+        }
+      """
+    ).void
+
+  /** Set the explicit acquisition type on a GNIRS LongSlit observation. */
+  def setAcquisitionType(oid: Observation.Id, acqType: String): IO[Unit] =
+    query(
+      pi,
+      s"""
+        mutation {
+          updateObservations(input: {
+            SET: {
+              observingMode: {
+                gnirsLongSlit: {
+                  acquisition: {
+                    explicitAcquisitionType: $acqType
+                  }
+                }
+              }
+            }
+            WHERE: { id: { EQ: "$oid" } }
+          }) {
+            observations { id }
+          }
+        }
+      """
+    ).void
+
+  /** Set the acquisition sky offset on a GNIRS LongSlit observation. */
+  def setAcquisitionSkyOffset(oid: Observation.Id, pArcsec: BigDecimal, qArcsec: BigDecimal): IO[Unit] =
+    query(
+      pi,
+      s"""
+        mutation {
+          updateObservations(input: {
+            SET: {
+              observingMode: {
+                gnirsLongSlit: {
+                  acquisition: {
+                    skyOffset: {
+                      p: { arcseconds: $pArcsec }
+                      q: { arcseconds: $qArcsec }
+                    }
+                  }
+                }
+              }
+            }
+            WHERE: { id: { EQ: "$oid" } }
+          }) {
+            observations { id }
+          }
+        }
+      """
+    ).void
+
+  /** Set the explicit acquisition filter on a GNIRS LongSlit observation. */
+  def setAcquisitionFilter(oid: Observation.Id, filter: String): IO[Unit] =
+    query(
+      pi,
+      s"""
+        mutation {
+          updateObservations(input: {
+            SET: {
+              observingMode: {
+                gnirsLongSlit: {
+                  acquisition: {
+                    explicitFilter: $filter
+                  }
+                }
+              }
+            }
+            WHERE: { id: { EQ: "$oid" } }
+          }) {
+            observations { id }
+          }
+        }
+      """
+    ).void
 
   /**
    * Description of a single GNIRS dynamic config worth of fields, shared by

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirs.scala
@@ -1,0 +1,385 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.query
+
+import cats.effect.IO
+import cats.syntax.either.*
+import cats.syntax.option.*
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.enums.StepGuideState
+import lucuma.core.model.ExposureTimeMode
+import lucuma.core.model.Observation
+import lucuma.core.model.sequence.TelescopeConfig
+import lucuma.itc.IntegrationTime
+import lucuma.itc.client.ImagingInput
+import lucuma.odb.sequence.gnirs.longslit.Acquisition.RepeatingAtomCount
+
+class executionAcqGnirs extends ExecutionTestSupportForGnirs:
+
+  // Return T+C exposure/count directly from the input when T+C ETM is used.
+  override def fakeItcImagingResultFor(input: ImagingInput): Option[IntegrationTime] =
+    input.mode.exposureTimeMode match
+      case ExposureTimeMode.TimeAndCountMode(t, c, _) => IntegrationTime(t, c).some
+      case _                                          => none
+
+  // Default observation: camera=SHORT_BLUE, prism=MIRROR, fpu=LONG_SLIT_0_30.
+  // slitDecker = SHORT_CAM_LONG_SLIT; acquisitionMirror=In.
+  // Default acq coadds = 1.
+
+  // Narrow query used in most tests — omits fields with tricky formatting (centralWavelength, etc).
+  val AcqStepsQuery: String =
+    s"""
+      description
+      observeClass
+      steps {
+        instrumentConfig {
+          exposure { microseconds }
+          coadds
+          filter
+          decker
+          fpuSlit
+          fpuOther
+          readMode
+        }
+        telescopeConfig {
+          offset {
+            p { arcseconds }
+            q { arcseconds }
+          }
+          guiding
+        }
+        observeClass
+        breakpoint
+      }
+    """
+
+  def gnirsAcqNarrowQuery(oid: Observation.Id, futureLimit: Option[Int] = None): String =
+    executionConfigQuery(oid, "gnirs", "acquisition", AcqStepsQuery, futureLimit)
+
+  def acqStep(
+    microseconds: Long,
+    coadds:       Int,
+    filter:       String,
+    decker:       String,
+    fpuSlit:      Option[String],
+    fpuOther:     Option[String],
+    readMode:     String,
+    tc:           TelescopeConfig,
+    breakpoint:   String = "DISABLED"
+  ): Json =
+    json"""
+      {
+        "instrumentConfig": {
+          "exposure":  { "microseconds": $microseconds },
+          "coadds":    $coadds,
+          "filter":    $filter,
+          "decker":    $decker,
+          "fpuSlit":   ${fpuSlit.asJson},
+          "fpuOther":  ${fpuOther.asJson},
+          "readMode":  $readMode
+        },
+        "telescopeConfig": ${expectedTelescopeConfig(tc)},
+        "observeClass": "ACQUISITION",
+        "breakpoint":   $breakpoint
+      }
+    """
+
+  def tc(pArc: Int, qArc: Int, guiding: StepGuideState): TelescopeConfig =
+    telescopeConfig(pArc, qArc, guiding)
+
+  def slitImgStep(expUs: Long, coadds: Int, filter: String, readMode: String) =
+    acqStep(expUs, coadds, filter, "SHORT_CAM_LONG_SLIT", "LONG_SLIT_0_30".some, none, readMode,
+      tc(10, 0, StepGuideState.Disabled))
+
+  def fieldStep(expUs: Long, coadds: Int, filter: String, readMode: String, pArc: Int, qArc: Int) =
+    acqStep(expUs, coadds, filter, "ACQUISITION", none, "ACQUISITION".some, readMode,
+      tc(pArc, qArc, StepGuideState.Enabled))
+
+  def throughSlitStep(expUs: Long, coadds: Int, filter: String, readMode: String, pArc: Int, qArc: Int, breakpoint: String = "DISABLED") =
+    acqStep(expUs, coadds, filter, "SHORT_CAM_LONG_SLIT", "LONG_SLIT_0_30".some, none, readMode,
+      tc(pArc, qArc, StepGuideState.Enabled), breakpoint)
+
+  // 5_000_000 µs = 5 s  → Bright (1s < 5s ≤ 10s), readMode=BRIGHT
+  val BrightUs: Long = 5_000_000L
+
+  test("Bright acquisition — initial atom (3 steps, no sky)"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGnirsLongSlitObservationAs(pi, p, t)
+        _ <- setAcquisitionTimeAndCount(o, 5.0, 1, 1645)
+        _ <- setAcquisitionFilter(o, "ORDER4")
+      yield o
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = gnirsAcqNarrowQuery(oid),
+        expected = json"""
+          {
+            "executionConfig": {
+              "gnirs": {
+                "acquisition": {
+                  "nextAtom": {
+                    "description": "Initial Acquisition",
+                    "observeClass": "ACQUISITION",
+                    "steps": [
+                      ${slitImgStep(BrightUs, 1, "ORDER4", "BRIGHT")},
+                      ${fieldStep(BrightUs, 1, "ORDER4", "BRIGHT", 0, 0)},
+                      ${throughSlitStep(BrightUs, 1, "ORDER4", "BRIGHT", 0, 0, "ENABLED")}
+                    ]
+                  },
+                  "possibleFuture": ${brightFineAdjustments(RepeatingAtomCount)},
+                  "hasMore": false
+                }
+              }
+            }
+          }
+        """.asRight
+      )
+
+  def brightFineAdjustments(n: Int): Json =
+    List.fill(n):
+      json"""
+        {
+          "description": "Fine Adjustments",
+          "observeClass": "ACQUISITION",
+          "steps": [
+            ${throughSlitStep(BrightUs, 1, "ORDER4", "BRIGHT", 0, 0)}
+          ]
+        }
+      """
+    .asJson
+
+  // 30_000_000 µs = 30 s → Faint (> 10s), readMode=FAINT
+  val FaintUs: Long = 30_000_000L
+
+  test("Faint acquisition with sky offset — initial atom (5 steps with sky subtraction)"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGnirsLongSlitObservationAs(pi, p, t)
+        _ <- setAcquisitionTimeAndCount(o, 30.0, 1, 1645)
+        _ <- setAcquisitionFilter(o, "ORDER4")
+        _ <- setAcquisitionSkyOffset(o, 0, 10)
+      yield o
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = gnirsAcqNarrowQuery(oid),
+        expected = json"""
+          {
+            "executionConfig": {
+              "gnirs": {
+                "acquisition": {
+                  "nextAtom": {
+                    "description": "Initial Acquisition",
+                    "observeClass": "ACQUISITION",
+                    "steps": [
+                      ${slitImgStep(FaintUs, 1, "ORDER4", "FAINT")},
+                      ${fieldStep(FaintUs, 1, "ORDER4", "FAINT", 0, 10)},
+                      ${fieldStep(FaintUs, 1, "ORDER4", "FAINT", 0, 0)},
+                      ${throughSlitStep(FaintUs, 1, "ORDER4", "FAINT", 0, 10)},
+                      ${throughSlitStep(FaintUs, 1, "ORDER4", "FAINT", 0, 0, "ENABLED")}
+                    ]
+                  },
+                  "possibleFuture": ${faintFineAdjustments(RepeatingAtomCount)},
+                  "hasMore": false
+                }
+              }
+            }
+          }
+        """.asRight
+      )
+
+  def faintFineAdjustments(n: Int): Json =
+    List.fill(n):
+      json"""
+        {
+          "description": "Fine Adjustments",
+          "observeClass": "ACQUISITION",
+          "steps": [
+            ${throughSlitStep(FaintUs, 1, "ORDER4", "FAINT", 0, 0)}
+          ]
+        }
+      """
+    .asJson
+
+  test("Faint type explicit but no sky offset — falls back to 3-step structure"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGnirsLongSlitObservationAs(pi, p, t)
+        _ <- setAcquisitionTimeAndCount(o, 5.0, 1, 1645)
+        _ <- setAcquisitionFilter(o, "ORDER4")
+        _ <- setAcquisitionType(o, "FAINT")   // Faint type but no sky offset
+      yield o
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = s"""
+          query {
+            executionConfig(observationId: "$oid") {
+              gnirs {
+                acquisition {
+                  nextAtom {
+                    steps {
+                      telescopeConfig { guiding }
+                      breakpoint
+                    }
+                  }
+                }
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "executionConfig": {
+              "gnirs": {
+                "acquisition": {
+                  "nextAtom": {
+                    "steps": [
+                      { "telescopeConfig": { "guiding": "DISABLED" }, "breakpoint": "DISABLED" },
+                      { "telescopeConfig": { "guiding": "ENABLED"  }, "breakpoint": "DISABLED" },
+                      { "telescopeConfig": { "guiding": "ENABLED"  }, "breakpoint": "ENABLED" }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        """.asRight
+      )
+
+  // 500_000 µs = 0.5 s → VeryBright (< 1s), readMode=VERY_BRIGHT
+  val VeryBrightUs: Long = 500_000L
+
+  test("VeryBright acquisition (< 1s) — VERY_BRIGHT readMode"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGnirsLongSlitObservationAs(pi, p, t)
+        _ <- setAcquisitionTimeAndCount(o, 0.5, 1, 2122)
+        _ <- setAcquisitionFilter(o, "H2")
+      yield o
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = s"""
+          query {
+            executionConfig(observationId: "$oid") {
+              gnirs {
+                acquisition {
+                  nextAtom {
+                    steps {
+                      instrumentConfig { exposure { microseconds } readMode filter }
+                      telescopeConfig  { offset { p { arcseconds } q { arcseconds } } guiding }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "executionConfig": {
+              "gnirs": {
+                "acquisition": {
+                  "nextAtom": {
+                    "steps": [
+                      {
+                        "instrumentConfig": { "exposure": { "microseconds": $VeryBrightUs }, "readMode": "VERY_BRIGHT", "filter": "H2" },
+                        "telescopeConfig": { "offset": { "p": { "arcseconds": 10.000000 }, "q": { "arcseconds": 0.000000 } }, "guiding": "DISABLED" }
+                      },
+                      {
+                        "instrumentConfig": { "exposure": { "microseconds": $VeryBrightUs }, "readMode": "VERY_BRIGHT", "filter": "H2" },
+                        "telescopeConfig": { "offset": { "p": { "arcseconds": 0.000000 }, "q": { "arcseconds": 0.000000 } }, "guiding": "ENABLED" }
+                      },
+                      {
+                        "instrumentConfig": { "exposure": { "microseconds": $VeryBrightUs }, "readMode": "VERY_BRIGHT", "filter": "H2" },
+                        "telescopeConfig": { "offset": { "p": { "arcseconds": 0.000000 }, "q": { "arcseconds": 0.000000 } }, "guiding": "ENABLED" }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        """.asRight
+      )
+
+  test("Acquisition coadds come from acquisition config, not ITC"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGnirsLongSlitObservationAs(pi, p, t)
+        _ <- setAcquisitionTimeAndCount(o, 5.0, 1, 1645)
+        _ <- setAcquisitionFilter(o, "ORDER4")
+        _ <- query(
+               pi,
+               s"""
+                 mutation {
+                   updateObservations(input: {
+                     SET: {
+                       observingMode: {
+                         gnirsLongSlit: {
+                           acquisition: { coadds: 7 }
+                         }
+                       }
+                     }
+                     WHERE: { id: { EQ: "$o" } }
+                   }) { observations { id } }
+                 }
+               """
+             ).void
+      yield o
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = s"""
+          query {
+            executionConfig(observationId: "$oid") {
+              gnirs {
+                acquisition {
+                  nextAtom {
+                    steps {
+                      instrumentConfig { coadds }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "executionConfig": {
+              "gnirs": {
+                "acquisition": {
+                  "nextAtom": {
+                    "steps": [
+                      { "instrumentConfig": { "coadds": 7 } },
+                      { "instrumentConfig": { "coadds": 7 } },
+                      { "instrumentConfig": { "coadds": 7 } }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        """.asRight
+      )


### PR DESCRIPTION
- Remove the special cases for no-acquisition Gnirs spectroscopy.
- Implement preliminary acquisition sequence generation for Gnirs. Tried to mimick F2's logic with the new Gnirs requirements. It may need some iteration:
  - The specs show duplicated steps. I don't know if this was done in OCS to have a generated step handy in case it needed repetition or if we actually want the duplicated step in the sequence. I'm assuming the former. Since in GPP we can edit the sequence and clone steps, this wouldn't be necessary.
  - The specs show a different filter in the first step in some cases. I'm not sure what the logic is behind this. For the moment, the same filter is used throughout.

I've already asked these things to Andy. I'd like to merge this PR so it doesn't diverge too much and continue work on the explore logic while we wait for answers, we can fine tune later.