### PR TITLE
Shortcut 7179: `isSplittable`

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -3527,6 +3527,32 @@ input ConfigurationRequestProperties {
 }
 
 """
+Configuration that controls how and when the Scheduler may plan execution of an
+observation, including whether it can be split across multiple visits and any
+timing constraints.
+"""
+input SchedulingPropertiesInput {
+
+  """
+  Controls whether the observation may be split across multiple visits. When
+  true (default), the scheduler may divide the science sequence into discrete
+  segments (i.e. "atoms") scheduled in order across separate visits. When false,
+  the entire science sequence must complete within a single uninterrupted visit.
+  """
+  isSplittable: Boolean = true
+
+  """
+  One or more windows during which the observation is permitted to execute.
+  Defaults to empty (unconstrained) if omitted. To modify existing windows,
+  supply the complete desired array — the new value replaces the previous one
+  entirely. When this input is used to edit an observation, assigning a `null`
+  value clears all existing timing windows.
+  """
+  timingWindows: [TimingWindowInput!]
+
+}
+
+"""
 Observation properties
 """
 input ObservationPropertiesInput {
@@ -3557,9 +3583,22 @@ input ObservationPropertiesInput {
   constraintSet: ConstraintSetInput
 
   """
-  The timingWindows defaults to empty if not specified on creation, and may be edited by specifying a new whole array
+  Deprecated in favor of the scheduling field — use that instead. If both this
+  field and scheduling are specified in the same mutation, the mutation will be
+  rejected with a validation error. One or more timing windows during which the
+  observation may execute. Defaults to empty (unconstrained) if omitted. To
+  modify, supply the complete desired array — it replaces the previous value
+  entirely.
   """
-  timingWindows: [TimingWindowInput!]
+  timingWindows: [TimingWindowInput!] @deprecated(reason: "Use `scheduling` instead. (Deprecated June 4, 2026).")
+
+  """
+  Scheduling configuration for this observation, controlling visit splitting and
+  timing windows. If omitted, scheduling defaults apply (observation is
+  splittable, no timing windows). Set to `null` to reset any existing scheduling
+  configuration to those defaults.
+  """
+  scheduling: SchedulingPropertiesInput
 
   """
   The attachments defaults to empty if not specified on creation, and may be edited by specifying a new whole array

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ObservationPropertiesInput.scala
@@ -9,17 +9,24 @@ import cats.data.NonEmptyList
 import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import eu.timepit.refined.types.string.NonEmptyString
+import grackle.Result
+import grackle.syntax.*
 import lucuma.core.enums.ScienceBand
 import lucuma.core.model.Attachment
 import lucuma.core.model.Group
 import lucuma.core.model.Target
 import lucuma.odb.data.Existence
 import lucuma.odb.data.Nullable
+import lucuma.odb.data.OdbError
+import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.graphql.binding.*
 import monocle.Focus
 import monocle.Lens
 
 object ObservationPropertiesInput {
+
+  private val PleaseUseSchedulingField: Result[Nothing] =
+    OdbError.InvalidArgument("Set timing windows via the 'scheduling' properties field.".some).asFailure
 
   trait AsterismInput {
     def targetEnvironment: Option[TargetEnvironmentInput]
@@ -39,7 +46,7 @@ object ObservationPropertiesInput {
     posAngleConstraint:  Option[PosAngleConstraintInput],
     targetEnvironment:   Option[TargetEnvironmentInput.Create],
     constraintSet:       Option[ConstraintSetInput],
-    timingWindows:       Option[List[TimingWindowInput]],
+    scheduling:          Option[SchedulingPropertiesInput],
     attachments:         Option[List[Attachment.Id]],
     scienceRequirements: Option[ScienceRequirementsInput],
     observingMode:       Option[ObservingModeInput.Create],
@@ -63,7 +70,7 @@ object ObservationPropertiesInput {
         posAngleConstraint  = None,
         targetEnvironment   = None,
         constraintSet       = ConstraintSetInput.Default.some,
-        timingWindows       = None,
+        scheduling          = None,
         attachments         = None,
         scienceRequirements = None,
         observingMode       = None,
@@ -82,6 +89,7 @@ object ObservationPropertiesInput {
           TargetEnvironmentInput.Create.Binding.Option("targetEnvironment", rTargetEnvironment),
           ConstraintSetInput.Binding.Option("constraintSet", rConstraintSet),
           TimingWindowInput.Binding.List.Option("timingWindows", rTimingWindows),
+          SchedulingPropertiesInput.Binding.Option("scheduling", rScheduling),
           AttachmentIdBinding.List.Option("attachments", rAttachments),
           ScienceRequirementsInput.Binding.Option("scienceRequirements", rScienceRequirements),
           ObservingModeInput.Create.Binding.Option("observingMode", rObservingMode),
@@ -95,7 +103,11 @@ object ObservationPropertiesInput {
             rPosAngleConstraint,
             rTargetEnvironment,
             rConstraintSet,
-            rTimingWindows,
+            (rTimingWindows, rScheduling).parFlatMapN {
+              case (Some(_), Some(_)) => PleaseUseSchedulingField
+              case (Some(t), None)    => SchedulingPropertiesInput(None, Nullable.NonNull(t)).some.success
+              case (None,    s)       => s.success
+            },
             rAttachments,
             rScienceRequirements,
             rObservingMode,
@@ -114,7 +126,7 @@ object ObservationPropertiesInput {
     posAngleConstraint:  Option[PosAngleConstraintInput],
     targetEnvironment:   Option[TargetEnvironmentInput.Edit],
     constraintSet:       Option[ConstraintSetInput],
-    timingWindows:       Nullable[List[TimingWindowInput]],
+    scheduling:          Nullable[SchedulingPropertiesInput],
     attachments:         Nullable[List[Attachment.Id]],
     scienceRequirements: Option[ScienceRequirementsInput],
     observingMode:       Nullable[ObservingModeInput.Edit],
@@ -138,7 +150,7 @@ object ObservationPropertiesInput {
         posAngleConstraint =  None,
         targetEnvironment =   None,
         constraintSet =       None,
-        timingWindows =       Nullable.Absent,
+        scheduling =          Nullable.Absent,
         attachments =         Nullable.Absent,
         scienceRequirements = None,
         observingMode =       Nullable.Absent,
@@ -157,6 +169,7 @@ object ObservationPropertiesInput {
           TargetEnvironmentInput.Edit.Binding.Option("targetEnvironment", rTargetEnvironment),
           ConstraintSetInput.Binding.Option("constraintSet", rConstraintSet),
           TimingWindowInput.Binding.List.Nullable("timingWindows", rTimingWindows),
+          SchedulingPropertiesInput.Binding.Nullable("scheduling", rScheduling),
           AttachmentIdBinding.List.Nullable("attachments", rAttachments),
           ScienceRequirementsInput.Binding.Option("scienceRequirements", rScienceRequirements),
           ObservingModeInput.Edit.Binding.Nullable("observingMode", rObservingMode),
@@ -170,7 +183,13 @@ object ObservationPropertiesInput {
             rPosAngleConstraint,
             rTargetEnvironment,
             rConstraintSet,
-            rTimingWindows,
+            (rTimingWindows, rScheduling).parFlatMapN {
+              case (Nullable.Null,       Nullable.Absent)     => Nullable.NonNull(SchedulingPropertiesInput(None, Nullable.Null)).success
+              case (Nullable.Null,       Nullable.Null)       => Nullable.Null.success
+              case (Nullable.Absent,     s)                   => s.success
+              case (Nullable.NonNull(t), Nullable.Absent)     => Nullable.NonNull(SchedulingPropertiesInput(None, Nullable.NonNull(t))).success
+              case _                                          => PleaseUseSchedulingField
+            },
             rAttachments,
             rScienceRequirements,
             rObservingMode,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/SchedulingPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/SchedulingPropertiesInput.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.input
+
+import cats.syntax.all.*
+import grackle.Result
+import lucuma.odb.data.Nullable
+import lucuma.odb.graphql.binding.*
+
+case class SchedulingPropertiesInput(
+  isSplittable:  Option[Boolean],
+  timingWindows: Nullable[List[TimingWindowInput]]
+)
+
+object SchedulingPropertiesInput:
+
+  val Binding: Matcher[SchedulingPropertiesInput] =
+    ObjectFieldsBinding.rmap:
+      case List(
+        BooleanBinding.Option("isSplittable", rSplit),
+        TimingWindowInput.Binding.List.Nullable("timingWindows", rTiming)
+      ) => (rSplit, rTiming).parMapN(SchedulingPropertiesInput(_, _))

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
@@ -354,7 +354,7 @@ trait AccessControl[F[_]] extends Predicates[F] {
           SET.scienceBand.isDefined         ||
           SET.targetEnvironment.exists(_.limitToPreExecution(access)) ||
           SET.constraintSet.isDefined       ||
-          SET.timingWindows.isDefined       ||
+          SET.scheduling.isDefined          ||
           SET.attachments.isDefined         ||
           SET.scienceRequirements.isDefined ||
           SET.observingMode.exists(_.limitToPreExecution(access)) ||

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -273,7 +273,7 @@ object ObservationService {
 
               .flatTap: rOid =>
                 rOid.flatTraverse: oid =>
-                  Services.asSuperUser(setTimingWindows(List(oid), SET.timingWindows))
+                  Services.asSuperUser(setTimingWindows(List(oid), SET.scheduling.flatMap(_.timingWindows.toOption)))
 
               .flatMap: rOid =>
                 SET.attachments.fold(rOid.pure[F]): aids =>
@@ -494,7 +494,7 @@ object ObservationService {
 
                 _ <- validateBand(g.keys.toList)
                 _ <- ResultT(u.map(u => Services.asSuperUser(updateObservingModes(SET.observingMode, u, e.toOption))).getOrElse(Result.unit.pure[F]))
-                _ <- ResultT(Services.asSuperUser(setTimingWindows(u.foldMap(_.toList), SET.timingWindows.foldPresent(_.orEmpty))))
+                _ <- ResultT(Services.asSuperUser(setTimingWindows(u.foldMap(_.toList), SET.scheduling.flatMap(_.timingWindows).foldPresent(_.orEmpty))))
                 _ <- ResultT(g.toList.traverse { case (pid, oids) =>
                       obsAttachmentAssignmentService.setAssignments(pid, oids, SET.attachments)
                     }.map(_.sequence))

--- a/modules/service/src/main/scala/lucuma/odb/service/PerScienceObservationCalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/PerScienceObservationCalibrationsService.scala
@@ -147,7 +147,7 @@ object PerScienceObservationCalibrationsService:
           ).some,
           targetEnvironment = targetEnvironment.some,
           constraintSet = none,
-          timingWindows = none,
+          scheduling = none,
           attachments = none,
           scienceRequirements = none,
           observingMode = none,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/timingWindows_deprecated.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/timingWindows_deprecated.scala
@@ -13,7 +13,7 @@ import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.User
 
-class timingWindows extends OdbSuite {
+class timingWindows_deprecated extends OdbSuite {
   val pi       = TestUsers.Standard.pi(1, 30)
   val validUsers = List(pi)
 
@@ -29,9 +29,7 @@ class timingWindows extends OdbSuite {
         twisOpt.map(twis => 
           s""",
               SET: {
-                scheduling: {
-                  timingWindows: $twis
-                }
+                timingWindows: $twis
               }
           """
         ).orEmpty +
@@ -43,8 +41,9 @@ class timingWindows extends OdbSuite {
             }
           }
         """
-    ).map: json =>
+    ).map { json => 
       json.hcursor.downFields("createObservation", "observation", "id").require[Observation.Id]
+    }
 
   def updateObservation(user: User,  oid: Observation.Id, twisOpt: Option[String]): IO[Json] =
     query(
@@ -61,7 +60,7 @@ class timingWindows extends OdbSuite {
               SET: {
         """ + 
         twisOpt.map(twis => 
-          s"scheduling: { timingWindows: $twis }"
+          s"timingWindows: $twis"
         ).orEmpty +
         s"""
               }
@@ -73,8 +72,9 @@ class timingWindows extends OdbSuite {
           }
         """
 
-    ).map: json =>
+    ).map { json => 
       json.hcursor.downFields("updateObservations").require[Json]
+    }
 
   test("null timing windows should result in an empty set") {
     List(pi).traverse { user =>
@@ -293,42 +293,6 @@ class timingWindows extends OdbSuite {
     }
   }
 
-  test("scheduling edit to null"):
-    createProgramAs(pi).flatMap: pid =>
-      createObservation(pi, pid, TimingWindowsInput.some).flatMap: oid =>
-        expect(
-          user  = pi,
-          query = s"""
-            mutation {
-              updateObservations(input: {
-                WHERE: {
-                  id: {
-                    EQ: "$oid"
-                  }
-                }
-                SET: {
-                  scheduling: null
-                }
-              }) {
-                observations {
-                  $TimingWindowsGraph
-                }
-              }
-            }
-          """,
-          expected = json"""
-            {
-              "updateObservations": {
-                "observations": [
-                  {
-                    "timingWindows": []
-                  }
-                ]
-              }
-            }
-          """.asRight
-        )
-
   test("timing windows edit omit value") {
     List(pi).traverse { user =>
       createProgramAs(user).flatMap { pid =>
@@ -389,4 +353,58 @@ class timingWindows extends OdbSuite {
       }
     }
   }
+
+  test("create fail when both timingWindows and scheduling are present"):
+    createProgramAs(pi).flatMap: p =>
+      expect(
+        user  = pi,
+        query = s"""
+          mutation {
+            createObservation(input: {
+              programId: "$p"
+              SET: {
+                timingWindows: $TimingWindowsInput
+                scheduling: {
+                  timingWindows: $TimingWindowsInput
+                }
+              }
+            }) {
+              observation {
+                id
+              }
+            }
+          }
+        """,
+        expected = List("Argument 'input.SET' is invalid: Set timing windows via the 'scheduling' properties field.").asLeft
+      )
+
+  test("update fail when both timingWindows and scheduling are present"):
+    createProgramAs(pi).flatMap: p =>
+      createObservation(pi, p, TimingWindowsInput.some).flatMap: o =>
+        expect(
+          user  = pi,
+          query = s"""
+            mutation {
+              updateObservations(input: {
+                WHERE: {
+                  id: {
+                    EQ: "$o"
+                  }
+                },
+                SET: {
+                  timingWindows: $TimingWindowsInput
+                  scheduling: {
+                    timingWindows: $TimingWindowsInput
+                  }
+                }
+              }) {
+                observations {
+                  $TimingWindowsGraph
+                }
+              }
+            }
+          """,
+          expected = List("Argument 'input.SET' is invalid: Set timing windows via the 'scheduling' properties field.").asLeft
+        )
+
 }


### PR DESCRIPTION
This is part of [Shortcut 7179](https://app.shortcut.com/lucuma/story/7179/support-unsplittable-observations).  This PR only:

1. Adds a `scheduling: SchedulingPropertiesInput` to hold both the new `isSplittable` property and the existing `timingWindows`.  This corresponds to the UI suggestion grouping these items.
2. Deprecates (but does not remove) the existing `timingWindows` field in `ObservationPropertiesInput`, to ease the transition. If both `scheduling` and `timingWindows` are set, then the input is rejected with an error.

**Note: at the risk of attracting "it doesn't work" Shortcut tasks, the `isSplittable` field is not yet being used.** In the next installment I'll need to add the value to the observation table and make a scheduling properties field for `Observation` and the associated Grackle mapping.  Finally the sequence generation will need to respect the splittable field and manual edits that try to split an unsplittable observation will have to be rejected.

I'm not crazy about the term "splittable" but it was suggested even for the UI so it seemed best to go with it.