### PR TITLE
Rename scienceFov to agsDiameter

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4883,9 +4883,9 @@ input VisitorInput {
   centralWavelength: WavelengthInput
 
   """
-  Science field of view, understood as the diameter of a circular area.
+  AGS field of view, understood as the diameter of a circular area.
   """
-  scienceFov: AngleInput
+  agsDiameter: AngleInput
 
   """
   Optional descriptive name for this visitor mode selection.
@@ -4903,9 +4903,9 @@ type Visitor {
   centralWavelength: Wavelength!
 
   """
-  Science field of view, understood as the diameter of a circular area.
+  AGS field of view, understood as the diameter of a circular area.
   """
-  scienceFov: Angle!
+  agsDiameter: Angle!
 
   """
   Optional descriptive name for this visitor mode selection.

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/visitor/Config.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/visitor/Config.scala
@@ -13,8 +13,8 @@ import lucuma.odb.sequence.util.HashBytes
 final case class Config(
   mode: VisitorObservingModeType,
   centralWavelength: Wavelength,
-  // Science field of view, understood as the diameter of a circular area.
-  scienceFov: Angle,
+  // AGS field of view, understood as the diameter of a circular area.
+  agsDiameter: Angle,
   name: Option[NonEmptyString],
   totalRequestTime: Option[TimeSpan]
 ):
@@ -32,7 +32,7 @@ object Config:
       Array.concat(
         HashBytes[VisitorObservingModeType].hashBytes(c.mode),
         HashBytes[Wavelength].hashBytes(c.centralWavelength),
-        HashBytes[Angle].hashBytes(c.scienceFov),
+        HashBytes[Angle].hashBytes(c.agsDiameter),
         c.name.fold(Array.emptyByteArray)(n => HashBytes[String].hashBytes(n.value)),
         c.totalRequestTime.fold(Array.emptyByteArray)(HashBytes[TimeSpan].hashBytes)
       )

--- a/modules/service/src/main/resources/db/migration/V1168__visitor_ags_diameter.sql
+++ b/modules/service/src/main/resources/db/migration/V1168__visitor_ags_diameter.sql
@@ -1,0 +1,16 @@
+-- Rename c_science_fov to c_ags_diameter
+DROP VIEW v_visitor;
+
+ALTER TABLE t_visitor
+  RENAME COLUMN c_science_fov TO c_ags_diameter;
+
+UPDATE t_visitor
+  SET c_ags_diameter = 60000000
+  WHERE c_observing_mode_type = 'maroon_x';
+
+CREATE VIEW v_visitor AS
+  SELECT
+    v.*,
+    CASE WHEN v.c_total_request_time IS NOT NULL THEN v.c_observation_id END
+      AS c_total_request_time_id
+  FROM t_visitor v;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/VisitorInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/VisitorInput.scala
@@ -24,13 +24,13 @@ object VisitorInput:
   case class Edit(
     mode: Option[VisitorObservingModeType],
     centralWavelength: Option[Wavelength],
-    scienceFov: Option[Angle],
+    agsDiameter: Option[Angle],
     name: Option[NonEmptyString],
     totalRequestTime: Option[TimeSpan]
   ):
     def toCreate: Result[Create] =
       Result.fromOption(
-        (mode, centralWavelength, scienceFov).mapN((m, w, f) =>
+        (mode, centralWavelength, agsDiameter).mapN((m, w, f) =>
           Create(m, w, f, name, totalRequestTime)
         ),
         "Cannot turn edit into create; all required fields must be defined."
@@ -42,19 +42,19 @@ object VisitorInput:
       case List(
         VisitorObservingModeTypeBinding("mode", rMode),
         WavelengthInput.Binding("centralWavelength", rWavelength),
-        AngleInput.Binding("scienceFov", rScienceFov),
+        AngleInput.Binding("agsDiameter", rAgsDiameter),
         NonEmptyStringBinding.Option("name", rName),
         TimeSpanInput.Binding.Option("totalRequestTime", rTotalRequestTime)
       ) =>
-        (rMode, rWavelength, rScienceFov, rName, rTotalRequestTime).mapN(Create.apply)
+        (rMode, rWavelength, rAgsDiameter, rName, rTotalRequestTime).mapN(Create.apply)
 
   val EditBinding: Matcher[Edit] =
     ObjectFieldsBinding.rmap:
       case List(
         VisitorObservingModeTypeBinding.Option("mode", rMode),
         WavelengthInput.Binding.Option("centralWavelength", rWavelength),
-        AngleInput.Binding.Option("scienceFov", rScienceFov),
+        AngleInput.Binding.Option("agsDiameter", rAgsDiameter),
         NonEmptyStringBinding.Option("name", rName),
         TimeSpanInput.Binding.Option("totalRequestTime", rTotalRequestTime)
       ) =>
-        (rMode, rWavelength, rScienceFov, rName, rTotalRequestTime).mapN(Edit.apply)
+        (rMode, rWavelength, rAgsDiameter, rName, rTotalRequestTime).mapN(Edit.apply)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AngleMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AngleMapping.scala
@@ -75,9 +75,9 @@ trait AngleMapping[F[_]] extends ObservationView[F]
       angleMappingAtPath(ImagingScienceRequirementsType / "minimumFov", Imaging.MinimumFovAngle.Value, Imaging.MinimumFovAngle.SyntheticId),
       angleMappingAtPath(RandomTelescopeConfigGeneratorType / "size", TelescopeConfigGeneratorView.Size, TelescopeConfigGeneratorView.Random.ObservationId, TelescopeConfigGeneratorView.Random.Role),
       angleMappingAtPath(SpiralTelescopeConfigGeneratorType / "size", TelescopeConfigGeneratorView.Size, TelescopeConfigGeneratorView.Spiral.ObservationId, TelescopeConfigGeneratorView.Spiral.Role),
-      angleMappingAtPath(VisitorType / "scienceFov", VisitorTable.ScienceFov, VisitorTable.ObservationId),
+      angleMappingAtPath(VisitorType / "agsDiameter", VisitorTable.AgsDiameter, VisitorTable.ObservationId),
       angleMappingAtPath(ConfigurationRequestType / "configuration" / "observingMode" / "visitor" / "radius", ConfigurationRequestView.Visitor.Radius, ConfigurationRequestView.Visitor.Id),
-      angleMappingAtPath(ObservationType / "configuration" / "observingMode" / "visitor" / "radius", VisitorTable.ScienceFov, VisitorTable.ObservationId),
+      angleMappingAtPath(ObservationType / "configuration" / "observingMode" / "visitor" / "radius", VisitorTable.AgsDiameter, VisitorTable.ObservationId),
     )
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/VisitorMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/VisitorMapping.scala
@@ -17,7 +17,7 @@ trait VisitorMapping[F[_]] extends VisitorTable[F]:
       SqlField("observationId", VisitorTable.ObservationId, key = true, hidden = true),
       SqlField("mode", VisitorTable.ObservingModeType),
       SqlObject("centralWavelength"),
-      SqlObject("scienceFov"),
+      SqlObject("agsDiameter"),
       SqlField("name", VisitorTable.Name),
       SqlObject("totalRequestTime"),
     )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/VisitorTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/VisitorTable.scala
@@ -13,7 +13,7 @@ trait VisitorTable[F[_]] extends BaseMapping[F]:
     val ObservationId       = col("c_observation_id", observation_id)
     val ObservingModeType   = col("c_observing_mode_type", visitor_observing_mode_type)
     val CentralWavelength   = col("c_central_wavelength", wavelength_pm)
-    val ScienceFov          = col("c_science_fov", angle_µas)
+    val AgsDiameter         = col("c_ags_diameter", angle_µas)
     val Name                = col("c_name", text_nonempty.opt)
     val TotalRequestTime    = col("c_total_request_time", time_span.embedded)
     val TotalRequestTimeId  = col("c_total_request_time_id", observation_id.embedded)

--- a/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
@@ -341,7 +341,7 @@ object GuideService {
           case (c: visitor.Config, GuideProbe.PWFS1) if c.mode === VisitorObservingModeType.MaroonX =>
             AgsParams.MaroonX(PortDisposition.Bottom).withPWFS1.some
           case (c: visitor.Config, GuideProbe.PWFS2) =>
-            AgsParams.Visitor(c.scienceFov, PortDisposition.Bottom).withPWFS2.some
+            AgsParams.Visitor(c.agsDiameter, PortDisposition.Bottom).withPWFS2.some
           case _ =>
             none
 

--- a/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GuideService.scala
@@ -284,65 +284,65 @@ object GuideService {
 
     val (site, observingModeType, agsWavelength): (Site, ObservingModeType, Wavelength) =
       params.observingMode match
-        case mode: flamingos2.longslit.Config =>
+        case mode: flamingos2.longslit.Config                 =>
           (Site.GS, ObservingModeType.Flamingos2LongSlit, mode.filter.wavelength)
-        case mode: ghost.ifu.Config =>
+        case mode: ghost.ifu.Config                           =>
           (Site.GS, ObservingModeType.GhostIfu, GhostCentralWavelength)
         case gmos.imaging.Config.GmosNorth(filters = filters) =>
           (Site.GN, ObservingModeType.GmosNorthImaging, filters.map(_.filter.wavelength).maximum)
-        case mode: gmos.longslit.Config.GmosNorth =>
+        case mode: gmos.longslit.Config.GmosNorth             =>
           (Site.GN, ObservingModeType.GmosNorthLongSlit, mode.centralWavelength)
         case gmos.imaging.Config.GmosSouth(filters = filters) =>
           (Site.GS, ObservingModeType.GmosSouthImaging, filters.map(_.filter.wavelength).maximum)
-        case mode: gmos.longslit.Config.GmosSouth =>
+        case mode: gmos.longslit.Config.GmosSouth             =>
           (Site.GS, ObservingModeType.GmosSouthLongSlit, mode.centralWavelength)
-        case mode: gnirs.longslit.Config =>
+        case mode: gnirs.longslit.Config                      =>
           (Site.GN, ObservingModeType.GnirsLongSlit, mode.filter.centralWavelength)
-        case _: igrins2.longslit.Config =>
+        case _: igrins2.longslit.Config                       =>
           (Site.GN, ObservingModeType.Igrins2LongSlit, Igrins2CentralWavelength)
-        case visitor.Config(mode, wavelength, _, _, _) =>
+        case visitor.Config(mode, wavelength, _, _, _)        =>
           (mode.instrument.site, mode, wavelength)
 
     def agsParamsFor(trackType: TrackType): Option[AgsParams] =
       probes.guideProbe(observingModeType, trackType).flatMap: probe =>
         (params.observingMode, probe) match
-          case (gmos.longslit.Config.GmosNorth(fpu = fpu), GuideProbe.GmosOIWFS) =>
+          case (gmos.longslit.Config.GmosNorth(fpu = fpu), GuideProbe.GmosOIWFS)                            =>
             AgsParams.GmosLongSlit(fpu.asLeft, PortDisposition.Side).some
-          case (gmos.longslit.Config.GmosNorth(fpu = fpu), GuideProbe.PWFS1) =>
+          case (gmos.longslit.Config.GmosNorth(fpu = fpu), GuideProbe.PWFS1)                                =>
             AgsParams.GmosLongSlit(fpu.asLeft, PortDisposition.Side).withPWFS1.some
-          case (gmos.longslit.Config.GmosNorth(fpu = fpu), GuideProbe.PWFS2) =>
+          case (gmos.longslit.Config.GmosNorth(fpu = fpu), GuideProbe.PWFS2)                                =>
             AgsParams.GmosLongSlit(fpu.asLeft, PortDisposition.Side).withPWFS2.some
-          case (gmos.longslit.Config.GmosSouth(fpu = fpu), GuideProbe.GmosOIWFS) =>
+          case (gmos.longslit.Config.GmosSouth(fpu = fpu), GuideProbe.GmosOIWFS)                            =>
             AgsParams.GmosLongSlit(fpu.asRight, PortDisposition.Side).some
-          case (gmos.longslit.Config.GmosSouth(fpu = fpu), GuideProbe.PWFS1) =>
+          case (gmos.longslit.Config.GmosSouth(fpu = fpu), GuideProbe.PWFS1)                                =>
             AgsParams.GmosLongSlit(fpu.asRight, PortDisposition.Side).withPWFS1.some
-          case (gmos.longslit.Config.GmosSouth(fpu = fpu), GuideProbe.PWFS2) =>
+          case (gmos.longslit.Config.GmosSouth(fpu = fpu), GuideProbe.PWFS2)                                =>
             AgsParams.GmosLongSlit(fpu.asRight, PortDisposition.Side).withPWFS2.some
-          case (flamingos2.longslit.Config(fpu = fpu), GuideProbe.Flamingos2OIWFS) =>
+          case (flamingos2.longslit.Config(fpu = fpu), GuideProbe.Flamingos2OIWFS)                          =>
             AgsParams.Flamingos2LongSlit(Flamingos2LyotWheel.F16, Flamingos2FpuMask.Builtin(fpu), PortDisposition.Side).some
-          case (flamingos2.longslit.Config(fpu = fpu), GuideProbe.PWFS1) =>
+          case (flamingos2.longslit.Config(fpu = fpu), GuideProbe.PWFS1)                                    =>
             AgsParams.Flamingos2LongSlit(Flamingos2LyotWheel.F16, Flamingos2FpuMask.Builtin(fpu), PortDisposition.Side).withPWFS1.some
-          case (flamingos2.longslit.Config(fpu = fpu), GuideProbe.PWFS2) =>
+          case (flamingos2.longslit.Config(fpu = fpu), GuideProbe.PWFS2)                                    =>
             AgsParams.Flamingos2LongSlit(Flamingos2LyotWheel.F16, Flamingos2FpuMask.Builtin(fpu), PortDisposition.Side).withPWFS2.some
-          case (_: gmos.imaging.Config.GmosNorth | _: gmos.imaging.Config.GmosSouth, GuideProbe.GmosOIWFS) =>
+          case (_: gmos.imaging.Config.GmosNorth | _: gmos.imaging.Config.GmosSouth, GuideProbe.GmosOIWFS)  =>
             AgsParams.GmosImaging(PortDisposition.Side).some
-          case (_: gmos.imaging.Config.GmosNorth | _: gmos.imaging.Config.GmosSouth, GuideProbe.PWFS1) =>
+          case (_: gmos.imaging.Config.GmosNorth | _: gmos.imaging.Config.GmosSouth, GuideProbe.PWFS1)      =>
             AgsParams.GmosImaging(PortDisposition.Side).withPWFS1.some
-          case (_: gmos.imaging.Config.GmosNorth | _: gmos.imaging.Config.GmosSouth, GuideProbe.PWFS2) =>
+          case (_: gmos.imaging.Config.GmosNorth | _: gmos.imaging.Config.GmosSouth, GuideProbe.PWFS2)      =>
             AgsParams.GmosImaging(PortDisposition.Side).withPWFS2.some
-          case (_: igrins2.longslit.Config, GuideProbe.PWFS2) =>
+          case (_: igrins2.longslit.Config, GuideProbe.PWFS2)                                               =>
             AgsParams.Igrins2LongSlit(PortDisposition.Bottom).withPWFS2.some
-          case (_: igrins2.longslit.Config, GuideProbe.PWFS1) =>
+          case (_: igrins2.longslit.Config, GuideProbe.PWFS1)                                               =>
             AgsParams.Igrins2LongSlit(PortDisposition.Bottom).withPWFS1.some
-          case (_: ghost.ifu.Config, GuideProbe.PWFS2) =>
+          case (_: ghost.ifu.Config, GuideProbe.PWFS2)                                                      =>
             AgsParams.GhostIfu(PortDisposition.Bottom).withPWFS2.some
-          case (c: visitor.Config, GuideProbe.PWFS2) if c.mode === VisitorObservingModeType.MaroonX =>
+          case (c: visitor.Config, GuideProbe.PWFS2) if c.mode === VisitorObservingModeType.MaroonX         =>
             AgsParams.MaroonX(PortDisposition.Bottom).withPWFS2.some
-          case (c: visitor.Config, GuideProbe.PWFS1) if c.mode === VisitorObservingModeType.MaroonX =>
+          case (c: visitor.Config, GuideProbe.PWFS1) if c.mode === VisitorObservingModeType.MaroonX         =>
             AgsParams.MaroonX(PortDisposition.Bottom).withPWFS1.some
-          case (c: visitor.Config, GuideProbe.PWFS2) =>
+          case (c: visitor.Config, GuideProbe.PWFS2)                                                        =>
             AgsParams.Visitor(c.agsDiameter, PortDisposition.Bottom).withPWFS2.some
-          case _ =>
+          case _                                                                                            =>
             none
 
     def getScienceStartTime(obsTime: Timestamp): Timestamp = obsTime +| setupTime

--- a/modules/service/src/main/scala/lucuma/odb/service/VisitorService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/VisitorService.scala
@@ -96,7 +96,7 @@ object VisitorService:
               List(
                 SET.centralWavelength.map(sql"c_central_wavelength = $wavelength_pm"),
                 SET.mode.map(sql"c_observing_mode_type = $visitor_observing_mode_type"),
-                SET.scienceFov.map(sql"c_science_fov = $angle_µas"),
+                SET.agsDiameter.map(sql"c_ags_diameter = $angle_µas"),
                 SET.name.map(sql"c_name = $text_nonempty"),
                 SET.totalRequestTime.map(sql"c_total_request_time = $time_span")
               ).flatten
@@ -150,7 +150,7 @@ object VisitorService:
           c_observation_id,
           c_observing_mode_type,
           c_central_wavelength,
-          c_science_fov,
+          c_ags_diameter,
           c_name,
           c_total_request_time
         FROM
@@ -167,7 +167,7 @@ object VisitorService:
           c_observation_id,
           c_observing_mode_type,
           c_central_wavelength,
-          c_science_fov,
+          c_ags_diameter,
           c_name,
           c_total_request_time
         ) VALUES (

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -1232,7 +1232,7 @@ trait DatabaseOperations { this: OdbSuite =>
           visitor: {
             mode: ${v.tag.toScreamingSnakeCase}
             centralWavelength: { nanometers: 2200 }
-            scienceFov: { arcseconds: 1 }$extras
+            agsDiameter: { arcseconds: 1 }$extras
           }
         }"""
 
@@ -1342,7 +1342,7 @@ trait DatabaseOperations { this: OdbSuite =>
           visitor: {
             mode: ${v.tag.toScreamingSnakeCase}
             centralWavelength: { nanometers: 2200 }
-            scienceFov: { arcseconds: 1 }$extras
+            agsDiameter: { arcseconds: 1 }$extras
           }
         }"""
       case _ => ???

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation.scala
@@ -2979,7 +2979,7 @@ class createObservation extends OdbSuite with TelluricTypeGraphQLFormat {
       visitor: {
         mode: $mode
         centralWavelength: { nanometers: 2200 }
-        scienceFov: { arcseconds: 1 }
+        agsDiameter: { arcseconds: 1 }
         $extras
       }
     """

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setObservationWorkflowState.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setObservationWorkflowState.scala
@@ -251,7 +251,7 @@ class setObservationWorkflowState
         centralWavelength: {
           picometers: 123
         }
-        scienceFov: {
+        agsDiameter: {
           arcminutes: 1.23
         }
       }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations.scala
@@ -4799,7 +4799,7 @@ class updateObservations extends OdbSuite with UpdateObservationsOps with Execut
         visitor: {
           mode: VISITOR_NORTH
           centralWavelength: { nanometers: 2200 }
-          scienceFov: { degrees: 1 }
+          agsDiameter: { degrees: 1 }
         }
       }
     """
@@ -4816,7 +4816,7 @@ class updateObservations extends OdbSuite with UpdateObservationsOps with Execut
         visitor: {
           mode: VISITOR_NORTH
           centralWavelength: { nanometers: 2200 }
-          scienceFov: { degrees: 1 }
+          agsDiameter: { degrees: 1 }
           name: "north run"
           totalRequestTime: { hours: 3 }
         }
@@ -4847,7 +4847,7 @@ class updateObservations extends OdbSuite with UpdateObservationsOps with Execut
         observingMode {
           visitor {
             mode
-            scienceFov { arcseconds }
+            agsDiameter { arcseconds }
             name
             totalRequestTime { hours }
           }
@@ -4865,7 +4865,7 @@ class updateObservations extends OdbSuite with UpdateObservationsOps with Execut
                 "observingMode": {
                   "visitor": {
                     "mode": $mode,
-                    "scienceFov": { "arcseconds": $fovArcsec },
+                    "agsDiameter": { "arcseconds": $fovArcsec },
                     "name": "IQUEYE",
                     "totalRequestTime": { "hours": ${BigDecimal(hours).setScale(6)} }
                   }
@@ -4881,7 +4881,7 @@ class updateObservations extends OdbSuite with UpdateObservationsOps with Execut
         visitor: {
           mode: VISITOR_NORTH
           centralWavelength: { nanometers: 2200 }
-          scienceFov: { arcseconds: 5 }
+          agsDiameter: { arcseconds: 5 }
           name: "IQUEYE"
           totalRequestTime: { hours: 3 }
         }
@@ -4898,11 +4898,11 @@ class updateObservations extends OdbSuite with UpdateObservationsOps with Execut
       }
     """
 
-    val editScienceFov = """
+    val editAgsDiameter = """
       observingMode: {
         visitor: {
           mode: VISITOR_NORTH
-          scienceFov: { arcseconds: 10 }
+          agsDiameter: { arcseconds: 10 }
         }
       }
     """
@@ -4912,7 +4912,7 @@ class updateObservations extends OdbSuite with UpdateObservationsOps with Execut
         visitor: {
           mode: VISITOR_SOUTH
           centralWavelength: { nanometers: 2200 }
-          scienceFov: { arcseconds: 5 }
+          agsDiameter: { arcseconds: 5 }
           name: "IQUEYE"
           totalRequestTime: { hours: 3 }
         }
@@ -4923,7 +4923,7 @@ class updateObservations extends OdbSuite with UpdateObservationsOps with Execut
       List(
         (create,               AlienVisQuery, expected("VISITOR_NORTH",  5, 3)),
         (editTotalRequestTime, AlienVisQuery, expected("VISITOR_NORTH",  5, 4)),
-        (editScienceFov,       AlienVisQuery, expected("VISITOR_NORTH", 10, 4)),
+        (editAgsDiameter,       AlienVisQuery, expected("VISITOR_NORTH", 10, 4)),
         (switchToSouth,        AlienVisQuery, expected("VISITOR_SOUTH",  5, 3))
       )
     )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionPlannedTime_AlienVisitor.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionPlannedTime_AlienVisitor.scala
@@ -31,7 +31,7 @@ class executionPlannedTime_AlienVisitor extends ExecutionTestSupport:
                 visitor: {
                   mode: ${mode.tag.toScreamingSnakeCase}
                   centralWavelength: { nanometers: 2200 }
-                  scienceFov: { arcseconds: 1 }
+                  agsDiameter: { arcseconds: 1 }
                   name: "test visitor"
                   totalRequestTime: { milliseconds: ${time.toMilliseconds} }
                 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow_viistors.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow_viistors.scala
@@ -83,7 +83,7 @@ class observation_workflow_visitors extends OdbSuite with ObservingModeSetupOper
         centralWavelength: {
           picometers: 123
         }
-        scienceFov: {
+        agsDiameter: {
           arcminutes: 1.23
         }
       }


### PR DESCRIPTION
MaroonX will use the sky fiber diameter of 30 arcsecs rather than the fiber fov

Now looking at the schema changes, should we keep both fields? it would only make a difference for MaroonX @swalker2m wdyt?

Don't merge until explore is updated