### PR TITLE
Shortcut 7179: un-splittable observations (part 3)

### DIFF
--- a/docker-init/02-migrate-sso.sh
+++ b/docker-init/02-migrate-sso.sh
@@ -8,11 +8,11 @@ SSO_MIGRATIONS_DIR="/docker-entrypoint-initdb.d/sso-migrations"
 
 if [ -d "$SSO_MIGRATIONS_DIR" ]; then
     # Apply migrations in version order
-    for migration_file in $(ls "$SSO_MIGRATIONS_DIR"/V*.sql | sort -V); do
+    while IFS= read -r migration_file; do
         if [ -f "$migration_file" ]; then
             psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "lucuma-sso" < "$migration_file"
         fi
-    done
+    done < <(ls "$SSO_MIGRATIONS_DIR"/V*.sql | sort -V)
 else
     echo "Warning: SSO migrations directory $SSO_MIGRATIONS_DIR does not exist"
 fi

--- a/docker-init/03-migrate-odb.sh
+++ b/docker-init/03-migrate-odb.sh
@@ -8,11 +8,11 @@ ODB_MIGRATIONS_DIR="/docker-entrypoint-initdb.d/odb-migrations"
 
 if [ -d "$ODB_MIGRATIONS_DIR" ]; then
     # Apply migrations in version order
-    for migration_file in $(ls "$ODB_MIGRATIONS_DIR"/V*.sql | sort -V); do
+    while IFS= read -r migration_file; do
         if [ -f "$migration_file" ]; then
             psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "lucuma-odb" < "$migration_file"
         fi
-    done
+    done < <(ls "$ODB_MIGRATIONS_DIR"/V*.sql | sort -V)
 else
     echo "Warning: ODB migrations directory $ODB_MIGRATIONS_DIR does not exist"
 fi

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/GeneratorParams.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/GeneratorParams.scala
@@ -23,7 +23,8 @@ case class GeneratorParams(
   calibrationRole:  Option[CalibrationRole],
   declaredState:    Option[DeclaredExecutionState],
   executionState:   ExecutionState,
-  stepCount:        Long
+  stepCount:        Long,
+  isSplittable:     Boolean
 )
 
 object GeneratorParams:
@@ -37,7 +38,8 @@ object GeneratorParams:
         a.calibrationRole,
         a.declaredState,
         a.executionState,
-        a.stepCount
+        a.stepCount,
+        a.isSplittable
       )
 
   given HashBytes[GeneratorParams] with
@@ -49,5 +51,6 @@ object GeneratorParams:
         a.calibrationRole.hashBytes,
         a.declaredState.hashBytes,
         a.executionState.hashBytes,
-        a.stepCount.hashBytes
+        a.stepCount.hashBytes,
+        a.isSplittable.hashBytes
       )

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/StreamingExecutionConfig.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/StreamingExecutionConfig.scala
@@ -52,16 +52,16 @@ object StreamingExecutionConfig:
      */
     def unsplit(
       observationId: Observation.Id,
-      description: NonEmptyString = UnsplittableAtom.Descripton,
+      description: NonEmptyString = UnsplittableAtom.Description,
       stepLimit: PosInt           = UnsplittableAtom.StepLimit
     ): Either[OdbError, StreamingExecutionConfig[Pure, S, D]]  =
-      self.science.toList match
-        case Nil          =>
+      self.science.take(1).toList match
+        case Nil       =>
           self.asRight
-        case head :: tail =>
+        case head :: _ =>
           val allSteps =
-            (Stream.emits(head.steps.toList) ++
-             Stream.emits(tail).flatMap(a => Stream.emits(a.steps.toList)))
+            self.science
+              .flatMap(a => Stream.emits(a.steps.toList))
               .take(stepLimit.value.toLong + 1)
               .toList
           Either.cond(

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/StreamingExecutionConfig.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/StreamingExecutionConfig.scala
@@ -3,9 +3,15 @@
 
 package lucuma.odb.sequence.data
 
+import cats.data.NonEmptyList
+import cats.syntax.all.*
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.NonEmptyString
 import fs2.Pure
 import fs2.Stream
+import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Atom
+import lucuma.odb.data.OdbError
 
 /**
  * A precursor to a lucuma.core.model.sequence.ExecutionConfig, which contains
@@ -32,3 +38,34 @@ object StreamingExecutionConfig:
         self.acquisition.covary[F],
         self.science.covary[F]
       )
+
+    /**
+     * Converts the science sequence of a StreamingExecutionConfig into a
+     * one-atom sequence containing all the steps of whatever atoms it otherwise
+     * would contain.
+     *
+     * @param observationId observation id (used for the message if there is an error)
+     * @param description atom description
+     * @param stepLimit maximum number of steps that may appear in the atom
+     *
+     * @return a new StreamingExecutionConfig with a single-atom science sequence
+     */
+    def unsplit(
+      observationId: Observation.Id,
+      description: NonEmptyString = UnsplittableAtom.Descripton,
+      stepLimit: PosInt           = UnsplittableAtom.StepLimit
+    ): Either[OdbError, StreamingExecutionConfig[Pure, S, D]]  =
+      self.science.toList match
+        case Nil          =>
+          self.asRight
+        case head :: tail =>
+          val allSteps =
+            (Stream.emits(head.steps.toList) ++
+             Stream.emits(tail).flatMap(a => Stream.emits(a.steps.toList)))
+              .take(stepLimit.value.toLong + 1)
+              .toList
+          Either.cond(
+            allSteps.sizeIs <= stepLimit.value,
+            self.copy(science = Stream.emit(Atom(head.id, description.some, NonEmptyList.fromListUnsafe(allSteps)))),
+            OdbError.SequenceUnavailable(observationId, s"Unsplittable observation contains too many (> ${stepLimit.value}) steps.".some)
+          )

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/UnsplittableAtom.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/UnsplittableAtom.scala
@@ -12,7 +12,7 @@ object UnsplittableAtom:
    * Default title for the single atom that appears in the science sequence of
    * an unsplittable observation.
    */
-  val Descripton: NonEmptyString =
+  val Description: NonEmptyString =
     NonEmptyString.unsafeFrom("Unsplittable Science Atom")
 
   /**

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/UnsplittableAtom.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/UnsplittableAtom.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence.data
+
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.NonEmptyString
+
+object UnsplittableAtom:
+
+  /**
+   * Default title for the single atom that appears in the science sequence of
+   * an unsplittable observation.
+   */
+  val Descripton: NonEmptyString =
+    NonEmptyString.unsafeFrom("Unsplittable Science Atom")
+
+  /**
+   * Size limit for the number of steps in the single atom of an unsplittable
+   * observation.
+   */
+  val StepLimit: PosInt =
+    PosInt.unsafeFrom(2048)

--- a/modules/sequence/src/test/scala/lucuma/odb/sequence/data/arb/ArbGeneratorParams.scala
+++ b/modules/sequence/src/test/scala/lucuma/odb/sequence/data/arb/ArbGeneratorParams.scala
@@ -44,7 +44,8 @@ trait ArbGeneratorParams:
       dc  <- arbitrary[Option[DeclaredExecutionState]]
       es  <- arbitrary[ExecutionState]
       sc  <- arbitrary[Long]
-    yield GeneratorParams(Either.right(itc), bnd, cfg, rol, dc, es, sc)
+      sp  <- arbitrary[Boolean]
+    yield GeneratorParams(Either.right(itc), bnd, cfg, rol, dc, es, sc, sp)
 
   val genGmosSouthLongSlit: Gen[GeneratorParams] =
     for
@@ -56,7 +57,8 @@ trait ArbGeneratorParams:
       dc  <- arbitrary[Option[DeclaredExecutionState]]
       es  <- arbitrary[ExecutionState]
       sc  <- arbitrary[Long]
-    yield GeneratorParams(Either.right(itc), bnd, cfg, rol, dc, es, sc)
+      sp  <- arbitrary[Boolean]
+    yield GeneratorParams(Either.right(itc), bnd, cfg, rol, dc, es, sc, sp)
 
   given Arbitrary[GeneratorParams] =
     Arbitrary:

--- a/modules/service/src/main/resources/db/migration/V1174__scheduling.sql
+++ b/modules/service/src/main/resources/db/migration/V1174__scheduling.sql
@@ -1,0 +1,84 @@
+-- Update v_generator_params from V1141 to add the splittable flag.
+
+DROP VIEW v_generator_params;
+
+CREATE VIEW v_generator_params AS
+SELECT
+  o.c_program_id,
+  o.c_observation_id,
+  o.c_calibration_role,
+  o.c_image_quality,
+  o.c_cloud_extinction,
+  o.c_sky_background,
+  o.c_water_vapor,
+  o.c_air_mass_min,
+  o.c_air_mass_max,
+  o.c_hour_angle_min,
+  o.c_hour_angle_max,
+  e.c_exposure_time_mode,
+  e.c_signal_to_noise,
+  e.c_signal_to_noise_at,
+  e.c_exposure_time,
+  e.c_exposure_count,
+  o.c_observing_mode_type,
+  o.c_science_band,
+  o.c_declared_state,
+  CASE
+    -- The observation has a declared state.
+    WHEN o.c_declared_state IS NOT NULL THEN o.c_declared_state
+
+    -- No events have been fired at all -> not_started (just slewing to the
+    -- target doesn't count as execution).
+    WHEN NOT EXISTS (
+      SELECT 1
+      FROM   t_execution_event v
+      WHERE  v.c_observation_id = o.c_observation_id
+        AND  v.c_event_type != 'slew'::e_execution_event_type
+    ) THEN 'not_started'::e_execution_state
+
+    -- At least one step not completed -> ongoing
+    WHEN EXISTS (
+      SELECT 1
+      FROM t_step s
+      JOIN t_atom a ON a.c_atom_id = s.c_atom_id AND a.c_observation_id = o.c_observation_id AND a.c_sequence_type = 'science'
+      LEFT JOIN t_step_execution se       ON se.c_step_id = s.c_step_id
+      LEFT JOIN t_step_execution_state es ON es.c_tag     = se.c_execution_state AND es.c_terminal
+      WHERE es.c_tag IS NULL -- no step execution or a non-terminal execution state
+    ) THEN 'ongoing'::e_execution_state
+
+    ELSE 'completed'::e_execution_state
+  END AS c_execution_state,
+  COALESCE(s_counts.c_step_count, 0) AS c_step_count,
+  o.c_is_splittable,
+  o.c_blind_offset_target_id,
+  b.c_sid_rv AS c_blind_rv,
+  b.c_source_profile AS c_blind_source_profile,
+  t.c_target_id,
+  t.c_sid_rv,
+  t.c_source_profile
+FROM
+  t_observation o
+LEFT JOIN t_target b ON b.c_target_id = o.c_blind_offset_target_id
+LEFT JOIN LATERAL (
+  SELECT t.c_target_id,
+         t.c_sid_rv,
+         t.c_source_profile
+    FROM t_asterism_target a
+    INNER JOIN t_target t
+      ON a.c_target_id = t.c_target_id
+     AND t.c_existence = 'present'
+   WHERE a.c_observation_id = o.c_observation_id
+) t ON TRUE
+LEFT JOIN t_exposure_time_mode e
+  ON e.c_observation_id = o.c_observation_id
+ AND e.c_role = 'requirement'
+LEFT JOIN (
+  SELECT
+    se.c_observation_id,
+    COUNT(*) AS c_step_count
+  FROM t_step_execution se
+  GROUP BY se.c_observation_id
+) s_counts ON s_counts.c_observation_id = o.c_observation_id
+ORDER BY
+  o.c_observation_id,
+  t.c_target_id;

--- a/modules/service/src/main/scala/lucuma/odb/logic/GeneratorStreaming.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/GeneratorStreaming.scala
@@ -10,6 +10,7 @@ import cats.syntax.either.*
 import cats.syntax.flatMap.*
 import cats.syntax.functor.*
 import cats.syntax.option.*
+import fs2.Pure
 import fs2.Stream
 import lucuma.core.enums.SequenceType
 import lucuma.core.model.Observation
@@ -193,6 +194,16 @@ object GeneratorStreaming:
           r <- result(a, s)
         yield r
 
+      private def collapseIfNecessary[S, D](
+        context: GeneratorContext,
+        gen:     StreamingExecutionConfig[Pure, S, D]
+      ): EitherT[F, OdbError, StreamingExecutionConfig[F, S, D]] =
+        EitherT.fromEither:
+          (
+            if context.params.isSplittable then gen.asRight
+            else gen.unsplit(context.oid)
+          ).map(_.covary[F])
+
       override def selectOrGenerateFlamingos2LongSlit(
         context: GeneratorContext
       )(using Transaction[F]): F[Either[OdbError, StreamingExecutionConfig[F, Flamingos2Static, Flamingos2Dynamic]]] =
@@ -211,7 +222,8 @@ object GeneratorStreaming:
           itc  = requireSpectroscopyItc(context.oid, context.itcRes)
           rol  = context.params.calibrationRole
           gen <- EitherT(LongSlit.instantiate(context.oid, calculator.flamingos2Step, context.namespace, exp.flamingos2, cfg, itc, rol))
-        yield gen.covary[F]).value
+          res <- collapseIfNecessary(context, gen)
+        yield res).value
 
       override def selectOrGenerateGhost(
         context: GeneratorContext
@@ -236,7 +248,8 @@ object GeneratorStreaming:
           stc <- EitherT(ghostIfuService.computeStatic(context.oid))
           itc  = requireGhostItc(context.oid, context.itcRes)
           gen <- EitherT(Ifu.instantiate(calculator.ghostStep, stc, context.namespace, exp.ghost, cfg, itc))
-        yield gen.covary[F]).value
+          res <- collapseIfNecessary(context, gen)
+        yield res).value
 
       override def selectOrGenerateIgrins2LongSlit(
         context: GeneratorContext
@@ -260,7 +273,8 @@ object GeneratorStreaming:
           itc  = requireIgrins2SpectroscopyItc(context.oid, context.itcRes)
           rol  = context.params.calibrationRole
           gen <- EitherT.fromEither(LongSlit.instantiate(context.oid, calculator.igrins2Step, context.namespace, cfg, itc, rol))
-        yield gen.covary[F]).value
+          res <- collapseIfNecessary(context, gen)
+        yield res).value
 
       override def selectOrGenerateGnirsLongSlit(
         context: GeneratorContext
@@ -283,7 +297,8 @@ object GeneratorStreaming:
           cfg <- extractMode(ObservingMode.GnirsLongSlitName, context)(_.asGnirsLongSlit)
           itc  = requireSpectroscopyItc(context.oid, context.itcRes)
           gen <- EitherT.fromEither(LongSlit.instantiate(context.oid, calculator.gnirsStep, context.namespace, cfg, itc))
-        yield gen.covary[F]).value
+          res <- collapseIfNecessary(context, gen)
+        yield res).value
 
       override def selectOrGenerateGmosNorthImaging(
         context: GeneratorContext
@@ -305,7 +320,8 @@ object GeneratorStreaming:
           cfg <- extractMode(ObservingMode.GmosNorthImagingName, context)(_.asGmosNorthImaging)
           itc  = requireImagingItc(ObservingMode.GmosNorthImagingName, context.oid, context.itcRes, Itc.gmosNorthImaging.getOption)
           gen <- EitherT(Imaging.gmosNorth(calculator.gmosNorthStep, context.namespace, cfg, itc))
-        yield gen.covary[F]).value
+          res <- collapseIfNecessary(context, gen)
+        yield res).value
 
       override def selectOrGenerateGmosNorthLongSlit(
         context: GeneratorContext
@@ -325,7 +341,8 @@ object GeneratorStreaming:
           itc  = requireSpectroscopyItc(context.oid, context.itcRes)
           rol  = context.params.calibrationRole
           gen <- EitherT(LongSlit.gmosNorth(context.oid, calculator.gmosNorthStep, context.namespace, exp.gmosNorth, cfg, itc, rol))
-        yield gen.covary[F]).value
+          res <- collapseIfNecessary(context, gen)
+        yield res).value
 
 
       override def selectOrGenerateGmosSouthImaging(
@@ -348,7 +365,8 @@ object GeneratorStreaming:
           cfg <- extractMode(ObservingMode.GmosSouthImagingName, context)(_.asGmosSouthImaging)
           itc  = requireImagingItc(ObservingMode.GmosSouthImagingName, context.oid, context.itcRes, Itc.gmosSouthImaging.getOption)
           gen <- EitherT(Imaging.gmosSouth(calculator.gmosSouthStep, context.namespace, cfg, itc))
-        yield gen.covary[F]).value
+          res <- collapseIfNecessary(context, gen)
+        yield res).value
 
 
       override def selectOrGenerateGmosSouthLongSlit(
@@ -369,4 +387,5 @@ object GeneratorStreaming:
           itc  = requireSpectroscopyItc(context.oid, context.itcRes)
           rol  = context.params.calibrationRole
           gen <- EitherT(LongSlit.gmosSouth(context.oid, calculator.gmosSouthStep, context.namespace, exp.gmosSouth, cfg, itc, rol))
-        yield gen.covary[F]).value
+          res <- collapseIfNecessary(context, gen)
+        yield res).value

--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsService.scala
@@ -111,7 +111,7 @@ object CalibrationsService extends CalibrationObservations {
         requiresItcInputs: Boolean
       ): PartialFunction[(Observation.Id, Either[GeneratorParamsService.Error, GeneratorParams]), ObsExtract[ObservingMode]] =
         {
-          case (oid, Right(GeneratorParams(itc, band, mode, calibRole, _, _, _))) if itc.isRight || !requiresItcInputs =>
+          case (oid, Right(GeneratorParams(itc, band, mode, calibRole, _, _, _, _))) if itc.isRight || !requiresItcInputs =>
             ObsExtract(oid, itc.toOption, band, calibRole, mode)
         }
 

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -59,6 +59,7 @@ import lucuma.odb.sequence.visitor
 import lucuma.odb.util.Codecs.*
 import skunk.*
 import skunk.circe.codec.json.*
+import skunk.codec.boolean.bool
 import skunk.codec.numeric.int8
 import skunk.implicits.*
 
@@ -174,7 +175,7 @@ object GeneratorParamsService {
       )(using Transaction[F]): F[Map[Observation.Id, Either[Error, GeneratorParams]]] =
         for
           paramsRows <- params
-          oms         = paramsRows.collect { case ParamsRow(oid, _, _, _, Some(om), _, _, _, _, _, _, _, _, _, _, _) => (oid, om) }.distinct
+          oms         = paramsRows.collect { case ParamsRow(oid, _, _, _, Some(om), _, _, _, _, _, _, _, _, _, _, _, _) => (oid, om) }.distinct
           m          <- Services.asSuperUser(observingModeServices.selectObservingMode(oms))
         yield
           NonEmptyList.fromList(paramsRows).fold(Map.empty): paramsRowsNel =>
@@ -277,7 +278,7 @@ object GeneratorParamsService {
             .leftMap(MissingParamSet.fromParams)
             .toEither
 
-          GeneratorParams(itcInput, obsParams.scienceBand, obsMode, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount)
+          GeneratorParams(itcInput, obsParams.scienceBand, obsMode, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount, obsParams.isSplittable)
 
         observingMode(obsParams.targets, config).flatMap:
 
@@ -305,7 +306,7 @@ object GeneratorParamsService {
                   .leftMap(MissingParamSet.fromParams)
                   .toEither
 
-              GeneratorParams(itcInput, obsParams.scienceBand, gh, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount)
+              GeneratorParams(itcInput, obsParams.scienceBand, gh, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount, obsParams.isSplittable)
 
           case gn @ gmos.longslit.Config.GmosNorth(g, f, u, c, a) =>
             val sciMode = InstrumentMode.GmosNorthSpectroscopy(
@@ -378,7 +379,7 @@ object GeneratorParamsService {
                 .leftMap(MissingParamSet.fromParams)
                 .toEither
 
-            GeneratorParams(itcInput, obsParams.scienceBand, ig, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount).asRight
+            GeneratorParams(itcInput, obsParams.scienceBand, ig, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount, obsParams.isSplittable).asRight
 
           case gn @ gmos.imaging.Config.GmosNorth(_, fs, _) =>
             // An input per filter.
@@ -396,7 +397,7 @@ object GeneratorParamsService {
                 .leftMap(MissingParamSet.fromParams)
                 .toEither
 
-            GeneratorParams(itcInput, obsParams.scienceBand, gn, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount).asRight
+            GeneratorParams(itcInput, obsParams.scienceBand, gn, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount, obsParams.isSplittable).asRight
 
           case gs @ gmos.imaging.Config.GmosSouth(_, fs, _) =>
             // An input per filter.
@@ -414,7 +415,7 @@ object GeneratorParamsService {
                 .leftMap(MissingParamSet.fromParams)
                 .toEither
 
-            GeneratorParams(itcInput, obsParams.scienceBand, gs, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount).asRight
+            GeneratorParams(itcInput, obsParams.scienceBand, gs, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount, obsParams.isSplittable).asRight
 
           case gn: gnirs.longslit.Config =>
             for
@@ -462,7 +463,8 @@ object GeneratorParamsService {
               obsParams.calibrationRole,
               obsParams.declaredState,
               obsParams.executionState,
-              obsParams.stepCount
+              obsParams.stepCount,
+              obsParams.isSplittable
             ).asRight
           
 
@@ -517,6 +519,7 @@ object GeneratorParamsService {
     declaredState:       Option[DeclaredExecutionState],
     executionState:      ExecutionState,
     stepCount:           Long,
+    isSplittable:        Boolean,
     customSedTimestamp:  Option[Timestamp] = none
   )
 
@@ -538,7 +541,8 @@ object GeneratorParamsService {
     targets:           NonEmptyList[TargetParams],
     declaredState:     Option[DeclaredExecutionState],
     executionState:    ExecutionState,
-    stepCount:         Long
+    stepCount:         Long,
+    isSplittable:      Boolean
   )
 
   object ObsParams {
@@ -556,7 +560,8 @@ object GeneratorParamsService {
             TargetParams(r.targetId, r.radialVelocity, r.sourceProfile, r.customSedTimestamp),
           oParams.head.declaredState,
           oParams.head.executionState,
-          oParams.head.stepCount
+          oParams.head.stepCount,
+          oParams.head.isSplittable
         )
       .toMap
   }
@@ -597,9 +602,10 @@ object GeneratorParamsService {
        source_profile.opt      *:
        declared_execution_state.opt *:
        execution_state         *:
-       int8
-      ).map( (oid, role, cs, etm, om, sb, btid, brv, bsp, tid, rv, sp, dc, es, sc) =>
-        ParamsRow(oid, role, cs, etm, om, sb, btid, brv, bsp, tid, rv, sp, dc, es, sc, None))
+       int8                    *:
+       bool
+      ).map( (oid, role, cs, etm, om, sb, btid, brv, bsp, tid, rv, sp, dc, es, sc, split) =>
+        ParamsRow(oid, role, cs, etm, om, sb, btid, brv, bsp, tid, rv, sp, dc, es, sc, split, None))
 
     private def ParamColumns(tab: String): String =
       s"""
@@ -628,7 +634,8 @@ object GeneratorParamsService {
         $tab.c_source_profile,
         $tab.c_declared_state,
         $tab.c_execution_state,
-        $tab.c_step_count
+        $tab.c_step_count,
+        $tab.c_is_splittable
       """
 
     def selectManyParams(

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -491,9 +491,9 @@ object ObservationWorkflowService {
         val generatorValidator: Validator = info =>
           if info.isVisitor then ObservationValidationMap.empty
           else info.generatorParams.foldMap:
-            case Left(error)                                       => ObservationValidationMap.singleton(error.toObsValidation)
-            case Right(GeneratorParams(Left(m), _, _, _, _, _, _)) => ObservationValidationMap.singleton(m.toObsValidation)
-            case Right(ps)                                         => ObservationValidationMap.empty
+            case Left(error)                                          => ObservationValidationMap.singleton(error.toObsValidation)
+            case Right(GeneratorParams(Left(m), _, _, _, _, _, _, _)) => ObservationValidationMap.singleton(m.toObsValidation)
+            case Right(ps)                                            => ObservationValidationMap.empty
 
         val cfpInstrumentValidator: Validator = info =>
           info.cfpInfo.foldMap: cfp =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -4384,4 +4384,31 @@ trait DatabaseOperations { this: OdbSuite =>
   |""".stripMargin
   )
 
+  def setIsSplittableAs(
+    user:         User,
+    oid:          Observation.Id,
+    isSplittable: Boolean
+  ): IO[Unit] =
+    query(
+      user  = user,
+      query = s"""
+        mutation {
+          updateObservations(input: {
+            SET: {
+              schedulingConstraints: {
+                isSplittable: $isSplittable
+              }
+            }
+            WHERE: {
+              id: { EQ: "$oid" }
+            }
+          }) {
+            observations {
+              id
+            }
+          }
+        }
+      """
+    ).void
+
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
@@ -9,9 +9,11 @@ import cats.effect.IO
 import cats.syntax.all.*
 import io.circe.Json
 import io.circe.literal.*
+import io.circe.syntax.*
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.DatasetQaState
 import lucuma.core.enums.DatasetStage
+import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.StepGuideState
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
@@ -29,6 +31,7 @@ import lucuma.core.syntax.string.*
 import lucuma.core.util.Timestamp
 import lucuma.odb.graphql.enums.Enums
 import lucuma.odb.logic.TimeEstimateCalculatorImplementation
+import lucuma.odb.sequence.data.UnsplittableAtom
 import lucuma.odb.service.Services
 import lucuma.odb.service.UserService
 import lucuma.odb.util.Codecs.*
@@ -289,4 +292,41 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations wi
                      Services.asSuperUser(services.telluricTargetsService.resolveTargets(p))
       yield ()
     }
+
+  def expectedUnsplittableExecutionConfig(
+    instrument:       String,
+    expectedAtomHead: Json,
+    expectedAtomTail: Json*
+  ): Json =
+    Json.obj(
+      "executionConfig" -> Json.obj(
+        instrument -> Json.obj(
+          "science" -> Json.obj(
+            "nextAtom" ->
+              expectedUnsplittableAtom(
+                expectedAtomHead,
+                expectedAtomTail*
+              ),
+            "possibleFuture" -> List.empty[Json].asJson,
+            "hasMore" -> false.asJson
+          )
+        )
+      )
+    )
+
+  def expectedUnsplittableAtom(
+    expectedAtomHead: Json,
+    expectedAtomTail: Json*
+  ): Json =
+    val steps: List[Json] =
+      (expectedAtomHead +: expectedAtomTail.toVector)
+        .flatMap: atom =>
+          atom.asObject.get.toMap.get("steps").get.asArray.toVector.flatten
+        .toList
+
+    Json.obj(
+      "description"  -> UnsplittableAtom.Descripton.value.asJson,
+      "observeClass" -> ObserveClass.Science.tag.toScreamingSnakeCase.asJson,
+      "steps"        -> steps.asJson
+    )
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupport.scala
@@ -325,7 +325,7 @@ trait ExecutionTestSupport extends OdbSuite with ObservingModeSetupOperations wi
         .toList
 
     Json.obj(
-      "description"  -> UnsplittableAtom.Descripton.value.asJson,
+      "description"  -> UnsplittableAtom.Description.value.asJson,
       "observeClass" -> ObserveClass.Science.tag.toScreamingSnakeCase.asJson,
       "steps"        -> steps.asJson
     )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciFlamingos2.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciFlamingos2.scala
@@ -178,3 +178,23 @@ class executionSciFlamingos2 extends ExecutionTestSupportForFlamingos2:
             s"Could not generate a sequence for $oid: At least one exposure must be taken on slit."
           ).asLeft
       )
+
+  test("simple generation - unsplittable"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createFlamingos2LongSlitObservationAs(pi, p, List(t))
+        _ <- setIsSplittableAs(pi, o, isSplittable = false)
+      yield o
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = flamingos2ScienceQuery(oid, 1.some),
+        expected = expectedUnsplittableExecutionConfig(
+          "flamingos2",
+          flamingos2ExpectedScienceAtom(ExposureTime, (0, 15, Enabled), (0, -15, Enabled), (0, -15, Enabled), (0, 15, Enabled)),
+          flamingos2ExpectedGcals((0, 15))
+        ).asRight
+      )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGmosNorth.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGmosNorth.scala
@@ -755,3 +755,25 @@ class executionSciGmosNorth extends ExecutionTestSupportForGmos:
       yield Set(x0, x1, x2, x3, x4, x5)
 
     assertIO(execSci.map(_.size), 1)
+
+  test("simple generation - unsplittable"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setIsSplittableAs(pi, o, isSplittable = false)
+      yield o
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = gmosNorthScienceQuery(oid),
+        expected = expectedUnsplittableExecutionConfig(
+          "gmosNorth",
+          gmosNorthExpectedScienceAtom(ditherNm =  0, 0, 15, -15),
+          gmosNorthExpectedScienceAtom(ditherNm =  5, 0, 15, -15),
+          gmosNorthExpectedScienceAtom(ditherNm = -5, 0, 15, -15),
+          gmosNorthExpectedScienceAtom(ditherNm =  0, 0)
+        ).asRight
+      )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGmosNorthImaging.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGmosNorthImaging.scala
@@ -259,6 +259,44 @@ class executionSciGmosNorthImaging extends ExecutionTestSupportForGmos:
         expected = expectedResult(json).asRight
       )
 
+  test("grouped, no offsets, no sky (INCREASING), Unsplittable"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservation(p, t, Site.GN):
+          s"""{
+            gmosNorthImaging: {
+              variant: {
+                grouped: { skyCount: 0 }
+              }
+              filters: [
+                { filter: G_PRIME },
+                { filter: I_PRIME },
+                { filter: Y       }
+              ]
+            }
+          }"""
+        _ <- setIsSplittableAs(pi, o, isSplittable = false)
+      yield o
+
+    val json: List[Json] = List(
+      List.fill( 6)(gnAtom(Step(GmosNorthFilter.GPrime, Time120x06))) ++
+      List.fill(12)(gnAtom(Step(GmosNorthFilter.IPrime, Time060x12))) ++
+      List.fill(30)(gnAtom(Step(GmosNorthFilter.Y,      Time030x30)))
+    ).flatten
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = gmosNorthScienceQuery(oid, 100.some),
+        expected = expectedUnsplittableExecutionConfig(
+          "gmosNorth",
+          json.head,
+          json.tail*
+        ).asRight
+      )
+
   test("grouped, no offsets, no sky (DECREASING)"):
     val setup: IO[Observation.Id] =
       for

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
@@ -76,6 +76,26 @@ class executionSciGnirsLongSlit extends ExecutionTestSupportForGnirs:
           ).asRight
       )
 
+  test("[gnirs] short camera default offsets, exposureCount=3 -> 1 cycle of 4, unsplittable"):
+    for
+      o <- gnirsObs
+      _ <- setIsSplittableAs(pi, o, isSplittable = false)
+      _ <- expect(
+        user     = pi,
+        query    = gnirsScienceQuery(o),
+        expected = expectedUnsplittableExecutionConfig(
+          "gnirs",
+          gnirsExpectedScienceAtom(
+            DynamicSnapshot,
+            (0,  2, Enabled),
+            (0, -4, Enabled),
+            (0, -4, Enabled),
+            (0,  2, Enabled)
+          )
+        ).asRight
+      )
+    yield ()
+
   test("[gnirs] materialized sequence round-trips through t_gnirs_dynamic"):
     // Recording a visit materializes the science sequence into the DB.  The
     // subsequent query must then read it back (via SelectGnirsSequence) and

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciIgrins2.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciIgrins2.scala
@@ -56,6 +56,31 @@ class executionSciIgrins2 extends ExecutionTestSupportForIgrins2:
           ).asRight
       )
 
+  test("[igrins2] mode nod along slit (4 offsets, 1 atom), unsplittable"):
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createIgrins2LongSlitObservationAs(pi, p, t)
+        _ <- setIsSplittableAs(pi, o, isSplittable = false)
+      } yield o
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = igrins2ScienceQuery(oid),
+        expected = expectedUnsplittableExecutionConfig(
+          "igrins2",
+          igrins2ExpectedScienceAtom(
+            ExposureTime,
+            (0, qA, Enabled),
+            (0, qB, Enabled),
+            (0, qB, Enabled),
+            (0, qA, Enabled)
+          )
+        ).asRight
+      )
+
   test("[igrins2] mode nod along slit, all offsets off slit"):
     val setup: IO[Observation.Id] =
       for {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSci_TooLongToBeUnsplittable.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSci_TooLongToBeUnsplittable.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.query
+
+import cats.effect.IO
+import cats.syntax.either.*
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.model.Observation
+import lucuma.core.syntax.timespan.*
+import lucuma.itc.IntegrationTime
+import lucuma.odb.sequence.data.UnsplittableAtom
+
+class executionSci_TooLongToBeUnsplittable extends ExecutionTestSupportForGmos:
+
+  override def fakeItcSpectroscopyResult: IntegrationTime =
+    IntegrationTime(
+      20.minTimeSpan,
+      PosInt.unsafeFrom(UnsplittableAtom.StepLimit.value) // including calibrations goes over limit
+    )
+
+  test("simple generation - unsplittable"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        _ <- setIsSplittableAs(pi, o, isSplittable = false)
+      yield o
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = gmosNorthScienceQuery(oid),
+        expected = List("Unsplittable observation contains too many (> 2048) steps.").asLeft
+      )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSci_TooLongToBeUnsplittable.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSci_TooLongToBeUnsplittable.scala
@@ -32,5 +32,5 @@ class executionSci_TooLongToBeUnsplittable extends ExecutionTestSupportForGmos:
       expect(
         user     = pi,
         query    = gmosNorthScienceQuery(oid),
-        expected = List("Unsplittable observation contains too many (> 2048) steps.").asLeft
+        expected = List(s"Unsplittable observation contains too many (> ${UnsplittableAtom.StepLimit.value}) steps.").asLeft
       )


### PR DESCRIPTION
When an observation is marked un-splittable, the generated science sequence should contain a single atom containing all the steps of whatever atoms it would have otherwise contained.  This is accomplished by doing a normal sequence generation and then combining all the atoms' steps into a single atom.

Note, for the next PR(s), there is more work to do for manual sequences and for the setup count estimation.