### PR TITLE
Add cassRotator field to the target enviroment

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -6864,6 +6864,21 @@ type CatalogInfo {
 }
 
 """
+Cassegrain rotator tracking mode
+"""
+enum CassRotator {
+  """
+  The cass rotator is held at a fixed angle.
+  """
+  FIXED
+
+  """
+  The cass rotator follows the field.
+  """
+  FOLLOWING
+}
+
+"""
 Catalog name values
 """
 enum CatalogName {
@@ -16243,6 +16258,11 @@ type TargetEnvironment {
   The type of blind offset (automatic or manual) if a blind offset exists.
   """
   blindOffsetType: BlindOffsetType!
+
+  """
+  The cassegrain rotator tracking mode.
+  """
+  cassRotator: CassRotator!
 }
 
 type TargetGroup {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -52,6 +52,7 @@ trait BaseMapping[F[_]]
   lazy val CallForProposalsPartnerType             = schema.ref("CallForProposalsPartner")
   lazy val CallsForProposalsSelectResultType       = schema.ref("CallsForProposalsSelectResult")
   lazy val CallForProposalsTypeType                = schema.ref("CallForProposalsType")
+  lazy val CassRotatorType                         = schema.ref("CassRotator")
   lazy val CategorizedTimeType                     = schema.ref("CategorizedTime")
   lazy val CatalogInfoType                         = schema.ref("CatalogInfo")
   lazy val CatalogNameType                         = schema.ref("CatalogName")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/LeafMappings.scala
@@ -85,6 +85,7 @@ trait LeafMappings[F[_]] extends BaseMapping[F] {
       LeafMapping[CalibrationRole](CalibrationRoleType),
       LeafMapping[CallForProposals.Id](CallForProposalsIdType),
       LeafMapping[CallForProposalsType](CallForProposalsTypeType),
+      LeafMapping[CassRotator](CassRotatorType),
       LeafMapping[CatalogName](CatalogNameType),
       LeafMapping[ChargeClass](ChargeClassType),
       LeafMapping[Long](ChronicleIdType),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
@@ -19,6 +19,8 @@ import grackle.skunk.SkunkMapping
 import grackle.syntax.*
 import io.circe.refined.given
 import lucuma.catalog.clients.GaiaClient
+import lucuma.core.enums.CassRotator
+import lucuma.core.enums.Instrument
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Target
@@ -73,6 +75,15 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
       SqlField("useBlindOffset", ObservationView.UseBlindOffset),
       blindOffsetTargetObject("blindOffsetTarget"),
       SqlField("blindOffsetType", ObservationView.BlindOffsetType),
+      SqlField("instrument", ObservationView.Instrument, hidden = true),
+      CursorField[CassRotator](
+        "cassRotator",
+        _.fieldAs[Option[Instrument]]("instrument").map:
+          case Some(Instrument.MaroonX) => CassRotator.Fixed
+          case _                        => CassRotator.Following
+        ,
+        List("instrument")
+      ),
       EffectField("basePosition", basePositionQueryHandler, List("id", "programId")),
       EffectField("guideEnvironment", guideEnvironmentQueryHandler, List("id", "programId")),
       EffectField("guideAvailability", guideAvailabilityQueryHandler, List("id", "programId")),

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/cassRotator.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/cassRotator.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package query
+
+import cats.syntax.all.*
+import io.circe.literal.*
+import lucuma.core.enums.VisitorObservingModeType
+import lucuma.core.model.Observation
+
+class cassRotator extends OdbSuite:
+
+  val pi         = TestUsers.Standard.pi(1, 30)
+  val validUsers = List(pi)
+
+  def cassRotatorQuery(oid: Observation.Id) =
+    s"""
+      query {
+        observation(observationId: "$oid") {
+          instrument
+          targetEnvironment {
+            cassRotator
+          }
+        }
+      }
+    """
+
+  test("cassRotator is following for other instruments"):
+    for
+      p <- createProgramAs(pi)
+      t <- createTargetAs(pi, p)
+      o <- createGmosNorthImagingObservationAs(pi, p, t)
+      _ <- expect(
+             pi,
+             cassRotatorQuery(o),
+             json"""{
+              "observation": {
+                "instrument": "GMOS_NORTH",
+                "targetEnvironment": {
+                  "cassRotator": "FOLLOWING"
+                  }
+                }
+              }""".asRight
+           )
+    yield ()
+
+  test("cassRotator is fixed for Maroon-X"):
+    for
+      p <- createProgramAs(pi)
+      t <- createTargetAs(pi, p)
+      o <- createVisitorModeObservationAs(pi, p, VisitorObservingModeType.MaroonX, t)
+      _ <- expect(
+             pi,
+             cassRotatorQuery(o),
+             json"""{
+              "observation": {
+                "instrument": "MAROON_X",
+                "targetEnvironment": {
+                  "cassRotator": "FIXED"
+                  }
+                }
+              }""".asRight
+           )
+    yield ()


### PR DESCRIPTION
This is used by navigate to select the kind of cass rotation mode. I didn't add a field to the db as the rule for now is that maroonx uses `fixed` and the rest are `following`. 

Eventually this field would be user selectable when we add `Altair` support