### PR TITLE
Shortcut 7179: Unsplittable observation manual sequence edit

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -204,7 +204,9 @@ object Generator:
           for
             a <- EitherT(sequenceDigest(stream.acquisition))
             s <- EitherT(sequenceDigest(stream.science))
-          yield ExecutionDigest(estimator.estimateSetupTime, estimator.estimateSetupCount(s.timeEstimate.sum), a, s)
+            c  = if ctx.params.isSplittable then estimator.estimateSetupCount(s.timeEstimate.sum)
+                 else NonNegInt.unsafeFrom(1)
+          yield ExecutionDigest(estimator.estimateSetupTime, c, a, s)
 
         val done =
           EitherT.pure[F, OdbError]:

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -64,6 +64,7 @@ import lucuma.odb.graphql.input.SpectroscopyScienceRequirementsInput
 import lucuma.odb.graphql.input.TargetEnvironmentInput
 import lucuma.odb.graphql.input.TimingWindowInput
 import lucuma.odb.graphql.mapping.AccessControl
+import lucuma.odb.sequence.data.UnsplittableAtom
 import lucuma.odb.service.Services.ServiceAccess
 import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
@@ -454,6 +455,24 @@ object ObservationService {
                   Services.asSuperUser:
                     allocationService.validateBand(band, pids)
 
+            // Checks that the stored sequence, if any, for each observation is
+            // valid for an unsplittable observation.
+            val validateUnsplittableStoredSequence: ResultT[F, Unit] =
+              ResultT:
+                val af = Statements.validateUnsplittableSequence(which)
+                session
+                  .prepareR(af.fragment.query(observation_id *: text))
+                  .use: p =>
+                    p.stream(af.argument, chunkSize = 1024)
+                     .compile
+                     .toList
+                  .map: problems =>
+                    problems
+                      .map: (oid, error) =>
+                        OdbError.InvalidArgument(s"Cannot make observation $oid un-splittable: $error".some).asFailure.void
+                      .combineAllOption
+                      .getOrElse(Result.unit)
+
             // Observations in system groups (telluric, etc.) cannot be moved
             // by non-service callers.
             // doing so may introduce orphan groups, at least for tellurics.
@@ -497,6 +516,12 @@ object ObservationService {
                          )
 
                 _ <- validateBand(g.keys.toList)
+
+                // If we are trying to edit this observation to make it un-splittable,
+                // then ensure that any existing materialized sequence is compatible.
+                isSplittable = SET.scheduling.toOption.forall(_.isSplittable.forall(identity))
+                _ <- if isSplittable then ResultT.unit else validateUnsplittableStoredSequence
+
                 _ <- ResultT(u.map(u => Services.asSuperUser(updateObservingModes(SET.observingMode, u, e.toOption))).getOrElse(Result.unit.pure[F]))
                 _ <- ResultT(Services.asSuperUser(setTimingWindows(u.foldMap(_.toList), SET.scheduling.flatMap(_.timingWindows).foldPresent(_.orEmpty))))
                 _ <- ResultT(g.toList.traverse { case (pid, oids) =>
@@ -1285,6 +1310,30 @@ object ObservationService {
           FROM t_observation
          WHERE c_observation_id = $observation_id
       """.query(bool)
+
+    def validateUnsplittableSequence(
+      which: AppliedFragment,
+      limit: Int = UnsplittableAtom.StepLimit.value,
+    ): AppliedFragment =
+      sql"""
+        SELECT
+          a.c_observation_id,
+          CASE
+            WHEN COUNT(DISTINCT a.c_atom_id) > 1 THEN
+              'Unsplittable observations may only contain a single atom.'
+            WHEN COUNT(s.c_step_id) > $int4 THEN
+              'An unsplittable observation''s atom may not contain more than #${limit.toString} steps.'
+            ELSE
+              NULL
+          END AS c_error_message
+        FROM t_atom a
+        LEFT JOIN t_step s ON s.c_atom_id = a.c_atom_id
+        WHERE a.c_observation_id IN (""".apply(limit) |+| which |+| sql""")
+        GROUP BY a.c_observation_id
+        HAVING
+          COUNT(DISTINCT a.c_atom_id) > 1 OR
+          COUNT(s.c_step_id) > $int4
+      """.apply(limit)
   }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -469,7 +469,7 @@ object ObservationService {
                   .map: problems =>
                     problems
                       .map: (oid, error) =>
-                        OdbError.InvalidArgument(s"Cannot make observation $oid un-splittable: $error".some).asFailure.void
+                        OdbError.InvalidArgument(s"Cannot make observation $oid unsplittable: $error".some).asFailure.void
                       .combineAllOption
                       .getOrElse(Result.unit)
 
@@ -517,7 +517,7 @@ object ObservationService {
 
                 _ <- validateBand(g.keys.toList)
 
-                // If we are trying to edit this observation to make it un-splittable,
+                // If we are trying to edit this observation to make it unsplittable,
                 // then ensure that any existing materialized sequence is compatible.
                 isSplittable = SET.scheduling.toOption.forall(_.isSplittable.forall(identity))
                 _ <- if isSplittable then ResultT.unit else validateUnsplittableStoredSequence

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -118,6 +118,10 @@ sealed trait ObservationService[F[_]] {
     oid: Observation.Id
   )(using Transaction[F]): F[Option[Instrument]]
 
+  def selectIsSplittable(
+    oid: Observation.Id
+  )(using Transaction[F]): F[Option[Boolean]]
+
 }
 
 object ObservationService {
@@ -643,6 +647,11 @@ object ObservationService {
         oid: Observation.Id
       )(using Transaction[F]): F[Option[Instrument]] =
         session.option(Statements.SelectInstrument)(oid)
+
+      override def selectIsSplittable(
+        oid: Observation.Id
+      )(using Transaction[F]): F[Option[Boolean]] =
+        session.option(Statements.SelectIsSplittable)(oid)
 
     }
 
@@ -1269,6 +1278,13 @@ object ObservationService {
           FROM t_observation
          WHERE c_observation_id = $observation_id
       """.query(instrument)
+
+    val SelectIsSplittable: Query[Observation.Id, Boolean] =
+      sql"""
+        SELECT c_is_splittable
+          FROM t_observation
+         WHERE c_observation_id = $observation_id
+      """.query(bool)
   }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/SequenceService.scala
@@ -55,6 +55,7 @@ import lucuma.odb.sequence.StepTimeEstimateCalculator
 import lucuma.odb.sequence.data.ProtoAtom
 import lucuma.odb.sequence.data.ProtoStep
 import lucuma.odb.sequence.data.StreamingExecutionConfig
+import lucuma.odb.sequence.data.UnsplittableAtom
 import lucuma.odb.sequence.util.AtomBuilder
 import lucuma.odb.util.Codecs.*
 import lucuma.odb.util.Flamingos2Codecs.*
@@ -537,14 +538,26 @@ object SequenceService:
         sequence:         List[ProtoAtom[ProtoStep[D]]],
         insertInstConfig: Command[(Step.Id, D)],
         atomBuilder:      AtomBuilder[D]
-      ): ResultT[F, Stream[Pure, Atom[D]]] =
+      )(using Transaction[F]): ResultT[F, Stream[Pure, Atom[D]]] =
 
-        val checkLength =
+        val checkAtomLength: ResultT[F, Unit] =
           if sequence.lengthIs <= SequenceAtomLimit then ResultT.unit
           else ResultT:
             OdbError
               .InvalidArgument(s"Execution sequences containing over $SequenceAtomLimit atoms are not supported.".some)
               .asFailureF
+
+        val checkUnsplittable: ResultT[F, Unit] =
+           ResultT.liftF(observationService.selectIsSplittable(observationId)).flatMap:
+             case Some(false) => // means that the observation is not dividable into multiple atoms
+               val stepLimit = UnsplittableAtom.StepLimit.value
+               val message   = sequence match
+                 case a :: Nil => Option.when(a.steps.size > stepLimit)(s"An unsplittable observation's atom may not contain more than $stepLimit steps.")
+                 case Nil      => none
+                 case _        => s"Unsplittable observations may only contain a single atom.".some
+               message.fold(ResultT.unit)(m => ResultT(OdbError.InvalidArgument(m.some).asFailureF))
+             case _           =>
+               ResultT.unit
 
         val doReplace: F[Stream[Pure, Atom[D]]] =
           val atoms = atomBuilder.buildStream(Stream.emits(sequence))
@@ -555,7 +568,7 @@ object SequenceService:
             _ <- insertSequence(instrument, observationId, sequenceType, atoms.covary[F], insertInstConfig)
           yield atoms
 
-        checkLength *> ResultT.liftF(doReplace)
+        checkAtomLength *> checkUnsplittable *> ResultT.liftF(doReplace)
 
       private def selectStatic[S](
         observationId: Observation.Id,

--- a/modules/service/src/main/scala/lucuma/odb/service/extensions.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/extensions.scala
@@ -38,9 +38,10 @@ extension (self: SourceProfile)
       .getOrElse(self)
 
 def observationIdIn(
-  oids: NonEmptyList[Observation.Id]
+  oids: NonEmptyList[Observation.Id],
+  prefix: Option[String] = None
 ): AppliedFragment =
-  void"c_observation_id IN (" |+|
+  sql"#${prefix.map(p => s"$p.").getOrElse("")}c_observation_id IN ("(Void) |+|
     oids.map(sql"$observation_id").intercalate(void", ") |+|
   void")"
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/replaceGmosNorthSequence.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/replaceGmosNorthSequence.scala
@@ -138,6 +138,17 @@ class replaceGmosNorthSequence extends query.ExecutionTestSupportForGmos with Re
         """.asRight
       )
 
+  private def replaceSequenceQuery(inputString: String): String =
+    s"""
+      mutation {
+        replaceGmosNorthSequence(input: $inputString) {
+          sequence {
+            description
+          }
+        }
+      }
+    """
+
   test("manual sequence for unsplittable observation with multiple atoms"):
     val setup: IO[Observation.Id] =
       for
@@ -156,16 +167,8 @@ class replaceGmosNorthSequence extends query.ExecutionTestSupportForGmos with Re
       )
 
       expect(
-        user  = pi,
-        query = s"""
-          mutation {
-            replaceGmosNorthSequence(input: $inputString) {
-              sequence {
-                description
-              }
-            }
-          }
-        """,
+        user     = pi,
+        query    = replaceSequenceQuery(inputString),
         expected = List("Unsplittable observations may only contain a single atom.").asLeft
       )
 
@@ -188,17 +191,82 @@ class replaceGmosNorthSequence extends query.ExecutionTestSupportForGmos with Re
       )
 
       expect(
-        user  = pi,
-        query = s"""
-          mutation {
-            replaceGmosNorthSequence(input: $inputString) {
-              sequence {
-                description
-              }
-            }
-          }
-        """,
+        user     = pi,
+        query    = replaceSequenceQuery(inputString),
         expected = List(
           s"An unsplittable observation's atom may not contain more than ${UnsplittableAtom.StepLimit.value} steps."
         ).asLeft
       )
+
+  private def failToMakeUnsplittable(
+    o: Observation.Id,
+    e: String
+  ): IO[Unit] =
+    expect(
+      user  = pi,
+      query = s"""
+        mutation {
+          updateObservations(input: {
+            SET: {
+              schedulingConstraints: {
+                isSplittable: false
+              }
+            }
+            WHERE: {
+              id: { EQ: "$o" }
+            }
+          }) {
+            observations {
+              id
+            }
+          }
+        }
+      """,
+      expected = List(e).asLeft
+    )
+
+  test("cannot set isSplittable=false with multi-atom materialized sequence"):
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthImagingObservationAs(pi, p, t)
+        _ <- query(
+          user  = pi,
+          query = replaceSequenceQuery(
+            input(
+              o,
+              SequenceType.Science,
+              atomInput("Atom1", stepInput(GmosNorthFilter.GPrime)),
+              atomInput("Atom2", stepInput(GmosNorthFilter.IPrime))
+            )
+          )
+        )
+        _ <- failToMakeUnsplittable(
+          o,
+          s"Cannot make observation $o un-splittable: Unsplittable observations may only contain a single atom."
+        )
+      yield ()
+
+  test("cannot set isSplittable=false with too many steps in the materialized sequence"):
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthImagingObservationAs(pi, p, t)
+        _ <- query(
+          user  = pi,
+          query = replaceSequenceQuery(
+            input(
+              o,
+              SequenceType.Science,
+              atomInput(
+                "Atom",
+                List.fill(UnsplittableAtom.StepLimit.value + 1)(stepInput(GmosNorthFilter.GPrime))*
+              )
+            )
+          )
+        )
+        _ <- failToMakeUnsplittable(
+          o,
+          s"Cannot make observation $o un-splittable: An unsplittable observation's atom may not contain more than ${UnsplittableAtom.StepLimit.value} steps."
+        )
+      yield ()

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/replaceGmosNorthSequence.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/replaceGmosNorthSequence.scala
@@ -243,7 +243,7 @@ class replaceGmosNorthSequence extends query.ExecutionTestSupportForGmos with Re
         )
         _ <- failToMakeUnsplittable(
           o,
-          s"Cannot make observation $o un-splittable: Unsplittable observations may only contain a single atom."
+          s"Cannot make observation $o unsplittable: Unsplittable observations may only contain a single atom."
         )
       yield ()
 
@@ -267,6 +267,6 @@ class replaceGmosNorthSequence extends query.ExecutionTestSupportForGmos with Re
         )
         _ <- failToMakeUnsplittable(
           o,
-          s"Cannot make observation $o un-splittable: An unsplittable observation's atom may not contain more than ${UnsplittableAtom.StepLimit.value} steps."
+          s"Cannot make observation $o unsplittable: An unsplittable observation's atom may not contain more than ${UnsplittableAtom.StepLimit.value} steps."
         )
       yield ()

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/replaceGmosNorthSequence.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/replaceGmosNorthSequence.scala
@@ -13,6 +13,7 @@ import lucuma.core.enums.GmosNorthFilter
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.SequenceType
 import lucuma.core.model.Observation
+import lucuma.odb.sequence.data.UnsplittableAtom
 
 class replaceGmosNorthSequence extends query.ExecutionTestSupportForGmos with ReplaceGmosNorthSequenceOps:
 
@@ -135,4 +136,69 @@ class replaceGmosNorthSequence extends query.ExecutionTestSupportForGmos with Re
             }
           }
         """.asRight
+      )
+
+  test("manual sequence for unsplittable observation with multiple atoms"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthImagingObservationAs(pi, p, t)
+        _ <- setIsSplittableAs(pi, o, isSplittable = false)
+      yield o
+
+    setup.flatMap: oid =>
+      val inputString = input(
+        oid,
+        SequenceType.Science,
+        atomInput("Atom1", stepInput(GmosNorthFilter.GPrime)),
+        atomInput("Atom2", stepInput(GmosNorthFilter.IPrime))
+      )
+
+      expect(
+        user  = pi,
+        query = s"""
+          mutation {
+            replaceGmosNorthSequence(input: $inputString) {
+              sequence {
+                description
+              }
+            }
+          }
+        """,
+        expected = List("Unsplittable observations may only contain a single atom.").asLeft
+      )
+
+  test("manual sequence for unsplittable observation with too many steps"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGmosNorthImagingObservationAs(pi, p, t)
+        _ <- setIsSplittableAs(pi, o, isSplittable = false)
+      yield o
+
+    setup.flatMap: oid =>
+      val step  = stepInput(GmosNorthFilter.GPrime)
+      val steps = List.fill(UnsplittableAtom.StepLimit.value + 1)(step)
+      val inputString = input(
+        oid,
+        SequenceType.Science,
+        atomInput("Atom1", steps*)
+      )
+
+      expect(
+        user  = pi,
+        query = s"""
+          mutation {
+            replaceGmosNorthSequence(input: $inputString) {
+              sequence {
+                description
+              }
+            }
+          }
+        """,
+        expected = List(
+          s"An unsplittable observation's atom may not contain more than ${UnsplittableAtom.StepLimit.value} steps."
+        ).asLeft
       )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest_setupCount.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest_setupCount.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package query
+
+import cats.effect.IO
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.syntax.timespan.*
+import lucuma.itc.IntegrationTime
+
+class executionDigest_setupCount extends OdbSuite with ExecutionTestSupportForGmos:
+
+  override def fakeItcSpectroscopyResult: IntegrationTime =
+    // 5.5 hours => 3 setups
+    IntegrationTime(
+      30.minTimeSpan,
+      PosInt.unsafeFrom(11)
+    )
+
+  def digestQuery(oid: Observation.Id): String =
+    s"""
+      query {
+        observation(observationId: "$oid") {
+          execution { digest { value { setupCount } } }
+        }
+      }
+    """
+
+  def setupCount(pid: Program.Id, oid: Observation.Id): IO[Int] =
+    runObscalcUpdate(pid, oid) *>
+    query(
+      pi,
+      digestQuery(oid)
+    ).map: json =>
+      json.hcursor.downFields("observation", "execution", "digest", "value", "setupCount").require[Int]
+
+  test("multiple setups"):
+    assertIO(
+      for
+        p  <- createProgramWithNonPartnerPi(pi)
+        t  <- createTargetAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        c0 <- setupCount(p, o)  // 5.8 ~ hours => 3 setups
+
+        _  <- setIsSplittableAs(pi, o, isSplittable = false)
+        c1 <- setupCount(p, o) // 1
+
+      yield (c0, c1),
+      (3, 1)
+    )


### PR DESCRIPTION
Updates the handling of unsplittable observations such that:

* Attempting to replace the sequence (i.e., manual sequence edit) of an unsplittable observation is rejected if it contains more than one atom or if that atom has too many steps
* Marking a heretofore splittable observation as unsplittable is not allowed if it has a materialized sequence with multiple atoms, or with a single atom containing too many steps