### PR TITLE
Shortcut 7179: Estimate setup cost for unsplittable observations

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/Generator.scala
@@ -204,7 +204,9 @@ object Generator:
           for
             a <- EitherT(sequenceDigest(stream.acquisition))
             s <- EitherT(sequenceDigest(stream.science))
-          yield ExecutionDigest(estimator.estimateSetupTime, estimator.estimateSetupCount(s.timeEstimate.sum), a, s)
+            c  = if ctx.params.isSplittable then estimator.estimateSetupCount(s.timeEstimate.sum)
+                 else NonNegInt.unsafeFrom(1)
+          yield ExecutionDigest(estimator.estimateSetupTime, c, a, s)
 
         val done =
           EitherT.pure[F, OdbError]:

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest_setupCount.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionDigest_setupCount.scala
@@ -1,0 +1,53 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package query
+
+import cats.effect.IO
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.syntax.timespan.*
+import lucuma.itc.IntegrationTime
+
+class executionDigest_setupCount extends OdbSuite with ExecutionTestSupportForGmos:
+
+  override def fakeItcSpectroscopyResult: IntegrationTime =
+    // 5.5 hours => 3 setups
+    IntegrationTime(
+      30.minTimeSpan,
+      PosInt.unsafeFrom(11)
+    )
+
+  def digestQuery(oid: Observation.Id): String =
+    s"""
+      query {
+        observation(observationId: "$oid") {
+          execution { digest { value { setupCount } } }
+        }
+      }
+    """
+
+  def setupCount(pid: Program.Id, oid: Observation.Id): IO[Int] =
+    runObscalcUpdate(pid, oid) *>
+    query(
+      pi,
+      digestQuery(oid)
+    ).map: json =>
+      json.hcursor.downFields("observation", "execution", "digest", "value", "setupCount").require[Int]
+
+  test("multiple setups"):
+    assertIO(
+      for
+        p  <- createProgramWithNonPartnerPi(pi)
+        t  <- createTargetAs(pi, p)
+        o  <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+        c0 <- setupCount(p, o)  // 5.8 ~ hours => 3 setups
+
+        _  <- setIsSplittableAs(pi, o, isSplittable = false)
+        c1 <- setupCount(p, o) // 1
+
+      yield (c0, c1),
+      (3, 1)
+    )


### PR DESCRIPTION
Unsplittable observations should have a single setup, which this PR guarantees.

There are a couple of valid criticisms that occur to me:

* We are not validating, at least not yet, that the single atom is short enough to run in a single night.
* The splittable observation setup count doesn't look at the number of atoms, though it probably should.  For example, if there is only one atom we can't have multiple setups even if it is super long.

We should look at the time estimates for the sequence atoms to come up with this estimate rather than checking the splittable property or the total time estimate.  Perhaps someday we'll address those concerns.