### PR TITLE
Add changePrincipalInvestigator mutation

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -733,6 +733,21 @@ type ChangeProgramUserRoleResult {
 }
 
 """
+Input to changePrincipalInvestigator: the coinvestigator to promote to PI.
+"""
+input ChangePrincipalInvestigatorInput {
+  "Program user (currently a coinvestigator) to make the new PI."
+  programUserId: ProgramUserId!
+}
+
+"""
+Result of changePrincipalInvestigator, which is the program user who is now the PI.
+"""
+type ChangePrincipalInvestigatorResult {
+  programUser: ProgramUser!
+}
+
+"""
 Describes an observation clone operation, making any edits in the `SET`
 parameter.  The observation status in the cloned observation defaults to NEW.
 Identify the observation to clone by specifying either its id or reference.  If
@@ -3049,6 +3064,17 @@ type Mutation {
   changeProgramUserRole(
     input: ChangeProgramUserRoleInput!
   ): ChangeProgramUserRoleResult!
+
+  """
+  Transfer the principal investigator (PI) role of a program to one of its
+  coinvestigators.  The program user identified in the input, which must
+  currently be a coinvestigator, becomes the new PI, and the current PI is
+  demoted to coinvestigator.  Only the current PI of the program or a user with
+  staff access (or greater) may perform this operation.
+  """
+  changePrincipalInvestigator(
+    input: ChangePrincipalInvestigatorInput!
+  ): ChangePrincipalInvestigatorResult!
 
   cloneObservation(
     """

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -57,6 +57,7 @@ trait BaseMapping[F[_]]
   lazy val CatalogInfoType                         = schema.ref("CatalogInfo")
   lazy val CatalogNameType                         = schema.ref("CatalogName")
   lazy val ChangeProgramUserRoleResultType         = schema.ref("ChangeProgramUserRoleResult")
+  lazy val ChangePrincipalInvestigatorResultType   = schema.ref("ChangePrincipalInvestigatorResult")
   lazy val ChargeClassType                         = schema.ref("ChargeClass")
   lazy val ChronicleIdType                         = schema.ref("ChronicleId")
   lazy val ClassicalType                           = schema.ref("Classical")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -131,6 +131,7 @@ object OdbMapping {
           with CatalogInfoMapping[F]
           with CategorizedTimeMapping[F]
           with ChangeProgramUserRoleResultMapping[F]
+          with ChangePrincipalInvestigatorResultMapping[F]
           with CloneGroupResultMapping[F]
           with CloneObservationResultMapping[F]
           with CloneTargetResultMapping[F]
@@ -388,6 +389,7 @@ object OdbMapping {
                 CallsForProposalsSelectResultMapping,
                 CatalogInfoMapping,
                 ChangeProgramUserRoleResultMapping,
+                ChangePrincipalInvestigatorResultMapping,
                 ClassicalMapping,
                 CloneGroupResultMapping,
                 CloneObservationResultMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ChangePrincipalInvestigatorInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ChangePrincipalInvestigatorInput.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.input
+
+import lucuma.core.model.ProgramUser
+import lucuma.odb.graphql.binding.*
+
+case class ChangePrincipalInvestigatorInput(
+  programUserId: ProgramUser.Id
+)
+
+object ChangePrincipalInvestigatorInput:
+  val Binding: Matcher[ChangePrincipalInvestigatorInput] =
+    ObjectFieldsBinding.rmap:
+      case List(
+        ProgramUserIdBinding("programUserId", rProgramUserId)
+      ) =>
+        rProgramUserId.map(ChangePrincipalInvestigatorInput.apply)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ChangePrincipalInvestigatorResultMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ChangePrincipalInvestigatorResultMapping.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mapping
+
+import grackle.skunk.SkunkMapping
+
+import table.ProgramUserView
+
+trait ChangePrincipalInvestigatorResultMapping[F[_]] extends ProgramUserView[F]:
+
+  lazy val ChangePrincipalInvestigatorResultMapping: ObjectMapping =
+    ObjectMapping(ChangePrincipalInvestigatorResultType)(
+      SqlField("id", ProgramUserView.ProgramUserId, key = true, hidden = true),
+      SqlObject("programUser")
+    )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/MutationMapping.scala
@@ -78,6 +78,7 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
       AddStepEvent,
       AddTimeChargeCorrection,
       ChangeProgramUserRole,
+      ChangePrincipalInvestigator,
       CloneGroup,
       CloneObservation,
       CloneTarget,
@@ -319,6 +320,13 @@ trait MutationMapping[F[_]] extends AccessControl[F] {
     MutationField("changeProgramUserRole", ChangeProgramUserRoleInput.Binding): (input, child) =>
       services.useTransactionally:
         programUserService.changeProgramUserRole(input).map: m =>
+          m.map: pui =>
+            Unique(Filter(Predicates.programUser.id.eql(pui), child))
+
+  private lazy val ChangePrincipalInvestigator: MutationField =
+    MutationField("changePrincipalInvestigator", ChangePrincipalInvestigatorInput.Binding): (input, child) =>
+      services.useTransactionally:
+        programUserService.changePrincipalInvestigator(input).map: m =>
           m.map: pui =>
             Unique(Filter(Predicates.programUser.id.eql(pui), child))
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ProgramUserService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProgramUserService.scala
@@ -33,6 +33,7 @@ import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.data.UserType
 import lucuma.odb.graphql.input.AddProgramUserInput
+import lucuma.odb.graphql.input.ChangePrincipalInvestigatorInput
 import lucuma.odb.graphql.input.ChangeProgramUserRoleInput
 import lucuma.odb.graphql.input.LinkUserInput
 import lucuma.odb.graphql.input.ProgramUserPropertiesInput
@@ -72,6 +73,19 @@ trait ProgramUserService[F[_]]:
 
   def changeProgramUserRole(
     input: ChangeProgramUserRoleInput
+  )(using Transaction[F]): F[Result[ProgramUser.Id]]
+
+  /**
+   * Transfers the PI role of a program to one of its coinvestigators.  The
+   * program user identified by `input.programUserId`, which must currently be a
+   * coinvestigator, becomes the new PI; the current PI is demoted to
+   * coinvestigator.  Only the current PI of the program or a staff (or greater)
+   * user may perform this operation.
+   *
+   * @return the program user id of the new PI
+   */
+  def changePrincipalInvestigator(
+    input: ChangePrincipalInvestigatorInput
   )(using Transaction[F]): F[Result[ProgramUser.Id]]
 
   /**
@@ -190,6 +204,33 @@ object ProgramUserService:
                       case Completion.Update(1) => input.programUserId.success
                       case _                    => OdbError.NotAuthorized(user.id).asFailure
 
+      override def changePrincipalInvestigator(
+        input: ChangePrincipalInvestigatorInput
+      )(using Transaction[F]): F[Result[ProgramUser.Id]] =
+
+        def execUpdate(af: AppliedFragment, onFailure: => OdbError): F[Result[Unit]] =
+          session.prepare(af.fragment.command).flatMap: pq =>
+            pq.execute(af.argument).map:
+              case Completion.Update(1) => ().success
+              case _                    => onFailure.asFailure
+
+        session
+          .prepare(Statements.SelectLinkData)
+          .flatMap(_.option(input.programUserId))
+          .flatMap:
+            case None =>
+              OdbError.InvalidProgramUser(input.programUserId, s"ProgramUser ${input.programUserId} was not found.".some).asFailureF
+            case Some((_, role, _)) if role =!= ProgramUserRole.Coi =>
+              OdbError.UpdateFailed("The specified program user must be a coinvestigator.".some).asFailureF
+            case Some((pid, _, _)) =>
+              // Demote the current PI to Coi *before* promoting the target Coi to
+              // PI, since at most one PI per program is allowed.  The access check
+              // is baked into the demotion, so an unauthorized caller updates zero
+              // rows and is rejected as not authorized.
+              (for
+                _ <- ResultT(execUpdate(Statements.demoteCurrentPi(pid, user), OdbError.NotAuthorized(user.id)))
+                _ <- ResultT(execUpdate(Statements.promoteCoiToPi(input.programUserId), OdbError.UpdateFailed("Failed to promote the coinvestigator to PI.".some)))
+              yield input.programUserId).value
 
       override def deleteProgramUser(
         id: ProgramUser.Id
@@ -355,6 +396,46 @@ object ProgramUserService:
                SET c_role = $program_user_role
              WHERE c_program_user_id = $program_user_id
           """(nextRole, targetProgramUserId) |+| ac
+
+    /**
+     * Access check for changing a program's PI: the source user must have staff
+     * access (or greater), or must be the current PI of the program.  Returns an
+     * optional SQL fragment to append (as an additional `AND` condition) so that
+     * an unauthorized caller matches no rows.
+     */
+    private def authPiOrStaff(
+      programId:  Program.Id,
+      sourceUser: User
+    ): Option[AppliedFragment] =
+      import Access.{Admin, Staff, Service}
+      sourceUser.role.access match
+        case Admin | Staff | Service => none
+        case _                       => existsUserAsPi(programId, sourceUser.id).some
+
+    /** Demotes the program's current PI to Coi, subject to the access check. */
+    def demoteCurrentPi(
+      programId:  Program.Id,
+      sourceUser: User
+    ): AppliedFragment =
+      val base =
+        sql"""
+          UPDATE t_program_user
+             SET c_role = $program_user_role
+           WHERE c_program_id = $program_id
+             AND c_role = $program_user_role
+        """(ProgramUserRole.Coi, programId, ProgramUserRole.Pi)
+      authPiOrStaff(programId, sourceUser).fold(base)(ac => base |+| void" AND " |+| ac)
+
+    /** Promotes the given program user to PI, provided it is currently a Coi. */
+    def promoteCoiToPi(
+      targetProgramUserId: ProgramUser.Id
+    ): AppliedFragment =
+      sql"""
+        UPDATE t_program_user
+           SET c_role = $program_user_role
+         WHERE c_program_user_id = $program_user_id
+           AND c_role = $program_user_role
+      """(ProgramUserRole.Pi, targetProgramUserId, ProgramUserRole.Coi)
 
     def deleteProgramUser(
       pui:             ProgramUser.Id,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/changePrincipalInvestigator.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/changePrincipalInvestigator.scala
@@ -1,0 +1,132 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package mutation
+
+import cats.effect.IO
+import cats.syntax.either.*
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.enums.ProgramUserRole
+import lucuma.core.model.Program
+import lucuma.core.model.ProgramUser
+
+class changePrincipalInvestigator extends OdbSuite:
+  val pi1      = TestUsers.Standard.pi(nextId, nextId)
+  val pi2      = TestUsers.Standard.pi(nextId, nextId)
+  val pi3      = TestUsers.Standard.pi(nextId, nextId)
+  val staff    = TestUsers.Standard.staff(nextId, nextId)
+  val admin    = TestUsers.Standard.admin(nextId, nextId)
+  val service  = TestUsers.service(nextId)
+
+  lazy val validUsers = List(pi1, pi2, pi3, staff, admin, service)
+
+  private def changePiQuery(puid: ProgramUser.Id): String =
+    s"""
+      mutation {
+        changePrincipalInvestigator(
+          input: {
+            programUserId: "$puid"
+          }
+        ) {
+          programUser {
+            id
+            role
+          }
+        }
+      }
+    """
+
+  private def changePiResult(puid: ProgramUser.Id): Json =
+    json"""
+      {
+        "changePrincipalInvestigator": {
+          "programUser": {
+            "id": $puid,
+            "role": ${ProgramUserRole.Pi}
+          }
+        }
+      }
+    """
+
+  /** The current role recorded for `puid` within program `pid`, as JSON. */
+  private def roleOf(pid: Program.Id, puid: ProgramUser.Id): IO[Json] =
+    query(
+      user  = service,
+      query = s"""
+        query {
+          program(programId: "$pid") {
+            pi    { id role }
+            users { id role }
+          }
+        }
+      """
+    ).map: js =>
+      val c       = js.hcursor.downField("program")
+      val entries = c.downField("pi").focus.toList ::: c.downField("users").values.toList.flatten
+      entries
+        .find(j => j.hcursor.downField("id").focus.contains(puid.asJson))
+        .flatMap(_.hcursor.downField("role").focus)
+        .getOrElse(Json.Null)
+
+  test("PI can promote a Coi to PI, demoting the current PI to Coi"):
+    createUsers(pi2) >>
+    createProgramAs(pi1).flatMap: pid =>
+      piProgramUserIdAs(pi1, pid).flatMap: oldPi =>
+        addProgramUserAs(pi1, pid, ProgramUserRole.Coi).flatMap: coi =>
+          linkUserAs(pi1, coi, pi2.id) >>
+          expect(
+            user     = pi1,
+            query    = changePiQuery(coi),
+            expected = changePiResult(coi).asRight
+          ) >>
+          assertIO(piProgramUserIdAs(pi1, pid), coi) >>      // PI pointer moved to the promoted Coi
+          assertIO(roleOf(pid, oldPi), ProgramUserRole.Coi.asJson) >> // old PI demoted
+          assertIO(roleOf(pid, coi),   ProgramUserRole.Pi.asJson)     // new PI promoted
+
+  List(staff, admin, service).foreach: u =>
+    test(s"${u.role.access} can transfer the PI role"):
+      createProgramAs(pi1).flatMap: pid =>
+        addProgramUserAs(pi1, pid, ProgramUserRole.Coi).flatMap: coi =>
+          expect(
+            user     = u,
+            query    = changePiQuery(coi),
+            expected = changePiResult(coi).asRight
+          )
+
+  test("A Coi cannot transfer the PI role"):
+    createUsers(pi2) >>
+    createProgramAs(pi1).flatMap: pid =>
+      addProgramUserAs(pi1, pid, ProgramUserRole.Coi).flatMap: coi =>
+        linkUserAs(pi1, coi, pi2.id) >>
+        expect(
+          user     = pi2,
+          query    = changePiQuery(coi),
+          expected = List(s"User ${pi2.id} is not authorized to perform this operation.").asLeft
+        )
+
+  test("A user from another program cannot transfer the PI role"):
+    createUsers(pi3) >>
+    createProgramAs(pi1).flatMap: pid =>
+      addProgramUserAs(pi1, pid, ProgramUserRole.Coi).flatMap: coi =>
+        expect(
+          user     = pi3,
+          query    = changePiQuery(coi),
+          expected = List(s"User ${pi3.id} is not authorized to perform this operation.").asLeft
+        )
+
+  List(
+    ProgramUserRole.CoiRO,
+    ProgramUserRole.SupportPrimary,
+    ProgramUserRole.SupportSecondary
+  ).foreach: role =>
+    test(s"Cannot promote a $role to PI"):
+      createProgramAs(pi1).flatMap: pid =>
+        addProgramUserAs(staff, pid, role).flatMap: pu =>
+          expect(
+            user     = pi1,
+            query    = changePiQuery(pu),
+            expected = List("The specified program user must be a coinvestigator.").asLeft
+          )


### PR DESCRIPTION
Adds a GraphQL mutation that transfers the PI role of a program to one of its coinvestigators. The target program user, which must currently be a coinvestigator, becomes the new PI and the current PI is demoted to coinvestigator. Because at most one PI per program is allowed, the demotion is performed before the promotion.

Only the program's current PI or a user with staff access (or greater) is authorized to perform this operation; the access check is baked into the demotion SQL so an unauthorized caller updates no rows.