### PR TITLE
Add a predicate for observation mode type

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -17352,6 +17352,38 @@ input WhereOptionEqInstrument {
 }
 
 """
+Filters on equality (or not) of the observing mode type. All supplied criteria
+must match, but usually only one is selected.
+"""
+input WhereOptionEqObservingModeType {
+  """
+  When `true`, matches if the observing mode type is not defined. When `false`
+  matches if the observing mode type is defined.
+  """
+  IS_NULL: Boolean
+
+  """
+  Matches if the observing mode type is exactly the supplied value.
+  """
+  EQ: ObservingModeType
+
+  """
+  Matches if the observing mode type is not the supplied value.
+  """
+  NEQ: ObservingModeType
+
+  """
+  Matches if the observing mode type is any of the supplied options.
+  """
+  IN: [ObservingModeType!]
+
+  """
+  Matches if the observing mode type is none of the supplied values.
+  """
+  NIN: [ObservingModeType!]
+}
+
+"""
 Filters on equality (or not) of the property value and the supplied criteria.
 All supplied criteria must match, but usually only one is selected.  E.g.
 'EQ = "Foo"' will match when the property value is "FOO".
@@ -17752,6 +17784,11 @@ input WhereObservation {
   Matches on the instrument in use, if any.
   """
   instrument: WhereOptionEqInstrument
+
+  """
+  Matches on the observation's observing mode type, if any.
+  """
+  observingModeType: WhereOptionEqObservingModeType
 
   """
   Matches on the site associated with the observation's instrument, if any.

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
@@ -10,6 +10,7 @@ import grackle.Path
 import grackle.Predicate
 import grackle.Predicate.*
 import lucuma.core.enums.Instrument
+import lucuma.core.enums.ObservingModeType
 import lucuma.core.enums.ScienceBand
 import lucuma.core.enums.Site
 import lucuma.core.model.Observation
@@ -52,12 +53,32 @@ object WhereObservation {
               ).flatten)
           }
 
+    def observingModeTypeBinding(binding: Matcher[ObservingModeType]): Matcher[Predicate] =
+      val modePath = path / "observingMode" / "mode"
+      ObjectFieldsBinding.rmap:
+        case List(
+          BooleanBinding.Option("IS_NULL", rIsNull),
+          binding.Option("EQ", rEQ),
+          binding.Option("NEQ", rNEQ),
+          binding.List.Option("IN", rIN),
+          binding.List.Option("NIN", rNIN)
+        ) =>
+          (rIsNull, rEQ, rNEQ, rIN, rNIN).parMapN: (isNull, EQ, NEQ, IN, NIN) =>
+              and(List(
+                isNull.map(IsNull(modePath, _)),
+                EQ.map(a => Eql(modePath, Const(a))),
+                NEQ.map(a => NEql(modePath, Const(a))),
+                IN.map(as => In(modePath, as)),
+                NIN.map(as => Not(In(modePath, as)))
+              ).flatten)
+
     val SubtitleBinding = WhereOptionString.binding(path / "subtitle")
     val WhereOrderObservationIdBinding = WhereOrder.binding[Observation.Id](path / "id", ObservationIdBinding)
     val WhereReferenceBinding = WhereObservationReference.binding(path / "reference")
     val WhereProgramBinding = WhereProgram.binding(path / "program")
     val ScienceBandBinding = WhereOptionOrder.binding(path / "scienceBand", enumeratedBinding[ScienceBand])
     val InstrumentBinding = WhereOptionEq.binding(path / "instrument", enumeratedBinding[Instrument])
+    val ObservingModeTypeBinding = observingModeTypeBinding(enumeratedBinding[ObservingModeType])
     val SiteBinding = siteBinding(enumeratedBinding[Site])
     val WorkflowBinding = WhereCalculatedObservationWorkflow.binding(path / "workflow")
 
@@ -73,11 +94,12 @@ object WhereObservation {
         SubtitleBinding.Option("subtitle", rSubtitle),
         ScienceBandBinding.Option("scienceBand", rScienceBand),
         InstrumentBinding.Option("instrument", rInstrument),
+        ObservingModeTypeBinding.Option("observingModeType", rObservingModeType),
         SiteBinding.Option("site", rSite),
         WorkflowBinding.Option("workflow", rWorkflow)
       ) =>
-        (rAND, rOR, rNOT, rId, rRef, rProgram, rSubtitle, rScienceBand, rInstrument, rSite, rWorkflow).parMapN {
-          (AND, OR, NOT, id, ref, program, subtitle, scienceBand, instrument, site, workflow) =>
+        (rAND, rOR, rNOT, rId, rRef, rProgram, rSubtitle, rScienceBand, rInstrument, rObservingModeType, rSite, rWorkflow).parMapN {
+          (AND, OR, NOT, id, ref, program, subtitle, scienceBand, instrument, observingModeType, site, workflow) =>
             and(List(
               AND.map(and),
               OR.map(or),
@@ -88,6 +110,7 @@ object WhereObservation {
               subtitle,
               scienceBand,
               instrument,
+              observingModeType,
               site,
               workflow
             ).flatten)
@@ -96,4 +119,3 @@ object WhereObservation {
   }
 
 }
-

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observations.scala
@@ -61,7 +61,7 @@ class observations extends OdbSuite with ObservingModeSetupOperations {
                         "observerNotes"   -> Json.Null,
                         "targetEnvironment" -> Json.obj(
                           "useBlindOffset"  -> Json.False
-                        )  
+                        )
                       )
                     }
                 )
@@ -125,7 +125,7 @@ class observations extends OdbSuite with ObservingModeSetupOperations {
                 matches {
                   id
                   targetEnvironment {
-                    useBlindOffset 
+                    useBlindOffset
                   }
                 }
               }
@@ -479,6 +479,28 @@ class observations extends OdbSuite with ObservingModeSetupOperations {
       assertEquals(gn, List(oid1, oid4))
       assertEquals(gs, List(oid2, oid5))
       assertEquals(both,    List(oid1, oid2, oid4, oid5))
+      assertEquals(isNull,  List(oid3))
+      assertEquals(notNull, List(oid1, oid2, oid4, oid5))
+
+  test("filter on observingModeType"):
+    for
+      pid     <- createProgramAs(pi4)
+      oid1    <- createObservationAs(pi4, pid, ObservingModeType.GmosNorthLongSlit.some)
+      oid2    <- createObservationAs(pi4, pid, ObservingModeType.GmosSouthLongSlit.some)
+      oid3    <- createObservationAs(pi4, pid)
+      oid4    <- createObservationAs(pi4, pid, ObservingModeType.GmosNorthImaging.some)
+      oid5    <- createObservationAs(pi4, pid, ObservingModeType.GmosSouthImaging.some)
+      gnLs    <- observationsWhere(pi4, s"""program: { id: { EQ: "$pid" } }, observingModeType: { EQ: GMOS_NORTH_LONG_SLIT }""")
+      longSl  <- observationsWhere(pi4, s"""program: { id: { EQ: "$pid" } }, observingModeType: { IN: [ GMOS_NORTH_LONG_SLIT, GMOS_SOUTH_LONG_SLIT ] }""")
+      notImg  <- observationsWhere(pi4, s"""program: { id: { EQ: "$pid" } }, observingModeType: { NEQ: GMOS_NORTH_IMAGING }""")
+      notInIm <- observationsWhere(pi4, s"""program: { id: { EQ: "$pid" } }, observingModeType: { NIN: [ GMOS_NORTH_IMAGING, GMOS_SOUTH_IMAGING ] }""")
+      isNull  <- observationsWhere(pi4, s"""program: { id: { EQ: "$pid" } }, observingModeType: { IS_NULL: true }""")
+      notNull <- observationsWhere(pi4, s"""program: { id: { EQ: "$pid" } }, observingModeType: { IS_NULL: false }""")
+    yield
+      assertEquals(gnLs,    List(oid1))
+      assertEquals(longSl,  List(oid1, oid2))
+      assertEquals(notImg,  List(oid1, oid2, oid5))
+      assertEquals(notInIm, List(oid1, oid2))
       assertEquals(isNull,  List(oid3))
       assertEquals(notNull, List(oid1, oid2, oid4, oid5))
 


### PR DESCRIPTION
I want to use this feature to split explore queries on a per mode basis