### PR TITLE
Shortcut 8952: Support exchange time at Gemini

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -4458,6 +4458,14 @@ type Classical implements ProposalType {
   partnerSplits: [PartnerSplit!]!
 
   """
+  When the time request is made on behalf of an exchange partner community
+  (i.e., the PI is from Keck or Subaru), the exchange partner is given here and
+  the entire request is associated with it.  In that case `partnerSplits` is
+  empty.  Null when the request uses Gemini partner splits.
+  """
+  exchangePartner: ExchangePartner
+
+  """
   Whether this proposal is part of the AEON/Multi-facility program.
   """
   aeonMultiFacility: Boolean!
@@ -4618,6 +4626,14 @@ type Queue implements ProposalType {
   partnerSplits: [PartnerSplit!]!
 
   """
+  When the time request is made on behalf of an exchange partner community
+  (i.e., the PI is from Keck or Subaru), the exchange partner is given here and
+  the entire request is associated with it.  In that case `partnerSplits` is
+  empty.  Null when the request uses Gemini partner splits.
+  """
+  exchangePartner: ExchangePartner
+
+  """
   Whether this proposal should be considered for Band 3. Defaults to UNSET
   on creation; must be CONSIDER or DO_NOT_CONSIDER before the proposal can
   be submitted.
@@ -4692,9 +4708,17 @@ input ClassicalInput {
   """
   The partnerSplits field specifies how time is apportioned over partners. This
   will default to empty but if specified, the partner percents must sum to 100.
-  By submission time, it must be specified.
+  By submission time, it must be specified.  Mutually exclusive with
+  `exchangePartner`.
   """
   partnerSplits: [PartnerSplitInput!]
+
+  """
+  Set when the time request is on behalf of an exchange partner community (the
+  PI is from Keck or Subaru); the entire request is associated with it and
+  `partnerSplits` must be empty.  Mutually exclusive with `partnerSplits`.
+  """
+  exchangePartner: ExchangePartner
 
   """
   Whether this proposal is part of the AEON/Multi-facility program.
@@ -4855,9 +4879,17 @@ input QueueInput {
   """
   The partnerSplits field specifies how time is apportioned over partners. This
   will default to empty but if specified, the partner percents must sum to 100.
-  By submission time, it must be specified.
+  By submission time, it must be specified.  Mutually exclusive with
+  `exchangePartner`.
   """
   partnerSplits: [PartnerSplitInput!]
+
+  """
+  Set when the time request is on behalf of an exchange partner community (the
+  PI is from Keck or Subaru); the entire request is associated with it and
+  `partnerSplits` must be empty.  Mutually exclusive with `partnerSplits`.
+  """
+  exchangePartner: ExchangePartner
 
   """
   Whether this proposal should be considered for Band 3. Defaults to UNSET

--- a/modules/service/src/main/resources/db/migration/V1179__exchange.sql
+++ b/modules/service/src/main/resources/db/migration/V1179__exchange.sql
@@ -152,11 +152,11 @@ BEGIN
   END IF;
 
   IF (observatory = 'keck') THEN
-    RETURN 'Keck Exchange';
+    RETURN concat(semester, ' Keck Exchange');
   ELSIF (observatory = 'subaru') THEN
     RETURN CASE
-      WHEN subaruType = 'intensive' THEN 'Subaru Exchange (Intensive)'
-      ELSE 'Subaru Exchange'
+      WHEN subaruType = 'intensive' THEN concat(semester, ' Subaru Exchange (Intensive)')
+      ELSE concat(semester, ' Subaru Exchange')
     END;
   END IF;
 

--- a/modules/service/src/main/resources/db/migration/V1180__proposal_exchange_partner.sql
+++ b/modules/service/src/main/resources/db/migration/V1180__proposal_exchange_partner.sql
@@ -1,0 +1,54 @@
+-- A proposal's time request is either apportioned across Gemini partners (via
+-- t_partner_split) or assigned 100% to a single exchange partner.  Store the
+-- latter here; null when the request uses partner splits.
+ALTER TABLE t_proposal
+  ADD COLUMN c_exchange_partner e_exchange_partner NULL;
+
+-- Recreate v_proposal so its `p.*` picks up the new column (a plain ADD COLUMN
+-- does not alter the existing view, and the new column lands before the
+-- appended CASE columns so CREATE OR REPLACE cannot be used).
+DROP VIEW v_proposal;
+CREATE VIEW v_proposal AS
+  SELECT
+    p.*,
+    CASE WHEN p.c_science_subtype = 'classical'           THEN c_program_id END AS c_program_id_c,
+    CASE WHEN p.c_science_subtype = 'demo_science'        THEN c_program_id END AS c_program_id_s,
+    CASE WHEN p.c_science_subtype = 'directors_time'      THEN c_program_id END AS c_program_id_d,
+    CASE WHEN p.c_science_subtype = 'fast_turnaround'     THEN c_program_id END AS c_program_id_f,
+    CASE WHEN p.c_science_subtype = 'large_program'       THEN c_program_id END AS c_program_id_l,
+    CASE WHEN p.c_science_subtype = 'poor_weather'        THEN c_program_id END AS c_program_id_p,
+    CASE WHEN p.c_science_subtype = 'queue'               THEN c_program_id END AS c_program_id_q,
+    CASE WHEN p.c_science_subtype = 'system_verification' THEN c_program_id END AS c_program_id_v
+  FROM
+    t_proposal p;
+
+-- Enforce the time-request invariant: a proposal cannot have both an exchange
+-- partner (t_proposal.c_exchange_partner) and Gemini partner splits
+-- (t_partner_split rows).  These live in different tables, so a CHECK cannot
+-- express it.  Plain (immediate) row triggers raise during the offending
+-- statement so the service can surface a clean error (a deferred constraint
+-- trigger would instead fail at COMMIT, outside the request handler).
+CREATE FUNCTION check_proposal_time_request() RETURNS trigger AS $$
+DECLARE
+  pid          d_program_id := COALESCE(NEW.c_program_id, OLD.c_program_id);
+  has_exchange boolean;
+BEGIN
+  SELECT (c_exchange_partner IS NOT NULL) INTO has_exchange
+    FROM t_proposal WHERE c_program_id = pid;
+
+  IF has_exchange AND EXISTS (SELECT 1 FROM t_partner_split WHERE c_program_id = pid) THEN
+    RAISE EXCEPTION 'A proposal may not have both an exchange partner and partner splits'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER check_proposal_time_request_proposal
+  AFTER INSERT OR UPDATE ON t_proposal
+  FOR EACH ROW EXECUTE FUNCTION check_proposal_time_request();
+
+CREATE TRIGGER check_proposal_time_request_split
+  AFTER INSERT OR UPDATE ON t_partner_split
+  FOR EACH ROW EXECUTE FUNCTION check_proposal_time_request();

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ProposalTypeInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ProposalTypeInput.scala
@@ -15,6 +15,7 @@ import cats.syntax.parallel.*
 import grackle.Result
 import grackle.syntax.*
 import lucuma.core.enums.ConsiderForBand3
+import lucuma.core.enums.ExchangePartner
 import lucuma.core.enums.Partner
 import lucuma.core.enums.ScienceSubtype
 import lucuma.core.enums.ToOActivation
@@ -65,6 +66,16 @@ object ProposalTypeInput {
 
     }
 
+  // The time request is either an exchange-partner assignment or a set of
+  // Gemini partner splits, never both.
+  private def exchangeXorSplits(
+    exchangePartner: Option[ExchangePartner],
+    partnerSplits:   Option[Map[Partner, IntPercent]]
+  ): Result[Unit] =
+    Matcher
+      .validationFailure("Specify either 'partnerSplits' or 'exchangePartner', not both.")
+      .whenA(exchangePartner.isDefined && partnerSplits.exists(_.nonEmpty))
+
   case class Create(
     scienceSubtype:     ScienceSubtype,
     tooActivation:      ToOActivation            = ToOActivation.None,
@@ -72,6 +83,7 @@ object ProposalTypeInput {
     minPercentTotal:    Option[IntPercent]       = none,
     totalTime:          Option[TimeSpan]         = none,
     partnerSplits:      Map[Partner, IntPercent] = Map.empty,
+    exchangePartner:    Option[ExchangePartner]  = none,
     reviewerId:         Option[ProgramUser.Id]   = none,
     mentorId:           Option[ProgramUser.Id]   = none,
     aeonMultiFacility:  Boolean                  = false,
@@ -88,6 +100,7 @@ object ProposalTypeInput {
         Nullable.orNull(minPercentTotal),
         Nullable.orNull(totalTime),
         Nullable.NonNull(partnerSplits),
+        Nullable.orNull(exchangePartner),
         Nullable.orNull(reviewerId),
         Nullable.orNull(mentorId),
         aeonMultiFacility.some,
@@ -119,6 +132,7 @@ object ProposalTypeInput {
     val minPercentTotal: Lens[Create, Option[IntPercent]]     = Focus[Create](_.minPercentTotal)
     val totalTime: Lens[Create, Option[TimeSpan]]             = Focus[Create](_.totalTime)
     val partnerSplits: Lens[Create, Map[Partner, IntPercent]] = Focus[Create](_.partnerSplits)
+    val exchangePartner: Lens[Create, Option[ExchangePartner]] = Focus[Create](_.exchangePartner)
     val reviewerId: Lens[Create, Option[ProgramUser.Id]]      = Focus[Create](_.reviewerId)
     val mentorId: Lens[Create, Option[ProgramUser.Id]]        = Focus[Create](_.mentorId)
     val aeonMultiFacility: Lens[Create, Boolean]              = Focus[Create](_.aeonMultiFacility)
@@ -146,18 +160,22 @@ object ProposalTypeInput {
         case List(
           IntPercentBinding.Option("minPercentTime", rMin),
           PartnerSplitsInput.Option("partnerSplits", rSplits),
+          ExchangePartnerBinding.Option("exchangePartner", rExchange),
           BooleanBinding.Option("aeonMultiFacility", rAeon),
           BooleanBinding.Option("jwstSynergy", rJwst),
           BooleanBinding.Option("usLongTerm", rUsLong)
-        ) => (rMin, rSplits, rAeon, rJwst, rUsLong).parMapN { (min, splits, aeon, jwst, usLong) =>
-          Create(ScienceSubtype.Classical).update(
-            for {
-              _ <- minPercentTime     := min
-              _ <- partnerSplits      := splits
-              _ <- aeonMultiFacility  := aeon
-              _ <- jwstSynergy        := jwst
-              _ <- usLongTerm         := usLong
-            } yield ()
+        ) => (rMin, rSplits, rExchange, rAeon, rJwst, rUsLong).parTupled.flatMap { case (min, splits, exchange, aeon, jwst, usLong) =>
+          exchangeXorSplits(exchange, splits).as(
+            Create(ScienceSubtype.Classical).update(
+              for {
+                _ <- minPercentTime     := min
+                _ <- partnerSplits      := splits
+                _ <- exchangePartner    := exchange
+                _ <- aeonMultiFacility  := aeon
+                _ <- jwstSynergy        := jwst
+                _ <- usLongTerm         := usLong
+              } yield ()
+            )
           )
         }
       }
@@ -223,21 +241,25 @@ object ProposalTypeInput {
           ToOActivationBinding.Option("toOActivation", rToo),
           IntPercentBinding.Option("minPercentTime", rMin),
           PartnerSplitsInput.Option("partnerSplits", rSplits),
+          ExchangePartnerBinding.Option("exchangePartner", rExchange),
           ConsiderForBand3Binding.Option("considerForBand3", rBand3),
           BooleanBinding.Option("aeonMultiFacility", rAeon),
           BooleanBinding.Option("jwstSynergy", rJwst),
           BooleanBinding.Option("usLongTerm", rUsLong)
-        ) => (rToo, rMin, rSplits, rBand3, rAeon, rJwst, rUsLong).parMapN { (too, min, splits, band3, aeon, jwst, usLong) =>
-          Create(ScienceSubtype.Queue).update(
-            for {
-              _ <- tooActivation     := too
-              _ <- minPercentTime    := min
-              _ <- partnerSplits     := splits
-              _ <- considerForBand3  := band3
-              _ <- aeonMultiFacility := aeon
-              _ <- jwstSynergy       := jwst
-              _ <- usLongTerm        := usLong
-            } yield ()
+        ) => (rToo, rMin, rSplits, rExchange, rBand3, rAeon, rJwst, rUsLong).parTupled.flatMap { case (too, min, splits, exchange, band3, aeon, jwst, usLong) =>
+          exchangeXorSplits(exchange, splits).as(
+            Create(ScienceSubtype.Queue).update(
+              for {
+                _ <- tooActivation     := too
+                _ <- minPercentTime    := min
+                _ <- partnerSplits     := splits
+                _ <- exchangePartner   := exchange
+                _ <- considerForBand3  := band3
+                _ <- aeonMultiFacility := aeon
+                _ <- jwstSynergy       := jwst
+                _ <- usLongTerm        := usLong
+              } yield ()
+            )
           )
         }
       }
@@ -265,6 +287,7 @@ object ProposalTypeInput {
     minPercentTotal:    Nullable[IntPercent]               = Nullable.Null,
     totalTime:          Nullable[TimeSpan]                 = Nullable.Null,
     partnerSplits:      Nullable[Map[Partner, IntPercent]] = Nullable.Null,
+    exchangePartner:    Nullable[ExchangePartner]          = Nullable.Null,
     reviewerId:         Nullable[ProgramUser.Id]           = Nullable.Null,
     mentorId:           Nullable[ProgramUser.Id]           = Nullable.Null,
     aeonMultiFacility:  Option[Boolean]                    = None,
@@ -280,6 +303,7 @@ object ProposalTypeInput {
           _ <- Create.minPercentTotal   := minPercentTotal.toOptionOption
           _ <- Create.totalTime         := totalTime.toOptionOption
           _ <- Create.partnerSplits     := partnerSplits.toOption
+          _ <- Create.exchangePartner   := exchangePartner.toOptionOption
           _ <- Create.reviewerId        := reviewerId.toOptionOption
           _ <- Create.mentorId          := mentorId.toOptionOption
           _ <- Create.aeonMultiFacility := aeonMultiFacility
@@ -307,11 +331,14 @@ object ProposalTypeInput {
         case List(
           IntPercentBinding.Option("minPercentTime", rMin),
           PartnerSplitsInput.Nullable("partnerSplits", rSplits),
+          ExchangePartnerBinding.Nullable("exchangePartner", rExchange),
           BooleanBinding.Option("aeonMultiFacility", rAeon),
           BooleanBinding.Option("jwstSynergy", rJwst),
           BooleanBinding.Option("usLongTerm", rUsLong)
-        ) => (rMin, rSplits, rAeon, rJwst, rUsLong).parMapN { (min, splits, aeon, jwst, usLong) =>
-          Edit(ScienceSubtype.Classical, minPercentTime = min, partnerSplits = splits, aeonMultiFacility = aeon, jwstSynergy = jwst, usLongTerm = usLong)
+        ) => (rMin, rSplits, rExchange, rAeon, rJwst, rUsLong).parTupled.flatMap { case (min, splits, exchange, aeon, jwst, usLong) =>
+          exchangeXorSplits(exchange.toOption, splits.toOption).as(
+            Edit(ScienceSubtype.Classical, minPercentTime = min, partnerSplits = splits, exchangePartner = exchange, aeonMultiFacility = aeon, jwstSynergy = jwst, usLongTerm = usLong)
+          )
         }
       }
 
@@ -360,12 +387,15 @@ object ProposalTypeInput {
           ToOActivationBinding.Option("toOActivation", rToo),
           IntPercentBinding.Option("minPercentTime", rMin),
           PartnerSplitsInput.Nullable("partnerSplits", rSplits),
+          ExchangePartnerBinding.Nullable("exchangePartner", rExchange),
           ConsiderForBand3Binding.Option("considerForBand3", rBand3),
           BooleanBinding.Option("aeonMultiFacility", rAeon),
           BooleanBinding.Option("jwstSynergy", rJwst),
           BooleanBinding.Option("usLongTerm", rUsLong)
-        ) => (rToo, rMin, rSplits, rBand3, rAeon, rJwst, rUsLong).parMapN { (too, min, splits, band3, aeon, jwst, usLong) =>
-          Edit(ScienceSubtype.Queue, too, min, partnerSplits = splits, considerForBand3 = band3, aeonMultiFacility = aeon, jwstSynergy = jwst, usLongTerm = usLong)
+        ) => (rToo, rMin, rSplits, rExchange, rBand3, rAeon, rJwst, rUsLong).parTupled.flatMap { case (too, min, splits, exchange, band3, aeon, jwst, usLong) =>
+          exchangeXorSplits(exchange.toOption, splits.toOption).as(
+            Edit(ScienceSubtype.Queue, too, min, partnerSplits = splits, exchangePartner = exchange, considerForBand3 = band3, aeonMultiFacility = aeon, jwstSynergy = jwst, usLongTerm = usLong)
+          )
         }
       }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProposalTypeMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ProposalTypeMapping.scala
@@ -79,6 +79,7 @@ trait ProposalTypeMapping[F[_]] extends BaseMapping[F]
       SqlField("aeonMultiFacility",  ProposalView.Classical.AeonMultiFacility),
       SqlField("jwstSynergy",        ProposalView.Classical.JwstSynergy),
       SqlField("usLongTerm",         ProposalView.Classical.UsLongTerm),
+      SqlField("exchangePartner",    ProposalView.ExchangePartner),
       SqlObject("partnerSplits",     Join(ProposalView.Classical.Id, PartnerSplitTable.ProgramId))
     )
 
@@ -130,6 +131,7 @@ trait ProposalTypeMapping[F[_]] extends BaseMapping[F]
       SqlField("jwstSynergy",        ProposalView.Queue.JwstSynergy),
       SqlField("usLongTerm",         ProposalView.Queue.UsLongTerm),
       SqlField("considerForBand3",   ProposalView.Queue.ConsiderForBand3),
+      SqlField("exchangePartner",    ProposalView.ExchangePartner),
       SqlObject("partnerSplits",     Join(ProposalView.Queue.Id, PartnerSplitTable.ProgramId))
     )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ProposalView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ProposalView.scala
@@ -22,6 +22,7 @@ trait ProposalView[F[_]] extends BaseMapping[F] {
 
     val TooActivation   = col("c_too_activation", too_activation)
     val MinPercent      = col("c_min_percent",    int_percent)
+    val ExchangePartner = col("c_exchange_partner", exchange_partner.opt)
 
     val CallId          = col("c_cfp_id", cfp_id.opt)
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
@@ -14,6 +14,7 @@ import grackle.ResultT
 import grackle.syntax.*
 import lucuma.core.data.EmailAddress
 import lucuma.core.enums.ConsiderForBand3
+import lucuma.core.enums.ExchangePartner
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.Partner
 import lucuma.core.enums.ProgramType
@@ -127,6 +128,9 @@ object ProposalService {
     def missingOrInvalidSplits(pid: Program.Id, subtype: ScienceSubtype): OdbError =
       s"Submitted proposal $pid of type ${subtype.title} must specify partner time percentages which sum to 100%.".invalidArg
 
+    def bothTimeRequests(pid: Program.Id): OdbError =
+      s"Proposal $pid may not have both an exchange partner and partner splits.".invalidArg
+
     def missingPartners(pid: Program.Id, partners: Set[Partner] = Set.empty): OdbError =
       partners.toList.map(_.abbreviation).sorted match
         case Nil     =>
@@ -208,7 +212,8 @@ object ProposalService {
         deadline:          Option[Timestamp],
         cfpTitle:          Option[NonEmptyString],
         cfp:               Option[CfpProperties],
-        considerForBand3:  Option[ConsiderForBand3]
+        considerForBand3:  Option[ConsiderForBand3],
+        exchangePartner:   Option[ExchangePartner]
       ) {
         val isPastDeadline: Option[Boolean] =
           deadline.map(_ < currentTime)
@@ -233,8 +238,15 @@ object ProposalService {
             missingCfP(pid).asFailure.unlessA(cfp.isDefined),
             missingSemester(pid).asFailure.unlessA(semester.isDefined),
             missingScienceSubtype(pid).asFailure.unlessA(scienceSubtype.isDefined),
+            // Defense in depth: the DB trigger also forbids this, but reject a
+            // both-set time request here with a clear message rather than
+            // silently treating it as an exchange request below.
+            bothTimeRequests(pid).asFailure.whenA(exchangePartner.isDefined && splitsSum =!= 0),
             scienceSubtype.fold(().success) { s =>
+              // An exchange-partner time request carries no Gemini partner
+              // splits, so the sum-to-100 rule does not apply to it.
               missingOrInvalidSplits(pid, s).asFailure.whenA(
+                exchangePartner.isEmpty &&
                 splitsSum =!= 100 &&
                 ((s === ScienceSubtype.Classical) ||
                  (s === ScienceSubtype.Queue))
@@ -384,7 +396,7 @@ object ProposalService {
           _text.map(_.toList.map(n => NonEmptyString.from(n).toOption))
 
         val codec: Decoder[ProposalContext] =
-          (proposal_status *: bool *: varchar_nonempty.opt *: text_nonempty.opt *: proposal_reference.opt *: semester.opt *: science_subtype.opt *: int8 *: parts *: parts *: int4_nonneg *: core_timestamp *: core_timestamp.opt *: text_nonempty.opt *: CallForProposalsService.Statements.cfp_properties.opt *: consider_for_band_3.opt).to[ProposalContext]
+          (proposal_status *: bool *: varchar_nonempty.opt *: text_nonempty.opt *: proposal_reference.opt *: semester.opt *: science_subtype.opt *: int8 *: parts *: parts *: int4_nonneg *: core_timestamp *: core_timestamp.opt *: text_nonempty.opt *: CallForProposalsService.Statements.cfp_properties.opt *: consider_for_band_3.opt *: exchange_partner.opt).to[ProposalContext]
 
         def lookup(pid: Program.Id): F[Result[ProposalContext]] =
           val af = Statements.selectProposalContext(user, pid)
@@ -613,6 +625,7 @@ object ProposalService {
             call.aeonMultiFacility.map(sql"c_aeon_multi_facility = ${bool}"),
             call.jwstSynergy.map(sql"c_jwst_synergy = ${bool}"),
             call.usLongTerm.map(sql"c_us_long_term = ${bool}"),
+            call.exchangePartner.foldPresent(sql"c_exchange_partner = ${exchange_partner.opt}"),
             considerForBand3Update
           ).flatten
         }
@@ -647,7 +660,8 @@ object ProposalService {
           c_aeon_multi_facility,
           c_jwst_synergy,
           c_us_long_term,
-          c_consider_for_band_3
+          c_consider_for_band_3,
+          c_exchange_partner
         ) SELECT
           ${program_id},
           ${cfp_id.opt},
@@ -662,7 +676,8 @@ object ProposalService {
           ${bool},
           ${bool},
           ${bool},
-          ${consider_for_band_3}
+          ${consider_for_band_3},
+          ${exchange_partner.opt}
       """.apply(
         pid,
         c.callId,
@@ -677,7 +692,8 @@ object ProposalService {
         c.typeʹ.aeonMultiFacility,
         c.typeʹ.jwstSynergy,
         c.typeʹ.usLongTerm,
-        c.typeʹ.considerForBand3
+        c.typeʹ.considerForBand3,
+        c.typeʹ.exchangePartner
       )
 
     val UpdateProgram: Command[(Program.Id, Option[ScienceSubtype], Option[Semester], Option[NonNegInt])] =
@@ -736,14 +752,19 @@ object ProposalService {
           COALESCE(
             cfp_pi.c_deadline,
             (SELECT cfp.c_gemini_non_partner_deadline
-             WHERE pi.c_partner_link = 'has_non_partner')
+             WHERE pi.c_partner_link = 'has_non_partner'),
+            -- An exchange-partner request is not tied to any Gemini partner, so
+            -- it uses the call's default submission deadline.
+            (SELECT cfp.c_deadline_default
+             WHERE prop.c_exchange_partner IS NOT NULL)
           ) AS c_deadline,
           cfp.c_title,
           cfp.c_cfp_id,
           cfp.c_semester,
           cfp.c_gemini_proposal_type,
           cfp.c_gemini_proprietary,
-          prop.c_consider_for_band_3
+          prop.c_consider_for_band_3,
+          prop.c_exchange_partner
         FROM t_program prog
         LEFT JOIN t_proposal prop
           ON prog.c_program_id = prop.c_program_id

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -31,6 +31,8 @@ import lucuma.core.enums.ScienceBand
 import lucuma.core.enums.SequenceCommand
 import lucuma.core.enums.SlewStage
 import lucuma.core.enums.StepStage
+import lucuma.core.enums.SubaruInstrument
+import lucuma.core.enums.SubaruProposalType
 import lucuma.core.enums.TimeAccountingCategory
 import lucuma.core.enums.VisitorObservingModeType
 import lucuma.core.math.Angle
@@ -126,6 +128,22 @@ trait DatabaseOperations { this: OdbSuite =>
 
       session.execute(states).map(_.toMap)
 
+  private def deadlineString(deadline: Option[Timestamp]): String =
+    deadline
+      .foldMap(ts => s"submissionDeadlineDefault: \"${ts.isoFormat}\"")
+
+  private def geminiPartnerListInput(
+    partners: List[(Partner, Option[Timestamp])]
+  ): String =
+    partners.map((p, d) =>
+      s"""
+        {
+          geminiPartner: ${p.tag.toScreamingSnakeCase}
+          ${d.foldMap(ts => s"submissionDeadlineOverride: \"${ts.isoFormat}\"")}
+        }
+      """
+    ).mkString("[", ", ", "]")
+
   def createGeminiCallForProposalsAs(
      user:        User,
      callType:    CallForProposalsType = CallForProposalsType.RegularSemester,
@@ -136,16 +154,6 @@ trait DatabaseOperations { this: OdbSuite =>
      partners:    List[(Partner, Option[Timestamp])] = List((Partner.US, none)),
      otherGemini: Option[String]       = None
   ): IO[CallForProposals.Id] =
-    val deadlineStr = deadline.foldMap(ts => s"submissionDeadlineDefault: \"${ts.isoFormat}\"")
-    val partnerList =
-      partners.map((p, d) =>
-        s"""
-          {
-            geminiPartner: ${p.tag.toScreamingSnakeCase}
-            ${d.foldMap(ts => s"submissionDeadlineOverride: \"${ts.isoFormat}\"")}
-          }
-        """
-      ).mkString("[", ", ", "]")
     query(user, s"""
       mutation {
         createCallForProposals(
@@ -154,8 +162,8 @@ trait DatabaseOperations { this: OdbSuite =>
               semester:    "${semester.format}"
               activeStart: "${activeStart.format(DateTimeFormatter.ISO_DATE)}"
               activeEnd:   "${activeEnd.format(DateTimeFormatter.ISO_DATE)}"
-              $deadlineStr
-              partners: $partnerList
+              ${deadlineString(deadline)}
+              partners: ${geminiPartnerListInput(partners)}
               gemini: {
                 type: ${callType.tag.toScreamingSnakeCase}
                 ${otherGemini.getOrElse("")}
@@ -176,6 +184,45 @@ trait DatabaseOperations { this: OdbSuite =>
         .leftMap(f => new RuntimeException(f.message))
         .liftTo[IO]
     }
+
+  def createSubaruCallForProposalsAs(
+     user:        User,
+     semester:    Semester               = Semester.unsafeFromString("2025A"),
+     activeStart: LocalDate              = LocalDate.parse("2025-02-01"),
+     activeEnd:   LocalDate              = LocalDate.parse("2025-07-31"),
+     deadline:    Option[Timestamp]      = Timestamp.Max.some,
+     partners:    List[(Partner, Option[Timestamp])] = List((Partner.US, none)),
+     subaruType:  SubaruProposalType     = SubaruProposalType.Normal,
+     instruments: List[SubaruInstrument] = Nil,
+     otherGemini: Option[String]         = None
+  ): IO[CallForProposals.Id] =
+    query(user, s"""
+      mutation {
+        createCallForProposals(
+          input: {
+            SET: {
+              semester:    "${semester.format}"
+              activeStart: "${activeStart.format(DateTimeFormatter.ISO_DATE)}"
+              activeEnd:   "${activeEnd.format(DateTimeFormatter.ISO_DATE)}"
+              ${deadlineString(deadline)}
+              partners: ${geminiPartnerListInput(partners)}
+              subaru: {
+                type: ${subaruType.tag.toScreamingSnakeCase}
+                ${if instruments.isEmpty then "" else instruments.map(_.tag.toScreamingSnakeCase).mkString("instruments: [ ", ", ", "]")}
+              }
+            }
+          }
+        ) {
+          callForProposals {
+            id
+          }
+        }
+      }
+    """
+    ).map:
+      _.hcursor
+       .downFields("createCallForProposals", "callForProposals", "id")
+       .require[CallForProposals.Id]
 
   def updateCallForProposalsAs(
     user: User,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createCallForProposals.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createCallForProposals.scala
@@ -894,3 +894,103 @@ class createCallForProposals extends OdbSuite:
         }
       """.asRight
     )
+
+  test("success - subaru"):
+    expect(
+      user = staff,
+      query = """
+        mutation {
+          createCallForProposals(
+            input: {
+              SET: {
+                semester:    "2024B"
+                activeStart: "2024-07-31"
+                activeEnd:   "2025-02-01"
+                subaru: {
+                  type: NORMAL
+                }
+              }
+            }
+          ) {
+            callForProposals {
+              semester
+              active {
+                start
+                end
+              }
+              submissionDeadlineDefault
+              partners {
+                geminiPartner
+                submissionDeadline
+              }
+              existence
+              subaru {
+                type
+                coordinateLimits {
+                  raStart { hms }
+                  raEnd { hms }
+                  decStart { dms }
+                  decEnd { dms }
+                }
+                instruments
+              }
+            }
+          }
+        }
+      """,
+      expected = json"""
+        {
+          "createCallForProposals": {
+            "callForProposals": {
+              "semester": "2024B",
+              "active": {
+                "start": "2024-07-31",
+                "end": "2025-02-01"
+              },
+              "submissionDeadlineDefault": null,
+              "partners": [
+                {
+                  "geminiPartner" : "AR",
+                  "submissionDeadline": null
+                },
+                {
+                  "geminiPartner" : "BR",
+                  "submissionDeadline": null
+                },
+                {
+                  "geminiPartner" : "CA",
+                  "submissionDeadline": null
+                },
+                {
+                  "geminiPartner" : "CL",
+                  "submissionDeadline": null
+                },
+                {
+                  "geminiPartner" : "KR",
+                  "submissionDeadline": null
+                },
+                {
+                  "geminiPartner" : "UH",
+                  "submissionDeadline": null
+                },
+                {
+                  "geminiPartner" : "US",
+                  "submissionDeadline": null
+                }
+              ],
+              "existence":         "PRESENT",
+              "subaru": {
+                "type": "NORMAL",
+                "coordinateLimits": {
+                  "raStart": { "hms": "16:30:00.000000" },
+                  "raEnd": { "hms": "14:00:00.000000" },
+                  "decStart": { "dms": "-37:00:00.000000" },
+                  "decEnd": { "dms": "+90:00:00.000000" }
+                },
+                "instruments":       []
+              }
+            }
+          }
+        }
+      """.asRight
+    )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createProposal.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createProposal.scala
@@ -357,6 +357,86 @@ class createProposal extends OdbSuite with DatabaseOperations {
     }
   }
 
+  test("✓ classical with exchange partner") {
+    createProgramAs(pi, "My Classical Proposal").flatMap { pid =>
+      expect(
+        user = pi,
+        query = s"""
+          mutation {
+            createProposal(
+              input: {
+                programId: "$pid"
+                SET: {
+                  category: COSMOLOGY
+                  type: {
+                    classical: {
+                      minPercentTime: 50
+                      exchangePartner: KECK
+                    }
+                  }
+                }
+              }
+            ) {
+              proposal {
+                type {
+                  scienceSubtype
+                  ... on Classical {
+                    exchangePartner
+                    partnerSplits {
+                      partner
+                      percent
+                    }
+                  }
+                }
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "createProposal" : {
+              "proposal" : {
+                "type": {
+                  "scienceSubtype": "CLASSICAL",
+                  "exchangePartner": "KECK",
+                  "partnerSplits": []
+                }
+              }
+            }
+          }
+        """.asRight
+      )
+    }
+  }
+
+  test("⨯ classical with both partner splits and exchange partner") {
+    createProgramAs(pi, "My Classical Proposal").flatMap { pid =>
+      expect(
+        user = pi,
+        query = s"""
+          mutation {
+            createProposal(
+              input: {
+                programId: "$pid"
+                SET: {
+                  type: {
+                    classical: {
+                      partnerSplits: [ { partner: US, percent: 100 } ]
+                      exchangePartner: KECK
+                    }
+                  }
+                }
+              }
+            ) {
+              proposal { type { scienceSubtype } }
+            }
+          }
+        """,
+        expected = List("Argument 'input.SET.type.classical' is invalid: Specify either 'partnerSplits' or 'exchangePartner', not both.").asLeft
+      )
+    }
+  }
+
   test("✓ classical defaults") {
     createProgramAs(pi, "My Classical Proposal").flatMap { pid =>
       expect(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatus.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatus.scala
@@ -28,6 +28,7 @@ import lucuma.odb.graphql.query.ObservingModeSetupOperations
 import lucuma.odb.service.ProposalService.error
 
 import java.time.Instant
+import java.time.LocalDate
 
 class setProposalStatus extends OdbSuite
   with ObservingModeSetupOperations {
@@ -81,6 +82,68 @@ class setProposalStatus extends OdbSuite
             """.asRight
         ) *>
         ensureSomeQueuedEmailsForAddress(defaultPiEmail, 1)
+      }
+    }
+  }
+
+  test("✓ exchange partner submission") {
+    // A Keck/Subaru PI requesting Gemini time: the proposal carries an exchange
+    // partner instead of partner splits, and uses the call's default submission
+    // deadline rather than any Gemini partner deadline.  Uses its own semester
+    // so the assigned proposal reference doesn't perturb other tests' counts.
+    createGeminiCallForProposalsAs(
+      staff,
+      CallForProposalsType.RegularSemester,
+      semester    = Semester.unsafeFromString("2026A"),
+      activeStart = LocalDate.parse("2026-02-01"),
+      activeEnd   = LocalDate.parse("2026-07-31")
+    ).flatMap { cid =>
+      createProgramWithNonPartnerPi(pi).flatMap { pid =>
+        addProposal(pi, pid, cid.some, "classical: { exchangePartner: KECK }".some) *>
+        addCoisAs(pi, pid) *>
+        expect(
+          user = pi,
+          query = s"""
+            mutation {
+              setProposalStatus(
+                input: {
+                  programId: "$pid"
+                  status: SUBMITTED
+                }
+              ) {
+                program {
+                  id
+                  proposalStatus
+                  proposal {
+                    type {
+                      ... on Classical {
+                        exchangePartner
+                        partnerSplits { partner }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          """,
+          expected =
+            json"""
+              {
+                "setProposalStatus": {
+                  "program": {
+                    "id": $pid,
+                    "proposalStatus": "SUBMITTED",
+                    "proposal": {
+                      "type": {
+                        "exchangePartner": "KECK",
+                        "partnerSplits": []
+                      }
+                    }
+                  }
+                }
+              }
+            """.asRight
+        )
       }
     }
   }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProposal.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProposal.scala
@@ -129,6 +129,38 @@ class updateProposal extends OdbSuite with DatabaseOperations {
     }
   }
 
+  test("⨯ cannot have both partner splits and an exchange partner") {
+    createProgramAs(pi).flatMap { pid =>
+      addProposal(pi, pid) *>
+      // First give it partner splits...
+      query(
+        user = pi,
+        query = s"""
+          mutation {
+            updateProposal(input: {
+              programId: "$pid"
+              SET: { type: { queue: { partnerSplits: [ { partner: US, percent: 100 } ] } } }
+            }) { proposal { type { scienceSubtype } } }
+          }
+        """
+      ) *>
+      // ...then setting an exchange partner (leaving the splits) violates the
+      // deferred constraint trigger at commit.
+      expect(
+        user = pi,
+        query = s"""
+          mutation {
+            updateProposal(input: {
+              programId: "$pid"
+              SET: { type: { queue: { exchangePartner: KECK } } }
+            }) { proposal { type { scienceSubtype } } }
+          }
+        """,
+        expected = List("A proposal may not have both an exchange partner and partner splits.").asLeft
+      )
+    }
+  }
+
   test("✓ change type") {
     createProgramAs(pi).flatMap { pid =>
       addProposal(pi, pid) *>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/callForProposals.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/callForProposals.scala
@@ -11,6 +11,7 @@ import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.CallForProposalsType
+import lucuma.core.enums.SubaruProposalType
 import lucuma.core.model.CallForProposals
 import lucuma.core.syntax.string.*
 
@@ -173,6 +174,84 @@ class callForProposals extends OdbSuite:
 
   test("system verification - no instruments"):
     assertIO(getTitle(CallForProposalsType.SystemVerification), "2025A System Verification")
+
+  private def getSubaruTitle(
+    subaruType: SubaruProposalType,
+    title:      Option[String] = None
+  ): IO[String] =
+    query(
+      user = staff,
+      query = s"""
+        mutation {
+          createCallForProposals(
+            input: {
+              SET: {
+                semester:    "2025A"
+                ${title.fold("")(title => s"title: \"$title\"")}
+                activeStart: "2025-02-01"
+                activeEnd:   "2025-07-31"
+                subaru: {
+                  type: ${subaruType.tag.toScreamingSnakeCase}
+                }
+              }
+            }
+          ) {
+            callForProposals {
+              title
+            }
+          }
+        }
+      """
+    ).map:
+      _.hcursor
+       .downFields("createCallForProposals", "callForProposals", "title")
+       .require[String]
+
+  test("subaru - default title"):
+    assertIO(getSubaruTitle(SubaruProposalType.Normal), "2025A Subaru Exchange")
+
+  test("subaru - default intensive title"):
+    assertIO(getSubaruTitle(SubaruProposalType.Intensive), "2025A Subaru Exchange (Intensive)")
+
+  test("subaru - override title"):
+    assertIO(getSubaruTitle(SubaruProposalType.Normal, "Foobaru".some), "Foobaru")
+
+  private def getKeckTitle(
+    title: Option[String] = None
+  ): IO[String] =
+    query(
+      user = staff,
+      query = s"""
+        mutation {
+          createCallForProposals(
+            input: {
+              SET: {
+                semester:    "2025A"
+                ${title.fold("")(title => s"title: \"$title\"")}
+                activeStart: "2025-02-01"
+                activeEnd:   "2025-07-31"
+                keck: {
+
+                }
+              }
+            }
+          ) {
+            callForProposals {
+              title
+            }
+          }
+        }
+      """
+    ).map:
+      _.hcursor
+       .downFields("createCallForProposals", "callForProposals", "title")
+       .require[String]
+
+  test("keck - default title"):
+    assertIO(getKeckTitle(), "2025A Keck Exchange")
+
+  test("keck - override title"):
+    assertIO(getKeckTitle("Feck".some), "Feck")
 
   test("system verification - one instrument"):
     val title = query(


### PR DESCRIPTION
Adds support for tying a proposal from a Subaru or Keck PI to a Gemini CfP and submitting it.  This adds an `exchangePartner` field to the Queue and Classical proposal type inputs.  The `exchangePartner` and `partnerSplits` are mutually exclusive.  If you specify one, the other may not be set.  On submission, we guarantee that one is defined (and if it is partner splits, that they add to 100 as before).