### PR TITLE
Fix SED-type switching on Gaussian source profiles

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/GaussianInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/GaussianInput.scala
@@ -9,6 +9,7 @@ import cats.syntax.all.*
 import grackle.Result
 import lucuma.core.model.SourceProfile
 import lucuma.odb.graphql.binding.*
+import lucuma.odb.graphql.input.sourceprofile.SpectralDefinitionInput.createOrEdit
 
 object GaussianInput {
 
@@ -28,13 +29,14 @@ object GaussianInput {
     ObjectFieldsBinding.rmap {
       case List(
         AngleInput.Binding.Option("fwhm", rFwhm),
-        SpectralDefinitionInput.Integrated.EditBinding.Option("spectralDefinition", rSpectralDefinition)
+        SpectralDefinitionInput.Integrated.CreateOrEditBinding.Option("spectralDefinition", rSpectralDefinition)
       ) =>
-        (rFwhm, rSpectralDefinition).parMapN {
-          case (None, None)       => g => Result(g)
-          case (Some(v), None)    => g => Result(g.copy(fwhm = v))
-          case (None, Some(f))    => g => f(g.spectralDefinition).map(sd => g.copy(spectralDefinition = sd))
-          case (Some(v), Some(f)) => g => f(g.spectralDefinition).map(sd => g.copy(fwhm = v, spectralDefinition = sd))
+        (rFwhm, rSpectralDefinition).parMapN { (fwhmOpt, sdOpt) => g =>
+          val fwhm = fwhmOpt.getOrElse(g.fwhm)
+          // Edit the spectral definition in place when the SED type matches, otherwise replace it.
+          sdOpt
+            .fold(Result(g.spectralDefinition))(g.spectralDefinition.createOrEdit)
+            .map(sd => g.copy(fwhm = fwhm, spectralDefinition = sd))
         }
 
     }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/SourceProfileInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/SourceProfileInput.scala
@@ -10,19 +10,10 @@ import cats.syntax.all.*
 import grackle.Result
 import lucuma.core.model.SourceProfile
 import lucuma.core.model.SourceProfile.*
-import lucuma.core.model.SpectralDefinition
-import lucuma.core.model.SpectralDefinition.BandNormalized
-import lucuma.core.model.SpectralDefinition.EmissionLines
 import lucuma.odb.graphql.binding.*
+import lucuma.odb.graphql.input.sourceprofile.SpectralDefinitionInput.matches
 
 object SourceProfileInput {
-  extension [A](sd1: SpectralDefinition[A])
-    def matches(sd2: SpectralDefinition[A]): Boolean =
-      (sd1, sd2) match {
-        case (_: BandNormalized[A], _: BandNormalized[A]) => true
-        case (_: EmissionLines[A], _: EmissionLines[A])   => true
-        case _                                            => false
-      } 
 
   // convenience projections
   implicit class SourceProfileOps(self: SourceProfile) {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/SpectralDefinitionInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/sourceprofile/SpectralDefinitionInput.scala
@@ -5,6 +5,7 @@ package lucuma.odb.graphql
 package input
 package sourceprofile
 
+import cats.data.Ior
 import cats.syntax.all.*
 import grackle.Result
 import lucuma.core.math.BrightnessUnits.*
@@ -25,6 +26,31 @@ object SpectralDefinitionInput {
       case a: EmissionLines[A]  => Result(a)
       case u => Matcher.validationFailure(s"Not an emission lines spectral definition ${u}.")
     }
+
+    /** True if `self` and `other` are the same kind of spectral definition (both band
+      * normalized, or both emission lines).
+      */
+    def matches(other: SpectralDefinition[A]): Boolean =
+      (self, other) match {
+        case (_: BandNormalized[A], _: BandNormalized[A]) => true
+        case (_: EmissionLines[A], _: EmissionLines[A])   => true
+        case _                                            => false
+      }
+
+    /** Apply the result of a `Create.or(Edit)` binding against this existing definition:
+      * a create-only (`Ior.Left`) input replaces, an edit-only (`Ior.Right`) input edits,
+      * and a both (`Ior.Both`) input edits when the SED types match but replaces when they
+      * differ. This is what lets a user switch a definition's SED type (e.g. band normalized
+      * <-> emission lines) in place rather than failing the edit.
+      */
+    def createOrEdit(
+      ce: Ior[SpectralDefinition[A], SpectralDefinition[A] => Result[SpectralDefinition[A]]]
+    ): Result[SpectralDefinition[A]] =
+      ce match {
+        case Ior.Left(c)    => Result(c)
+        case Ior.Right(e)   => e(self)
+        case Ior.Both(c, e) => if (self.matches(c)) e(self) else Result(c)
+      }
 
   object Integrated {
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateTargets.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateTargets.scala
@@ -1306,6 +1306,226 @@ class updateTargets extends OdbSuite {
     }
   }
 
+  test("update source profile (gaussian/bandNormalized -> gaussian/emissionLines, complete)") {
+    createProgramAs(pi).flatMap { pid =>
+      createAllTargetTypesAs(pi, pid, """
+        sourceProfile: {
+          gaussian: {
+            spectralDefinition: {
+              bandNormalized: {
+                sed: {
+                  stellarLibrary: B5_III
+                }
+                brightnesses: []
+              }
+            }
+            fwhm: {
+              microarcseconds: 42
+            }
+          }
+        }
+      """).flatMap { tids =>
+        tids.traverse { tid =>
+          expect(
+            user = pi,
+            query = s"""
+              mutation {
+                updateTargets(input: {
+                  SET: {
+                    sourceProfile: {
+                      gaussian: {
+                        spectralDefinition: {
+                          emissionLines: {
+                            lines: []
+                            fluxDensityContinuum: {
+                              value: 1
+                              units: ERG_PER_S_PER_CM_SQUARED_PER_A
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                  WHERE: {
+                    id: { EQ: "$tid"}
+                  }
+                }) {
+                  targets {
+                    sourceProfile {
+                      gaussian {
+                        fwhm {
+                          microarcseconds
+                        }
+                        emissionLines {
+                          lines {
+                            wavelength { nanometers }
+                          }
+                          fluxDensityContinuum {
+                            value
+                            units
+                            error
+                          }
+                        }
+                        bandNormalized {
+                          brightnesses {
+                            value
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            """,
+            expected = Right(
+              json"""
+                {
+                  "updateTargets" : {
+                    "targets" : [
+                      {
+                        "sourceProfile" : {
+                          "gaussian" : {
+                            "fwhm" : {
+                              "microarcseconds" : 42
+                            },
+                            "emissionLines" : {
+                              "lines" : [],
+                              "fluxDensityContinuum" : {
+                                "value" : "1",
+                                "units" : "ERG_PER_S_PER_CM_SQUARED_PER_A",
+                                "error" : null
+                              }
+                            },
+                            "bandNormalized" : null
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              """
+            )
+          )
+        }
+      }
+    }
+  }
+
+  test("update source profile (gaussian/emissionLines -> gaussian/bandNormalized, complete)") {
+    createProgramAs(pi).flatMap { pid =>
+      createAllTargetTypesAs(pi, pid, """
+        sourceProfile: {
+          gaussian: {
+            spectralDefinition: {
+              emissionLines: {
+                lines: []
+                fluxDensityContinuum: {
+                  value: 1
+                  units: ERG_PER_S_PER_CM_SQUARED_PER_A
+                }
+              }
+            }
+            fwhm: {
+              microarcseconds: 42
+            }
+          }
+        }
+      """).flatMap { tids =>
+        tids.traverse { tid =>
+          expect(
+            user = pi,
+            query = s"""
+              mutation {
+                updateTargets(input: {
+                  SET: {
+                    sourceProfile: {
+                      gaussian: {
+                        spectralDefinition: {
+                          bandNormalized: {
+                            sed: {
+                              stellarLibrary: B5_III
+                            }
+                            brightnesses: [
+                              {
+                                band: R
+                                value: 15.0
+                                units: VEGA_MAGNITUDE
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                  WHERE: {
+                    id: { EQ: "$tid"}
+                  }
+                }) {
+                  targets {
+                    sourceProfile {
+                      gaussian {
+                        fwhm {
+                          microarcseconds
+                        }
+                        emissionLines {
+                          fluxDensityContinuum {
+                            value
+                          }
+                        }
+                        bandNormalized {
+                          sed {
+                            stellarLibrary
+                          }
+                          brightnesses {
+                            band
+                            value
+                            units
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            """,
+            expected = Right(
+              json"""
+                {
+                  "updateTargets" : {
+                    "targets" : [
+                      {
+                        "sourceProfile" : {
+                          "gaussian" : {
+                            "fwhm" : {
+                              "microarcseconds" : 42
+                            },
+                            "emissionLines" : null,
+                            "bandNormalized" : {
+                              "sed" : {
+                                "stellarLibrary" : "B5_III"
+                              },
+                              "brightnesses" : [
+                                {
+                                  "band" : "R",
+                                  "value" : "15.0",
+                                  "units" : "VEGA_MAGNITUDE"
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              """
+            )
+          )
+        }
+      }
+    }
+  }
+
   test("update source profile (point -> gaussian, incomplete)") {
     createProgramAs(pi).flatMap { pid =>
       createAllTargetTypesAs(pi, pid).flatMap { tids =>


### PR DESCRIPTION
Switching a target's SED between band-normalized and emission-lines on a Gaussian profile failed with "Not a band normalized spectral definition." or "Not an emission lines spectral definition ...". Unlike Point/Uniform, GaussianInput.EditBinding applied the spectral-definition edit unconditionally, so a type switch tried to read the existing definition as the new type and failed.

Add a shared SpectralDefinition.createOrEdit helper (replace on SED-type mismatch, edit on match) in SpectralDefinitionInput, reuse the existing matches check from there, and route GaussianInput.EditBinding through it via Integrated.CreateOrEditBinding. This gives Gaussian the same in-place SED-type switching semantics Point and Uniform already had.

Add updateTargets coverage for in-place Gaussian SED switches in both directions.