### PR TITLE
Revert to state at 8909f025b to isolate ITC dev-server OOM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ val slf4jVersion                 = "2.0.18"
 val testcontainersScalaVersion   = "0.44.1" // check test output if you attempt to update this
 val weaverVersion                = "0.13.0"
 
-ThisBuild / tlBaseVersion      := "0.80"
+ThisBuild / tlBaseVersion      := "0.82"
 ThisBuild / scalaVersion       := "3.8.4"
 ThisBuild / crossScalaVersions := Seq("3.8.4")
 ThisBuild / scalacOptions     ++= Seq("-Xmax-inlines", "50") // Hash derivation fails with default of 32

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ val jmhVersion                   = "1.37"
 val jwtVersion                   = "11.0.4"
 val keySemaphoreVersion          = "0.3.0-M1"
 val kittensVersion               = "3.5.0"
-val logbackVersion               = "1.5.35"
+val logbackVersion               = "1.5.34"
 val log4catsVersion              = "2.8.0"
 val lucumaCoreVersion            = "0.212.0"
 val lucumaGraphQLRoutesVersion   = "0.13.6"
@@ -55,7 +55,7 @@ val slf4jVersion                 = "2.0.18"
 val testcontainersScalaVersion   = "0.44.1" // check test output if you attempt to update this
 val weaverVersion                = "0.13.0"
 
-ThisBuild / tlBaseVersion      := "0.81"
+ThisBuild / tlBaseVersion      := "0.80"
 ThisBuild / scalaVersion       := "3.8.4"
 ThisBuild / crossScalaVersions := Seq("3.8.4")
 ThisBuild / scalacOptions     ++= Seq("-Xmax-inlines", "50") // Hash derivation fails with default of 32

--- a/itc/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
+++ b/itc/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
@@ -190,7 +190,6 @@ object InstrumentMode {
     camera:            GnirsCamera,
     readMode:          GnirsReadMode,
     wellDepth:         GnirsWellDepth,
-    coadds:            PosInt,
     port:              PortDisposition = PortDisposition.Bottom
   ) extends InstrumentMode derives Eq:
     override def displayName: String =
@@ -208,7 +207,6 @@ object InstrumentMode {
         "camera"            -> a.camera.asScreamingJson,
         "readMode"          -> a.readMode.asScreamingJson,
         "wellDepth"         -> a.wellDepth.asScreamingJson,
-        "coadds"            -> a.coadds.asJson,
         "port"              -> a.port.asScreamingJson
       )
 
@@ -277,7 +275,6 @@ object InstrumentMode {
     camera:           GnirsCamera,
     readMode:         GnirsReadMode,
     wellDepth:        GnirsWellDepth,
-    coadds:           PosInt,
     port:             PortDisposition = PortDisposition.Side
   ) extends InstrumentMode derives Eq:
     override def displayName: String =
@@ -292,7 +289,6 @@ object InstrumentMode {
         "camera"           -> a.camera.asScreamingJson,
         "readMode"         -> a.readMode.asScreamingJson,
         "wellDepth"        -> a.wellDepth.asScreamingJson,
-        "coadds"           -> a.coadds.asJson,
         "port"             -> a.port.asScreamingJson
       )
 
@@ -328,24 +324,24 @@ object InstrumentMode {
 
   given Encoder[InstrumentMode] = a =>
     a match
-      case a @ GmosNorthSpectroscopy(_, _, _, _, _, _, _, _)      =>
+      case a @ GmosNorthSpectroscopy(_, _, _, _, _, _, _, _)   =>
         Json.obj("gmosNSpectroscopy" -> a.asJson)
-      case a @ GmosSouthSpectroscopy(_, _, _, _, _, _, _, _)      =>
+      case a @ GmosSouthSpectroscopy(_, _, _, _, _, _, _, _)   =>
         Json.obj("gmosSSpectroscopy" -> a.asJson)
-      case a @ GmosNorthImaging(_, _, _, _)                       =>
+      case a @ GmosNorthImaging(_, _, _, _)                    =>
         Json.obj("gmosNImaging" -> a.asJson)
-      case a @ GmosSouthImaging(_, _, _, _)                       =>
+      case a @ GmosSouthImaging(_, _, _, _)                    =>
         Json.obj("gmosSImaging" -> a.asJson)
-      case a @ Flamingos2Spectroscopy(_, _, _, _, _, _)           =>
+      case a @ Flamingos2Spectroscopy(_, _, _, _, _, _)        =>
         Json.obj("flamingos2Spectroscopy" -> a.asJson)
-      case a @ Flamingos2Imaging(_, _, _, _)                      =>
+      case a @ Flamingos2Imaging(_, _, _, _)                   =>
         Json.obj("flamingos2Imaging" -> a.asJson)
-      case a @ Igrins2Spectroscopy(_, _)                          =>
+      case a @ Igrins2Spectroscopy(_, _)                       =>
         Json.obj("igrins2Spectroscopy" -> a.asJson)
-      case a @ GhostSpectroscopy(_, _, _, _)                      =>
+      case a @ GhostSpectroscopy(_, _, _, _)                   =>
         Json.obj("ghostSpectroscopy" -> a.asJson)
-      case a @ GnirsSpectroscopy(_, _, _, _, _, _, _, _, _, _, _) =>
+      case a @ GnirsSpectroscopy(_, _, _, _, _, _, _, _, _, _) =>
         Json.obj("gnirsSpectroscopy" -> a.asJson)
-      case a @ GnirsImaging(_, _, _, _, _, _, _)                  =>
+      case a @ GnirsImaging(_, _, _, _, _, _)                  =>
         Json.obj("gnirsImaging" -> a.asJson)
 }

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsImgExpTimeSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsImgExpTimeSuite.scala
@@ -3,7 +3,6 @@
 
 package lucuma.itc.legacy
 
-import eu.timepit.refined.types.numeric.PosInt
 import io.circe.syntax.*
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsFilter
@@ -41,7 +40,6 @@ class LegacyITCGnirsImgExpTimeSuite extends CommonITCLegacySuite:
     camera = GnirsCamera.ShortBlue,
     readMode = GnirsReadMode.Bright,
     wellDepth = GnirsWellDepth.Shallow,
-    coadds = PosInt.unsafeFrom(1),
     portDisposition = PortDisposition.Bottom
   )
 

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsImgSignalToNoiseSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsImgSignalToNoiseSuite.scala
@@ -3,7 +3,6 @@
 
 package lucuma.itc.legacy
 
-import eu.timepit.refined.types.numeric.PosInt
 import io.circe.syntax.*
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsFilter
@@ -39,7 +38,6 @@ class LegacyITCGnirsImgSignalToNoiseSuite extends CommonITCLegacySuite:
     camera = GnirsCamera.ShortBlue,
     readMode = GnirsReadMode.Bright,
     wellDepth = GnirsWellDepth.Shallow,
-    coadds = PosInt.unsafeFrom(1),
     portDisposition = PortDisposition.Bottom
   )
 

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecExpTimeSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecExpTimeSuite.scala
@@ -4,7 +4,6 @@
 package lucuma.itc.legacy
 
 import cats.syntax.option.*
-import eu.timepit.refined.types.numeric.PosInt
 import io.circe.syntax.*
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsFilter
@@ -52,7 +51,6 @@ class LegacyITCGnirsSpecExpTimeSuite extends CommonITCLegacySuite:
     readMode = GnirsReadMode.Bright,
     slitWidth = GnirsFpuSlit.LongSlit_0_30,
     wellDepth = GnirsWellDepth.Shallow,
-    coadds = PosInt.unsafeFrom(1),
     portDisposition = PortDisposition.Bottom
   )
 

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecSignalToNoiseSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecSignalToNoiseSuite.scala
@@ -3,7 +3,6 @@
 
 package lucuma.itc.legacy
 
-import eu.timepit.refined.types.numeric.PosInt
 import io.circe.syntax.*
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsFilter
@@ -51,7 +50,6 @@ class LegacyITCGnirsSpecSignalToNoiseSuite extends CommonITCLegacySuite:
     readMode = GnirsReadMode.Bright,
     slitWidth = GnirsFpuSlit.LongSlit_0_30,
     wellDepth = GnirsWellDepth.Shallow,
-    coadds = PosInt.unsafeFrom(1),
     portDisposition = PortDisposition.Bottom
   )
 

--- a/itc/service/src/main/resources/graphql/itc.graphql
+++ b/itc/service/src/main/resources/graphql/itc.graphql
@@ -336,11 +336,6 @@ input GnirsSpectroscopyInput {
   wellDepth: GnirsWellDepth!
 
   """
-  Number of coadds
-  """
-  coadds: PosInt!
-
-  """
   Instrument port disposition
   """
   port: PortDisposition = SIDE
@@ -371,11 +366,6 @@ input GnirsImagingInput {
   GNIRS well depth
   """
   wellDepth: GnirsWellDepth!
-
-  """
-  Number of coadds
-  """
-  coadds: PosInt!
 
   """
   Instrument port disposition

--- a/itc/service/src/main/scala/lucuma/itc/input/GnirsImagingInput.scala
+++ b/itc/service/src/main/scala/lucuma/itc/input/GnirsImagingInput.scala
@@ -4,7 +4,6 @@
 package lucuma.itc.input
 
 import cats.syntax.parallel.*
-import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.enums.GnirsReadMode
@@ -21,7 +20,6 @@ final case class GnirsImagingInput(
   camera:           GnirsCamera,
   readMode:         GnirsReadMode,
   wellDepth:        GnirsWellDepth,
-  coadds:           PosInt,
   port:             PortDisposition
 ) extends InstrumentModesInput
 
@@ -35,9 +33,6 @@ object GnirsImagingInput:
             GnirsCameraBinding("camera", camera),
             GnirsReadModeBinding("readMode", readMode),
             GnirsWellDepthBinding("wellDepth", wellDepth),
-            PosIntBinding("coadds", coadds),
             PortDispositionBinding("port", portDisposition)
           ) =>
-        (exposureTimeMode, filter, camera, readMode, wellDepth, coadds, portDisposition).parMapN(
-          apply
-        )
+        (exposureTimeMode, filter, camera, readMode, wellDepth, portDisposition).parMapN(apply)

--- a/itc/service/src/main/scala/lucuma/itc/input/GnirsSpectroscopyInput.scala
+++ b/itc/service/src/main/scala/lucuma/itc/input/GnirsSpectroscopyInput.scala
@@ -4,7 +4,6 @@
 package lucuma.itc.input
 
 import cats.syntax.parallel.*
-import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.enums.GnirsFpuSlit
@@ -29,7 +28,6 @@ final case class GnirsSpectroscopyInput(
   camera:            GnirsCamera,
   readMode:          GnirsReadMode,
   wellDepth:         GnirsWellDepth,
-  coadds:            PosInt,
   port:              PortDisposition
 ) extends InstrumentModesInput
 
@@ -47,7 +45,6 @@ object GnirsSpectroscopyInput:
             GnirsCameraBinding("camera", camera),
             GnirsReadModeBinding("readMode", readMode),
             GnirsWellDepthBinding("wellDepth", wellDepth),
-            PosIntBinding("coadds", coadds),
             PortDispositionBinding("port", portDisposition)
           ) =>
         (exposureTimeMode,
@@ -59,6 +56,5 @@ object GnirsSpectroscopyInput:
          camera,
          readMode,
          wellDepth,
-         coadds,
          portDisposition
         ).parMapN(apply)

--- a/itc/service/src/main/scala/lucuma/itc/legacy/ItcImpl.scala
+++ b/itc/service/src/main/scala/lucuma/itc/legacy/ItcImpl.scala
@@ -139,7 +139,7 @@ object ItcImpl {
                   SpectroscopyMode.GmosSouth(_, _, _, _, _, _, _) |
                   SpectroscopyMode.Flamingos2(_, _, _, _, _) | SpectroscopyMode.Igrins2(_) |
                   SpectroscopyMode.Ghost(_, _, _, _, _) |
-                  SpectroscopyMode.GnirsLongSlit(_, _, _, _, _, _, _, _, _, _)) =>
+                  SpectroscopyMode.GnirsLongSlit(_, _, _, _, _, _, _, _, _)) =>
                 spectroscopyTimeAndGraphs(
                   target,
                   observingMode,
@@ -147,7 +147,7 @@ object ItcImpl {
                   exposureTimeMode
                 )
               case ImagingMode.GmosNorth(_, _, _) | ImagingMode.GmosSouth(_, _, _) |
-                  ImagingMode.Flamingos2(_, _, _) | ImagingMode.Gnirs(_, _, _, _, _, _) =>
+                  ImagingMode.Flamingos2(_, _, _) | ImagingMode.Gnirs(_, _, _, _, _) =>
                 F.raiseError:
                   new IllegalArgumentException("Imaging mode not supported for graph calculation")
 

--- a/itc/service/src/main/scala/lucuma/itc/legacy/codecs.scala
+++ b/itc/service/src/main/scala/lucuma/itc/legacy/codecs.scala
@@ -242,7 +242,7 @@ private[legacy] object codecs:
       Json.obj(
         "readMode"          -> d.readMode.ocs2Tag.asJson,
         "binning"           -> d.binning.ocs2Tag.asJson,
-        "calculationMethod" -> d.timeAndCount.spectroscopyCalculationMethod().asJson
+        "calculationMethod" -> d.timeAndCount.spectroscopyCalculationMethod.asJson
       )
 
     // The legacy ITC doesn't know about step count, so we "include" it by multiplying the

--- a/itc/service/src/main/scala/lucuma/itc/legacy/package.scala
+++ b/itc/service/src/main/scala/lucuma/itc/legacy/package.scala
@@ -3,7 +3,6 @@
 
 package lucuma.itc.legacy
 
-import cats.syntax.option.*
 import lucuma.core.enums.*
 import lucuma.core.math.Angle
 import lucuma.core.math.Redshift
@@ -30,51 +29,39 @@ case class ItcSourceDefinition(
 ):
   export target.*
 
-extension (mode: ObservingMode)
-  /** The number of coadds for instruments that support it (currently GNIRS), else None. */
-  def coadds: Option[Int] =
-    mode match
-      case ObservingMode.SpectroscopyMode.GnirsLongSlit(coadds = coadds) => coadds.value.some
-      case ObservingMode.ImagingMode.Gnirs(coadds = coadds)              => coadds.value.some
-      case _                                                             => none
-
 extension (etm: ExposureTimeMode)
-  def spectroscopyCalculationMethod(
-    coadds: Option[Int] = none
-  ): ItcObservationDetails.CalculationMethod =
+  def spectroscopyCalculationMethod: ItcObservationDetails.CalculationMethod =
     etm match
       case ExposureTimeMode.SignalToNoiseMode(sn, at)         =>
         ItcObservationDetails.CalculationMethod.IntegrationTimeMethod.SpectroscopyIntegrationTime(
           sigma = sn.toBigDecimal.toDouble,
-          coadds = coadds,
+          coadds = None,
           wavelengthAt = at,
           sourceFraction = 1.0,
           ditherOffset = Angle.Angle0
         )
-      case ExposureTimeMode.TimeAndCountMode(time, count, at) =>
+      case ExposureTimeMode.TimeAndCountMode(time, count, at) => // TODO add coadds
         ItcObservationDetails.CalculationMethod.S2NMethod.SpectroscopyS2N(
           exposureCount = count.value,
-          coadds = coadds,
+          coadds = None,
           exposureDuration = time.toMilliseconds.toDouble.milliseconds,
           sourceFraction = 1.0,
           ditherOffset = Angle.Angle0,
           wavelengthAt = at
         )
-  def imagingCalculationMethod(
-    coadds: Option[Int] = none
-  ): ItcObservationDetails.CalculationMethod =
+  def imagingCalculationMethod: ItcObservationDetails.CalculationMethod      =
     etm match
       case ExposureTimeMode.SignalToNoiseMode(sn, at)         =>
         ItcObservationDetails.CalculationMethod.IntegrationTimeMethod.ImagingIntegrationTime(
           sigma = sn.toBigDecimal.toDouble,
-          coadds = coadds,
+          coadds = None,
           sourceFraction = 1.0,
           ditherOffset = Angle.Angle0
         )
-      case ExposureTimeMode.TimeAndCountMode(time, count, at) =>
+      case ExposureTimeMode.TimeAndCountMode(time, count, at) => // TODO add coadds
         ItcObservationDetails.CalculationMethod.S2NMethod.ImagingS2N(
           exposureCount = count.value,
-          coadds = coadds,
+          coadds = None,
           exposureDuration = time.toMilliseconds.toDouble.milliseconds,
           sourceFraction = 1.0,
           ditherOffset = Angle.Angle0
@@ -92,9 +79,9 @@ def getCalculationMethod(
 ): ItcObservationDetails.CalculationMethod =
   observingMode match
     case s: ObservingMode.SpectroscopyMode =>
-      exposureTimeMode.spectroscopyCalculationMethod(observingMode.coadds)
+      exposureTimeMode.spectroscopyCalculationMethod
     case i: ObservingMode.ImagingMode      =>
-      exposureTimeMode.imagingCalculationMethod(observingMode.coadds)
+      exposureTimeMode.imagingCalculationMethod
 
 case class ItcParameters(
   source:      ItcSourceDefinition,
@@ -130,7 +117,7 @@ def spectroscopyGraphParams(
       observation = ItcObservationDetails(
         calculationMethod = ItcObservationDetails.CalculationMethod.S2NMethod.SpectroscopyS2N(
           exposureCount = exposureCount,
-          coadds = observingMode.coadds,
+          coadds = None,
           exposureDuration = exposureDuration,
           sourceFraction = 1.0,
           ditherOffset = Angle.Angle0,

--- a/itc/service/src/main/scala/lucuma/itc/service/ItcMapping.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/ItcMapping.scala
@@ -122,7 +122,7 @@ object ItcMapping extends ItcCacheOrRemote with Version {
                             .focusIndex(1) // For gmos focus on the second CCD
                             .getOrElse(integrationTime)
                         case ObservingMode.ImagingMode.Flamingos2(_, _, _) |
-                            ObservingMode.ImagingMode.Gnirs(_, _, _, _, _, _) =>
+                            ObservingMode.ImagingMode.Gnirs(_, _, _, _, _) =>
                           integrationTime
       .flatMap: (targetOutcomes: NonEmptyChain[TargetIntegrationTimeOutcome]) =>
         Tracer[F]

--- a/itc/service/src/main/scala/lucuma/itc/service/ObservingMode.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/ObservingMode.scala
@@ -167,7 +167,6 @@ object ObservingMode {
       camera:            GnirsCamera,
       readMode:          GnirsReadMode,
       wellDepth:         GnirsWellDepth,
-      coadds:            PosInt,
       portDisposition:   PortDisposition
     ) extends SpectroscopyMode derives Hash {
       val instrument: Instrument =
@@ -244,7 +243,6 @@ object ObservingMode {
       camera:          GnirsCamera,
       readMode:        GnirsReadMode,
       wellDepth:       GnirsWellDepth,
-      coadds:          PosInt,
       portDisposition: PortDisposition
     ) extends ImagingMode derives Hash {
       val instrument: Instrument = Instrument.Gnirs

--- a/itc/service/src/main/scala/lucuma/itc/service/requests/imagingTime.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/requests/imagingTime.scala
@@ -50,19 +50,19 @@ object AsterismImagingTimeRequest:
 
     val modeResult: Result[ObservingMode.ImagingMode] =
       mode match
-        case GmosNImagingInput(_, filter, ccdMode, port)                             =>
+        case GmosNImagingInput(_, filter, ccdMode, port)                     =>
           Result.success:
             ObservingMode.ImagingMode.GmosNorth(filter, ccdMode, port)
-        case GmosSImagingInput(_, filter, ccdMode, port)                             =>
+        case GmosSImagingInput(_, filter, ccdMode, port)                     =>
           Result.success:
             ObservingMode.ImagingMode.GmosSouth(filter, ccdMode, port)
-        case Flamingos2ImagingInput(_, filter, readMode, port)                       =>
+        case Flamingos2ImagingInput(_, filter, readMode, port)               =>
           Result.success:
             ObservingMode.ImagingMode.Flamingos2(filter, readMode, port)
-        case GnirsImagingInput(_, filter, camera, readMode, wellDepth, coadds, port) =>
+        case GnirsImagingInput(_, filter, camera, readMode, wellDepth, port) =>
           Result.success:
-            ObservingMode.ImagingMode.Gnirs(filter, camera, readMode, wellDepth, coadds, port)
-        case _                                                                       =>
+            ObservingMode.ImagingMode.Gnirs(filter, camera, readMode, wellDepth, port)
+        case _                                                               =>
           Result.failure("Invalid imaging mode")
 
     (asterism.targetInputsToData, modeResult, constraints.create).parMapN:

--- a/itc/service/src/main/scala/lucuma/itc/service/requests/spectroscopyTime.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/requests/spectroscopyTime.scala
@@ -103,20 +103,18 @@ object AsterismSpectroscopyTimeRequest:
         case Igrins2SpectroscopyInput(_, port) =>
           Result.success:
             ObservingMode.SpectroscopyMode.Igrins2(port)
-        case GhostSpectroscopyInput(
-              numSkyMicrolens,
-              stepCount,
-              resolutionMode,
-              redDetector,
-              blueDetector
+        case GhostSpectroscopyInput(numSkyMicrolens,
+                                    stepCount,
+                                    resolutionMode,
+                                    redDetector,
+                                    blueDetector
             ) =>
           Result.success:
-            ObservingMode.SpectroscopyMode.Ghost(
-              numSkyMicrolens,
-              stepCount,
-              resolutionMode,
-              redDetector,
-              blueDetector
+            ObservingMode.SpectroscopyMode.Ghost(numSkyMicrolens,
+                                                 stepCount,
+                                                 resolutionMode,
+                                                 redDetector,
+                                                 blueDetector
             )
         case GnirsSpectroscopyInput(
               _,
@@ -128,7 +126,6 @@ object AsterismSpectroscopyTimeRequest:
               camera,
               readMode,
               wellDepth,
-              coadds,
               port
             ) =>
           Result.success:
@@ -141,7 +138,6 @@ object AsterismSpectroscopyTimeRequest:
               camera,
               readMode,
               wellDepth,
-              coadds,
               port
             )
         case _                                 =>

--- a/itc/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
@@ -810,14 +810,12 @@ object WiringSuite:
           waterVapor = WaterVapor.VeryDry,
           elevationRange = ElevationRange.ByAirMass.Default
         ),
-        InstrumentMode.GnirsImaging(
-          etm,
-          GnirsFilter.H2,
-          GnirsCamera.ShortBlue,
-          GnirsReadMode.Bright,
-          GnirsWellDepth.Shallow,
-          PosInt.unsafeFrom(1),
-          PortDisposition.Side
+        InstrumentMode.GnirsImaging(etm,
+                                    GnirsFilter.H2,
+                                    GnirsCamera.ShortBlue,
+                                    GnirsReadMode.Bright,
+                                    GnirsWellDepth.Shallow,
+                                    PortDisposition.Side
         )
       ),
       NonEmptyList.of(

--- a/itc/tests/src/test/scala/lucuma/itc/service/spectroscopySignalToNoiseSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/service/spectroscopySignalToNoiseSuite.scala
@@ -1416,8 +1416,7 @@ class spectroscopySignalToNoiseSuite extends GraphQLSuite:
               grating: D32,
               camera: SHORT_BLUE,
               readMode: BRIGHT,
-              wellDepth: SHALLOW,
-              coadds: 1
+              wellDepth: SHALLOW
             }
           }
         }) {

--- a/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyTimeAndCountSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyTimeAndCountSuite.scala
@@ -1936,8 +1936,7 @@ class spectroscopyTimeAndCountSuite extends GraphQLSuite:
                 grating: D32,
                 camera: SHORT_BLUE,
                 readMode: BRIGHT,
-                wellDepth: SHALLOW,
-                coadds: 1
+                wellDepth: SHALLOW
               }
             }
           }) {

--- a/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyTimeAndGraphSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyTimeAndGraphSuite.scala
@@ -377,8 +377,7 @@ class spectroscopyTimeAndGraphSuite extends GraphQLSuite {
                 grating: D32,
                 camera: SHORT_BLUE,
                 readMode: BRIGHT,
-                wellDepth: SHALLOW,
-                coadds: 1
+                wellDepth: SHALLOW
               }
             },
             significantFigures: {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsLongSlitInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsLongSlitInput.scala
@@ -40,16 +40,6 @@ import lucuma.odb.graphql.binding.*
 
 object GnirsLongSlitInput:
 
-  // Signal-to-noise exposure time mode does not support coadds. When the ETM is set to
-  // signal-to-noise, force coadds to 1 so a previously-set value doesn't linger.
-  private def coaddsForEtm(
-    etm:    Option[ExposureTimeMode],
-    coadds: Option[PosInt]
-  ): Option[PosInt] =
-    etm match
-      case Some(ExposureTimeMode.SignalToNoiseMode(_, _)) => PosInt.from(1).toOption
-      case _                                           => coadds
-
   object TelescopeConfigAlongSlitInput:
     val Binding: Matcher[TelescopeConfigAlongSlit] =
       ObjectFieldsBinding.rmap:
@@ -119,9 +109,7 @@ object GnirsLongSlitInput:
                 else OdbError.InvalidArgument(s"'explicitFilter' must contain one of: ${GnirsFilter.AcquisitionFilters.map(_.tag.toScreamingSnakeCase).mkString_(", ")}".some).asFailure
             ,
             rAcqType, rCoadds, rSkyOffset, rEtm
-          ).parMapN(AcquisitionInput.apply)
-           .map(a => a.copy(coadds = coaddsForEtm(a.exposureTimeMode, a.coadds)))
-           .flatMap(validateSkyOffset)
+          ).parMapN(AcquisitionInput.apply).flatMap(validateSkyOffset)
 
   case class Create(
     exposureTimeMode: Option[ExposureTimeMode],
@@ -175,7 +163,7 @@ object GnirsLongSlitInput:
             (etm, coadds, filter, fpu, camera, grating, prism,
              centralWavelength, decker, explGrating, explPrism,
              focus, readMode, wellDepth, explTelescope, acq, telluricType) =>
-              Create(etm, coaddsForEtm(etm, coadds), filter, fpu, camera, grating, prism,
+              Create(etm, coadds, filter, fpu, camera, grating, prism,
                      centralWavelength, decker, explGrating, explPrism,
                      focus, readMode, wellDepth, explTelescope, acq,
                      telluricType.getOrElse(TelluricType.Hot))
@@ -251,4 +239,3 @@ object GnirsLongSlitInput:
           (rEtm, rCoadds, rFilter, rFpu, rCamera, rGrating, rPrism,
            rCentralWavelength, rDecker, rExplGrating, rExplPrism,
            rFocus, rReadMode, rWellDepth, rExplTelescope, rAcq, rTelluricType).parMapN(Edit.apply)
-            .map(e => e.copy(coadds = coaddsForEtm(e.exposureTimeMode, e.coadds)))

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -464,8 +464,7 @@ object GeneratorParamsService {
                 grating           = gn.grating,
                 camera            = gn.camera,
                 readMode          = sciReadMode,
-                wellDepth         = gn.wellDepth,
-                coadds            = gn.coadds
+                wellDepth         = gn.wellDepth
               )
               spectroscopyGeneratorParams(
                 obsMode = gn,
@@ -474,8 +473,7 @@ object GeneratorParamsService {
                   filter           = acqFilter,
                   camera           = gn.camera,
                   readMode         = GnirsReadMode.Bright,
-                  wellDepth        = gn.wellDepth,
-                  coadds           = gn.acquisition.coadds
+                  wellDepth        = gn.wellDepth
                 ),
                 sciMode = sciMode
               )

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -295,7 +295,7 @@ object ItcService {
           case InstrumentMode.Flamingos2Imaging(_, _, _, _) =>
             go(lucuma.odb.sequence.flamingos2.MinAcquisitionExposureTime,
                lucuma.odb.sequence.flamingos2.MaxAcquisitionExposureTime)
-          case InstrumentMode.GnirsImaging(_, _, _, _, _, _, _) =>
+          case InstrumentMode.GnirsImaging(_, _, _, _, _, _) =>
             go(lucuma.odb.sequence.gnirs.MinAcquisitionExposureTime,
                lucuma.odb.sequence.gnirs.MaxAcquisitionExposureTime)
           case m                                                      =>


### PR DESCRIPTION
Restores every file to commit 8909f025b. This reverts the GNIRS coadds changes (#2627) and the logback 1.5.35 bump. redis4cats stays at 2.0.5 (it predates 8909, so reverting here does not undo it).

Purpose: deploy this to the dev server to determine whether the ITC timeouts/heap OOM were introduced by the coadds work.