### PR TITLE
Coadds required in ITC schema again

### DIFF
--- a/itc/service/src/main/resources/graphql/itc.graphql
+++ b/itc/service/src/main/resources/graphql/itc.graphql
@@ -336,9 +336,9 @@ input GnirsSpectroscopyInput {
   wellDepth: GnirsWellDepth!
 
   """
-  Number of coadds. Optional for compatibility with clients that don't send it; defaults to 1.
+  Number of coadds
   """
-  coadds: PosInt
+  coadds: PosInt!
 
   """
   Instrument port disposition
@@ -373,9 +373,9 @@ input GnirsImagingInput {
   wellDepth: GnirsWellDepth!
 
   """
-  Number of coadds. Optional for compatibility with clients that don't send it; defaults to 1.
+  Number of coadds
   """
-  coadds: PosInt
+  coadds: PosInt!
 
   """
   Instrument port disposition

--- a/itc/service/src/main/scala/lucuma/itc/input/GnirsImagingInput.scala
+++ b/itc/service/src/main/scala/lucuma/itc/input/GnirsImagingInput.scala
@@ -38,11 +38,6 @@ object GnirsImagingInput:
             PosIntBinding("coadds", coadds),
             PortDispositionBinding("port", portDisposition)
           ) =>
-        (exposureTimeMode,
-         filter,
-         camera,
-         readMode,
-         wellDepth,
-         coadds,
-         portDisposition
-        ).parMapN(apply)
+        (exposureTimeMode, filter, camera, readMode, wellDepth, coadds, portDisposition).parMapN(
+          apply
+        )

--- a/itc/service/src/main/scala/lucuma/itc/input/GnirsImagingInput.scala
+++ b/itc/service/src/main/scala/lucuma/itc/input/GnirsImagingInput.scala
@@ -35,15 +35,14 @@ object GnirsImagingInput:
             GnirsCameraBinding("camera", camera),
             GnirsReadModeBinding("readMode", readMode),
             GnirsWellDepthBinding("wellDepth", wellDepth),
-            PosIntBinding.Option("coadds", coadds),
+            PosIntBinding("coadds", coadds),
             PortDispositionBinding("port", portDisposition)
           ) =>
-        // coadds is optional for compatibility with clients that don't send it; default to 1.
         (exposureTimeMode,
          filter,
          camera,
          readMode,
          wellDepth,
-         coadds.map(_.getOrElse(PosInt.MinValue)),
+         coadds,
          portDisposition
         ).parMapN(apply)

--- a/itc/service/src/main/scala/lucuma/itc/input/GnirsSpectroscopyInput.scala
+++ b/itc/service/src/main/scala/lucuma/itc/input/GnirsSpectroscopyInput.scala
@@ -47,10 +47,9 @@ object GnirsSpectroscopyInput:
             GnirsCameraBinding("camera", camera),
             GnirsReadModeBinding("readMode", readMode),
             GnirsWellDepthBinding("wellDepth", wellDepth),
-            PosIntBinding.Option("coadds", coadds),
+            PosIntBinding("coadds", coadds),
             PortDispositionBinding("port", portDisposition)
           ) =>
-        // coadds is optional for compatibility with clients that don't send it; default to 1.
         (exposureTimeMode,
          centralWavelength,
          filter,
@@ -60,6 +59,6 @@ object GnirsSpectroscopyInput:
          camera,
          readMode,
          wellDepth,
-         coadds.map(_.getOrElse(PosInt.MinValue)),
+         coadds,
          portDisposition
         ).parMapN(apply)


### PR DESCRIPTION
They were hardly the issue, so I'm reinstating them as required. They always remained required in the client lib anyway.

This PR subsumes https://github.com/gemini-hlsw/lucuma-odb/pull/2639, but I want to merge them separately and check if nothing breaks at each step.