### PR TITLE
Itc failures cache

### DIFF
--- a/modules/service/src/main/resources/db/migration/V1187__itc_result_failure.sql
+++ b/modules/service/src/main/resources/db/migration/V1187__itc_result_failure.sql
@@ -1,28 +1,9 @@
--- Persistent cache for deterministic ITC failures.
--- Keyed by (program_id, observation_id) with a hash column matching the ITC input hash.
---
--- A hash mismatch means the observation changed, so the cached failure is ignored and
--- ITC is re-called.
-CREATE TABLE t_itc_result_failure (
-  c_program_id      d_program_id     NOT NULL,
-  c_observation_id  d_observation_id NOT NULL,
-  c_hash            bytea            NOT NULL,
-  c_error_message   text             NOT NULL,
-  FOREIGN KEY (c_program_id, c_observation_id)
-    REFERENCES t_observation(c_program_id, c_observation_id)
-    ON DELETE CASCADE,
-  CONSTRAINT t_itc_result_failure_pkey PRIMARY KEY (c_program_id, c_observation_id)
-);
+-- Truncate to allow schema change (c_asterism_results was NOT NULL).
+TRUNCATE TABLE t_itc_result;
 
--- Extend the ITC version trigger to also clear failures when ITC is updated.
-CREATE OR REPLACE FUNCTION itc_version_update()
-  RETURNS trigger AS $$
-BEGIN
-  NEW.c_last_update = NOW();
-  IF (OLD.c_version IS DISTINCT FROM NEW.c_version OR OLD.c_data IS DISTINCT FROM NEW.c_data) THEN
-    TRUNCATE t_itc_result;
-    TRUNCATE t_itc_result_failure;
-  END IF;
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+-- Make c_asterism_results nullable and add c_error_message for deterministic failures.
+-- Exactly one of the two must be non-null (success vs. cached deterministic failure).
+ALTER TABLE t_itc_result
+  ALTER COLUMN c_asterism_results DROP NOT NULL,
+  ADD COLUMN c_error_message text,
+  ADD CONSTRAINT t_itc_result_one_result CHECK (num_nonnulls(c_asterism_results, c_error_message) = 1);

--- a/modules/service/src/main/resources/db/migration/V1187__itc_result_failure.sql
+++ b/modules/service/src/main/resources/db/migration/V1187__itc_result_failure.sql
@@ -1,0 +1,28 @@
+-- Persistent cache for deterministic ITC failures.
+-- Keyed by (program_id, observation_id) with a hash column matching the ITC input hash.
+--
+-- A hash mismatch means the observation changed, so the cached failure is ignored and
+-- ITC is re-called.
+CREATE TABLE t_itc_result_failure (
+  c_program_id      d_program_id     NOT NULL,
+  c_observation_id  d_observation_id NOT NULL,
+  c_hash            bytea            NOT NULL,
+  c_error_message   text             NOT NULL,
+  FOREIGN KEY (c_program_id, c_observation_id)
+    REFERENCES t_observation(c_program_id, c_observation_id)
+    ON DELETE CASCADE,
+  CONSTRAINT t_itc_result_failure_pkey PRIMARY KEY (c_program_id, c_observation_id)
+);
+
+-- Extend the ITC version trigger to also clear failures when ITC is updated.
+CREATE OR REPLACE FUNCTION itc_version_update()
+  RETURNS trigger AS $$
+BEGIN
+  NEW.c_last_update = NOW();
+  IF (OLD.c_version IS DISTINCT FROM NEW.c_version OR OLD.c_data IS DISTINCT FROM NEW.c_data) THEN
+    TRUNCATE t_itc_result;
+    TRUNCATE t_itc_result_failure;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/modules/service/src/main/resources/db/migration/V1187__itc_result_failure.sql
+++ b/modules/service/src/main/resources/db/migration/V1187__itc_result_failure.sql
@@ -7,3 +7,24 @@ ALTER TABLE t_itc_result
   ALTER COLUMN c_asterism_results DROP NOT NULL,
   ADD COLUMN c_error_message text,
   ADD CONSTRAINT t_itc_result_one_result CHECK (num_nonnulls(c_asterism_results, c_error_message) = 1);
+
+-- When the ITC version changes, reset obscalc
+CREATE OR REPLACE FUNCTION itc_version_update()
+  RETURNS trigger AS $$
+BEGIN
+  NEW.c_last_update = NOW();
+  IF (OLD.c_version IS DISTINCT FROM NEW.c_version OR OLD.c_data IS DISTINCT FROM NEW.c_data) THEN
+    TRUNCATE t_itc_result;
+
+    -- Reset to pending. Inactive, ongoing, completed and calculating are left alone.
+    UPDATE t_obscalc SET
+      c_last_invalidation = NOW(),
+      c_failure_count     = 0,
+      c_retry_at          = NULL,
+      c_obscalc_state     = 'pending'
+    WHERE c_obscalc_state IN ('ready', 'retry')
+      AND c_workflow_state NOT IN ('inactive', 'ongoing', 'completed');
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/modules/service/src/main/scala/lucuma/odb/logic/GeneratorContext.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/GeneratorContext.scala
@@ -4,7 +4,6 @@
 package lucuma.odb.logic
 
 import cats.data.EitherT
-import cats.data.OptionT
 import cats.effect.Concurrent
 import cats.syntax.applicative.*
 import cats.syntax.either.*
@@ -92,7 +91,7 @@ object GeneratorContext:
       pid:    Program.Id,
       params: GeneratorParams
     )(using Transaction[F]): F[Option[Either[OdbError, Itc]]] =
-      OptionT(itc.selectOne(pid, oid, params)).map(_.asRight).value
+      itc.selectOne(pid, oid, params)
 
     val opc: F[Either[OdbError, (Program.Id, GeneratorParams, Option[Either[OdbError, Itc]])]] =
       services.transactionally:

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -87,14 +87,17 @@ sealed trait ItcService[F[_]] {
   )(using NoTransaction[F]): F[Either[OdbError, Itc]]
 
   /**
-   * Selects the cached ITC results for a single observation, if available and
-   * still valid.  Does not perform a remote ITC service call if not available.
+   * Selects the cached ITC result for a single observation, if available and
+   * still valid.  
+   * Returns Some(Right) for a cached success, Some(Left) for a
+   * cached deterministic failure, and None if not cached.
+   * Does not perform a remote ITC service call.
    */
   def selectOne(
     programId:    Program.Id,
     observatinId: Observation.Id,
     params:       GeneratorParams
-  )(using Transaction[F]): F[Option[Itc]]
+  )(using Transaction[F]): F[Option[Either[OdbError, Itc]]]
 
   /**
    * Selects the cached ITC results for a program, for those observations where
@@ -238,8 +241,8 @@ object ItcService {
         pid:    Program.Id,
         oid:    Observation.Id,
         params: GeneratorParams
-      )(using Transaction[F]): F[Option[Itc]] =
-        selectOneCached(pid, oid, params).map(_.flatMap(_.toOption))
+      )(using Transaction[F]): F[Option[Either[OdbError, Itc]]] =
+        selectOneCached(pid, oid, params)
 
       override def selectAll(
         pid:    Program.Id,

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -204,7 +204,7 @@ object ItcService {
                 case Left(_)                        => F.unit
           )
 
-      // Selects the parameters then checks both success and failure caches.
+      // Selects the parameters then checks the cache
       // Returns None if not cached (call remote), Some(Right) for cached success,
       // Some(Left) for cached deterministic failure.
       private def attemptLookup(
@@ -214,37 +214,32 @@ object ItcService {
         services.transactionally {
           (for {
             p <- EitherT(generatorParamsService.selectOne(pid, oid).map(_.leftMap(Error.invalidObservation(oid, _))))
-            r <- EitherT.liftF:
-              selectOne(pid, oid, p).flatMap:
-                case Some(itc) => Some(itc.asRight[OdbError]).pure[F]
-                case None      => selectOneFailure(pid, oid, p).map(_.map(_.asLeft[Itc]))
+            r <- EitherT.liftF(selectOneCached(pid, oid, p))
           } yield (p, r)).value
         }
 
-      private def selectOneFailure(
+      private def selectOneCached(
         pid:    Program.Id,
         oid:    Observation.Id,
         params: GeneratorParams
-      ): F[Option[OdbError]] =
+      ): F[Option[Either[OdbError, Itc]]] =
         params.itcInput.toOption.flatTraverse: ps =>
           val inputHash = Md5Hash.unsafeFromByteArray(ps.md5)
           session
-            .option(Statements.SelectOneItcFailure)(pid, oid)
-            .map:
-              _.collect:
-                case (h, msg) if h === inputHash => OdbError.ItcError(msg.some)
+            .option(Statements.SelectOneCachedResult)(pid, oid)
+            .map: rowOpt =>
+              for
+                (h, itcOpt, errOpt) <- rowOpt
+                if h === inputHash
+                result              <- itcOpt.map(_.asRight).orElse(errOpt.map(msg => OdbError.ItcError(msg.some).asLeft))
+              yield result
 
       override def selectOne(
         pid:    Program.Id,
         oid:    Observation.Id,
         params: GeneratorParams
       )(using Transaction[F]): F[Option[Itc]] =
-        params.itcInput.toOption.flatTraverse: ps =>
-          val inputHash = Md5Hash.unsafeFromByteArray(ps.md5)
-          session
-            .option(Statements.SelectOneItcResult)(pid, oid)
-            .map:
-              _.collect { case (h, rs) if h === inputHash => rs }
+        selectOneCached(pid, oid, params).map(_.flatMap(_.toOption))
 
       override def selectAll(
         pid:    Program.Id,
@@ -548,18 +543,19 @@ object ItcService {
                c_data    = ${text.opt}
       """.command
 
-    val SelectOneItcResult: Query[(
+    val SelectOneCachedResult: Query[(
       Program.Id,
       Observation.Id,
-    ), (Md5Hash, Itc)] =
+    ), (Md5Hash, Option[Itc], Option[String])] =
       sql"""
         SELECT
           c_hash,
-          c_asterism_results
+          c_asterism_results,
+          c_error_message
         FROM t_itc_result
         WHERE c_program_id     = $program_id     AND
               c_observation_id = $observation_id
-      """.query(md5_hash *: itc)
+      """.query(md5_hash *: itc.opt *: text.opt)
 
     val SelectAllItcResults: Query[Program.Id, (Observation.Id, Md5Hash, Itc)] =
       sql"""
@@ -568,7 +564,8 @@ object ItcService {
           c_hash,
           c_asterism_results
         FROM t_itc_result
-        WHERE c_program_id = $program_id
+        WHERE c_program_id         = $program_id AND
+              c_asterism_results IS NOT NULL
       """.query(observation_id *: md5_hash *: itc)
 
     def selectAllItcResults[A <: NonEmptyList[Observation.Id]](enc: skunk.Encoder[A]): Query[A, (Observation.Id, Md5Hash, Itc)] =
@@ -578,7 +575,8 @@ object ItcService {
           c_hash,
           c_asterism_results
         FROM t_itc_result
-        WHERE c_observation_id IN ($enc)
+        WHERE c_observation_id    IN ($enc) AND
+              c_asterism_results IS NOT NULL
       """.query(observation_id *: md5_hash *: itc)
 
     val InsertOrUpdateItcResult: Command[(
@@ -595,23 +593,17 @@ object ItcService {
           c_observation_id,
           c_hash,
           c_asterism_results
-        ) SELECT
+        ) VALUES (
           $program_id,
           $observation_id,
           $md5_hash,
           $itc
+        )
         ON CONFLICT ON CONSTRAINT t_itc_result_pkey DO UPDATE
           SET c_hash             = $md5_hash,
-              c_asterism_results = $itc
+              c_asterism_results = $itc,
+              c_error_message    = NULL
       """.command
-
-    val SelectOneItcFailure: Query[(Program.Id, Observation.Id), (Md5Hash, String)] =
-      sql"""
-        SELECT c_hash, c_error_message
-        FROM t_itc_result_failure
-        WHERE c_program_id     = $program_id AND
-              c_observation_id = $observation_id
-      """.query(md5_hash *: text)
 
     val InsertOrUpdateItcFailure: Command[(
       Program.Id,
@@ -622,7 +614,7 @@ object ItcService {
       String
     )] =
       sql"""
-        INSERT INTO t_itc_result_failure (
+        INSERT INTO t_itc_result (
           c_program_id,
           c_observation_id,
           c_hash,
@@ -633,9 +625,10 @@ object ItcService {
           $md5_hash,
           $text
         )
-        ON CONFLICT ON CONSTRAINT t_itc_result_failure_pkey DO UPDATE
-          SET c_hash          = $md5_hash,
-              c_error_message = $text
+        ON CONFLICT ON CONSTRAINT t_itc_result_pkey DO UPDATE
+          SET c_hash             = $md5_hash,
+              c_asterism_results = NULL,
+              c_error_message    = $text
       """.command
 
   }

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -24,6 +24,7 @@ import cats.syntax.option.*
 import cats.syntax.order.*
 import cats.syntax.parallel.*
 import cats.syntax.traverse.*
+import clue.ResponseException
 import fs2.Stream
 import io.circe.syntax.*
 import lucuma.core.data.Zipper
@@ -174,7 +175,7 @@ object ItcService {
 
   }
 
-  def instantiate[F[_]: Concurrent: Parallel: Logger](client: ItcClient[F])(using Services[F]): ItcService[F] =
+  def instantiate[F[_]: Concurrent: Parallel: Logger: Services](client: ItcClient[F]): ItcService[F] =
     new ItcService[F] {
 
       override def lookup(
@@ -184,7 +185,7 @@ object ItcService {
         (for {
           pr     <- EitherT(attemptLookup(pid, oid))
           (params, oa) = pr
-          result <- oa.fold(EitherT(callRemote(pid, oid, params)))(EitherT.pure(_))
+          result <- oa.fold(EitherT(callRemote(pid, oid, params)))(EitherT.fromEither(_))
         } yield result).value
 
       override def callRemote(
@@ -192,23 +193,46 @@ object ItcService {
         oid:    Observation.Id,
         params: GeneratorParams
       )(using NoTransaction[F]): F[Either[OdbError, Itc]] =
-        (for {
-          p <- EitherT.fromEither(params.itcInput.leftMap(m => Error.invalidObservation(oid, GeneratorParamsService.Error.MissingData(m))))
-          r <- EitherT(callRemoteItc(oid, p))
-          _ <- EitherT.liftF(services.transactionally(insertOrUpdate(pid, oid, p, r)))
-        } yield r).value
+        params.itcInput
+          .leftMap(m => Error.invalidObservation(oid, GeneratorParamsService.Error.MissingData(m)))
+          .fold(
+            err => Left(err).pure[F],
+            p =>
+              callRemoteItc(oid, p).flatTap:
+                case Right(r)                       => services.transactionally(insertOrUpdate(pid, oid, p, r))
+                case Left(e @ OdbError.ItcError(_)) => services.transactionally(insertOrUpdateFailure(pid, oid, p, e))
+                case Left(_)                        => Concurrent[F].unit
+          )
 
-      // Selects the parameters then selects the previously stored result set, if any.
+      // Selects the parameters then checks both success and failure caches.
+      // Returns None if not cached (call remote), Some(Right) for cached success,
+      // Some(Left) for cached deterministic failure.
       private def attemptLookup(
         pid: Program.Id,
         oid: Observation.Id
-      )(using NoTransaction[F]): F[Either[OdbError, (GeneratorParams, Option[Itc])]] =
+      )(using NoTransaction[F]): F[Either[OdbError, (GeneratorParams, Option[Either[OdbError, Itc]])]] =
         services.transactionally {
           (for {
             p <- EitherT(generatorParamsService.selectOne(pid, oid).map(_.leftMap(Error.invalidObservation(oid, _))))
-            r <- EitherT.liftF(selectOne(pid, oid, p))
+            r <- EitherT.liftF:
+              selectOne(pid, oid, p).flatMap:
+                case Some(itc) => Some(itc.asRight[OdbError]).pure[F]
+                case None      => selectOneFailure(pid, oid, p).map(_.map(_.asLeft[Itc]))
           } yield (p, r)).value
         }
+
+      private def selectOneFailure(
+        pid:    Program.Id,
+        oid:    Observation.Id,
+        params: GeneratorParams
+      ): F[Option[OdbError]] =
+        params.itcInput.toOption.flatTraverse: ps =>
+          val inputHash = Md5Hash.unsafeFromByteArray(ps.md5)
+          session
+            .option(Statements.SelectOneItcFailure)(pid, oid)
+            .map:
+              _.collect:
+                case (h, msg) if h === inputHash => OdbError.ItcError(msg.some)
 
       override def selectOne(
         pid:    Program.Id,
@@ -286,6 +310,11 @@ object ItcService {
 
                 val modifiedCcr = ClientCalculationResult(ccr.versions, modifiedTargetTimes)
                 toTargetResults(targets, NonEmptyList.one(modifiedCcr)).map(_.head)
+              .handleErrorWith:
+                case e: ResponseException[?] =>
+                  OdbError.ItcError(e.getMessage.some).asLeft.pure
+                case t =>
+                  OdbError.RemoteServiceCallError(s"Error calling ITC service: ${t.getMessage}".some).asLeft.pure
 
         input.mode match
           case InstrumentMode.GmosNorthImaging(_, _, _, _) |
@@ -375,8 +404,11 @@ object ItcService {
             .parTraverse: in =>
               client.imaging(in, useCache = false)
             .map(_.asRight)
-            .handleError: err =>
-              OdbError.RemoteServiceCallError(s"Error calling ITC service: ${err.getMessage}".some).asLeft
+            .handleErrorWith:
+              case e: ResponseException[?] =>
+                OdbError.ItcError(e.getMessage.some).asLeft.pure
+              case t =>
+                OdbError.RemoteServiceCallError(s"Error calling ITC service: ${t.getMessage}".some).asLeft.pure
 
         for
           fs <- EitherT.fromEither(extractFilters(input.science.map(_.mode).toList, Nil))
@@ -395,8 +427,11 @@ object ItcService {
             client
               .spectroscopy(si, useCache = false)
               .map(_.asRight)
-              .handleError: t =>
-                OdbError.RemoteServiceCallError(s"Error calling ITC service: ${t.getMessage}".some).asLeft
+              .handleErrorWith:
+                case e: ResponseException[?] =>
+                  OdbError.ItcError(e.getMessage.some).asLeft.pure
+                case t =>
+                  OdbError.RemoteServiceCallError(s"Error calling ITC service: ${t.getMessage}".some).asLeft.pure
 
         // A placeholder result for GHOST, at least for now.
         //
@@ -464,13 +499,12 @@ object ItcService {
             EitherT.leftT(OdbError.InvalidObservation(oid, s"Unrecognized ItcInput: $input".some))
         ).value
 
-      @annotation.nowarn("msg=unused implicit parameter")
       private def insertOrUpdate(
         pid:     Program.Id,
         oid:     Observation.Id,
         input:   ItcInput,
         results: Itc
-      )(using Transaction[F]): F[Unit] =
+      ): F[Unit] =
         val h = Md5Hash.unsafeFromByteArray(input.md5)
         session.execute(Statements.InsertOrUpdateItcResult)(pid, oid, h, results, h, results)
           .void
@@ -478,6 +512,20 @@ object ItcService {
             case SqlState.ForeignKeyViolation(ex) =>
               Logger[F].info(ex)(s"Failed to insert or update ITC result for program $pid, observation $oid. Probably due to a deleted calibration observation.")
           }
+
+      private def insertOrUpdateFailure(
+        pid:   Program.Id,
+        oid:   Observation.Id,
+        input: ItcInput,
+        error: OdbError.ItcError
+      ): F[Unit] =
+        val h   = Md5Hash.unsafeFromByteArray(input.md5)
+        val msg = error.detail.getOrElse("")
+        session.execute(Statements.InsertOrUpdateItcFailure)(pid, oid, h, msg, h, msg)
+          .void
+          .recoverWith:
+            case SqlState.ForeignKeyViolation(ex) =>
+              Logger[F].info(ex)(s"Failed to insert or update ITC failure for program $pid, observation $oid. Probably due to a deleted calibration observation.")
     }
 
   object Statements {
@@ -555,6 +603,39 @@ object ItcService {
         ON CONFLICT ON CONSTRAINT t_itc_result_pkey DO UPDATE
           SET c_hash             = $md5_hash,
               c_asterism_results = $itc
+      """.command
+
+    val SelectOneItcFailure: Query[(Program.Id, Observation.Id), (Md5Hash, String)] =
+      sql"""
+        SELECT c_hash, c_error_message
+        FROM t_itc_result_failure
+        WHERE c_program_id     = $program_id AND
+              c_observation_id = $observation_id
+      """.query(md5_hash *: text)
+
+    val InsertOrUpdateItcFailure: Command[(
+      Program.Id,
+      Observation.Id,
+      Md5Hash,
+      String,
+      Md5Hash,
+      String
+    )] =
+      sql"""
+        INSERT INTO t_itc_result_failure (
+          c_program_id,
+          c_observation_id,
+          c_hash,
+          c_error_message
+        ) VALUES (
+          $program_id,
+          $observation_id,
+          $md5_hash,
+          $text
+        )
+        ON CONFLICT ON CONSTRAINT t_itc_result_failure_pkey DO UPDATE
+          SET c_hash          = $md5_hash,
+              c_error_message = $text
       """.command
 
   }

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -175,7 +175,7 @@ object ItcService {
 
   }
 
-  def instantiate[F[_]: Concurrent: Parallel: Logger: Services](client: ItcClient[F]): ItcService[F] =
+  def instantiate[F[_]: Concurrent as F: Parallel: Logger as L: Services](client: ItcClient[F]): ItcService[F] =
     new ItcService[F] {
 
       override def lookup(
@@ -201,7 +201,7 @@ object ItcService {
               callRemoteItc(oid, p).flatTap:
                 case Right(r)                       => services.transactionally(insertOrUpdate(pid, oid, p, r))
                 case Left(e @ OdbError.ItcError(_)) => services.transactionally(insertOrUpdateFailure(pid, oid, p, e))
-                case Left(_)                        => Concurrent[F].unit
+                case Left(_)                        => F.unit
           )
 
       // Selects the parameters then checks both success and failure caches.
@@ -368,14 +368,14 @@ object ItcService {
 
         case object GmosNorthImaging extends Imaging[GmosNorthFilter]:
           override def pf: PartialFunction[InstrumentMode, GmosNorthFilter] =
-            case InstrumentMode.GmosNorthImaging(_, f, _, _) => f
+            case InstrumentMode.GmosNorthImaging(filter = f) => f
 
           override def wrap(nem: NonEmptyMap[GmosNorthFilter, Zipper[Itc.Result]]): Itc =
             Itc.GmosNorthImaging(nem)
 
         case object GmosSouthImaging extends Imaging[GmosSouthFilter]:
           override def pf: PartialFunction[InstrumentMode, GmosSouthFilter] =
-               case InstrumentMode.GmosSouthImaging(_, f, _, _) => f
+               case InstrumentMode.GmosSouthImaging(filter = f) => f
 
           override def wrap(nem: NonEmptyMap[GmosSouthFilter, Zipper[Itc.Result]]): Itc =
             Itc.GmosSouthImaging(nem)
@@ -510,7 +510,7 @@ object ItcService {
           .void
           .recoverWith {
             case SqlState.ForeignKeyViolation(ex) =>
-              Logger[F].info(ex)(s"Failed to insert or update ITC result for program $pid, observation $oid. Probably due to a deleted calibration observation.")
+              L.info(ex)(s"Failed to insert or update ITC result for program $pid, observation $oid. Probably due to a deleted calibration observation.")
           }
 
       private def insertOrUpdateFailure(
@@ -525,7 +525,7 @@ object ItcService {
           .void
           .recoverWith:
             case SqlState.ForeignKeyViolation(ex) =>
-              Logger[F].info(ex)(s"Failed to insert or update ITC failure for program $pid, observation $oid. Probably due to a deleted calibration observation.")
+              L.info(ex)(s"Failed to insert or update ITC failure for program $pid, observation $oid. Probably due to a deleted calibration observation.")
     }
 
   object Statements {

--- a/modules/service/src/test/scala/lucuma/odb/service/ItcServiceSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/ItcServiceSuite.scala
@@ -52,8 +52,10 @@ trait ItcServiceSuiteSupport extends ExecutionTestSupportForGmos:
     withSession: s =>
       s.unique(
         sql"""
-          SELECT count(*) FROM t_itc_result_failure
-          WHERE c_program_id = $program_id AND c_observation_id = $observation_id
+          SELECT count(*) FROM t_itc_result
+          WHERE c_program_id      = $program_id      AND
+                c_observation_id  = $observation_id  AND
+                c_error_message  IS NOT NULL
         """.query(skunk.codec.numeric.int8)
       )(pid, oid).map(_ > 0)
 

--- a/modules/service/src/test/scala/lucuma/odb/service/ItcServiceSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/ItcServiceSuite.scala
@@ -19,9 +19,10 @@ import lucuma.itc.client.SpectroscopyIntegrationTimeAndGraphsInput
 import lucuma.itc.client.SpectroscopyIntegrationTimeAndGraphsResult
 import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
 import lucuma.odb.service.Services.ServiceAccess
+import lucuma.odb.util.Codecs.*
 import skunk.*
 import skunk.implicits.*
-import lucuma.odb.util.Codecs.*
+
 import java.io.IOException
 
 // Shared support for ITC service caching tests.

--- a/modules/service/src/test/scala/lucuma/odb/service/ItcServiceSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/ItcServiceSuite.scala
@@ -1,0 +1,107 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.Ref
+import clue.ResponseException
+import clue.model.GraphQLError
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.itc.ItcVersions
+import lucuma.itc.client.ClientCalculationResult
+import lucuma.itc.client.ImagingInput
+import lucuma.itc.client.ItcClient
+import lucuma.itc.client.SpectroscopyInput
+import lucuma.itc.client.SpectroscopyIntegrationTimeAndGraphsInput
+import lucuma.itc.client.SpectroscopyIntegrationTimeAndGraphsResult
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
+import lucuma.odb.service.Services.ServiceAccess
+import skunk.*
+import skunk.implicits.*
+import lucuma.odb.util.Codecs.*
+import java.io.IOException
+
+// Shared support for ITC service caching tests.
+trait ItcServiceSuiteSupport extends ExecutionTestSupportForGmos:
+
+  def erroringClient(err: Throwable, callCount: Ref[IO, Int]): ItcClient[IO] =
+    new ItcClient[IO]:
+      def spectroscopy(input: SpectroscopyInput, useCache: Boolean): IO[ClientCalculationResult] =
+        callCount.update(_ + 1) *> IO.raiseError(err)
+
+      def imaging(input: ImagingInput, useCache: Boolean): IO[ClientCalculationResult] =
+        callCount.update(_ + 1) *> IO.raiseError(err)
+
+      def spectroscopyIntegrationTimeAndGraphs(
+        input: SpectroscopyIntegrationTimeAndGraphsInput, useCache: Boolean
+      ): IO[SpectroscopyIntegrationTimeAndGraphsResult] =
+        callCount.update(_ + 1) *> IO.raiseError(err)
+
+      def versions: IO[ItcVersions] = IO.raiseError(err)
+
+  def withItcService[A](client: ItcClient[IO])(f: ServiceAccess ?=> ItcService[IO] => IO[A]): IO[A] =
+    withServicesForObscalc(serviceUser): services =>
+      given Services[IO] = services
+      f(ItcService.instantiate[IO](client))
+
+  def itcFailureRowExists(pid: Program.Id, oid: Observation.Id): IO[Boolean] =
+    withSession: s =>
+      s.unique(
+        sql"""
+          SELECT count(*) FROM t_itc_result_failure
+          WHERE c_program_id = $program_id AND c_observation_id = $observation_id
+        """.query(skunk.codec.numeric.int8)
+      )(pid, oid).map(_ > 0)
+
+// Deterministic ITC failure test. It is for cases like sourec too bright or exposure time too long
+class ItcServiceDeterministicFailureSuite extends ItcServiceSuiteSupport:
+
+  test("deterministic failure is cached — second lookup skips remote ITC"):
+    val deterministicErr = ResponseException[Unit](
+      NonEmptyList.one(GraphQLError("The maximum exposure time is 600.0 seconds")),
+      None
+    )
+
+    for
+      callCount <- IO.ref(0)
+      client     = erroringClient(deterministicErr, callCount)
+      pid       <- createProgramAs(pi)
+      tid       <- createTargetWithProfileAs(pi, pid)
+      oid       <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _         <- withItcService(client): svc =>
+                     for
+                       r1    <- svc.lookup(pid, oid)
+                       r2    <- svc.lookup(pid, oid)
+                       calls <- callCount.get
+                     yield
+                       assert(r1.isLeft)
+                       assertEquals(r1, r2)
+                       // Second lookup must be served from DB, not from remote ITC.
+                       assertEquals(calls, 1)
+      exists    <- itcFailureRowExists(pid, oid)
+    yield assert(exists) // a row added to the db
+
+// Transient ITC failure: e.g. IOException
+class ItcServiceTransientFailureSuite extends ItcServiceSuiteSupport:
+
+  test("transient failure is NOT cached — remote ITC is called on every lookup"):
+    for
+      callCount <- IO.ref(0)
+      client     = erroringClient(new IOException("Connection refused"), callCount)
+      pid       <- createProgramAs(pi)
+      tid       <- createTargetWithProfileAs(pi, pid)
+      oid       <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _         <- withItcService(client): svc =>
+                     for
+                       r1    <- svc.lookup(pid, oid)
+                       r2    <- svc.lookup(pid, oid)
+                       calls <- callCount.get
+                     yield
+                       assert(r1.isLeft)
+                       // Both lookups must hit the remote
+                       assertEquals(calls, 2)
+      exists    <- itcFailureRowExists(pid, oid)
+    yield assert(!exists) // no row in the db


### PR DESCRIPTION
I keep checking the traces for a very large program. The program has 258 observation and from those 27 show itc "deterministic" errors, meaning they are not due to connection errors but will be errors always regardless of how often we repeat them.

Measurements for this particular case show that almost 60% of the time is spent requerying the itc for the same error

This PR proposes to store these errors in db acting as a cache, equivalent to the succesful itc case. Random errors will be retried again.

itc version changes will clear the table as it is already done for the successful case

A question for @swalker2m. Should itc version changes invalidate obscalc? I don't see that happening for the succesful case either