### PR TITLE
Support GNIRS IFU in ITC

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ val slf4jVersion                 = "2.0.18"
 val testcontainersScalaVersion   = "0.44.1" // check test output if you attempt to update this
 val weaverVersion                = "0.13.0"
 
-ThisBuild / tlBaseVersion      := "0.83"
+ThisBuild / tlBaseVersion      := "0.84"
 ThisBuild / scalaVersion       := "3.8.4"
 ThisBuild / crossScalaVersions := Seq("3.8.4")
 ThisBuild / scalacOptions     ++= Seq("-Xmax-inlines", "50") // Hash derivation fails with default of 32

--- a/itc/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
+++ b/itc/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
@@ -24,7 +24,6 @@ import lucuma.core.enums.GmosSouthFilter
 import lucuma.core.enums.GmosSouthGrating
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsFilter
-import lucuma.core.enums.GnirsFpuSlit
 import lucuma.core.enums.GnirsGrating
 import lucuma.core.enums.GnirsPrism
 import lucuma.core.enums.GnirsReadMode
@@ -33,6 +32,7 @@ import lucuma.core.enums.PortDisposition
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ExposureTimeMode
 import lucuma.core.model.sequence.gmos.GmosCcdMode
+import lucuma.core.model.sequence.gnirs.GnirsFpu
 import lucuma.itc.ItcGhostDetector
 import lucuma.itc.client.json.encoders.given
 import lucuma.itc.client.json.syntax.*
@@ -184,7 +184,7 @@ object InstrumentMode {
     exposureTimeMode:  ExposureTimeMode,
     centralWavelength: Wavelength,
     filter:            GnirsFilter,
-    slitWidth:         GnirsFpuSlit,
+    fpu:               GnirsFpu.Spectroscopy,
     prism:             GnirsPrism,
     grating:           GnirsGrating,
     camera:            GnirsCamera,
@@ -198,11 +198,16 @@ object InstrumentMode {
 
   object GnirsSpectroscopy:
     given Encoder[GnirsSpectroscopy] = a =>
+      // `fpu` is a @oneOf input: exactly one of `slitWidth` / `ifu`.
+      val fpuJson: Json =
+        a.fpu match
+          case GnirsFpu.Spectroscopy.Slit(s) => Json.obj("slitWidth" -> s.asScreamingJson)
+          case GnirsFpu.Spectroscopy.Ifu(i)  => Json.obj("ifu" -> i.asScreamingJson)
       Json.obj(
         "exposureTimeMode"  -> a.exposureTimeMode.asJson,
         "centralWavelength" -> a.centralWavelength.asJson,
         "filter"            -> a.filter.asScreamingJson,
-        "slitWidth"         -> a.slitWidth.asScreamingJson,
+        "fpu"               -> fpuJson,
         "prism"             -> a.prism.asScreamingJson,
         "grating"           -> a.grating.asScreamingJson,
         "camera"            -> a.camera.asScreamingJson,

--- a/itc/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
+++ b/itc/client/shared/src/main/scala/lucuma/itc/client/InstrumentMode.scala
@@ -199,7 +199,7 @@ object InstrumentMode {
   object GnirsSpectroscopy:
     given Encoder[GnirsSpectroscopy] = a =>
       // `fpu` is a @oneOf input: exactly one of `slitWidth` / `ifu`.
-      val fpuJson: Json =
+      val fpuJson: Json  =
         a.fpu match
           case GnirsFpu.Spectroscopy.Slit(s) => Json.obj("slitWidth" -> s.asScreamingJson)
           case GnirsFpu.Spectroscopy.Ifu(i)  => Json.obj("ifu" -> i.asScreamingJson)

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/CommonITCLegacySuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/CommonITCLegacySuite.scala
@@ -108,6 +108,24 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
   def ifuAnalysisMethod =
     ItcObservationDetails.AnalysisMethod.Ifu.Single(skyFibres = 250, offset = 5.0)
 
+  // The production GNIRS IFU analysis method: "sum of 2x2 elements at the center"
+  // with a single sky fibre (see lucuma.itc.service.ObservingMode).
+  def gnirsIfuAnalysisMethod =
+    ItcObservationDetails.AnalysisMethod.Ifu.Summed(
+      skyFibres = 1,
+      numX = 2,
+      numY = 2,
+      centerX = 0.0,
+      centerY = 0.0
+    )
+
+  // The OCS GNIRS recipe requires a specific camera per IFU resolution: LR-IFU on the
+  // 0.15"/pix (Short) camera, HR-IFU on the 0.05"/pix (Long) camera.
+  def gnirsCameraForIfu(ifu: GnirsFpuIfu): GnirsCamera =
+    ifu match
+      case GnirsFpuIfu.LowResolution  => GnirsCamera.ShortBlue
+      case GnirsFpuIfu.HighResolution => GnirsCamera.LongBlue
+
   // Common telescope details - this will be used in tests
   def telescope = ItcTelescopeDetails(
     wfs = ItcWavefrontSensor.OIWFS,

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecExpTimeSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecExpTimeSuite.scala
@@ -8,6 +8,7 @@ import eu.timepit.refined.types.numeric.PosInt
 import io.circe.syntax.*
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsFilter
+import lucuma.core.enums.GnirsFpuIfu
 import lucuma.core.enums.GnirsFpuSlit
 import lucuma.core.enums.GnirsGrating
 import lucuma.core.enums.GnirsPrism
@@ -92,7 +93,20 @@ class LegacyITCGnirsSpecExpTimeSuite extends CommonITCLegacySuite:
   test("gnirs slit width".tag(LegacyITCTest)):
     Enumerated[GnirsFpuSlit].all.foreach: s =>
       val result = localItc.calculate:
-        bodyConf(sourceDefinition, obs, gnirs.copy(fpu = GnirsFpu.Spectroscopy.Slit(s))).asJson.noSpaces
+        bodyConf(sourceDefinition,
+                 obs,
+                 gnirs.copy(fpu = GnirsFpu.Spectroscopy.Slit(s))
+        ).asJson.noSpaces
+      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
+
+  test("gnirs IFU".tag(LegacyITCTest)):
+    Enumerated[GnirsFpuIfu].all.foreach: ifu =>
+      val ifuMode = gnirs.copy(
+        fpu = GnirsFpu.Spectroscopy.Ifu(ifu),
+        camera = gnirsCameraForIfu(ifu)
+      )
+      val result  = localItc.calculate:
+        bodyConf(sourceDefinition, obs, ifuMode, gnirsIfuAnalysisMethod).asJson.noSpaces
       assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs well depth".tag(LegacyITCTest)):

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecExpTimeSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecExpTimeSuite.scala
@@ -16,6 +16,7 @@ import lucuma.core.enums.GnirsWellDepth
 import lucuma.core.enums.PortDisposition
 import lucuma.core.math.Angle
 import lucuma.core.math.Wavelength
+import lucuma.core.model.sequence.gnirs.GnirsFpu
 import lucuma.core.util.Enumerated
 import lucuma.itc.legacy.codecs.given
 import lucuma.itc.service.ItcObservationDetails
@@ -43,14 +44,14 @@ class LegacyITCGnirsSpecExpTimeSuite extends CommonITCLegacySuite:
     analysisMethod = ItcObservationDetails.AnalysisMethod.Aperture.Auto(1)
   )
 
-  val gnirs = ObservingMode.SpectroscopyMode.GnirsLongSlit(
+  val gnirs = ObservingMode.SpectroscopyMode.GnirsSpectroscopy(
     centralWavelength = centralWavelength,
     grating = GnirsGrating.D32,
     filter = GnirsFilter.Order3,
     camera = GnirsCamera.ShortBlue,
     prism = GnirsPrism.Mirror,
     readMode = GnirsReadMode.Bright,
-    slitWidth = GnirsFpuSlit.LongSlit_0_30,
+    fpu = GnirsFpu.Spectroscopy.Slit(GnirsFpuSlit.LongSlit_0_30),
     wellDepth = GnirsWellDepth.Shallow,
     coadds = PosInt.unsafeFrom(1),
     portDisposition = PortDisposition.Bottom
@@ -91,7 +92,7 @@ class LegacyITCGnirsSpecExpTimeSuite extends CommonITCLegacySuite:
   test("gnirs slit width".tag(LegacyITCTest)):
     Enumerated[GnirsFpuSlit].all.foreach: s =>
       val result = localItc.calculate:
-        bodyConf(sourceDefinition, obs, gnirs.copy(slitWidth = s)).asJson.noSpaces
+        bodyConf(sourceDefinition, obs, gnirs.copy(fpu = GnirsFpu.Spectroscopy.Slit(s))).asJson.noSpaces
       assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs well depth".tag(LegacyITCTest)):

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecSignalToNoiseSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecSignalToNoiseSuite.scala
@@ -116,7 +116,10 @@ class LegacyITCGnirsSpecSignalToNoiseSuite extends CommonITCLegacySuite:
   test("gnirs slit width".tag(LegacyITCTest)):
     Enumerated[GnirsFpuSlit].all.foreach: s =>
       val result = localItc.calculate:
-        bodyConf(sourceDefinition, obs, gnirs.copy(fpu = GnirsFpu.Spectroscopy.Slit(s))).asJson.noSpaces
+        bodyConf(sourceDefinition,
+                 obs,
+                 gnirs.copy(fpu = GnirsFpu.Spectroscopy.Slit(s))
+        ).asJson.noSpaces
       assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs well depth".tag(LegacyITCTest)):

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecSignalToNoiseSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecSignalToNoiseSuite.scala
@@ -7,6 +7,7 @@ import eu.timepit.refined.types.numeric.PosInt
 import io.circe.syntax.*
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsFilter
+import lucuma.core.enums.GnirsFpuIfu
 import lucuma.core.enums.GnirsFpuSlit
 import lucuma.core.enums.GnirsGrating
 import lucuma.core.enums.GnirsPrism
@@ -15,6 +16,7 @@ import lucuma.core.enums.GnirsWellDepth
 import lucuma.core.enums.PortDisposition
 import lucuma.core.math.Angle
 import lucuma.core.math.Wavelength
+import lucuma.core.model.sequence.gnirs.GnirsFpu
 import lucuma.core.util.Enumerated
 import lucuma.itc.legacy.codecs.given
 import lucuma.itc.service.ItcObservationDetails
@@ -42,14 +44,14 @@ class LegacyITCGnirsSpecSignalToNoiseSuite extends CommonITCLegacySuite:
     analysisMethod = lsAnalysisMethod
   )
 
-  val gnirs = ObservingMode.SpectroscopyMode.GnirsLongSlit(
+  val gnirs = ObservingMode.SpectroscopyMode.GnirsSpectroscopy(
     centralWavelength = centralWavelength,
     grating = GnirsGrating.D32,
     filter = GnirsFilter.Order3,
     camera = GnirsCamera.ShortBlue,
     prism = GnirsPrism.Mirror,
     readMode = GnirsReadMode.Bright,
-    slitWidth = GnirsFpuSlit.LongSlit_0_30,
+    fpu = GnirsFpu.Spectroscopy.Slit(GnirsFpuSlit.LongSlit_0_30),
     wellDepth = GnirsWellDepth.Shallow,
     coadds = PosInt.unsafeFrom(1),
     portDisposition = PortDisposition.Bottom
@@ -65,6 +67,26 @@ class LegacyITCGnirsSpecSignalToNoiseSuite extends CommonITCLegacySuite:
   // directly — no allowedErrors fallback (which would silently absorb the bug).
   test("gnirs signal-to-noise base config yields valid results".tag(LegacyITCTest)):
     val result = localItc.calculate(baseParams.asJson.noSpaces)
+    assertIOBoolean(result.map(_.fold(_ => false, containsValidResults)))
+
+  // Exercises the IFU path through the real OCS jars: slitWidth encodes to LR_IFU,
+  // crossDispersed to NO, and the analysis method is "sum of 2x2 elements at the
+  // center" with a single sky fibre (the production default). LR-IFU requires the
+  // 0.15"/pix (Short) camera.
+  test("gnirs IFU yields valid results".tag(LegacyITCTest)):
+    val ifuMode     = gnirs.copy(
+      fpu = GnirsFpu.Spectroscopy.Ifu(GnirsFpuIfu.LowResolution),
+      camera = GnirsCamera.ShortBlue
+    )
+    val ifuAnalysis = ItcObservationDetails.AnalysisMethod.Ifu.Summed(
+      skyFibres = 1,
+      numX = 2,
+      numY = 2,
+      centerX = 0.0,
+      centerY = 0.0
+    )
+    val result      = localItc.calculate:
+      bodyConf(sourceDefinition, obs, ifuMode, ifuAnalysis).asJson.noSpaces
     assertIOBoolean(result.map(_.fold(_ => false, containsValidResults)))
 
   test("gnirs grating".tag(LegacyITCTest)):
@@ -100,7 +122,7 @@ class LegacyITCGnirsSpecSignalToNoiseSuite extends CommonITCLegacySuite:
   test("gnirs slit width".tag(LegacyITCTest)):
     Enumerated[GnirsFpuSlit].all.foreach: s =>
       val result = localItc.calculate:
-        bodyConf(sourceDefinition, obs, gnirs.copy(slitWidth = s)).asJson.noSpaces
+        bodyConf(sourceDefinition, obs, gnirs.copy(fpu = GnirsFpu.Spectroscopy.Slit(s))).asJson.noSpaces
       assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs well depth".tag(LegacyITCTest)):

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecSignalToNoiseSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecSignalToNoiseSuite.scala
@@ -69,25 +69,19 @@ class LegacyITCGnirsSpecSignalToNoiseSuite extends CommonITCLegacySuite:
     val result = localItc.calculate(baseParams.asJson.noSpaces)
     assertIOBoolean(result.map(_.fold(_ => false, containsValidResults)))
 
-  // Exercises the IFU path through the real OCS jars: slitWidth encodes to LR_IFU,
-  // crossDispersed to NO, and the analysis method is "sum of 2x2 elements at the
-  // center" with a single sky fibre (the production default). LR-IFU requires the
-  // 0.15"/pix (Short) camera.
-  test("gnirs IFU yields valid results".tag(LegacyITCTest)):
-    val ifuMode     = gnirs.copy(
-      fpu = GnirsFpu.Spectroscopy.Ifu(GnirsFpuIfu.LowResolution),
-      camera = GnirsCamera.ShortBlue
-    )
-    val ifuAnalysis = ItcObservationDetails.AnalysisMethod.Ifu.Summed(
-      skyFibres = 1,
-      numX = 2,
-      numY = 2,
-      centerX = 0.0,
-      centerY = 0.0
-    )
-    val result      = localItc.calculate:
-      bodyConf(sourceDefinition, obs, ifuMode, ifuAnalysis).asJson.noSpaces
-    assertIOBoolean(result.map(_.fold(_ => false, containsValidResults)))
+  // Exercises both IFU FPU mappings through the real OCS jars: the slitWidth field
+  // encodes to LR_IFU / HR_IFU, crossDispersed to NO, and the analysis method is
+  // "sum of 2x2 elements at the center" with a single sky fibre (the production
+  // default). Each resolution requires its specific camera.
+  test("gnirs IFU".tag(LegacyITCTest)):
+    Enumerated[GnirsFpuIfu].all.foreach: ifu =>
+      val ifuMode = gnirs.copy(
+        fpu = GnirsFpu.Spectroscopy.Ifu(ifu),
+        camera = gnirsCameraForIfu(ifu)
+      )
+      val result  = localItc.calculate:
+        bodyConf(sourceDefinition, obs, ifuMode, gnirsIfuAnalysisMethod).asJson.noSpaces
+      assertIOBoolean(result.map(_.fold(_ => false, containsValidResults)))
 
   test("gnirs grating".tag(LegacyITCTest)):
     Enumerated[GnirsGrating].all.foreach: g =>

--- a/itc/service/src/main/resources/graphql/itc.graphql
+++ b/itc/service/src/main/resources/graphql/itc.graphql
@@ -4,7 +4,7 @@
 #import GmosSouthGrating, GmosSouthFpuInput, GmosSouthFilter, GmosCcdModeInput, GmosRoi, GmosNorthGrating, GmosNorthFpuInput, GmosNorthFilter from "lucuma/odb/graphql/OdbSchema.graphql"
 #import Flamingos2Disperser, Flamingos2Fpu, Flamingos2Filter, Flamingos2ReadMode from "lucuma/odb/graphql/OdbSchema.graphql"
 #import GhostReadMode, GhostBinning, GhostResolutionMode from "lucuma/odb/graphql/OdbSchema.graphql"
-#import GnirsFilter, GnirsFpuSlit, GnirsPrism, GnirsGrating, GnirsCamera, GnirsReadMode, GnirsWellDepth from "lucuma/odb/graphql/OdbSchema.graphql"
+#import GnirsFilter, GnirsFpuSlit, GnirsFpuIfu, GnirsPrism, GnirsGrating, GnirsCamera, GnirsReadMode, GnirsWellDepth from "lucuma/odb/graphql/OdbSchema.graphql"
 
 """
 ##########
@@ -289,6 +289,21 @@ input GhostSpectroscopyInput {
   blueDetector: ItcGhostDetectorInput!
 }
 
+"""
+GNIRS spectroscopy FPU: exactly one of a long slit or an IFU.
+"""
+input GnirsFpuSpectroscopyInput @oneOf {
+  """
+  GNIRS slit width
+  """
+  slitWidth: GnirsFpuSlit
+
+  """
+  GNIRS IFU
+  """
+  ifu: GnirsFpuIfu
+}
+
 input GnirsSpectroscopyInput {
   """
   Exposure time mode.
@@ -306,9 +321,9 @@ input GnirsSpectroscopyInput {
   filter: GnirsFilter!
 
   """
-  GNIRS slit width
+  GNIRS spectroscopy FPU (long slit or IFU)
   """
-  slitWidth: GnirsFpuSlit!
+  fpu: GnirsFpuSpectroscopyInput!
 
   """
   GNIRS cross-disperser prism
@@ -428,7 +443,7 @@ input InstrumentModesInput @oneOf {
   ghostSpectroscopy: GhostSpectroscopyInput
 
   """
-  Gnirs Longslit Spectroscopy
+  Gnirs Spectroscopy (long slit or IFU)
   """
   gnirsSpectroscopy: GnirsSpectroscopyInput
 

--- a/itc/service/src/main/scala/lucuma/itc/input/GnirsFpuSpectroscopyInput.scala
+++ b/itc/service/src/main/scala/lucuma/itc/input/GnirsFpuSpectroscopyInput.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.itc.input
+
+import cats.syntax.parallel.*
+import lucuma.core.model.sequence.gnirs.GnirsFpu
+import lucuma.odb.graphql.binding.*
+import lucuma.odb.graphql.input.*
+
+// A GNIRS spectroscopy FPU: exactly one of a long slit or an IFU (`@oneOf`).
+object GnirsFpuSpectroscopyInput:
+
+  val Binding: Matcher[GnirsFpu.Spectroscopy] =
+    ObjectFieldsBinding.rmap:
+      case List(
+            GnirsFpuSlitBinding.Option("slitWidth", slitWidth),
+            GnirsFpuIfuBinding.Option("ifu", ifu)
+          ) =>
+        (slitWidth, ifu).parTupled.flatMap: (slitWidth, ifu) =>
+          oneOrFail(
+            slitWidth.map(GnirsFpu.Spectroscopy.Slit(_)) -> "slitWidth",
+            ifu.map(GnirsFpu.Spectroscopy.Ifu(_))        -> "ifu"
+          )

--- a/itc/service/src/main/scala/lucuma/itc/input/GnirsSpectroscopyInput.scala
+++ b/itc/service/src/main/scala/lucuma/itc/input/GnirsSpectroscopyInput.scala
@@ -7,7 +7,6 @@ import cats.syntax.parallel.*
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsFilter
-import lucuma.core.enums.GnirsFpuSlit
 import lucuma.core.enums.GnirsGrating
 import lucuma.core.enums.GnirsPrism
 import lucuma.core.enums.GnirsReadMode
@@ -15,6 +14,7 @@ import lucuma.core.enums.GnirsWellDepth
 import lucuma.core.enums.PortDisposition
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ExposureTimeMode
+import lucuma.core.model.sequence.gnirs.GnirsFpu
 import lucuma.itc.binding.*
 import lucuma.odb.graphql.binding.*
 import lucuma.odb.graphql.input.*
@@ -23,7 +23,7 @@ final case class GnirsSpectroscopyInput(
   exposureTimeMode:  ExposureTimeMode,
   centralWavelength: Wavelength,
   filter:            GnirsFilter,
-  slitWidth:         GnirsFpuSlit,
+  fpu:               GnirsFpu.Spectroscopy,
   prism:             GnirsPrism,
   grating:           GnirsGrating,
   camera:            GnirsCamera,
@@ -41,7 +41,7 @@ object GnirsSpectroscopyInput:
             ExposureTimeModeInput.Binding("exposureTimeMode", exposureTimeMode),
             WavelengthInput.Binding("centralWavelength", centralWavelength),
             GnirsFilterBinding("filter", filter),
-            GnirsFpuSlitBinding("slitWidth", slitWidth),
+            GnirsFpuSpectroscopyInput.Binding("fpu", fpu),
             GnirsPrismBinding("prism", prism),
             GnirsGratingBinding("grating", grating),
             GnirsCameraBinding("camera", camera),
@@ -53,7 +53,7 @@ object GnirsSpectroscopyInput:
         (exposureTimeMode,
          centralWavelength,
          filter,
-         slitWidth,
+         fpu,
          prism,
          grating,
          camera,

--- a/itc/service/src/main/scala/lucuma/itc/legacy/ItcImpl.scala
+++ b/itc/service/src/main/scala/lucuma/itc/legacy/ItcImpl.scala
@@ -139,7 +139,7 @@ object ItcImpl {
                   SpectroscopyMode.GmosSouth(_, _, _, _, _, _, _) |
                   SpectroscopyMode.Flamingos2(_, _, _, _, _) | SpectroscopyMode.Igrins2(_) |
                   SpectroscopyMode.Ghost(_, _, _, _, _) |
-                  SpectroscopyMode.GnirsLongSlit(_, _, _, _, _, _, _, _, _, _)) =>
+                  SpectroscopyMode.GnirsSpectroscopy(_, _, _, _, _, _, _, _, _, _)) =>
                 spectroscopyTimeAndGraphs(
                   target,
                   observingMode,

--- a/itc/service/src/main/scala/lucuma/itc/legacy/codecs.scala
+++ b/itc/service/src/main/scala/lucuma/itc/legacy/codecs.scala
@@ -24,6 +24,7 @@ import lucuma.core.math.dimensional.syntax.*
 import lucuma.core.model.SourceProfile
 import lucuma.core.model.SpectralDefinition
 import lucuma.core.model.UnnormalizedSED
+import lucuma.core.model.sequence.gnirs.GnirsFpu
 import lucuma.core.syntax.display.*
 import lucuma.core.syntax.string.*
 import lucuma.itc.GraphType
@@ -268,12 +269,18 @@ private[legacy] object codecs:
       "redCamera"     -> a.redDetector.multiplyCount(a.stepCount).asJson
     )
 
-  private val encodeGnirsLongSlitSpectroscopy
-    : Encoder[ObservingMode.SpectroscopyMode.GnirsLongSlit] = a =>
+  private val encodeGnirsSpectroscopy
+    : Encoder[ObservingMode.SpectroscopyMode.GnirsSpectroscopy] = a =>
+    // The OCS recipe takes the slit width and the IFU through the same `slitWidth`
+    // parameter (GNIRSParams.SlitWidth includes the LR/HR IFU values).
+    val slitWidthTag: String =
+      a.fpu match
+        case GnirsFpu.Spectroscopy.Slit(s) => s.ocs2Tag
+        case GnirsFpu.Spectroscopy.Ifu(i)  => i.ocs2Tag
     Json.obj(
       "centralWavelength" -> a.centralWavelength.asJson,
       "filter"            -> Json.fromString(a.filter.ocs2Tag),
-      "slitWidth"         -> Json.fromString(a.slitWidth.ocs2Tag),
+      "slitWidth"         -> Json.fromString(slitWidthTag),
       "crossDispersed"    -> Json.fromString(a.prism.ocs2Tag),
       "grating"           -> Json.fromString(a.grating.ocs2Tag),
       "camera"            -> Json.fromString(a.camera.ocs2Tag),
@@ -310,8 +317,8 @@ private[legacy] object codecs:
         Json.obj("Igrins2Parameters" -> encodeIgrins2Spectroscopy(a))
       case a: ObservingMode.SpectroscopyMode.Ghost         =>
         Json.obj("GhostParameters" -> encodeGhostSpectroscopy(a))
-      case a: ObservingMode.SpectroscopyMode.GnirsLongSlit =>
-        Json.obj("GnirsParameters" -> encodeGnirsLongSlitSpectroscopy(a))
+      case a: ObservingMode.SpectroscopyMode.GnirsSpectroscopy =>
+        Json.obj("GnirsParameters" -> encodeGnirsSpectroscopy(a))
       // Imaging
       case a: ObservingMode.ImagingMode.Flamingos2         =>
         Json.obj("Flamingos2Parameters" -> encodeF2Imaging(a))

--- a/itc/service/src/main/scala/lucuma/itc/legacy/codecs.scala
+++ b/itc/service/src/main/scala/lucuma/itc/legacy/codecs.scala
@@ -269,26 +269,26 @@ private[legacy] object codecs:
       "redCamera"     -> a.redDetector.multiplyCount(a.stepCount).asJson
     )
 
-  private val encodeGnirsSpectroscopy
-    : Encoder[ObservingMode.SpectroscopyMode.GnirsSpectroscopy] = a =>
-    // The OCS recipe takes the slit width and the IFU through the same `slitWidth`
-    // parameter (GNIRSParams.SlitWidth includes the LR/HR IFU values).
-    val slitWidthTag: String =
-      a.fpu match
-        case GnirsFpu.Spectroscopy.Slit(s) => s.ocs2Tag
-        case GnirsFpu.Spectroscopy.Ifu(i)  => i.ocs2Tag
-    Json.obj(
-      "centralWavelength" -> a.centralWavelength.asJson,
-      "filter"            -> Json.fromString(a.filter.ocs2Tag),
-      "slitWidth"         -> Json.fromString(slitWidthTag),
-      "crossDispersed"    -> Json.fromString(a.prism.ocs2Tag),
-      "grating"           -> Json.fromString(a.grating.ocs2Tag),
-      "camera"            -> Json.fromString(a.camera.ocs2Tag),
-      "pixelScale"        -> Json.fromString(a.camera.pixelScale.ocs2Tag),
-      "readMode"          -> Json.fromString(a.readMode.ocs2Tag),
-      "wellDepth"         -> Json.fromString(a.wellDepth.ocs2Tag),
-      "altair"            -> Json.Null
-    )
+  private val encodeGnirsSpectroscopy: Encoder[ObservingMode.SpectroscopyMode.GnirsSpectroscopy] =
+    a =>
+      // The OCS recipe takes the slit width and the IFU through the same `slitWidth`
+      // parameter (GNIRSParams.SlitWidth includes the LR/HR IFU values).
+      val slitWidthTag: String =
+        a.fpu match
+          case GnirsFpu.Spectroscopy.Slit(s) => s.ocs2Tag
+          case GnirsFpu.Spectroscopy.Ifu(i)  => i.ocs2Tag
+      Json.obj(
+        "centralWavelength" -> a.centralWavelength.asJson,
+        "filter"            -> Json.fromString(a.filter.ocs2Tag),
+        "slitWidth"         -> Json.fromString(slitWidthTag),
+        "crossDispersed"    -> Json.fromString(a.prism.ocs2Tag),
+        "grating"           -> Json.fromString(a.grating.ocs2Tag),
+        "camera"            -> Json.fromString(a.camera.ocs2Tag),
+        "pixelScale"        -> Json.fromString(a.camera.pixelScale.ocs2Tag),
+        "readMode"          -> Json.fromString(a.readMode.ocs2Tag),
+        "wellDepth"         -> Json.fromString(a.wellDepth.ocs2Tag),
+        "altair"            -> Json.Null
+      )
 
   private val encodeGnirsImaging: Encoder[ObservingMode.ImagingMode.Gnirs] = a =>
     Json.obj(
@@ -307,26 +307,26 @@ private[legacy] object codecs:
   private given Encoder[ItcInstrumentDetails] = (a: ItcInstrumentDetails) =>
     a.mode match
       // Spectroscopy
-      case a: ObservingMode.SpectroscopyMode.GmosNorth     =>
+      case a: ObservingMode.SpectroscopyMode.GmosNorth         =>
         Json.obj("GmosParameters" -> encodeGmosNorthSpectroscopy(a))
-      case a: ObservingMode.SpectroscopyMode.GmosSouth     =>
+      case a: ObservingMode.SpectroscopyMode.GmosSouth         =>
         Json.obj("GmosParameters" -> encodeGmosSouthSpectroscopy(a))
-      case a: ObservingMode.SpectroscopyMode.Flamingos2    =>
+      case a: ObservingMode.SpectroscopyMode.Flamingos2        =>
         Json.obj("Flamingos2Parameters" -> encodeF2Spectroscopy(a))
-      case a: ObservingMode.SpectroscopyMode.Igrins2       =>
+      case a: ObservingMode.SpectroscopyMode.Igrins2           =>
         Json.obj("Igrins2Parameters" -> encodeIgrins2Spectroscopy(a))
-      case a: ObservingMode.SpectroscopyMode.Ghost         =>
+      case a: ObservingMode.SpectroscopyMode.Ghost             =>
         Json.obj("GhostParameters" -> encodeGhostSpectroscopy(a))
       case a: ObservingMode.SpectroscopyMode.GnirsSpectroscopy =>
         Json.obj("GnirsParameters" -> encodeGnirsSpectroscopy(a))
       // Imaging
-      case a: ObservingMode.ImagingMode.Flamingos2         =>
+      case a: ObservingMode.ImagingMode.Flamingos2             =>
         Json.obj("Flamingos2Parameters" -> encodeF2Imaging(a))
-      case a: ObservingMode.ImagingMode.GmosNorth          =>
+      case a: ObservingMode.ImagingMode.GmosNorth              =>
         Json.obj("GmosParameters" -> encodeGmosNorthImaging(a))
-      case a: ObservingMode.ImagingMode.GmosSouth          =>
+      case a: ObservingMode.ImagingMode.GmosSouth              =>
         Json.obj("GmosParameters" -> encodeGmosSouthImaging(a))
-      case a: ObservingMode.ImagingMode.Gnirs              =>
+      case a: ObservingMode.ImagingMode.Gnirs                  =>
         Json.obj("GnirsParameters" -> encodeGnirsImaging(a))
 
   private given Encoder[ItcWavefrontSensor] = Encoder[String].contramap(_.ocs2Tag)

--- a/itc/service/src/main/scala/lucuma/itc/legacy/package.scala
+++ b/itc/service/src/main/scala/lucuma/itc/legacy/package.scala
@@ -34,9 +34,9 @@ extension (mode: ObservingMode)
   /** The number of coadds for instruments that support it (currently GNIRS), else None. */
   def coadds: Option[Int] =
     mode match
-      case ObservingMode.SpectroscopyMode.GnirsLongSlit(coadds = coadds) => coadds.value.some
-      case ObservingMode.ImagingMode.Gnirs(coadds = coadds)              => coadds.value.some
-      case _                                                             => none
+      case ObservingMode.SpectroscopyMode.GnirsSpectroscopy(coadds = coadds) => coadds.value.some
+      case ObservingMode.ImagingMode.Gnirs(coadds = coadds)                  => coadds.value.some
+      case _                                                                 => none
 
 extension (etm: ExposureTimeMode)
   def spectroscopyCalculationMethod(

--- a/itc/service/src/main/scala/lucuma/itc/legacy/syntax/InstrumentSyntax.scala
+++ b/itc/service/src/main/scala/lucuma/itc/legacy/syntax/InstrumentSyntax.scala
@@ -320,6 +320,16 @@ trait GnirsSlitWidthSyntax:
 
 object gnirsslitwidth extends GnirsSlitWidthSyntax
 
+trait GnirsFpuIfuSyntax:
+  import lucuma.core.enums.GnirsFpuIfu
+  extension (self: GnirsFpuIfu)
+    def ocs2Tag: String =
+      self match
+        case GnirsFpuIfu.LowResolution  => "LR_IFU"
+        case GnirsFpuIfu.HighResolution => "HR_IFU"
+
+object gnirsfpuifu extends GnirsFpuIfuSyntax
+
 trait GnirsWellDepthSyntax:
   import lucuma.core.enums.GnirsWellDepth
   extension (self: GnirsWellDepth) def ocs2Tag: String = self.shortName.toUpperCase

--- a/itc/service/src/main/scala/lucuma/itc/legacy/syntax/package.scala
+++ b/itc/service/src/main/scala/lucuma/itc/legacy/syntax/package.scala
@@ -24,6 +24,7 @@ object all
     with GnirsCrossDispersedSyntax
     with GnirsReadModeSyntax
     with GnirsSlitWidthSyntax
+    with GnirsFpuIfuSyntax
     with GnirsWellDepthSyntax
     with ConditionsSyntax
     with CoolStarModelSyntax

--- a/itc/service/src/main/scala/lucuma/itc/service/ObservingMode.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/ObservingMode.scala
@@ -10,6 +10,7 @@ import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.*
 import lucuma.core.math.Wavelength
 import lucuma.core.model.sequence.gmos.GmosCcdMode
+import lucuma.core.model.sequence.gnirs.GnirsFpu
 import lucuma.itc.ItcGhostDetector
 import lucuma.itc.service.ItcObservationDetails.AnalysisMethod
 import lucuma.itc.service.hashes.given
@@ -160,10 +161,10 @@ object ObservingMode {
         s"${instrument.shortName} IFU"
     }
 
-    final case class GnirsLongSlit(
+    final case class GnirsSpectroscopy(
       centralWavelength: Wavelength,
       filter:            GnirsFilter,
-      slitWidth:         GnirsFpuSlit,
+      fpu:               GnirsFpu.Spectroscopy,
       prism:             GnirsPrism,
       grating:           GnirsGrating,
       camera:            GnirsCamera,
@@ -176,12 +177,25 @@ object ObservingMode {
         Instrument.Gnirs
 
       override def analysisMethod: AnalysisMethod =
-        ItcObservationDetails.AnalysisMethod.Aperture.Auto(
-          skyAperture = 1.0
-        )
+        fpu match
+          case GnirsFpu.Spectroscopy.Slit(_) =>
+            ItcObservationDetails.AnalysisMethod.Aperture.Auto(
+              skyAperture = 1.0
+            )
+          case GnirsFpu.Spectroscopy.Ifu(_)  =>
+            // "Sum of 2x2 elements at the center" with a single sky fibre.
+            ItcObservationDetails.AnalysisMethod.Ifu.Summed(
+              skyFibres = 1,
+              numX = 2,
+              numY = 2,
+              centerX = 0.0,
+              centerY = 0.0
+            )
 
       val description: String =
-        s"${instrument.shortName} Longslit"
+        fpu match
+          case GnirsFpu.Spectroscopy.Slit(_) => s"${instrument.shortName} Longslit"
+          case GnirsFpu.Spectroscopy.Ifu(_)  => s"${instrument.shortName} IFU"
     }
   }
 

--- a/itc/service/src/main/scala/lucuma/itc/service/hashes.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/hashes.scala
@@ -17,6 +17,7 @@ import lucuma.core.model.Attachment
 import lucuma.core.model.NonNegDuration
 import lucuma.core.model.SourceProfile
 import lucuma.core.model.sequence.gmos.GmosCcdMode
+import lucuma.core.model.sequence.gnirs.GnirsFpu
 import lucuma.core.util.Enumerated
 import lucuma.core.util.TimeSpan
 
@@ -39,3 +40,7 @@ given Hash[GmosAmpGain]     = Hash.by(_.tag)
 given Hash[GmosAmpReadMode] = Hash.by(_.tag)
 given Hash[GmosCcdMode]     = Hash.by(x => (x.xBin, x.yBin, x.ampCount, x.ampGain, x.ampReadMode))
 given Hash[Attachment.Id]   = Hash.by(_.value)
+
+given Hash[GnirsFpu.Spectroscopy] = Hash.by:
+  case GnirsFpu.Spectroscopy.Slit(s) => (0, s.tag)
+  case GnirsFpu.Spectroscopy.Ifu(i)  => (1, i.tag)

--- a/itc/service/src/main/scala/lucuma/itc/service/requests/spectroscopyTime.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/requests/spectroscopyTime.scala
@@ -121,7 +121,7 @@ object AsterismSpectroscopyTimeRequest:
               _,
               centralWavelength,
               filter,
-              slitWidth,
+              fpu,
               prism,
               grating,
               camera,
@@ -131,10 +131,10 @@ object AsterismSpectroscopyTimeRequest:
               port
             ) =>
           Result.success:
-            ObservingMode.SpectroscopyMode.GnirsLongSlit(
+            ObservingMode.SpectroscopyMode.GnirsSpectroscopy(
               centralWavelength,
               filter,
-              slitWidth,
+              fpu,
               prism,
               grating,
               camera,

--- a/itc/tests/src/test/scala/lucuma/itc/service/spectroscopySignalToNoiseSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/service/spectroscopySignalToNoiseSuite.scala
@@ -1600,7 +1600,7 @@ class spectroscopySignalToNoiseSuite extends GraphQLSuite:
               exposureTimeMode: { signalToNoise: { value: 100, at: { nanometers: 2200 } } },
               centralWavelength: { nanometers: 2200 },
               filter: ORDER3,
-              slitWidth: LONG_SLIT_0_30,
+              fpu: { slitWidth: LONG_SLIT_0_30 },
               prism: MIRROR,
               grating: D32,
               camera: SHORT_BLUE,

--- a/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyTimeAndCountSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyTimeAndCountSuite.scala
@@ -1931,7 +1931,7 @@ class spectroscopyTimeAndCountSuite extends GraphQLSuite:
                 exposureTimeMode: { timeAndCount: { time: { seconds: 120 }, count: 30, at: { nanometers: 2200 } } },
                 centralWavelength: { nanometers: 2200 },
                 filter: ORDER3,
-                slitWidth: LONG_SLIT_0_30,
+                fpu: { slitWidth: LONG_SLIT_0_30 },
                 prism: MIRROR,
                 grating: D32,
                 camera: SHORT_BLUE,

--- a/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyTimeAndGraphSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/service/spectroscopyTimeAndGraphSuite.scala
@@ -372,7 +372,7 @@ class spectroscopyTimeAndGraphSuite extends GraphQLSuite {
                 exposureTimeMode: { timeAndCount: { time: { seconds: 120 }, count: 30, at: { nanometers: 2200 } } },
                 centralWavelength: { nanometers: 2200 },
                 filter: ORDER3,
-                slitWidth: LONG_SLIT_0_30,
+                fpu: { slitWidth: LONG_SLIT_0_30 },
                 prism: MIRROR,
                 grating: D32,
                 camera: SHORT_BLUE,

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -37,6 +37,7 @@ import lucuma.core.model.SourceProfile
 import lucuma.core.model.Target
 import lucuma.core.model.UnnormalizedSED
 import lucuma.core.model.User
+import lucuma.core.model.sequence.gnirs.GnirsFpu
 import lucuma.core.util.Timestamp
 import lucuma.itc.ItcGhostDetector
 import lucuma.itc.client.GmosFpu
@@ -459,7 +460,7 @@ object GeneratorParamsService {
                 exposureTimeMode  = gn.exposureTimeMode,
                 centralWavelength = gn.filter.centralWavelength,
                 filter            = gn.filter,
-                slitWidth         = gn.fpu,
+                fpu               = GnirsFpu.Spectroscopy.Slit(gn.fpu),
                 prism             = gn.prism,
                 grating           = gn.grating,
                 camera            = gn.camera,


### PR DESCRIPTION
As specified in https://app.shortcut.com/lucuma/story/9117/gnirs-ifu-itc-default-analysis-method,  the default analysis method is set to Sum of 2x2 elements at the center.


This is an incremental PR atop of https://github.com/gemini-hlsw/lucuma-odb/pull/2649.
