### PR TITLE
Gnirs off slit steps should not contribute to S/N

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
@@ -9,6 +9,7 @@ import cats.Monad
 import cats.data.EitherT
 import cats.data.NonEmptyList
 import cats.data.State
+import cats.syntax.either.*
 import cats.syntax.option.*
 import cats.syntax.order.*
 import eu.timepit.refined.types.numeric.NonNegInt
@@ -22,7 +23,10 @@ import lucuma.core.enums.GnirsPixelScale
 import lucuma.core.enums.GnirsReadMode
 import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.SequenceType
+import lucuma.core.enums.SlitOffsetMode
 import lucuma.core.enums.StepGuideState.Disabled
+import lucuma.core.geom.gnirs.all as GnirsGeometry
+import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Atom
@@ -76,27 +80,39 @@ object Science:
 
   private object SeqState extends gnirs.GnirsSequenceState
 
+  /**
+   * Whether an offset keeps the target on the slit (and so contributes to the
+   * science S/N).  When nodding along the slit the target stays on-slit as long
+   * as the offset falls within the slit; when nodding to sky, sky positions are
+   * offset in p, so only on-axis (p = 0) steps are on target.
+   */
+  private def isOnTarget(mode: SlitOffsetMode, slitLength: Angle, o: Offset): Boolean =
+    mode match
+      case SlitOffsetMode.NodAlongSlit => isOnSlit(slitLength, o)
+      case SlitOffsetMode.NodToSky     => o.p.toAngle.toMicroarcseconds === 0L
+
   case class StepDefinition(
     scienceSteps: NonEmptyList[ProtoStep[GnirsDynamicConfig]],
+    offsetMode:   SlitOffsetMode,
+    slitLength:   Angle,
     // Inline nighttime calibrations (flat + arc).  Empty for telluric sequences.
     cals:         Option[NonEmptyList[ProtoStep[GnirsDynamicConfig]]]
   ):
     /**
      * Cycle count: round up so that we always deliver at least the requested
-     * number of exposures. Sky-only offsets in the cycle (if any) are not
-     * given special treatment — we cycle blindly through whatever the
-     * observing mode defines.
+     * number of on-source exposures.  Sky steps (target off the slit) don't
+     * contribute to the S/N, so cycles with sky offsets require extra repeats.
      */
-    def cycleCount(t: IntegrationTime): NonNegInt =
-      val required = t.exposureCount.value
-      val perCycle = scienceSteps.length
-      NonNegInt.unsafeFrom((required + (perCycle - 1)) / perCycle)
+    def cycleCount(t: IntegrationTime): Either[String, NonNegInt] =
+      calculateCycleCount(isOnTarget(offsetMode, slitLength, _), scienceSteps.toList, t)
 
   object StepDefinition:
 
     // PreDef is a StepDefinition before SmartGcal expansion.
     case class PreDef(
       scienceSteps: NonEmptyList[ProtoStep[GnirsDynamicConfig]],
+      offsetMode:   SlitOffsetMode,
+      slitLength:   Angle,
       // Unexpanded SmartGcal (flat, arc), absent for telluric sequences.
       cals:         Option[(ProtoStep[GnirsDynamicConfig], ProtoStep[GnirsDynamicConfig])]
     ):
@@ -111,11 +127,11 @@ object Science:
         def adjustReadMode(s: ProtoStep[GnirsDynamicConfig]): ProtoStep[GnirsDynamicConfig] =
           s.copy(value = s.value.copy(readMode = GnirsReadMode.forExposureTime(s.value.exposure)))
 
-        cals.fold(EitherT.pure(StepDefinition(scienceSteps, none))): (flat, arc) =>
+        cals.fold(EitherT.pure(StepDefinition(scienceSteps, offsetMode, slitLength, none))): (flat, arc) =>
           for
             fs <- EitherT(expander.expandStep(static, flat))
             rs <- EitherT(expander.expandStep(static, arc))
-          yield StepDefinition(scienceSteps, (fs.map(adjustReadMode) ::: rs.map(adjustReadMode)).some)
+          yield StepDefinition(scienceSteps, offsetMode, slitLength, (fs.map(adjustReadMode) ::: rs.map(adjustReadMode)).some)
 
     object PreDef:
 
@@ -162,7 +178,12 @@ object Science:
             ct  = ss.last.telescopeConfig.copy(guiding = Disabled)
             f  <- SeqState.flatStep(ct, ObserveClass.NightCal)
             r  <- SeqState.arcStep(ct, ObserveClass.NightCal)
-          yield PreDef(ss, Option.when(includeCals)((f, r)))
+          yield PreDef(
+            ss,
+            config.telescopeConfigs.offsetsType,
+            GnirsGeometry.slitLength(config.camera, config.prism),
+            Option.when(includeCals)((f, r))
+          )
 
     def compute[F[_]: Monad](
       config:   Config,
@@ -339,11 +360,12 @@ object Science:
       t <- posTime
       s <- StepDefinition.compute(config, t, static, expander, calRole).leftMap(m => definitionError(observationId, m))
       e <- cycleEstimate(s)
+      c <- EitherT.fromEither(s.cycleCount(t).leftMap(m => definitionError(observationId, m)))
     yield Generator(
       s,
       e,
       AtomBuilder.instantiate(estimator, static, namespace, SequenceType.Science),
-      s.cycleCount(t)
+      c
     ): SequenceGenerator[GnirsDynamicConfig]
 
     gen.value

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
@@ -23,7 +23,6 @@ import lucuma.core.enums.GnirsPixelScale
 import lucuma.core.enums.GnirsReadMode
 import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.SequenceType
-import lucuma.core.enums.SlitOffsetMode
 import lucuma.core.enums.StepGuideState.Disabled
 import lucuma.core.geom.gnirs.all as GnirsGeometry
 import lucuma.core.math.Angle
@@ -80,38 +79,27 @@ object Science:
 
   private object SeqState extends gnirs.GnirsSequenceState
 
-  /**
-   * Whether an offset keeps the target on the slit (and so contributes to the
-   * science S/N).  When nodding along the slit the target stays on-slit as long
-   * as the offset falls within the slit; when nodding to sky, sky positions are
-   * offset in p, so only on-axis (p = 0) steps are on target.
-   */
-  private def isOnTarget(mode: SlitOffsetMode, slitLength: Angle, o: Offset): Boolean =
-    mode match
-      case SlitOffsetMode.NodAlongSlit => isOnSlit(slitLength, o)
-      case SlitOffsetMode.NodToSky     => o.p.toAngle.toMicroarcseconds === 0L
-
   case class StepDefinition(
     scienceSteps: NonEmptyList[ProtoStep[GnirsDynamicConfig]],
-    offsetMode:   SlitOffsetMode,
     slitLength:   Angle,
     // Inline nighttime calibrations (flat + arc).  Empty for telluric sequences.
     cals:         Option[NonEmptyList[ProtoStep[GnirsDynamicConfig]]]
   ):
     /**
      * Cycle count: round up so that we always deliver at least the requested
-     * number of on-source exposures.  Sky steps (target off the slit) don't
+     * number of on-source exposures. Sky steps (target off the slit) don't
      * contribute to the S/N, so cycles with sky offsets require extra repeats.
+     * A step counts as on source only when it is on the slit (both p and q),
+     * regardless of nod mode — matching Flamingos 2 and IGRINS-2.
      */
     def cycleCount(t: IntegrationTime): Either[String, NonNegInt] =
-      calculateCycleCount(isOnTarget(offsetMode, slitLength, _), scienceSteps.toList, t)
+      calculateCycleCount(isOnSlit(slitLength, _), scienceSteps.toList, t)
 
   object StepDefinition:
 
     // PreDef is a StepDefinition before SmartGcal expansion.
     case class PreDef(
       scienceSteps: NonEmptyList[ProtoStep[GnirsDynamicConfig]],
-      offsetMode:   SlitOffsetMode,
       slitLength:   Angle,
       // Unexpanded SmartGcal (flat, arc), absent for telluric sequences.
       cals:         Option[(ProtoStep[GnirsDynamicConfig], ProtoStep[GnirsDynamicConfig])]
@@ -127,11 +115,11 @@ object Science:
         def adjustReadMode(s: ProtoStep[GnirsDynamicConfig]): ProtoStep[GnirsDynamicConfig] =
           s.copy(value = s.value.copy(readMode = GnirsReadMode.forExposureTime(s.value.exposure)))
 
-        cals.fold(EitherT.pure(StepDefinition(scienceSteps, offsetMode, slitLength, none))): (flat, arc) =>
+        cals.fold(EitherT.pure(StepDefinition(scienceSteps, slitLength, none))): (flat, arc) =>
           for
             fs <- EitherT(expander.expandStep(static, flat))
             rs <- EitherT(expander.expandStep(static, arc))
-          yield StepDefinition(scienceSteps, offsetMode, slitLength, (fs.map(adjustReadMode) ::: rs.map(adjustReadMode)).some)
+          yield StepDefinition(scienceSteps, slitLength, (fs.map(adjustReadMode) ::: rs.map(adjustReadMode)).some)
 
     object PreDef:
 
@@ -180,7 +168,6 @@ object Science:
             r  <- SeqState.arcStep(ct, ObserveClass.NightCal)
           yield PreDef(
             ss,
-            config.telescopeConfigs.offsetsType,
             GnirsGeometry.slitLength(config.camera, config.prism),
             Option.when(includeCals)((f, r))
           )

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/igrins2/longslit/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/igrins2/longslit/Science.scala
@@ -8,7 +8,6 @@ package longslit
 import cats.data.NonEmptyList
 import cats.data.State
 import cats.syntax.either.*
-import cats.syntax.eq.*
 import cats.syntax.option.*
 import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.string.NonEmptyString
@@ -17,7 +16,6 @@ import fs2.Stream
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.SequenceType
-import lucuma.core.enums.SlitOffsetMode
 import lucuma.core.enums.StepGuideState.Disabled
 import lucuma.core.enums.StepGuideState.Enabled
 import lucuma.core.math.Angle
@@ -49,25 +47,21 @@ object Science:
   val SlitLength: Angle =
     Angle.fromBigDecimalArcseconds(5.0)
 
-  private def isOnTarget(mode: SlitOffsetMode, o: Offset): Boolean =
-    mode match
-      case SlitOffsetMode.NodAlongSlit => isOnSlit(SlitLength, o)
-      case SlitOffsetMode.NodToSky     => o.p.toAngle.toMicroarcseconds === 0L
-
   object Igrins2SequenceState extends SequenceState[Igrins2DynamicConfig]:
     override val initialDynamicConfig: Igrins2DynamicConfig =
       Igrins2DynamicConfig(TimeSpan.Min)
 
-    def igrins2ScienceStep(mode: SlitOffsetMode, obsClass: ObserveClass)(o: Offset): State[Igrins2DynamicConfig, ProtoStep[Igrins2DynamicConfig]] =
-      val guideState = if isOnTarget(mode, o) then Enabled else Disabled
+    // A step is on source (guided, and contributes to the S/N) only when it is
+    // on the slit — both p and q — regardless of nod mode, matching Flamingos 2.
+    def igrins2ScienceStep(obsClass: ObserveClass)(o: Offset): State[Igrins2DynamicConfig, ProtoStep[Igrins2DynamicConfig]] =
+      val guideState = if isOnSlit(SlitLength, o) then Enabled else Disabled
       scienceStep(TelescopeConfig(o, guideState), obsClass)
 
   case class StepDefinition(
-    scienceSteps: NonEmptyList[ProtoStep[Igrins2DynamicConfig]],
-    offsetMode:   SlitOffsetMode
+    scienceSteps: NonEmptyList[ProtoStep[Igrins2DynamicConfig]]
   ):
     def cycleCount(t: IntegrationTime): Either[String, NonNegInt] =
-      calculateCycleCount[Igrins2DynamicConfig](isOnTarget(offsetMode, _), scienceSteps.toList, t)
+      calculateCycleCount[Igrins2DynamicConfig](isOnSlit(SlitLength, _), scienceSteps.toList, t)
 
   object StepDefinition:
 
@@ -84,9 +78,9 @@ object Science:
           val sciSteps = Igrins2SequenceState.eval:
             for
               _  <- State.modify[Igrins2DynamicConfig](_.copy(exposure = time.exposureTime))
-              ss <- nel.traverse(Igrins2SequenceState.igrins2ScienceStep(config.offsetMode, sciClass))
+              ss <- nel.traverse(Igrins2SequenceState.igrins2ScienceStep(sciClass))
             yield ss
-          StepDefinition(sciSteps, config.offsetMode)
+          StepDefinition(sciSteps)
 
   case class Generator(
     steps:      StepDefinition,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
@@ -203,7 +203,7 @@ class executionSciGnirsLongSlit extends ExecutionTestSupportForGnirs:
   test("[gnirs] off-slit offsets don't contribute to S/N (extra cycles)"):
     // The SHORT_BLUE + MIRROR slit is 99" long, so |q| > 49.5" falls off slit.
     // Here q=+2 is on slit but q=+60 is off, so only 1 of the 2 steps per cycle
-    // is on source.  exposureCount=3 therefore needs 3 cycles (not 2).
+    // is on source. exposureCount=3 therefore needs 3 cycles (not 2).
     val setup: IO[Observation.Id] =
       for
         oid <- gnirsObs
@@ -340,6 +340,44 @@ class executionSciGnirsLongSlit extends ExecutionTestSupportForGnirs:
                 "science" -> Json.obj(
                   "nextAtom"       -> expectedAtom,
                   "possibleFuture" -> List(expectedAtom, expectedAtom, calAtom(60, 60)).asJson,
+                  "hasMore"        -> false.asJson
+                )
+              )
+            )
+          ).asRight
+      )
+
+  test("[gnirs] nod-to-sky sky position off the slit end (p=0, q>slit) counts as sky"):
+    // A sky nod along the slit direction (p=0) that runs past the slit end is
+    // off slit and so doesn't contribute to the S/N — the q check matters, not
+    // just p. The SHORT_BLUE + MIRROR slit is 99", so slit/2 = 49.5"; q = 49.6"
+    // is just one deci-arcsecond past the edge and therefore off slit. Only the
+    // on-axis step is on source, so exposureCount=3 needs 3 cycles.
+    val setup: IO[Observation.Id] =
+      for
+        oid <- gnirsObs
+        _   <- setToSkyTelescopeConfigs(oid,
+                 """[
+                   { offset: { p: { arcseconds: 0 }, q: { arcseconds:  0   } }, guiding: ENABLED  },
+                   { offset: { p: { arcseconds: 0 }, q: { arcseconds: 49.6 } }, guiding: DISABLED }
+                 ]"""
+               )
+      yield oid
+
+    setup.flatMap: oid =>
+      val expectedAtom = gnirsExpectedScienceAtom(DynamicSnapshot,
+        (0, 0, Enabled), (0, 49.6, Disabled)
+      )
+      expect(
+        user     = pi,
+        query    = gnirsScienceQuery(oid),
+        expected =
+          Json.obj(
+            "executionConfig" -> Json.obj(
+              "gnirs" -> Json.obj(
+                "science" -> Json.obj(
+                  "nextAtom"       -> expectedAtom,
+                  "possibleFuture" -> List(expectedAtom, expectedAtom, calAtom(0, BigDecimal("49.6"))).asJson,
                   "hasMore"        -> false.asJson
                 )
               )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
@@ -200,24 +200,24 @@ class executionSciGnirsLongSlit extends ExecutionTestSupportForGnirs:
           ).asRight
       )
 
-  test("[gnirs] all offsets off-slit are cycled blindly (no error)"):
-    // Deliberate divergence from IGRINS-2: GNIRS does not filter off-slit
-    // offsets out of the cycle.  Provide |q| > slit length and observe that
-    // we still get a valid atom (rather than a "must be on slit" error).
+  test("[gnirs] off-slit offsets don't contribute to S/N (extra cycles)"):
+    // The SHORT_BLUE + MIRROR slit is 99" long, so |q| > 49.5" falls off slit.
+    // Here q=+2 is on slit but q=+60 is off, so only 1 of the 2 steps per cycle
+    // is on source.  exposureCount=3 therefore needs 3 cycles (not 2).
     val setup: IO[Observation.Id] =
       for
         oid <- gnirsObs
         _   <- setAlongSlitTelescopeConfigs(oid,
                  """[
-                   { q: { arcseconds: 10 }, guiding: ENABLED },
-                   { q: { arcseconds: 20 }, guiding: ENABLED }
+                   { q: { arcseconds:  2 }, guiding: ENABLED  },
+                   { q: { arcseconds: 60 }, guiding: DISABLED }
                  ]"""
                )
       yield oid
 
     setup.flatMap: oid =>
       val expectedAtom = gnirsExpectedScienceAtom(DynamicSnapshot,
-        (0, 10, Enabled), (0, 20, Enabled)
+        (0, 2, Enabled), (0, 60, Disabled)
       )
       expect(
         user     = pi,
@@ -228,12 +228,36 @@ class executionSciGnirsLongSlit extends ExecutionTestSupportForGnirs:
               "gnirs" -> Json.obj(
                 "science" -> Json.obj(
                   "nextAtom"       -> expectedAtom,
-                  "possibleFuture" -> List(expectedAtom, calAtom(0, 20)).asJson,
+                  "possibleFuture" -> List(expectedAtom, expectedAtom, calAtom(0, 60)).asJson,
                   "hasMore"        -> false.asJson
                 )
               )
             )
           ).asRight
+      )
+
+  test("[gnirs] all along-slit offsets off slit -> error"):
+    // When no science step lands on the slit there are no on-source exposures,
+    // so the sequence cannot be generated.
+    val setup: IO[Observation.Id] =
+      for
+        oid <- gnirsObs
+        _   <- setAlongSlitTelescopeConfigs(oid,
+                 """[
+                   { q: { arcseconds: 60 }, guiding: DISABLED },
+                   { q: { arcseconds: 60 }, guiding: DISABLED }
+                 ]"""
+               )
+      yield oid
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = gnirsScienceQuery(oid),
+        expected =
+          List(
+            s"Could not generate a sequence for $oid: At least one exposure must be taken on slit."
+          ).asLeft
       )
 
   test("[gnirs] telluric sequences omit the inline flats & arcs"):
@@ -289,6 +313,8 @@ class executionSciGnirsLongSlit extends ExecutionTestSupportForGnirs:
       )
 
   test("[gnirs] nod-to-sky offsets carry full P/Q + per-entry guiding"):
+    // The sky position (p=60) is off target, so only the on-axis (p=0) step
+    // contributes to the S/N: exposureCount=3 requires 3 cycles.
     val setup: IO[Observation.Id] =
       for
         oid <- gnirsObs
@@ -313,7 +339,7 @@ class executionSciGnirsLongSlit extends ExecutionTestSupportForGnirs:
               "gnirs" -> Json.obj(
                 "science" -> Json.obj(
                   "nextAtom"       -> expectedAtom,
-                  "possibleFuture" -> List(expectedAtom, calAtom(60, 60)).asJson,
+                  "possibleFuture" -> List(expectedAtom, expectedAtom, calAtom(60, 60)).asJson,
                   "hasMore"        -> false.asJson
                 )
               )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciIgrins2.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciIgrins2.scala
@@ -171,6 +171,47 @@ class executionSciIgrins2 extends ExecutionTestSupportForIgrins2:
           ).asLeft
       )
 
+  test("[igrins2] nod to sky, sky position off the slit end (p=0, q>slit) counts as sky"):
+    // A sky nod along the slit direction (p=0) that runs past the slit end is
+    // off slit, so it doesn't contribute to the S/N (the q check matters, not
+    // just p). The slit is 5", so slit/2 = 2.5"; q = 2.6" is just one
+    // deci-arcsecond past the edge and therefore off slit. Only the on-axis
+    // step is on source, so exposureCount=4 needs 4 cycles. Under the previous
+    // p-only logic q=2.6" (p=0) would have counted as on target -> 2 cycles.
+    val setup: IO[Observation.Id] =
+      for {
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createIgrins2LongSlitObservationAs(pi, p, t)
+        _ <- setOffsets(o, SlitOffsetMode.NodToSky,
+               """[
+                 { p: { arcseconds: 0 }, q: { arcseconds: 0   } },
+                 { p: { arcseconds: 0 }, q: { arcseconds: 2.6 } }
+               ]"""
+             )
+      } yield o
+
+    setup.flatMap: oid =>
+      val expectedAtom = igrins2ExpectedScienceAtom(ExposureTime,
+        (0, 0, Enabled), (0, 2.6, Disabled)
+      )
+      expect(
+        user     = pi,
+        query    = igrins2ScienceQuery(oid),
+        expected =
+          Json.obj(
+            "executionConfig" -> Json.obj(
+              "igrins2" -> Json.obj(
+                "science" -> Json.obj(
+                  "nextAtom"       -> expectedAtom,
+                  "possibleFuture" -> List(expectedAtom, expectedAtom, expectedAtom).asJson,
+                  "hasMore"        -> false.asJson
+                )
+              )
+            )
+          ).asRight
+      )
+
   // This is legal though we nay need to forbid setting q larger than the slit?
   test("[igrins2] mode nod along slit, 3 offsets on slit"):
     val setup: IO[Observation.Id] =


### PR DESCRIPTION
Mirror the Igrins-2 and Flamingos2 logic to prevent off-slit offsets from contributing to the S/N.

Actually, I changed the logic for Igrins-2 so that an offset defined as `NodToSky` with p == 0 and q > slitlength/2 is considered a sky offset (previously it would be considered as on target). If the previous logic was correct @cquiroz please let me know and we can revert with a comment.