### PR TITLE
Cors fix

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -55,6 +55,14 @@ pull_request_rules:
       add:
       - client
       remove: []
+- name: Label common-middleware PRs
+  conditions:
+  - files~=^modules/common-middleware/
+  actions:
+    label:
+      add:
+      - common-middleware
+      remove: []
 - name: Label legacy-tests PRs
   conditions:
   - files~=^itc/legacy-tests/

--- a/build.sbt
+++ b/build.sbt
@@ -951,7 +951,7 @@ lazy val resourceModel =
 
 lazy val resourceService = project
   .in(file("resource/service"))
-  .dependsOn(resourceModel, binding, otel, schema.jvm)
+  .dependsOn(resourceModel, binding, otel, schema.jvm, common)
   .enablePlugins(NoPublishPlugin, LucumaDockerPlugin, JavaAppPackaging, BuildInfoPlugin)
   .settings(resourceCommonSettings, buildInfoSettings)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -544,7 +544,7 @@ ThisBuild / ocsLocal       := ocsBuildInfo.value._4
 // Contains the grackle server
 lazy val itcService = project
   .in(file("itc/service"))
-  .dependsOn(itcModel.jvm, binding, otel, common)
+  .dependsOn(itcModel.jvm, binding, otel)
   .enablePlugins(BuildInfoPlugin, LucumaDockerPlugin, JavaServerAppPackaging)
   .settings(itcCommonSettings)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -715,11 +715,12 @@ lazy val itcLegacyTests = project
 
 lazy val common = project
   .in(file("modules/common-middleware"))
+  .enablePlugins(NoPublishPlugin)
   .settings(
     name := "lucuma-common-middleware",
     libraryDependencies ++= Seq(
-      "org.http4s" %% "http4s-core" % http4sVersion,
-      "org.typelevel" %% "cats-core" % catsVersion,
+      "org.http4s"    %% "http4s-core" % http4sVersion,
+      "org.typelevel" %% "cats-core"   % catsVersion,
       "org.typelevel" %% "cats-effect" % catsEffectVersion
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -408,7 +408,7 @@ lazy val ssoBackendClient = project
 
 lazy val ssoService = project
   .in(file("modules/sso-service"))
-  .dependsOn(ssoBackendClient, binding)
+  .dependsOn(ssoBackendClient, binding, common)
   .enablePlugins(NoPublishPlugin, LucumaDockerPlugin, JavaAppPackaging, BuildInfoPlugin)
   .settings(buildInfoSettings)
   .settings(
@@ -544,7 +544,7 @@ ThisBuild / ocsLocal       := ocsBuildInfo.value._4
 // Contains the grackle server
 lazy val itcService = project
   .in(file("itc/service"))
-  .dependsOn(itcModel.jvm, binding, otel)
+  .dependsOn(itcModel.jvm, binding, otel, common)
   .enablePlugins(BuildInfoPlugin, LucumaDockerPlugin, JavaServerAppPackaging)
   .settings(itcCommonSettings)
   .settings(
@@ -713,6 +713,17 @@ lazy val itcLegacyTests = project
 
 // START ODB
 
+lazy val common = project
+  .in(file("modules/common-middleware"))
+  .settings(
+    name := "lucuma-common-middleware",
+    libraryDependencies ++= Seq(
+      "org.http4s" %% "http4s-core" % http4sVersion,
+      "org.typelevel" %% "cats-core" % catsVersion,
+      "org.typelevel" %% "cats-effect" % catsEffectVersion
+    )
+  )
+
 lazy val schema =
   crossProject(JVMPlatform, JSPlatform)
     .crossType(CrossType.Pure)
@@ -799,7 +810,7 @@ lazy val smartgcal = project
 
 lazy val service = project
   .in(file("modules/service"))
-  .dependsOn(binding, otel, phase0, sequence, smartgcal, ssoFrontendClient.jvm, ssoBackendClient)
+  .dependsOn(binding, otel, phase0, sequence, smartgcal, ssoFrontendClient.jvm, ssoBackendClient, common)
   .enablePlugins(NoPublishPlugin, LucumaDockerPlugin, JavaAppPackaging, BuildInfoPlugin)
   .settings(buildInfoSettings)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -719,9 +719,11 @@ lazy val common = project
   .settings(
     name := "lucuma-common-middleware",
     libraryDependencies ++= Seq(
-      "org.http4s"    %% "http4s-core" % http4sVersion,
-      "org.typelevel" %% "cats-core"   % catsVersion,
-      "org.typelevel" %% "cats-effect" % catsEffectVersion
+      "org.http4s"    %% "http4s-core"    % http4sVersion,
+      "org.http4s"    %% "http4s-server"  % http4sVersion,
+      "org.typelevel" %% "cats-core"      % catsVersion,
+      "org.typelevel" %% "cats-effect"    % catsEffectVersion,
+      "org.scalameta" %% "munit"          % munitVersion % Test
     )
   )
 

--- a/itc/service/src/main/scala/lucuma/itc/service/Main.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/Main.scala
@@ -17,7 +17,6 @@ import dev.profunktor.redis4cats.data.RedisCodec
 import dev.profunktor.redis4cats.log4cats.*
 import fs2.compression.Compression
 import fs2.io.net.Network
-import lucuma.common.middleware.CorsUtils
 import lucuma.graphql.routes.GraphQLService
 import lucuma.graphql.routes.Routes
 import lucuma.itc.cache.BinaryEffectfulCache
@@ -105,14 +104,12 @@ object Main extends IOApp with ItcCacheOrRemote {
 
     banner.linesIterator.toList.traverse_(Logger[F].info(_))
 
-  /** A middleware that adds CORS headers. In production the origin must match one of the allowed domains. */
-  def cors(env: ExecutionEnvironment, domain: List[String]): CORSPolicy =
-    env match
-      case Local | Review | Staging =>
-        CORS.policy
-      case Production               =>
-        CORS.policy
-          .withAllowOriginHost(u => CorsUtils.isAllowed(u.host.value, domain))
+  /**
+   * CORS policy. ITC serves public, unauthenticated calculations, so any origin is allowed.
+   * (This policy does not enable credentials, so reflecting any origin is safe.)
+   */
+  val corsPolicy: CORSPolicy =
+    CORS.policy
 
   def cacheMiddleware[F[_]: Functor](service: HttpRoutes[F]): HttpRoutes[F] =
     Kleisli: (req: Request[F]) =>
@@ -182,7 +179,7 @@ object Main extends IOApp with ItcCacheOrRemote {
     yield wsb =>
       otelMiddleware.asHttpRoutesMiddleware:
         GZip:
-          cors(cfg.environment, Nil):
+          corsPolicy:
             cacheMiddleware:
               Metrics[F](metricsOps):
                 Routes.forService(_ => GraphQLService[F](mapping).some.pure[F], wsb, "itc")

--- a/itc/service/src/main/scala/lucuma/itc/service/Main.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/Main.scala
@@ -111,7 +111,7 @@ object Main extends IOApp with ItcCacheOrRemote {
         CORS.policy
       case Production               =>
         CORS.policy
-          .withAllowOriginHostCi(domain.contains)
+          .withAllowOriginHostCi(u => domain.exists(d => u.host.value === d || u.host.value.endsWith("." + d)))
 
   def cacheMiddleware[F[_]: Functor](service: HttpRoutes[F]): HttpRoutes[F] =
     Kleisli: (req: Request[F]) =>

--- a/itc/service/src/main/scala/lucuma/itc/service/Main.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/Main.scala
@@ -106,7 +106,6 @@ object Main extends IOApp with ItcCacheOrRemote {
 
   /**
    * CORS policy. ITC serves public, unauthenticated calculations, so any origin is allowed.
-   * (This policy does not enable credentials, so reflecting any origin is safe.)
    */
   val corsPolicy: CORSPolicy =
     CORS.policy

--- a/itc/service/src/main/scala/lucuma/itc/service/Main.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/Main.scala
@@ -17,6 +17,7 @@ import dev.profunktor.redis4cats.data.RedisCodec
 import dev.profunktor.redis4cats.log4cats.*
 import fs2.compression.Compression
 import fs2.io.net.Network
+import lucuma.common.middleware.CorsUtils
 import lucuma.graphql.routes.GraphQLService
 import lucuma.graphql.routes.Routes
 import lucuma.itc.cache.BinaryEffectfulCache
@@ -104,14 +105,14 @@ object Main extends IOApp with ItcCacheOrRemote {
 
     banner.linesIterator.toList.traverse_(Logger[F].info(_))
 
-  /** A middleware that adds CORS headers. In production the origin must match the cookie domain. */
-  def cors(env: ExecutionEnvironment, domain: Option[String]): CORSPolicy =
+  /** A middleware that adds CORS headers. In production the origin must match one of the allowed domains. */
+  def cors(env: ExecutionEnvironment, domain: List[String]): CORSPolicy =
     env match
       case Local | Review | Staging =>
         CORS.policy
       case Production               =>
         CORS.policy
-          .withAllowOriginHostCi(u => domain.exists(d => u.host.value === d || u.host.value.endsWith("." + d)))
+          .withAllowOriginHost(u => CorsUtils.isAllowed(u.host.value, domain))
 
   def cacheMiddleware[F[_]: Functor](service: HttpRoutes[F]): HttpRoutes[F] =
     Kleisli: (req: Request[F]) =>
@@ -181,7 +182,7 @@ object Main extends IOApp with ItcCacheOrRemote {
     yield wsb =>
       otelMiddleware.asHttpRoutesMiddleware:
         GZip:
-          cors(cfg.environment, none):
+          cors(cfg.environment, Nil):
             cacheMiddleware:
               Metrics[F](metricsOps):
                 Routes.forService(_ => GraphQLService[F](mapping).some.pure[F], wsb, "itc")

--- a/modules/common-middleware/src/main/scala/lucuma/common/middleware/CorsMiddleware.scala
+++ b/modules/common-middleware/src/main/scala/lucuma/common/middleware/CorsMiddleware.scala
@@ -3,10 +3,19 @@
 
 package lucuma.common.middleware
 
+import cats.*
+import cats.implicits.*
+import org.http4s.HttpRoutes
 import org.http4s.Uri
-import cats.syntax.eq.*
+import org.http4s.Uri.Scheme
+import org.http4s.server.middleware.CORS
+
+import scala.concurrent.duration.*
 
 object CorsMiddleware:
+
+  type Middleware[F[_]] = Endo[HttpRoutes[F]]
+
   /**
    * Checks if a host matches any of the allowed domains, allowing for exact match
    * or subdomain matching (e.g., "sub.domain.com" matches "domain.com").
@@ -20,3 +29,18 @@ object CorsMiddleware:
     allowedDomains.exists: d =>
       val dd = d.toLowerCase
       h === dd || h.endsWith("." + dd)
+
+  /**
+   * A middleware that adds CORS headers. Credentials are allowed, so the origin must match one
+   * of the configured domains.
+   * When `corsOverHttps` is true, only HTTPS origins are accepted. (plain http is for dev)
+   *
+   * @param corsOverHttps whether to additionally require the origin to use HTTPS
+   * @param domain the trusted domains allowed to make credentialed cross-origin requests
+   */
+  def cors[F[_]: Monad](corsOverHttps: Boolean = false, domain: List[String]): Middleware[F] =
+    CORS.policy
+      .withAllowCredentials(true)
+      .withAllowOriginHost(u => (!corsOverHttps || (u.scheme === Scheme.https)) && isAllowed(u.host, domain))
+      .withMaxAge(1.day)
+      .apply

--- a/modules/common-middleware/src/main/scala/lucuma/common/middleware/CorsMiddleware.scala
+++ b/modules/common-middleware/src/main/scala/lucuma/common/middleware/CorsMiddleware.scala
@@ -3,7 +3,10 @@
 
 package lucuma.common.middleware
 
-object CorsUtils {
+import org.http4s.Uri
+import cats.syntax.eq.*
+
+object CorsMiddleware:
   /**
    * Checks if a host matches any of the allowed domains, allowing for exact match
    * or subdomain matching (e.g., "sub.domain.com" matches "domain.com").
@@ -12,6 +15,8 @@ object CorsUtils {
    * @param allowedDomains A list of trusted domains (e.g., List("example.com"))
    * @return true if the host is allowed, false otherwise
    */
-  def isAllowed(host: String, allowedDomains: List[String]): Boolean =
-    allowedDomains.exists(d => host == d || host.endsWith("." + d))
-}
+  def isAllowed(host: Uri.Host, allowedDomains: List[String]): Boolean =
+    val h = host.value.toLowerCase
+    allowedDomains.exists: d =>
+      val dd = d.toLowerCase
+      h === dd || h.endsWith("." + dd)

--- a/modules/common-middleware/src/main/scala/lucuma/common/middleware/CorsUtils.scala
+++ b/modules/common-middleware/src/main/scala/lucuma/common/middleware/CorsUtils.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.common.middleware
+
+object CorsUtils {
+  /**
+   * Checks if a host matches any of the allowed domains, allowing for exact match
+   * or subdomain matching (e.g., "sub.domain.com" matches "domain.com").
+   *
+   * @param host The host to check (e.g., "sub.example.com")
+   * @param allowedDomains A list of trusted domains (e.g., List("example.com"))
+   * @return true if the host is allowed, false otherwise
+   */
+  def isAllowed(host: String, allowedDomains: List[String]): Boolean =
+    allowedDomains.exists(d => host == d || host.endsWith("." + d))
+}

--- a/modules/common-middleware/src/test/scala/lucuma/common/middleware/CorsMiddlewareSuite.scala
+++ b/modules/common-middleware/src/test/scala/lucuma/common/middleware/CorsMiddlewareSuite.scala
@@ -1,0 +1,105 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.common.middleware
+
+import org.http4s.Uri
+
+final class CorsMiddlewareSuite extends munit.FunSuite:
+
+  private val domains = List("gemini.edu")
+
+  // --- Allowed: exact match and real subdomains ---
+
+  test("exact host match is allowed"):
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("gemini.edu"), domains))
+
+  test("direct subdomain is allowed"):
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("www.gemini.edu"), domains))
+
+  test("deep subdomain is allowed"):
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("a.b.gemini.edu"), domains))
+
+  test("host that merely ends with the domain (no dot boundary) is rejected"):
+    // Old buggy `endsWith("gemini.edu")` accepted these as trusted origins.
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("notgemini.edu"), domains))
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("evil-gemini.edu"), domains))
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("xgemini.edu"), domains))
+
+  test("unrelated domain is rejected"):
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("evil.com"), domains))
+
+  test("domain as a substring in a different TLD is rejected"):
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("gemini.edu.com"), domains))
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("gemini.edu.evil.com"), domains))
+
+  // --- Edge cases ---
+
+  test("empty host is rejected"):
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString(""), domains))
+
+  test("empty allowed-domain list rejects everything"):
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("gemini.edu"), Nil))
+
+  // --- Multiple configured domains ---
+
+  private val multiDomains = List("gemini.edu", "lucuma.xyz")
+
+  test("both configured domains are allowed (exact match)"):
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("gemini.edu"), multiDomains))
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("lucuma.xyz"), multiDomains))
+
+  test("subdomains of each configured domain are allowed"):
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("www.gemini.edu"), multiDomains))
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("app.gemini.edu"), multiDomains))
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("www.lucuma.xyz"), multiDomains))
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("odb.lucuma.xyz"), multiDomains))
+
+  test("an unrelated third domain is rejected under multi-domain config"):
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("evil.com"), multiDomains))
+
+  test("the suffix-bypass attack fails against each configured domain"):
+    // Borrowing the gemini.edu suffix without a dot boundary:
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("notgemini.edu"), multiDomains))
+    // Borrowing the lucuma.xyz suffix without a dot boundary:
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("notlucuma.xyz"), multiDomains))
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("evil-lucuma.xyz"), multiDomains))
+
+  test("a host cannot bypass by combining one domain's name with another's TLD"):
+    // Not a subdomain of either configured domain, despite reusing parts of each name.
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("gemini.xyz"), multiDomains))
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("lucuma.edu"), multiDomains))
+
+  test("a real subdomain of one domain is allowed even if it mentions the other"):
+    // `gemini.lucuma.xyz` is a legitimate subdomain of lucuma.xyz, so it must be allowed.
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("gemini.lucuma.xyz"), multiDomains))
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("lucuma.gemini.edu"), multiDomains))
+
+  test("multi-domain matching is case-insensitive"):
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("WWW.GEMINI.EDU"), multiDomains))
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("App.Lucuma.XYZ"), multiDomains))
+    // And the suffix attack still fails regardless of case.
+    assert(!CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("NOTLUCUMA.XYZ"), multiDomains))
+
+  // --- Case-insensitivity (both sides) ---
+
+  test("host matching is case-insensitive"):
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("WWW.GEMINI.EDU"), domains))
+    assert(CorsMiddleware.isAllowed(Uri.Host.unsafeFromString("Www.Gemini.Edu"), domains))
+
+  test("configured domain matching is case-insensitive"):
+    assert(
+      CorsMiddleware.isAllowed(
+        Uri.Host.unsafeFromString("www.gemini.edu"),
+        List("GEMINI.EDU")
+      )
+    )
+    // And the suffix attack still fails regardless of case.
+    assert(
+      !CorsMiddleware.isAllowed(
+        Uri.Host.unsafeFromString("NOTGEMINI.EDU"),
+        List("gemini.edu")
+      )
+    )
+
+end CorsMiddlewareSuite

--- a/modules/service/src/main/scala/lucuma/odb/ServerMiddleware.scala
+++ b/modules/service/src/main/scala/lucuma/odb/ServerMiddleware.scala
@@ -62,7 +62,7 @@ object ServerMiddleware {
   def cors[F[_]: Monad](corsOverHttps: Boolean, domain: List[String]): Middleware[F] =
     CORS.policy
       .withAllowCredentials(true)
-      .withAllowOriginHost(u => (!corsOverHttps || (u.scheme === Scheme.https)) && domain.exists(u.host.value.endsWith))
+      .withAllowOriginHost(u => (!corsOverHttps || (u.scheme === Scheme.https)) && domain.exists(d => u.host.value === d || u.host.value.endsWith("." + d)))
       .withMaxAge(1.day)
       .apply
 

--- a/modules/service/src/main/scala/lucuma/odb/ServerMiddleware.scala
+++ b/modules/service/src/main/scala/lucuma/odb/ServerMiddleware.scala
@@ -8,6 +8,7 @@ import cats.data.Kleisli
 import cats.data.OptionT
 import cats.effect.*
 import cats.implicits.*
+import lucuma.common.middleware.CorsUtils
 import lucuma.core.model.User
 import lucuma.odb.otel.given
 import lucuma.odb.service.Services
@@ -62,7 +63,7 @@ object ServerMiddleware {
   def cors[F[_]: Monad](corsOverHttps: Boolean, domain: List[String]): Middleware[F] =
     CORS.policy
       .withAllowCredentials(true)
-      .withAllowOriginHost(u => (!corsOverHttps || (u.scheme === Scheme.https)) && domain.exists(d => u.host.value === d || u.host.value.endsWith("." + d)))
+      .withAllowOriginHost(u => (!corsOverHttps || (u.scheme === Scheme.https)) && CorsUtils.isAllowed(u.host.value, domain))
       .withMaxAge(1.day)
       .apply
 

--- a/modules/service/src/main/scala/lucuma/odb/ServerMiddleware.scala
+++ b/modules/service/src/main/scala/lucuma/odb/ServerMiddleware.scala
@@ -8,7 +8,7 @@ import cats.data.Kleisli
 import cats.data.OptionT
 import cats.effect.*
 import cats.implicits.*
-import lucuma.common.middleware.CorsUtils
+import lucuma.common.middleware.CorsMiddleware
 import lucuma.core.model.User
 import lucuma.odb.otel.given
 import lucuma.odb.service.Services
@@ -63,7 +63,7 @@ object ServerMiddleware {
   def cors[F[_]: Monad](corsOverHttps: Boolean, domain: List[String]): Middleware[F] =
     CORS.policy
       .withAllowCredentials(true)
-      .withAllowOriginHost(u => (!corsOverHttps || (u.scheme === Scheme.https)) && CorsUtils.isAllowed(u.host.value, domain))
+      .withAllowOriginHost(u => (!corsOverHttps || (u.scheme === Scheme.https)) && CorsMiddleware.isAllowed(u.host, domain))
       .withMaxAge(1.day)
       .apply
 

--- a/modules/service/src/main/scala/lucuma/odb/ServerMiddleware.scala
+++ b/modules/service/src/main/scala/lucuma/odb/ServerMiddleware.scala
@@ -17,7 +17,6 @@ import lucuma.sso.client.SsoClient
 import org.http4s.HttpRoutes
 import org.http4s.Query
 import org.http4s.Uri
-import org.http4s.Uri.Scheme
 import org.http4s.dsl.Http4sDsl
 import org.http4s.headers.Upgrade
 import org.http4s.otel4s.middleware.metrics.OtelMetrics
@@ -27,7 +26,6 @@ import org.http4s.otel4s.middleware.trace.redact
 import org.http4s.otel4s.middleware.trace.redact.HeaderRedactor
 import org.http4s.otel4s.middleware.trace.server.ServerMiddleware as OtelServerMiddleware
 import org.http4s.otel4s.middleware.trace.server.ServerSpanDataProvider
-import org.http4s.server.middleware.CORS
 import org.http4s.server.middleware.ErrorAction
 import org.http4s.server.middleware.Metrics
 import org.typelevel.log4cats.Logger
@@ -37,7 +35,6 @@ import org.typelevel.otel4s.trace.Tracer
 import org.typelevel.otel4s.trace.TracerProvider
 
 import scala.collection.immutable.TreeMap
-import scala.concurrent.duration.*
 
 /** A module of all the middlewares we apply to the server routes. */
 object ServerMiddleware {
@@ -58,14 +55,6 @@ object ServerMiddleware {
       messageFailureLogAction = Logger[F].error(_)(_),
       serviceErrorLogAction   = Logger[F].error(_)(_)
     )
-
-  /** A middleware that adds CORS headers. The origin must match the cookie domain. */
-  def cors[F[_]: Monad](corsOverHttps: Boolean, domain: List[String]): Middleware[F] =
-    CORS.policy
-      .withAllowCredentials(true)
-      .withAllowOriginHost(u => (!corsOverHttps || (u.scheme === Scheme.https)) && CorsMiddleware.isAllowed(u.host, domain))
-      .withMaxAge(1.day)
-      .apply
 
   /**
    * A middleware that updates the user table when it sees a user it hasn't seen before, or when
@@ -165,7 +154,7 @@ object ServerMiddleware {
         Kleisli(req => if (req.headers.get[Upgrade].isDefined) routes(req) else withMetrics(req))
 
       List[Middleware[F]](
-        cors(corsOverHttps, domain),
+        CorsMiddleware.cors(corsOverHttps, domain),
         logging,
         httpMetrics,
         otel.asHttpRoutesMiddleware,

--- a/modules/sso-service/src/main/scala/ServerMiddleware.scala
+++ b/modules/sso-service/src/main/scala/ServerMiddleware.scala
@@ -12,11 +12,8 @@ import lucuma.sso.service.config.Environment.*
 import natchez.Trace
 import natchez.http4s.NatchezMiddleware
 import org.http4s.HttpRoutes
-import org.http4s.server.middleware.CORS
 import org.http4s.server.middleware.ErrorAction
 import org.typelevel.log4cats.Logger
-
-import scala.concurrent.duration.*
 
 /** A module of all the middlewares we apply to the server routes. */
 object ServerMiddleware {
@@ -50,20 +47,12 @@ object ServerMiddleware {
       serviceErrorLogAction   = Logger[F].error(_)(_)
     )
 
-  /** A middleware that adds CORS headers. The origin must match one of the allowed domains. */
-  def cors[F[_]: Monad](domain: List[String]): Middleware[F] =
-    CORS.policy
-      .withAllowCredentials(true)
-      .withAllowOriginHost(u => CorsMiddleware.isAllowed(u.host, domain))
-      .withMaxAge(1.day)
-      .apply
-
   /** A middleware that composes all the others defined in this module. */
   def apply[F[_]: Async: Trace: Logger](
     config: Config,
   ): Middleware[F] =
     List[Middleware[F]](
-      cors(List(config.cookieDomain)),
+      CorsMiddleware.cors(domain = List(config.cookieDomain)),
       logging(config.environment),
       natchez,
       errorReporting,

--- a/modules/sso-service/src/main/scala/ServerMiddleware.scala
+++ b/modules/sso-service/src/main/scala/ServerMiddleware.scala
@@ -5,7 +5,7 @@ package lucuma.sso.service
 
 import cats.*
 import cats.effect.*
-import lucuma.common.middleware.CorsUtils
+import lucuma.common.middleware.CorsMiddleware
 import lucuma.sso.service.config.Config
 import lucuma.sso.service.config.Environment
 import lucuma.sso.service.config.Environment.*
@@ -54,7 +54,7 @@ object ServerMiddleware {
   def cors[F[_]: Monad](domain: List[String]): Middleware[F] =
     CORS.policy
       .withAllowCredentials(true)
-      .withAllowOriginHost(u => CorsUtils.isAllowed(u.host.value, domain))
+      .withAllowOriginHost(u => CorsMiddleware.isAllowed(u.host, domain))
       .withMaxAge(1.day)
       .apply
 

--- a/modules/sso-service/src/main/scala/ServerMiddleware.scala
+++ b/modules/sso-service/src/main/scala/ServerMiddleware.scala
@@ -5,6 +5,7 @@ package lucuma.sso.service
 
 import cats.*
 import cats.effect.*
+import lucuma.common.middleware.CorsUtils
 import lucuma.sso.service.config.Config
 import lucuma.sso.service.config.Environment
 import lucuma.sso.service.config.Environment.*
@@ -49,11 +50,11 @@ object ServerMiddleware {
       serviceErrorLogAction   = Logger[F].error(_)(_)
     )
 
-  /** A middleware that adds CORS headers. The origin must match the cookie domain. */
-  def cors[F[_]: Monad](domain: String): Middleware[F] =
+  /** A middleware that adds CORS headers. The origin must match one of the allowed domains. */
+  def cors[F[_]: Monad](domain: List[String]): Middleware[F] =
     CORS.policy
       .withAllowCredentials(true)
-      .withAllowOriginHost(u => u.host.value === domain || u.host.value.endsWith("." + domain))
+      .withAllowOriginHost(u => CorsUtils.isAllowed(u.host.value, domain))
       .withMaxAge(1.day)
       .apply
 
@@ -62,7 +63,7 @@ object ServerMiddleware {
     config: Config,
   ): Middleware[F] =
     List[Middleware[F]](
-      cors(config.cookieDomain),
+      cors(List(config.cookieDomain)),
       logging(config.environment),
       natchez,
       errorReporting,

--- a/modules/sso-service/src/main/scala/ServerMiddleware.scala
+++ b/modules/sso-service/src/main/scala/ServerMiddleware.scala
@@ -53,7 +53,7 @@ object ServerMiddleware {
   def cors[F[_]: Monad](domain: String): Middleware[F] =
     CORS.policy
       .withAllowCredentials(true)
-      .withAllowOriginHost(_.host.value.endsWith(domain))
+      .withAllowOriginHost(u => u.host.value === domain || u.host.value.endsWith("." + domain))
       .withMaxAge(1.day)
       .apply
 

--- a/modules/sso-service/src/test/scala/CorsSuite.scala
+++ b/modules/sso-service/src/test/scala/CorsSuite.scala
@@ -12,7 +12,7 @@ import org.typelevel.ci.CIString
 object CorsSuite extends SsoSuite {
 
   def routes(domain: String): HttpRoutes[IO] =
-    ServerMiddleware.cors[IO](domain).apply(
+    ServerMiddleware.cors[IO](List(domain)).apply(
       Routes[IO](
         dbPool    = null,
         orcid     = null,

--- a/modules/sso-service/src/test/scala/CorsSuite.scala
+++ b/modules/sso-service/src/test/scala/CorsSuite.scala
@@ -4,6 +4,7 @@
 package lucuma.sso.service
 
 import cats.effect.*
+import lucuma.common.middleware.CorsMiddleware
 import natchez.Trace.Implicits.noop
 import org.http4s.*
 import org.http4s.implicits.*
@@ -12,7 +13,7 @@ import org.typelevel.ci.CIString
 object CorsSuite extends SsoSuite {
 
   def routes(domain: String): HttpRoutes[IO] =
-    ServerMiddleware.cors[IO](List(domain)).apply(
+    CorsMiddleware.cors[IO](domain = List(domain)).apply(
       Routes[IO](
         dbPool    = null,
         orcid     = null,

--- a/resource/service/src/main/scala/resource/server/http4s/ServerMiddleware.scala
+++ b/resource/service/src/main/scala/resource/server/http4s/ServerMiddleware.scala
@@ -8,10 +8,10 @@ import cats.data.OptionT
 import cats.effect.*
 import cats.syntax.all.*
 import fs2.compression.Compression
+import lucuma.common.middleware.CorsMiddleware
 import org.http4s.HttpRoutes
 import org.http4s.Query
 import org.http4s.Uri
-import org.http4s.Uri.Scheme
 import org.http4s.headers.Upgrade
 import org.http4s.metrics.MetricsOps
 import org.http4s.otel4s.middleware.metrics.OtelMetrics
@@ -20,7 +20,6 @@ import org.http4s.otel4s.middleware.trace.redact.PathRedactor
 import org.http4s.otel4s.middleware.trace.redact.QueryRedactor
 import org.http4s.otel4s.middleware.trace.server.ServerMiddleware as OtelServerMiddleware
 import org.http4s.otel4s.middleware.trace.server.ServerSpanDataProvider
-import org.http4s.server.middleware.CORS
 import org.http4s.server.middleware.ErrorAction
 import org.http4s.server.middleware.GZip
 import org.http4s.server.middleware.Logger as Http4sLogger
@@ -29,8 +28,6 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import org.typelevel.otel4s.metrics.MeterProvider
 import org.typelevel.otel4s.trace.TracerProvider
-
-import scala.concurrent.duration.*
 
 object ServerMiddleware {
   type Middleware[F[_]] = Endo[HttpRoutes[F]]
@@ -62,13 +59,7 @@ object ServerMiddleware {
       )
     val spanDataProvider              = ServerSpanDataProvider.openTelemetry(redactor)
 
-    val cors: Middleware[F] =
-      CORS.policy
-        .withAllowCredentials(true)
-        .withAllowOriginHost: u =>
-          (!corsOverHttps || (u.scheme === Scheme.https)) && domain.exists(u.host.value.endsWith)
-        .withMaxAge(1.day)
-        .apply
+    val cors: Middleware[F] = CorsMiddleware.cors(corsOverHttps, domain.toList)
 
     (
       OtelServerMiddleware.builder[F](spanDataProvider).build,


### PR DESCRIPTION
There is a slight security vulnerability with cors where we only check that the calling host ends with the domain, e.g. `gemini.edu` and that allows domains partially matching to be ok like `somegemini.edu`. 

The fix is simply to request domains ending with a `.gemini.edu` The dot allows e.g. `explore.gemini.edu` but avoids the partially matching bug.

I made a new module `common` to hold the logic and make it reusable in sso/odb. It maybe overkill but we could move a few more bits there in the future