### PR TITLE
Observations query improvements

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -49,6 +49,8 @@ import org.typelevel.otel4s.trace.Tracer
 import scala.concurrent.duration.*
 import scala.io.AnsiColor
 import scala.io.Source
+import java.nio.file.Files
+import java.nio.file.{Path => NIOPath}
 
 object OdbMapping {
 
@@ -687,33 +689,70 @@ object OdbMapping {
             val SlowQueryThreshold = 5.second
             val MaxSqlLength       = 1024
 
-            def truncateSql(sql: String): String =
-              if sql.length <= MaxSqlLength then sql
-              else s"${sql.take(MaxSqlLength)}... (${sql.length - MaxSqlLength} more chars)"
+            val sql = fragment.fragment.sql
 
-            L.debug {
-              val formatted = SqlFormatter.format(truncateSql(fragment.fragment.sql))
-              val cleanedUp = formatted.replaceAll("\\$ (\\d+)", "\\$$1") // turn $ 42 into $42
-              val colored   = cleanedUp.linesIterator.map(s => s"${AnsiColor.GREEN}$s${AnsiColor.RESET}").mkString("\n")
-              s"\n\n$colored\n\n"
-            } *>
-            T.span("grackle.fetch").use: span =>
+            def truncateSql(s: String): String =
+              if s.length <= MaxSqlLength then s
+              else s"${s.take(MaxSqlLength)}... (${s.length - MaxSqlLength} more chars)"
+
+            // When `ODB_FETCH_DUMP_DIR` is set, large statements are written raw to a file on that
+            // dir and a reference added to the trace via `db.statement_file`
+            val dumpDir = sys.env.get("ODB_FETCH_DUMP_DIR")
+
+            val DumpThreshold = 50000
+            val big           = sql.length > DumpThreshold
+
+            // Write raw SQL to a file iff dumping is enabled and the statement is large.
+            val dumpSqlToFile: F[Option[String]] =
+              dumpDir match
+                case Some(dir) if big =>
+                  Sync[F].blocking:
+                    val hash = Integer.toHexString(sql.hashCode)
+                    val path = NIOPath.of(dir, s"odb-fetch-$hash.sql")
+                    Files.writeString(path, sql)
+                    path.toString.some
+                case _ =>
+                  none.pure[F]
+
+            // Dumped queries skip the pretty-printer, else logs the colored truncated statement
+            val logQuery: F[Option[String]] =
+              dumpSqlToFile.flatTap:
+                case Some(path) =>
+                  L.warn(s"[grackle.fetch] SQL ${sql.length} chars written to $path")
+                case None       =>
+                  L.debug:
+                    val formatted = SqlFormatter.format(truncateSql(sql))
+                    val cleanedUp = formatted.replaceAll("\\$ (\\d+)", "\\$$1") // turn $ 42 into $42
+                    val colored   = cleanedUp.linesIterator.map(s => s"${AnsiColor.GREEN}$s${AnsiColor.RESET}").mkString("\n")
+                    s"\n\n$colored\n\n"
+
+            logQuery.flatMap: dumpPath =>
+              T.span("grackle.fetch").use: span =>
                 Temporal[F].timed(super.fetch(fragment, codecs)).flatMap: (elapsed, result) =>
                   val slowQuery = elapsed > SlowQueryThreshold
+
+                  val columnCount = codecs.size
 
                   // Add some attributes to every query and a few specific ones for slow queries
                   val baseAttrs =
                     span.addAttributes(
                       Attribute("db.duration_ms", elapsed.toMillis),
-                      Attribute("db.row_count", result.size.toLong)
-                    )
+                      Attribute("db.row_count", result.size.toLong),
+                      Attribute("db.column_count", columnCount.toLong),
+                      Attribute("db.cell_count", result.size.toLong * columnCount.toLong)
+                    ) *>
+                      dumpPath.traverse_(p => span.addAttribute(Attribute("db.statement_file", p)))
 
                   val slowQueryAttrsAndLog =
-                    val truncatedSql = truncateSql(fragment.fragment.sql)
-                    span.addAttributes(
-                      Attribute("db.statement", truncatedSql),
-                      Attribute("db.slow_query", true)) *>
-                      SlowQueryLogger.warn(s"Slow query (${elapsed.toMillis}ms):\n$truncatedSql")
+                    // For big queries the SQL lives in the dump file; don't push the
+                    // giant string into the trace, just flag it and point at the file.
+                    val stmtAttr =
+                      if dumpPath.isDefined then Attribute("db.statement", s"(${sql.length} chars, see db.statement_file)")
+                      else Attribute("db.statement", truncateSql(sql))
+                    span.addAttributes(stmtAttr, Attribute("db.slow_query", true)) *>
+                      SlowQueryLogger.warn(
+                        s"Slow query (${elapsed.toMillis}ms):\n${dumpPath.fold(truncateSql(sql))(p => s"(${sql.length} chars) $p")}"
+                      )
 
                   for {
                     _ <- baseAttrs

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -46,11 +46,11 @@ import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.trace.Tracer
 
+import java.nio.file.Files
+import java.nio.file.Path as NIOPath
 import scala.concurrent.duration.*
 import scala.io.AnsiColor
 import scala.io.Source
-import java.nio.file.Files
-import java.nio.file.{Path => NIOPath}
 
 object OdbMapping {
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -319,6 +319,9 @@ object OdbMapping {
           val schema: Schema =
             schema0.getOrElse(unsafeLoadSchema("OdbSchema.graphql") |+| enums.schema)
 
+          // Tracer for the effect-handler spans in the mapping traits.
+          override protected def T: Tracer[F] = summon[Tracer[F]]
+
           // Our services and resources needed by various mappings.
           override val commitHash = commitHash0
           override val goaUsers = goaUsers0

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -319,9 +319,6 @@ object OdbMapping {
           val schema: Schema =
             schema0.getOrElse(unsafeLoadSchema("OdbSchema.graphql") |+| enums.schema)
 
-          // Tracer for the effect-handler spans in the mapping traits.
-          override protected def T: Tracer[F] = summon[Tracer[F]]
-
           // Our services and resources needed by various mappings.
           override val commitHash = commitHash0
           override val goaUsers = goaUsers0

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConfigurationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConfigurationMapping.scala
@@ -76,22 +76,39 @@ trait ConfigurationMapping[F[_]]
     // the cursor, and we don't need the environment at all. Would be nice to abstract something out.
     new EffectHandler[F] {
 
-      def calculate(oid: Observation.Id, oRefTime: Option[Timestamp]): F[Result[Option[Either[Coordinates, Region]]]] =
-        oRefTime
-          .traverse: at =>
-            services.use { implicit s =>
-              Services.asSuperUser:
+      // Batched to avoid an N+1: Grackle hands us every observation in the result at once, so we
+      // resolve them in a single session, issuing one tracking query per distinct reference time
+      // (observations sharing a CFP share a time) rather than one query -- and one session -- per
+      // observation.
+      def calculateAll(
+        obs: List[(Observation.Id, Option[Timestamp])]
+      ): F[Result[Map[Observation.Id, Option[Either[Coordinates, Region]]]]] =
+        services.use { implicit s =>
+          Services.asSuperUser:
+            obs
+              .collect { case (oid, Some(at)) => at -> oid }
+              .groupMap(_._1)(_._2)
+              .toList
+              .flatTraverse { case (at, oids) =>
                 s.trackingService
-                  .getCoordinatesSnapshotOrRegion(oid, at, false)
-                  .map: res =>
-                    if res.isFailure then Result(None) // important, don't fail here
-                    else res
-                      .map:
+                  .getCoordinatesSnapshotOrRegion(oids, at, false)
+                  .map(_.toList)
+              }
+              .map { entries =>
+                entries
+                  .traverse { case (oid, res) =>
+                    val converted: Result[Option[Either[Coordinates, Region]]] =
+                      if res.isFailure then Result(none[Either[Coordinates, Region]]) // important, don't fail here
+                      else res.map {
                         case Left(a)             => Left(a.base).some // non-opportunity
                         case Right((_, Some(c))) => Left(c).some      // opportunity with explicit base
                         case Right((r, None))    => Right(r).some     // opportunity without explicit base
+                      }
+                    converted.tupleLeft(oid)
+                  }
+                  .map(_.toMap)
               }
-          .map(_.sequence.map(_.flatten))
+        }
 
       private def queryContext(queries: List[(Query, Cursor)]): Result[List[(Program.Id, Observation.Id, Option[Timestamp])]] =
         queries.parTraverse: (_, cursor) =>
@@ -103,12 +120,10 @@ trait ConfigurationMapping[F[_]]
 
       def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
         (for {
-          ctx <- ResultT(queryContext(queries).pure[F])
-          obs <- ctx.distinct.traverse { case (pid, oid, ldt) =>
-                   ResultT(calculate(oid, ldt)).map((oid, _))
-                 }
-          res <- ResultT(ctx
-                   .flatMap { case (pid, oid, ldt) => obs.find(r => r._1 === oid).map(_._2).toList }
+          ctx       <- ResultT(queryContext(queries).pure[F])
+          resultMap <- ResultT(calculateAll(ctx.distinct.map { case (_, oid, ldt) => (oid, ldt) }))
+          res       <- ResultT(ctx
+                   .map { case (_, oid, _) => resultMap.getOrElse(oid, None) }
                    .zip(queries)
                    .traverse { case (result, (query, parentCursor)) =>
                      Query.childContext(parentCursor.context, query).map { childContext =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConfigurationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConfigurationMapping.scala
@@ -84,16 +84,20 @@ trait ConfigurationMapping[F[_]]
 
       // Compute the configuration coordinates/region for every observation, batching the tracking
       // lookups by reference time (the CFP midpoint, which most observations share) rather than
-      // one query per observation. 
-      // Returns a map keyed by observation id. 
+      // one query per observation.
+      // Returns a map keyed by observation id.
       private def calculateAll(
         ctx: List[(Observation.Id, Option[Timestamp])]
       ): F[Map[Observation.Id, Result[Option[Either[Coordinates, Region]]]]] =
         val byTime: Map[Timestamp, List[Observation.Id]] =
-          ctx.collect { case (oid, Some(t)) => t -> oid }.groupMap(_._1)(_._2)
+          ctx.collect:
+            case (oid, Some(t)) => t -> oid
+          .groupMap(_._1)(_._2)
         val noTime: Map[Observation.Id, Result[Option[Either[Coordinates, Region]]]] =
-          ctx.collect { case (oid, None) => oid -> Result(None) }.toMap
-        services.use { implicit s =>
+          ctx.collect:
+            case (oid, None) => oid -> Result(none)
+          .toMap
+        services.use { s =>
           Services.asSuperUser:
             byTime.toList.foldLeftM(noTime): (acc, entry) =>
               val (at, oids) = entry
@@ -102,11 +106,11 @@ trait ConfigurationMapping[F[_]]
                 .map: results =>
                   acc ++ results.map: (oid, res) =>
                     oid -> (
-                      if res.isFailure then Result(None) // important, don't fail here
+                      if res.isFailure then Result(none) // important, don't fail here
                       else res.map:
-                        case Left(a)             => Left(a.base).some // non-opportunity
-                        case Right((_, Some(c))) => Left(c).some      // opportunity with explicit base
-                        case Right((r, None))    => Right(r).some     // opportunity without explicit base
+                        case Left(a)             => a.base.asLeft.some // non-opportunity
+                        case Right((_, Some(c))) => c.asLeft.some      // opportunity with explicit base
+                        case Right((r, None))    => r.asRight.some     // opportunity without explicit base
                     )
         }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConfigurationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConfigurationMapping.scala
@@ -67,7 +67,7 @@ trait ConfigurationMapping[F[_]]
       // associated CFP (if any). The reference time is used when computing coordintes for approved
       // configurations; it is not related to visualization time.
       SqlField("referenceTime", ObservationView.ReferenceTime, hidden = true),
-      EffectField("target", targetQueryHandler, List("id", "programId", "referenceTime")),
+      EffectField("target", targetQueryHandler, List("id", "referenceTime")),
       SqlObject("conditions"),
       SqlObject("observingMode"),
     )
@@ -118,7 +118,9 @@ trait ConfigurationMapping[F[_]]
         T.span("effect:configuration.target", Attribute("count", queries.size.toLong)).surround {
          (for {
           ctx     <- ResultT(queryContext(queries).pure[F])
-          results <- ResultT.liftF(T.span("effect:configuration.target.calculateAll").surround(calculateAll(ctx)))
+          results <- ResultT.liftF:
+                       T.span("effect:configuration.target.calculateAll")
+                         .surround(calculateAll(ctx))
           res     <- ResultT.fromResult:
                        ctx.map(_._1).zip(queries).traverse { case (oid, (query, parentCursor)) =>
                          for {

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConfigurationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConfigurationMapping.scala
@@ -17,7 +17,6 @@ import lucuma.catalog.clients.GaiaClient
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Region
 import lucuma.core.model.Observation
-import lucuma.core.model.Program
 import lucuma.core.util.Timestamp
 import lucuma.itc.client.ItcClient
 import lucuma.odb.graphql.table.ConfigurationRequestView
@@ -28,10 +27,13 @@ import lucuma.odb.logic.TimeEstimateCalculatorImplementation
 import lucuma.odb.sequence.util.CommitHash
 import lucuma.odb.service.Services
 import org.http4s.client.Client
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.trace.Tracer
 
 trait ConfigurationMapping[F[_]]
   extends ObservationView[F] with ConfigurationRequestView[F] {
 
+  protected def T: Tracer[F]
   def services: Resource[F, Services[F]]
   def itcClient: ItcClient[F]
   def httpClient: Client[F]
@@ -76,71 +78,65 @@ trait ConfigurationMapping[F[_]]
     // the cursor, and we don't need the environment at all. Would be nice to abstract something out.
     new EffectHandler[F] {
 
-      // Batched to avoid an N+1: Grackle hands us every observation in the result at once, so we
-      // resolve them in a single session, issuing one tracking query per distinct reference time
-      // (observations sharing a CFP share a time) rather than one query -- and one session -- per
-      // observation.
-      def calculateAll(
-        obs: List[(Observation.Id, Option[Timestamp])]
-      ): F[Result[Map[Observation.Id, Option[Either[Coordinates, Region]]]]] =
-        services.use { implicit s =>
-          Services.asSuperUser:
-            obs
-              .collect { case (oid, Some(at)) => at -> oid }
-              .groupMap(_._1)(_._2)
-              .toList
-              .flatTraverse { case (at, oids) =>
-                s.trackingService
-                  .getCoordinatesSnapshotOrRegion(oids, at, false)
-                  .map(_.toList)
-              }
-              .map { entries =>
-                entries
-                  .traverse { case (oid, res) =>
-                    val converted: Result[Option[Either[Coordinates, Region]]] =
-                      if res.isFailure then Result(none[Either[Coordinates, Region]]) // important, don't fail here
-                      else res.map {
-                        case Left(a)             => Left(a.base).some // non-opportunity
-                        case Right((_, Some(c))) => Left(c).some      // opportunity with explicit base
-                        case Right((r, None))    => Right(r).some     // opportunity without explicit base
-                      }
-                    converted.tupleLeft(oid)
-                  }
-                  .map(_.toMap)
-              }
-        }
-
-      private def queryContext(queries: List[(Query, Cursor)]): Result[List[(Program.Id, Observation.Id, Option[Timestamp])]] =
+      private def queryContext(queries: List[(Query, Cursor)]): Result[List[(Observation.Id, Option[Timestamp])]] =
         queries.parTraverse: (_, cursor) =>
           (
-            cursor.fieldAs[Program.Id]("programId"),
             cursor.fieldAs[Observation.Id]("id"),
             cursor.fieldAs[Option[Timestamp]]("referenceTime")
           ).parTupled
 
+      // Compute the configuration coordinates/region for every observation, batching the tracking
+      // lookups by reference time (the CFP midpoint, which most observations share) rather than
+      // issuing one query per observation. Returns a map keyed by observation id. N.B. we use
+      // `services.use` (not `useTransactionally`) because `getCoordinatesSnapshotOrRegion` manages
+      // its own transaction internally; wrapping it would nest transactions.
+      private def calculateAll(
+        ctx: List[(Observation.Id, Option[Timestamp])]
+      ): F[Map[Observation.Id, Result[Option[Either[Coordinates, Region]]]]] =
+        val byTime: Map[Timestamp, List[Observation.Id]] =
+          ctx.collect { case (oid, Some(t)) => t -> oid }.groupMap(_._1)(_._2)
+        val noTime: Map[Observation.Id, Result[Option[Either[Coordinates, Region]]]] =
+          ctx.collect { case (oid, None) => oid -> Result(None) }.toMap
+        services.use { implicit s =>
+          Services.asSuperUser:
+            byTime.toList.foldLeftM(noTime): (acc, entry) =>
+              val (at, oids) = entry
+              s.trackingService
+                .getCoordinatesSnapshotOrRegion(oids, at, false)
+                .map: results =>
+                  acc ++ results.map: (oid, res) =>
+                    oid -> (
+                      if res.isFailure then Result(None) // important, don't fail here
+                      else res.map:
+                        case Left(a)             => Left(a.base).some // non-opportunity
+                        case Right((_, Some(c))) => Left(c).some      // opportunity with explicit base
+                        case Right((r, None))    => Right(r).some      // opportunity without explicit base
+                    )
+        }
+
       def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
-        (for {
-          ctx       <- ResultT(queryContext(queries).pure[F])
-          resultMap <- ResultT(calculateAll(ctx.distinct.map { case (_, oid, ldt) => (oid, ldt) }))
-          res       <- ResultT(ctx
-                   .map { case (_, oid, _) => resultMap.getOrElse(oid, None) }
-                   .zip(queries)
-                   .traverse { case (result, (query, parentCursor)) =>
-                     Query.childContext(parentCursor.context, query).map { childContext =>
-                       CirceCursor(
-                        childContext,
-                        Json.obj(
-                          "coordinates" -> result.flatMap(_.left.toOption).asJson,
-                          "region"      -> result.flatMap(_.toOption).asJson,
-                        ),
-                        Some(parentCursor),
-                        parentCursor.fullEnv
-                      )
-                     }
-                   }.pure[F]
-                 )
+        T.span("effect:configuration.target", Attribute("count", queries.size.toLong)).surround {
+         (for {
+          ctx     <- ResultT(queryContext(queries).pure[F])
+          results <- ResultT.liftF(T.span("effect:configuration.target.calculateAll").surround(calculateAll(ctx)))
+          res     <- ResultT.fromResult:
+                       ctx.map(_._1).zip(queries).traverse { case (oid, (query, parentCursor)) =>
+                         for {
+                           result       <- results.getOrElse(oid, Result(None))
+                           childContext <- Query.childContext(parentCursor.context, query)
+                         } yield CirceCursor(
+                           childContext,
+                           Json.obj(
+                             "coordinates" -> result.flatMap(_.left.toOption).asJson,
+                             "region"      -> result.flatMap(_.toOption).asJson,
+                           ),
+                           Some(parentCursor),
+                           parentCursor.fullEnv
+                         )
+                       }
           } yield res
-        ).value
+         ).value
+        }
 
     }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConfigurationMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ConfigurationMapping.scala
@@ -27,13 +27,10 @@ import lucuma.odb.logic.TimeEstimateCalculatorImplementation
 import lucuma.odb.sequence.util.CommitHash
 import lucuma.odb.service.Services
 import org.http4s.client.Client
-import org.typelevel.otel4s.Attribute
-import org.typelevel.otel4s.trace.Tracer
 
 trait ConfigurationMapping[F[_]]
   extends ObservationView[F] with ConfigurationRequestView[F] {
 
-  protected def T: Tracer[F]
   def services: Resource[F, Services[F]]
   def itcClient: ItcClient[F]
   def httpClient: Client[F]
@@ -87,9 +84,8 @@ trait ConfigurationMapping[F[_]]
 
       // Compute the configuration coordinates/region for every observation, batching the tracking
       // lookups by reference time (the CFP midpoint, which most observations share) rather than
-      // issuing one query per observation. Returns a map keyed by observation id. N.B. we use
-      // `services.use` (not `useTransactionally`) because `getCoordinatesSnapshotOrRegion` manages
-      // its own transaction internally; wrapping it would nest transactions.
+      // one query per observation. 
+      // Returns a map keyed by observation id. 
       private def calculateAll(
         ctx: List[(Observation.Id, Option[Timestamp])]
       ): F[Map[Observation.Id, Result[Option[Either[Coordinates, Region]]]]] =
@@ -110,17 +106,14 @@ trait ConfigurationMapping[F[_]]
                       else res.map:
                         case Left(a)             => Left(a.base).some // non-opportunity
                         case Right((_, Some(c))) => Left(c).some      // opportunity with explicit base
-                        case Right((r, None))    => Right(r).some      // opportunity without explicit base
+                        case Right((r, None))    => Right(r).some     // opportunity without explicit base
                     )
         }
 
       def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
-        T.span("effect:configuration.target", Attribute("count", queries.size.toLong)).surround {
          (for {
           ctx     <- ResultT(queryContext(queries).pure[F])
-          results <- ResultT.liftF:
-                       T.span("effect:configuration.target.calculateAll")
-                         .surround(calculateAll(ctx))
+          results <- ResultT.liftF(calculateAll(ctx))
           res     <- ResultT.fromResult:
                        ctx.map(_._1).zip(queries).traverse { case (oid, (query, parentCursor)) =>
                          for {
@@ -138,7 +131,6 @@ trait ConfigurationMapping[F[_]]
                        }
           } yield res
          ).value
-        }
 
     }
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
@@ -16,13 +16,11 @@ import grackle.QueryCompiler.Elab
 import grackle.Result
 import grackle.ResultT
 import grackle.TypeRef
-import grackle.syntax.*
 import io.circe.Json
 import io.circe.syntax.*
 import lucuma.core.enums.ExecutionState
 import lucuma.core.model.ExecutionEvent
 import lucuma.core.model.Observation
-import lucuma.core.model.Program
 import lucuma.core.model.User
 import lucuma.core.model.Visit
 import lucuma.core.model.sequence.CategorizedTime
@@ -43,6 +41,7 @@ import lucuma.odb.logic.Generator
 import lucuma.odb.service.Services
 import lucuma.odb.service.Services.Syntax.*
 import org.http4s.client.Client
+import org.typelevel.otel4s.Attribute
 
 trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
                                 with ObscalcTable[F]
@@ -133,7 +132,8 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
                 oids.map(oid => states.getOrElse(oid, ExecutionState.NotDefined).asJson)
 
       override def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
-        (
+        T.span("effect:execution.executionState", Attribute("count", queries.size.toLong)).surround {
+         (
           for
             oids <- ResultT.fromResult(queryContext(queries))
             stat <- ResultT.liftF(execute(oids))
@@ -148,7 +148,8 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
                         }
 
           yield res
-        ).value
+         ).value
+        }
 
   private lazy val digestHandler: EffectHandler[F] =
     new EffectHandler[F]:
@@ -157,7 +158,8 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
           case (_, cursor) => cursor.fieldAs[Observation.Id]("id")
 
       override def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
-        (
+        T.span("effect:execution.digest", Attribute("count", queries.size.toLong)).surround {
+         (
           for
             oids    <- ResultT.fromResult(queryContext(queries))
             digests <- ResultT.liftF(services.useTransactionally(obscalcService.selectManyExecutionDigest(oids)))
@@ -177,7 +179,8 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
                               childContext <- Query.childContext(parentCursor.context, query)
                             yield CirceCursor(childContext, j, Some(parentCursor), parentCursor.fullEnv)
           yield res
-        ).value
+         ).value
+        }
 
   // Batched to avoid an N+1: resolve every observation's time charge in a single transaction with
   // one grouped query, rather than one transaction and one query per observation.
@@ -188,7 +191,8 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
           case (_, cursor) => cursor.fieldAs[Observation.Id]("id")
 
       override def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
-        (
+        T.span("effect:execution.timeCharge", Attribute("count", queries.size.toLong)).surround {
+         (
           for
             oids  <- ResultT.fromResult(queryContext(queries))
             times <- ResultT.liftF(services.useTransactionally {
@@ -202,6 +206,7 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
                              val json = times.getOrElse(oid, CategorizedTime.Zero).asJson
                              CirceCursor(childContext, json, Some(parentCursor), parentCursor.fullEnv)
           yield res
-        ).value
+         ).value
+        }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
@@ -114,7 +114,7 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
   }
 
   private lazy val executionStateHandler: EffectHandler[F] =
-    batchedEffectHandler("effect:execution.executionState"): oids =>
+    batchedEffectHandler: oids =>
       services.useTransactionally:
         generatorParamsService
           .selectExecutionStates(oids)
@@ -122,13 +122,12 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
             oids.map(oid => oid -> Result(states.getOrElse(oid, ExecutionState.NotDefined))).toMap
 
   private lazy val digestHandler: EffectHandler[F] =
-    batchedEffectHandler[Json]("effect:execution.digest"): oids =>
+    batchedEffectHandler: oids =>
       services.useTransactionally(obscalcService.selectManyExecutionDigest(oids)).map: digests =>
         oids.map: oid =>
-          val json: Result[Json] =
-            digests.get(oid).fold(OdbError.SequenceUnavailable(oid).asWarning(Json.Null)): cv =>
-              cv
-                .map: res =>
+          val json =
+            digests.get(oid).fold(OdbError.SequenceUnavailable(oid).asWarning(Json.Null)):
+              _.map: res =>
                   res.map(_.asJson) match
                     case Result.Failure(ps) => Result.Warning(ps, Json.Null)
                     case r                  => r
@@ -136,11 +135,8 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
           oid -> json
         .toMap
 
-  // Batched to avoid an N+1: resolve every observation's time charge in a single transaction with
-  // one grouped query, rather than one transaction and one query per observation. Observations with
-  // no visits default to `CategorizedTime.Zero`.
   private lazy val timeChargeHandler: EffectHandler[F] =
-    batchedEffectHandler("effect:execution.timeCharge"): oids =>
+    batchedEffectHandler: oids =>
       services.useTransactionally:
         Services.asSuperUser:
           timeAccountingService.selectObservations(oids).map: times =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
@@ -25,6 +25,7 @@ import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.User
 import lucuma.core.model.Visit
+import lucuma.core.model.sequence.CategorizedTime
 import lucuma.core.model.sequence.Dataset
 import lucuma.itc.client.ItcClient
 import lucuma.odb.data.OdbError
@@ -178,16 +179,29 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
           yield res
         ).value
 
-  private lazy val timeChargeHandler: EffectHandler[F] = {
-    val calculate: (Program.Id, Observation.Id, Unit) => F[Result[Json]] =
-      (_, oid, _) => {
-        services.useTransactionally {
-          Services.asSuperUser:
-            timeAccountingService.selectObservation(oid).map(_.asJson.success)
-        }
-      }
+  // Batched to avoid an N+1: resolve every observation's time charge in a single transaction with
+  // one grouped query, rather than one transaction and one query per observation.
+  private lazy val timeChargeHandler: EffectHandler[F] =
+    new EffectHandler[F]:
+      private def queryContext(queries: List[(Query, Cursor)]): Result[List[Observation.Id]] =
+        queries.traverse:
+          case (_, cursor) => cursor.fieldAs[Observation.Id]("id")
 
-    effectHandler(_ => ().success, calculate)
-  }
+      override def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
+        (
+          for
+            oids  <- ResultT.fromResult(queryContext(queries))
+            times <- ResultT.liftF(services.useTransactionally {
+                       Services.asSuperUser:
+                         timeAccountingService.selectObservations(oids)
+                     })
+            res   <- ResultT.fromResult:
+                       oids.zip(queries).traverse:
+                         case (oid, (query, parentCursor)) =>
+                           Query.childContext(parentCursor.context, query).map: childContext =>
+                             val json = times.getOrElse(oid, CategorizedTime.Zero).asJson
+                             CirceCursor(childContext, json, Some(parentCursor), parentCursor.fullEnv)
+          yield res
+        ).value
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExecutionMapping.scala
@@ -8,19 +8,15 @@ import cats.effect.Resource
 import cats.syntax.functor.*
 import cats.syntax.traverse.*
 import eu.timepit.refined.cats.*
-import grackle.Cursor
-import grackle.Query
 import grackle.Query.Binding
 import grackle.Query.EffectHandler
 import grackle.QueryCompiler.Elab
 import grackle.Result
-import grackle.ResultT
 import grackle.TypeRef
 import io.circe.Json
 import io.circe.syntax.*
 import lucuma.core.enums.ExecutionState
 import lucuma.core.model.ExecutionEvent
-import lucuma.core.model.Observation
 import lucuma.core.model.User
 import lucuma.core.model.Visit
 import lucuma.core.model.sequence.CategorizedTime
@@ -41,7 +37,6 @@ import lucuma.odb.logic.Generator
 import lucuma.odb.service.Services
 import lucuma.odb.service.Services.Syntax.*
 import org.http4s.client.Client
-import org.typelevel.otel4s.Attribute
 
 trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
                                 with ObscalcTable[F]
@@ -119,94 +114,36 @@ trait ExecutionMapping[F[_]] extends ObservationEffectHandler[F]
   }
 
   private lazy val executionStateHandler: EffectHandler[F] =
-    new EffectHandler[F]:
-      private def queryContext(queries: List[(Query, Cursor)]): Result[List[Observation.Id]] =
-        queries.traverse { case (_, cursor) => cursor.fieldAs[Observation.Id]("id") }
-
-      private def execute(oids: List[Observation.Id]): F[List[Json]] =
-        services
-          .useTransactionally:
-            generatorParamsService
-              .selectExecutionStates(oids)
-              .map: states =>
-                oids.map(oid => states.getOrElse(oid, ExecutionState.NotDefined).asJson)
-
-      override def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
-        T.span("effect:execution.executionState", Attribute("count", queries.size.toLong)).surround {
-         (
-          for
-            oids <- ResultT.fromResult(queryContext(queries))
-            stat <- ResultT.liftF(execute(oids))
-            res  <- ResultT.fromResult:
-                      stat
-                        .zip(queries)
-                        .traverse { case (state, (query, parentCursor)) =>
-                          Query
-                            .childContext(parentCursor.context, query)
-                            .map: childContext =>
-                              CirceCursor(childContext, state, Some(parentCursor), parentCursor.fullEnv)
-                        }
-
-          yield res
-         ).value
-        }
+    batchedEffectHandler("effect:execution.executionState"): oids =>
+      services.useTransactionally:
+        generatorParamsService
+          .selectExecutionStates(oids)
+          .map: states =>
+            oids.map(oid => oid -> Result(states.getOrElse(oid, ExecutionState.NotDefined))).toMap
 
   private lazy val digestHandler: EffectHandler[F] =
-    new EffectHandler[F]:
-      private def queryContext(queries: List[(Query, Cursor)]): Result[List[Observation.Id]] =
-        queries.traverse:
-          case (_, cursor) => cursor.fieldAs[Observation.Id]("id")
-
-      override def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
-        T.span("effect:execution.digest", Attribute("count", queries.size.toLong)).surround {
-         (
-          for
-            oids    <- ResultT.fromResult(queryContext(queries))
-            digests <- ResultT.liftF(services.useTransactionally(obscalcService.selectManyExecutionDigest(oids)))
-            res     <- ResultT.fromResult:
-                         oids.zip(queries).traverse:
-                           case (oid, (query, parentCursor)) =>
-                            val json: Result[Json] =
-                              digests.get(oid).fold(OdbError.SequenceUnavailable(oid).asWarning(Json.Null)): cv =>
-                                cv
-                                  .map: res =>
-                                    res.map(_.asJson) match
-                                      case Result.Failure(ps) => Result.Warning(ps, Json.Null)
-                                      case r                  => r
-                                  .sequence.map(_.asJson)
-                            for
-                              j            <- json
-                              childContext <- Query.childContext(parentCursor.context, query)
-                            yield CirceCursor(childContext, j, Some(parentCursor), parentCursor.fullEnv)
-          yield res
-         ).value
-        }
+    batchedEffectHandler[Json]("effect:execution.digest"): oids =>
+      services.useTransactionally(obscalcService.selectManyExecutionDigest(oids)).map: digests =>
+        oids.map: oid =>
+          val json: Result[Json] =
+            digests.get(oid).fold(OdbError.SequenceUnavailable(oid).asWarning(Json.Null)): cv =>
+              cv
+                .map: res =>
+                  res.map(_.asJson) match
+                    case Result.Failure(ps) => Result.Warning(ps, Json.Null)
+                    case r                  => r
+                .sequence.map(_.asJson)
+          oid -> json
+        .toMap
 
   // Batched to avoid an N+1: resolve every observation's time charge in a single transaction with
-  // one grouped query, rather than one transaction and one query per observation.
+  // one grouped query, rather than one transaction and one query per observation. Observations with
+  // no visits default to `CategorizedTime.Zero`.
   private lazy val timeChargeHandler: EffectHandler[F] =
-    new EffectHandler[F]:
-      private def queryContext(queries: List[(Query, Cursor)]): Result[List[Observation.Id]] =
-        queries.traverse:
-          case (_, cursor) => cursor.fieldAs[Observation.Id]("id")
-
-      override def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
-        T.span("effect:execution.timeCharge", Attribute("count", queries.size.toLong)).surround {
-         (
-          for
-            oids  <- ResultT.fromResult(queryContext(queries))
-            times <- ResultT.liftF(services.useTransactionally {
-                       Services.asSuperUser:
-                         timeAccountingService.selectObservations(oids)
-                     })
-            res   <- ResultT.fromResult:
-                       oids.zip(queries).traverse:
-                         case (oid, (query, parentCursor)) =>
-                           Query.childContext(parentCursor.context, query).map: childContext =>
-                             val json = times.getOrElse(oid, CategorizedTime.Zero).asJson
-                             CirceCursor(childContext, json, Some(parentCursor), parentCursor.fullEnv)
-          yield res
-         ).value
-        }
+    batchedEffectHandler("effect:execution.timeCharge"): oids =>
+      services.useTransactionally:
+        Services.asSuperUser:
+          timeAccountingService.selectObservations(oids).map: times =>
+            oids.map(oid => oid -> Result(times.getOrElse(oid, CategorizedTime.Zero))).toMap
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationEffectHandler.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationEffectHandler.scala
@@ -35,9 +35,10 @@ trait ObservationEffectHandler[F[_]] extends ObservationView[F] {
   /**
    * Batched effect handler keyed by observation id: `calculateAll` receives every observation id in
    * the result at once and returns a per-observation result map, replacing the
-   * one-transaction-per-observation N+1 of `effectHandler`. The map must contain an entry for every
-   * requested id; a missing key fails that observation's field. `spanName` names the tracing span so
-   * each field remains individually attributable in traces.
+   * one-transaction-per-observation N+1 of `effectHandler`. `calculateAll` must return an entry for
+   * every requested id; a missing id is a programming error and fails the whole effect (grackle's
+   * `Result` traverse is not per-field). `spanName` names the tracing span so each field remains
+   * individually attributable in traces.
    */
   protected def batchedEffectHandler[R](
     spanName: String
@@ -49,6 +50,9 @@ trait ObservationEffectHandler[F[_]] extends ObservationView[F] {
       private def oids(queries: List[(Query, Cursor)]): Result[List[Observation.Id]] =
         queries.traverse { case (_, cursor) => cursor.fieldAs[Observation.Id]("id") }
 
+      private def missing(oid: Observation.Id): Result[R] =
+        Result.failure(s"No result computed for observation $oid")
+
       def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
         T.span(spanName, Attribute("count", queries.size.toLong)).surround {
           (for {
@@ -56,7 +60,7 @@ trait ObservationEffectHandler[F[_]] extends ObservationView[F] {
             map <- ResultT.liftF(T.span(s"$spanName.calculateAll").surround(calculateAll(os)))
             res <- ResultT(os.zip(queries).traverse { case (oid, (query, parentCursor)) =>
                      for {
-                       r            <- map.getOrElse(oid, Result.failure(s"No result computed for observation $oid"))
+                       r            <- map.getOrElse(oid, missing(oid))
                        childContext <- Query.childContext(parentCursor.context, query)
                      } yield CirceCursor(childContext, r.asJson, Some(parentCursor), parentCursor.fullEnv)
                    }.pure[F])

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationEffectHandler.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationEffectHandler.scala
@@ -17,10 +17,14 @@ import grackle.ResultT
 import io.circe.syntax.*
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
+import org.typelevel.otel4s.Attribute
+import org.typelevel.otel4s.trace.Tracer
 
 import table.ObservationView
 
 trait ObservationEffectHandler[F[_]] extends ObservationView[F] {
+
+  protected def T: Tracer[F]
 
   protected def effectHandler[E, R](
     readEnv:   Env => Result[E],
@@ -45,22 +49,24 @@ trait ObservationEffectHandler[F[_]] extends ObservationView[F] {
         }
 
       def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
-        (for {
-          ctx <- ResultT(queryContext(queries).pure[F])
-          obs <- ctx.distinct.traverse { case (pid, oid, env) =>
-                   ResultT(calculate(pid, oid, env)).map((oid, env, _))
-                 }
-          res <- ResultT(ctx
-                   .flatMap { case (_, oid, env) => obs.find(r => r._1 === oid && r._2 === env).map(_._3).toList }
-                   .zip(queries)
-                   .traverse { case (result, (query, parentCursor)) =>
-                     Query.childContext(parentCursor.context, query).map { childContext =>
-                       CirceCursor(childContext, result.asJson, Some(parentCursor), parentCursor.fullEnv)
-                     }
-                   }.pure[F]
-                 )
-          } yield res
-        ).value
+        T.span("effect.perObs", Attribute("count", queries.size.toLong)).surround {
+          (for {
+            ctx <- ResultT(queryContext(queries).pure[F])
+            obs <- ctx.distinct.traverse { case (pid, oid, env) =>
+                     ResultT(calculate(pid, oid, env)).map((oid, env, _))
+                   }
+            res <- ResultT(ctx
+                     .flatMap { case (_, oid, env) => obs.find(r => r._1 === oid && r._2 === env).map(_._3).toList }
+                     .zip(queries)
+                     .traverse { case (result, (query, parentCursor)) =>
+                       Query.childContext(parentCursor.context, query).map { childContext =>
+                         CirceCursor(childContext, result.asJson, Some(parentCursor), parentCursor.fullEnv)
+                       }
+                     }.pure[F]
+                   )
+            } yield res
+          ).value
+        }
     }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationEffectHandler.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationEffectHandler.scala
@@ -32,6 +32,38 @@ trait ObservationEffectHandler[F[_]] extends ObservationView[F] {
   )(using Eq[E], io.circe.Encoder[R]): EffectHandler[F] =
     readQueryAndCursorEffectHander((_, c) => readEnv(c.fullEnv), calculate)
 
+  /**
+   * Batched effect handler keyed by observation id: `calculateAll` receives every observation id in
+   * the result at once and returns a per-observation result map, replacing the
+   * one-transaction-per-observation N+1 of `effectHandler`. The map must contain an entry for every
+   * requested id; a missing key fails that observation's field. `spanName` names the tracing span so
+   * each field remains individually attributable in traces.
+   */
+  protected def batchedEffectHandler[R](
+    spanName: String
+  )(
+    calculateAll: List[Observation.Id] => F[Map[Observation.Id, Result[R]]]
+  )(using io.circe.Encoder[R]): EffectHandler[F] =
+    new EffectHandler[F] {
+
+      private def oids(queries: List[(Query, Cursor)]): Result[List[Observation.Id]] =
+        queries.traverse { case (_, cursor) => cursor.fieldAs[Observation.Id]("id") }
+
+      def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
+        T.span(spanName, Attribute("count", queries.size.toLong)).surround {
+          (for {
+            os  <- ResultT(oids(queries).pure[F])
+            map <- ResultT.liftF(T.span(s"$spanName.calculateAll").surround(calculateAll(os)))
+            res <- ResultT(os.zip(queries).traverse { case (oid, (query, parentCursor)) =>
+                     for {
+                       r            <- map.getOrElse(oid, Result.failure(s"No result computed for observation $oid"))
+                       childContext <- Query.childContext(parentCursor.context, query)
+                     } yield CirceCursor(childContext, r.asJson, Some(parentCursor), parentCursor.fullEnv)
+                   }.pure[F])
+          } yield res).value
+        }
+    }
+
   protected def readQueryAndCursorEffectHander[E, R](
     readQueryAndCursor:   (Query, Cursor) => Result[E],
     calculate: (Program.Id, Observation.Id, E) => F[Result[R]]

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationEffectHandler.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ObservationEffectHandler.scala
@@ -14,64 +14,56 @@ import grackle.Query
 import grackle.Query.EffectHandler
 import grackle.Result
 import grackle.ResultT
+import io.circe.Encoder as CirceEncoder
 import io.circe.syntax.*
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
-import org.typelevel.otel4s.Attribute
-import org.typelevel.otel4s.trace.Tracer
 
 import table.ObservationView
 
 trait ObservationEffectHandler[F[_]] extends ObservationView[F] {
 
-  protected def T: Tracer[F]
-
   protected def effectHandler[E, R](
     readEnv:   Env => Result[E],
     calculate: (Program.Id, Observation.Id, E) => F[Result[R]]
-  )(using Eq[E], io.circe.Encoder[R]): EffectHandler[F] =
+  )(using Eq[E], CirceEncoder[R]): EffectHandler[F] =
     readQueryAndCursorEffectHander((_, c) => readEnv(c.fullEnv), calculate)
 
   /**
-   * Batched effect handler keyed by observation id: `calculateAll` receives every observation id in
-   * the result at once and returns a per-observation result map, replacing the
-   * one-transaction-per-observation N+1 of `effectHandler`. `calculateAll` must return an entry for
-   * every requested id; a missing id is a programming error and fails the whole effect (grackle's
-   * `Result` traverse is not per-field). `spanName` names the tracing span so each field remains
-   * individually attributable in traces.
+   * Batched effect handler keyed by observation id
+   * `calculateAll` receives every observation id in the result at once and returns a per-observation
+   * result map.
+   * It replaces the one transaction per observation N+1 of `effectHandler`.
    */
   protected def batchedEffectHandler[R](
-    spanName: String
-  )(
     calculateAll: List[Observation.Id] => F[Map[Observation.Id, Result[R]]]
-  )(using io.circe.Encoder[R]): EffectHandler[F] =
+  )(using CirceEncoder[R]): EffectHandler[F] =
     new EffectHandler[F] {
 
       private def oids(queries: List[(Query, Cursor)]): Result[List[Observation.Id]] =
-        queries.traverse { case (_, cursor) => cursor.fieldAs[Observation.Id]("id") }
+        queries.traverse:
+          case (_, cursor) => cursor.fieldAs[Observation.Id]("id")
 
       private def missing(oid: Observation.Id): Result[R] =
         Result.failure(s"No result computed for observation $oid")
 
       def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
-        T.span(spanName, Attribute("count", queries.size.toLong)).surround {
-          (for {
-            os  <- ResultT(oids(queries).pure[F])
-            map <- ResultT.liftF(T.span(s"$spanName.calculateAll").surround(calculateAll(os)))
-            res <- ResultT(os.zip(queries).traverse { case (oid, (query, parentCursor)) =>
-                     for {
-                       r            <- map.getOrElse(oid, missing(oid))
-                       childContext <- Query.childContext(parentCursor.context, query)
-                     } yield CirceCursor(childContext, r.asJson, Some(parentCursor), parentCursor.fullEnv)
-                   }.pure[F])
-          } yield res).value
-        }
+        (for {
+          os  <- ResultT(oids(queries).pure[F])
+          map <- ResultT.liftF(calculateAll(os))
+          res <- ResultT(os.zip(queries).traverse { case (oid, (query, parentCursor)) =>
+                   for {
+                     r            <- map.getOrElse(oid, missing(oid))
+                     childContext <- Query.childContext(parentCursor.context, query)
+                   } yield CirceCursor(childContext, r.asJson, Some(parentCursor), parentCursor.fullEnv)
+                 }.pure)
+        } yield res).value
     }
 
   protected def readQueryAndCursorEffectHander[E, R](
     readQueryAndCursor:   (Query, Cursor) => Result[E],
     calculate: (Program.Id, Observation.Id, E) => F[Result[R]]
-  )(using Eq[E], io.circe.Encoder[R]): EffectHandler[F] =
+  )(using Eq[E], CirceEncoder[R]): EffectHandler[F] =
 
     new EffectHandler[F] {
 
@@ -85,24 +77,22 @@ trait ObservationEffectHandler[F[_]] extends ObservationView[F] {
         }
 
       def runEffects(queries: List[(Query, Cursor)]): F[Result[List[Cursor]]] =
-        T.span("effect.perObs", Attribute("count", queries.size.toLong)).surround {
-          (for {
-            ctx <- ResultT(queryContext(queries).pure[F])
-            obs <- ctx.distinct.traverse { case (pid, oid, env) =>
-                     ResultT(calculate(pid, oid, env)).map((oid, env, _))
-                   }
-            res <- ResultT(ctx
-                     .flatMap { case (_, oid, env) => obs.find(r => r._1 === oid && r._2 === env).map(_._3).toList }
-                     .zip(queries)
-                     .traverse { case (result, (query, parentCursor)) =>
-                       Query.childContext(parentCursor.context, query).map { childContext =>
-                         CirceCursor(childContext, result.asJson, Some(parentCursor), parentCursor.fullEnv)
-                       }
-                     }.pure[F]
-                   )
-            } yield res
-          ).value
-        }
+        (for {
+          ctx <- ResultT(queryContext(queries).pure[F])
+          obs <- ctx.distinct.traverse { case (pid, oid, env) =>
+                   ResultT(calculate(pid, oid, env)).map((oid, env, _))
+                 }
+          res <- ResultT(ctx
+                   .flatMap { case (_, oid, env) => obs.find(r => r._1 === oid && r._2 === env).map(_._3).toList }
+                   .zip(queries)
+                   .traverse { case (result, (query, parentCursor)) =>
+                     Query.childContext(parentCursor.context, query).map { childContext =>
+                       CirceCursor(childContext, result.asJson, Some(parentCursor), parentCursor.fullEnv)
+                     }
+                   }.pure[F]
+                 )
+          } yield res
+        ).value
     }
 
 }

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TargetEnvironmentMapping.scala
@@ -27,7 +27,6 @@ import lucuma.core.model.Target
 import lucuma.core.util.Timestamp
 import lucuma.core.util.TimestampInterval
 import lucuma.itc.client.ItcClient
-import lucuma.odb.data.BasePosition
 import lucuma.odb.graphql.predicate.Predicates
 import lucuma.odb.json.basePosition.given
 import lucuma.odb.service.GuideService
@@ -91,7 +90,7 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
         ,
         List("instrument")
       ),
-      EffectField("basePosition", basePositionQueryHandler, List("id", "programId")),
+      EffectField("basePosition", basePositionQueryHandler, List("id")),
       EffectField("guideEnvironment", guideEnvironmentQueryHandler, List("id", "programId")),
       EffectField("guideAvailability", guideAvailabilityQueryHandler, List("id", "programId")),
       EffectField("guideTargetName", guideTargetNameQueryHandler, List("id", "programId"))
@@ -155,17 +154,12 @@ trait TargetEnvironmentMapping[F[_]: Temporal]
       }
   }
 
-  def basePositionQueryHandler: EffectHandler[F] = {
-    val readEnv: Env => Result[Unit] = _ => ().success
-
-    val calculate: (Program.Id, Observation.Id, Unit) => F[Result[Option[BasePosition]]] =
-      (_, oid, _) =>
-        services.use: s =>
-          Services.asSuperUser:
-            s.trackingService.getBasePosition(oid)
-
-    effectHandler(readEnv, calculate)
-  }
+  def basePositionQueryHandler: EffectHandler[F] =
+    // Collapse the per-observation N+1 by resolving the whole batch in a single session. 
+    batchedEffectHandler: oids =>
+      services.use: s =>
+        Services.asSuperUser:
+          oids.traverse(oid => s.trackingService.getBasePosition(oid).tupleLeft(oid)).map(_.toMap)
 
   def guideEnvironmentQueryHandler: EffectHandler[F] = {
     val readEnv: Env => Result[Unit] = _ => ().success

--- a/modules/service/src/main/scala/lucuma/odb/service/TimeAccountingService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TimeAccountingService.scala
@@ -270,7 +270,7 @@ object TimeAccountingService {
         observationIds: List[Observation.Id]
       )(using Transaction[F], SuperUserAccess): F[Map[Observation.Id, CategorizedTime]] =
         NonEmptyList.fromList(observationIds.distinct) match
-          case None      => Applicative[F].pure(Map.empty)
+          case None      => Map.empty.pure
           case Some(nel) =>
             session.execute(Statements.selectObservations(nel))(nel).map(_.toMap)
 

--- a/modules/service/src/main/scala/lucuma/odb/service/TimeAccountingService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TimeAccountingService.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.service
 
 import cats.Applicative
+import cats.data.NonEmptyList
 import cats.data.StateT
 import cats.effect.Concurrent
 import cats.syntax.all.*
@@ -62,6 +63,14 @@ trait TimeAccountingService[F[_]] {
   def selectObservation(
     observationId: Observation.Id
   )(using Transaction[F], SuperUserAccess): F[Option[CategorizedTime]]
+
+  /**
+   * Sums the final time accounting result for each of the given observations. Observations with
+   * no visits are absent from the resulting map.
+   */
+  def selectObservations(
+    observationIds: List[Observation.Id]
+  )(using Transaction[F], SuperUserAccess): F[Map[Observation.Id, CategorizedTime]]
 
   /**
    * Sums the final time accounting result for all observations of a program.
@@ -256,6 +265,14 @@ object TimeAccountingService {
       )(using Transaction[F], SuperUserAccess): F[Option[CategorizedTime]] =
         session
           .option(SelectObservation)(observationId)
+
+      def selectObservations(
+        observationIds: List[Observation.Id]
+      )(using Transaction[F], SuperUserAccess): F[Map[Observation.Id, CategorizedTime]] =
+        NonEmptyList.fromList(observationIds.distinct) match
+          case None      => Applicative[F].pure(Map.empty)
+          case Some(nel) =>
+            session.execute(Statements.selectObservations(nel))(nel).map(_.toMap)
 
       def selectProgram(
         programId: Program.Id
@@ -544,6 +561,19 @@ object TimeAccountingService {
         FROM t_visit
         WHERE c_observation_id = $observation_id
       """.query(categorized_time)
+
+    def selectObservations(
+      oids: NonEmptyList[Observation.Id]
+    ): Query[oids.type, (Observation.Id, CategorizedTime)] =
+      sql"""
+        SELECT
+          c_observation_id,
+          COALESCE(SUM(c_final_non_charged_time), '0'::interval),
+          COALESCE(SUM(c_final_program_time), '0'::interval)
+        FROM t_visit
+        WHERE c_observation_id IN (${observation_id.nel(oids)})
+        GROUP BY c_observation_id
+      """.query(observation_id *: categorized_time)
 
     val SelectProgram: Query[Program.Id, BandedTime] =
       sql"""

--- a/otel-collector/README.md
+++ b/otel-collector/README.md
@@ -66,12 +66,33 @@ heroku git:remote -a lucuma-otel-collector --remote heroku-collector
 
 ## Running locally
 
+### With `run-local.sh` (forwards to real Grafana Cloud)
+
+`run-local.sh` builds the image (if needed), generates the htpasswd entry, and
+runs the collector forwarding traces to your Grafana Cloud Tempo. Set the Grafana
+credentials in your environment and run it:
+
+```bash
+export GRAFANA_OTLP_ENDPOINT=https://otlp-gateway-...grafana.net/otlp
+export GRAFANA_OTLP_TOKEN=<base64 instanceID:token>   # see below
+./run-local.sh
+```
+
+The script prints the ODB env vars to set. Defaults (`PORT=8888`, `OTLP_USER=otlp`,
+`OTLP_PASSWORD=banana`) can be overridden on the command line.
+
+```bash
+export GRAFANA_OTLP_TOKEN=$(echo -n "${GRAFANA_INSTANCE_ID}:${GRAFANA_TOKEN}" | base64)
+```
+
+### With dummy secrets (no real backend)
+
 Build and run the collector with dummy exporter secrets:
 
 ```bash
 docker build -t otel-collector-local .
 
-# Generate an htpasswd entry for user oltp and password banana
+# Generate an htpasswd entry for user otlp and password banana
 HTPASSWD=$(docker run --rm httpd:2.4-alpine htpasswd -nbB otlp banana)
 
 docker run --rm --name otel-local \

--- a/otel-collector/run-local.sh
+++ b/otel-collector/run-local.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# Build (if needed) and run the OTel collector locally.
+#
+# Grafana endpoint and token are read from your environment:
+#
+#   export GRAFANA_OTLP_ENDPOINT=https://otlp-gateway-...grafana.net/otlp
+#   export GRAFANA_OTLP_TOKEN=<base64 instanceID:token>
+#   ./run-local.sh
+#
+# Optional overrides (defaults shown):
+#   PORT=8888 OTLP_USER=otlp OTLP_PASSWORD=banana ./run-local.sh
+#
+# Then point ODB at it:
+#   export ODB_OTEL_ENDPOINT=http://localhost:8888
+#   export ODB_OTEL_KEY=$(echo -n "${OTLP_USER}:${OTLP_PASSWORD}" | base64)
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+IMAGE="${IMAGE:-otel-collector-local}"
+CONTAINER="${CONTAINER:-otel-local}"
+PORT="${PORT:-8888}"
+OTLP_USER="${OTLP_USER:-otlp}"
+OTLP_PASSWORD="${OTLP_PASSWORD:-banana}"
+
+require() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    echo "error: \$$name is not set" >&2
+    exit 1
+  fi
+}
+
+require GRAFANA_OTLP_ENDPOINT
+require GRAFANA_OTLP_TOKEN
+
+# Build the image if it doesn't exist.
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "==> Building image $IMAGE"
+  docker build -t "$IMAGE" .
+else
+  echo "==> Image $IMAGE already present"
+fi
+
+# Generate the htpasswd entry for $OTLP_USER / $OTLP_PASSWORD.
+echo "==> Generating htpasswd entry for user '$OTLP_USER'"
+HTPASSWD="$(docker run --rm httpd:2.4-alpine htpasswd -nbB "$OTLP_USER" "$OTLP_PASSWORD")"
+
+# Replace any existing container with the same name.
+if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+  echo "==> Removing existing container '$CONTAINER'"
+  docker rm -f "$CONTAINER" >/dev/null
+fi
+
+echo "==> Starting container '$CONTAINER' on port $PORT"
+docker run --rm -d --name "$CONTAINER" \
+  -p "${PORT}:${PORT}" \
+  -e PORT="$PORT" \
+  -e OTLP_HTPASSWD="$HTPASSWD" \
+  -e GRAFANA_OTLP_ENDPOINT="$GRAFANA_OTLP_ENDPOINT" \
+  -e GRAFANA_OTLP_TOKEN="$GRAFANA_OTLP_TOKEN" \
+  "$IMAGE" >/dev/null
+
+cat <<EOF
+
+==> Collector running.
+
+ODB env vars:
+  export ODB_OTEL_ENDPOINT=http://localhost:${PORT}
+  export ODB_OTEL_KEY=$(echo -n "${OTLP_USER}:${OTLP_PASSWORD}" | base64)
+
+Logs:   docker logs -f ${CONTAINER}
+Stop:   docker stop ${CONTAINER}
+EOF


### PR DESCRIPTION
This is another PR about improving performance. As before this was driven examining traces for a large (265 observations) program and focusing on the slowest queries, in particular the one reading observations.

It was discovered that quite few transactions in the traces where due to on a N+1 type of code in the odb. 

From a high-level point of view this PR includes two big changes in queries that can be batched

* `configuration.target` (`ConfigurationMapping`): resolve the batch in a single session, grouping by `referenceTime` and calling the existing batched `TrackingService.getCoordinatesSnapshotOrRegion`.
* `timeCharge` (`ExecutionMapping` + `TimeAccountingService`): added a batched `selectObservations(oids)` and switched the handler from the per-obs `effectHandler` to the batched pattern already used by `digestHandler`. 
`executionMapping` also uses the new `batchedEffectHandler`

Here's the summary of the results before and after:

| Metric (server side) | Before | After | Change |
|---|---:|---:|---:|
| `graphql-query` duration | 17.8 s | **6.6 s** | **−63%** |
| Total spans | 12,005 | **126** | −99% |
| DB sessions (`pool.allocate`) | 533 | **5** | −99% |
| Single-id per-observation executes | 530 | **0** | eliminated |