### PR TITLE
Sec fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -723,6 +723,7 @@ lazy val common = project
   .settings(
     name := "lucuma-common-middleware",
     libraryDependencies ++= Seq(
+      "org.http4s"    %% "http4s-client"  % http4sVersion,
       "org.http4s"    %% "http4s-core"    % http4sVersion,
       "org.http4s"    %% "http4s-server"  % http4sVersion,
       "org.typelevel" %% "cats-core"      % catsVersion,

--- a/modules/common-middleware/src/main/scala/lucuma/common/middleware/LoggingMiddleware.scala
+++ b/modules/common-middleware/src/main/scala/lucuma/common/middleware/LoggingMiddleware.scala
@@ -7,6 +7,7 @@ import cats.*
 import cats.effect.Async
 import org.http4s.Headers
 import org.http4s.HttpRoutes
+import org.http4s.client.Client
 import org.http4s.server.middleware.Logger
 
 object LoggingMiddleware:
@@ -22,6 +23,22 @@ object LoggingMiddleware:
    */
   def logging[F[_]: Async](revealSensitiveHeaders: Boolean = false): Middleware[F] =
     Logger.httpRoutes[F](
+      logHeaders        = true,
+      logBody           = false,
+      redactHeadersWhen = h => !revealSensitiveHeaders && Headers.SensitiveHeaders.contains(h)
+    )
+
+  type ClientMiddleware[F[_]] = Endo[Client[F]]
+
+  /**
+   * A client middleware that logs outbound requests and responses.
+   *
+   * Same policy as `logging`: bodies are never logged (they may carry secrets such as an
+   * ORCID `client_secret` or a user access token), and sensitive headers (Authorization,
+   * Cookie, ...) are redacted unless `revealSensitiveHeaders` is true.
+   */
+  def client[F[_]: Async](revealSensitiveHeaders: Boolean = false): ClientMiddleware[F] =
+    org.http4s.client.middleware.Logger[F](
       logHeaders        = true,
       logBody           = false,
       redactHeadersWhen = h => !revealSensitiveHeaders && Headers.SensitiveHeaders.contains(h)

--- a/modules/common-middleware/src/main/scala/lucuma/common/middleware/LoggingMiddleware.scala
+++ b/modules/common-middleware/src/main/scala/lucuma/common/middleware/LoggingMiddleware.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.common.middleware
+
+import cats.*
+import cats.effect.Async
+import org.http4s.Headers
+import org.http4s.HttpRoutes
+import org.http4s.server.middleware.Logger
+
+object LoggingMiddleware:
+
+  type Middleware[F[_]] = Endo[HttpRoutes[F]]
+
+  /**
+   * A middleware that logs requests and responses. Bodies are never logged, since they may carry
+   * secrets (tokens, client secrets). Sensitive headers (Authorization, Cookie, ...) are redacted
+   * unless `revealSensitiveHeaders` is true, which should only be enabled in local development.
+   *
+   * @param revealSensitiveHeaders when true, log sensitive headers in the clear (dev only)
+   */
+  def logging[F[_]: Async](revealSensitiveHeaders: Boolean = false): Middleware[F] =
+    Logger.httpRoutes[F](
+      logHeaders        = true,
+      logBody           = false,
+      redactHeadersWhen = h => !revealSensitiveHeaders && Headers.SensitiveHeaders.contains(h)
+    )

--- a/modules/common-middleware/src/main/scala/lucuma/common/middleware/LoggingMiddleware.scala
+++ b/modules/common-middleware/src/main/scala/lucuma/common/middleware/LoggingMiddleware.scala
@@ -14,11 +14,11 @@ object LoggingMiddleware:
   type Middleware[F[_]] = Endo[HttpRoutes[F]]
 
   /**
-   * A middleware that logs requests and responses. Bodies are never logged, since they may carry
-   * secrets (tokens, client secrets). Sensitive headers (Authorization, Cookie, ...) are redacted
-   * unless `revealSensitiveHeaders` is true, which should only be enabled in local development.
+   * A middleware that logs requests and responses.
    *
-   * @param revealSensitiveHeaders when true, log sensitive headers in the clear (dev only)
+   * Bodies are never logged, since they may carry secrets (tokens, client secrets).
+   * Sensitive headers (Authorization, Cookie, ...) are redacted unless `revealSensitiveHeaders`
+   * is true, which should only be enabled in local development.
    */
   def logging[F[_]: Async](revealSensitiveHeaders: Boolean = false): Middleware[F] =
     Logger.httpRoutes[F](

--- a/modules/service/src/main/scala/lucuma/odb/ServerMiddleware.scala
+++ b/modules/service/src/main/scala/lucuma/odb/ServerMiddleware.scala
@@ -9,6 +9,7 @@ import cats.data.OptionT
 import cats.effect.*
 import cats.implicits.*
 import lucuma.common.middleware.CorsMiddleware
+import lucuma.common.middleware.LoggingMiddleware
 import lucuma.core.model.User
 import lucuma.odb.otel.given
 import lucuma.odb.service.Services
@@ -41,12 +42,9 @@ object ServerMiddleware {
 
   type Middleware[F[_]] = Endo[HttpRoutes[F]]
 
-  /** A middleware that logs request and response. Headers are redacted in staging/production. */
+  /** A middleware that logs request and response. Sensitive headers are always redacted. */
   def logging[F[_]: Async]: Middleware[F] =
-    org.http4s.server.middleware.Logger.httpRoutes[F](
-      logHeaders        = true,
-      logBody           = false,
-    )
+    LoggingMiddleware.logging[F]()
 
   /** A middleware that reports errors during requets processing. */
   def errorReporting[F[_]: MonadThrow: Logger]: Middleware[F] = routes =>

--- a/modules/sso-service/src/main/scala/Main.scala
+++ b/modules/sso-service/src/main/scala/Main.scala
@@ -226,6 +226,7 @@ object FMain extends AnsiColor {
         jwtWriter = config.ssoJwtWriter,
         publicUri = config.publicUri,
         cookies   = CookieService[F](config.cookieDomain, config.scheme === Scheme.https),
+        cookieDomain = config.cookieDomain,
       ) <+>
       GraphQLRoutes(localClient, pool, channels, SkunkMonitor.noopMonitor[F], wsb, schema)
     }

--- a/modules/sso-service/src/main/scala/Main.scala
+++ b/modules/sso-service/src/main/scala/Main.scala
@@ -203,7 +203,7 @@ object FMain extends AnsiColor {
   /** A resource that yields an OrcidService. */
   def orcidServiceResource[F[_]: Async: Trace: Network](config: OrcidConfig, env: Environment) =
     EmberClientBuilder.default[F].build
-      .map(LoggingMiddleware.client[F](revealSensitiveHeaders = env === Environment.Local))
+      .map(LoggingMiddleware.client[F](revealSensitiveHeaders = env == Environment.Local))
       .map: client =>
         OrcidService(config.orcidHost, config.clientId, config.clientSecret, client)
 

--- a/modules/sso-service/src/main/scala/Main.scala
+++ b/modules/sso-service/src/main/scala/Main.scala
@@ -18,6 +18,7 @@ import com.monovore.decline.*
 import com.monovore.decline.effect.CommandIOApp
 import fs2.io.net.Network
 import grackle.skunk.SkunkMonitor
+import lucuma.common.middleware.LoggingMiddleware
 import lucuma.core.model.StandardRole
 import lucuma.core.model.StandardUser
 import lucuma.core.util.Gid
@@ -200,13 +201,11 @@ object FMain extends AnsiColor {
     }
 
   /** A resource that yields an OrcidService. */
-  def orcidServiceResource[F[_]: Async: Trace: Network](config: OrcidConfig) =
-    EmberClientBuilder.default[F].build.map(org.http4s.client.middleware.Logger[F](
-      logHeaders = true,
-      logBody    = false, // bodies carry the ORCID client_secret and user access tokens
-    )).map { client =>
-      OrcidService(config.orcidHost, config.clientId, config.clientSecret, client)
-    }
+  def orcidServiceResource[F[_]: Async: Trace: Network](config: OrcidConfig, env: Environment) =
+    EmberClientBuilder.default[F].build
+      .map(LoggingMiddleware.client[F](revealSensitiveHeaders = env === Environment.Local))
+      .map: client =>
+        OrcidService(config.orcidHost, config.clientId, config.clientSecret, client)
 
   /** A resource that yields our HttpRoutes, wrapped in accessory middleware. */
   def routesResource[F[_]: Async: Trace: Tracer: Meter: Logger: Network: Console](config: Config): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
@@ -214,7 +213,7 @@ object FMain extends AnsiColor {
       pool     <- databasePoolResource[F](config.database)
       schema <- SsoMapping.loadSchema[F].toResource
       channels <- SsoMapping.Channels(pool)
-      orcid    <- orcidServiceResource(config.orcid)
+      orcid    <- orcidServiceResource(config.orcid, config.environment)
     } yield wsb => ServerMiddleware[F](config).apply {
       val dbPool = pool.map(Database.fromSession(_))
       val localClient = LocalSsoClient(config.ssoJwtReader, dbPool).collect:

--- a/modules/sso-service/src/main/scala/Main.scala
+++ b/modules/sso-service/src/main/scala/Main.scala
@@ -203,7 +203,7 @@ object FMain extends AnsiColor {
   def orcidServiceResource[F[_]: Async: Trace: Network](config: OrcidConfig) =
     EmberClientBuilder.default[F].build.map(org.http4s.client.middleware.Logger[F](
       logHeaders = true,
-      logBody    = true,
+      logBody    = false, // bodies carry the ORCID client_secret and user access tokens
     )).map { client =>
       OrcidService(config.orcidHost, config.clientId, config.clientSecret, client)
     }

--- a/modules/sso-service/src/main/scala/Routes.scala
+++ b/modules/sso-service/src/main/scala/Routes.scala
@@ -5,6 +5,7 @@ package lucuma.sso.service
 
 import cats.effect.*
 import cats.implicits.*
+import lucuma.common.middleware.CorsMiddleware
 import lucuma.core.model.StandardRole
 import lucuma.core.util.Gid
 import lucuma.sso.client.*
@@ -35,6 +36,7 @@ object Routes {
     jwtWriter: SsoJwtWriter[F],
     cookies:   CookieService[F],
     publicUri: Uri,
+    cookieDomain: String,
   ): HttpRoutes[F] = {
     object FDsl extends Http4sDsl[F]
     import FDsl._
@@ -43,6 +45,14 @@ object Routes {
     // a URL that makes sense to the user's browser!
     val Stage2Uri: Uri =
       publicUri.copy(path = Path.unsafeFromString("/auth/v1/stage2"))
+
+    // Post-auth redirects come from the caller-supplied `state` value. Only allow relative URIs
+    // (same origin) or absolute URIs whose host is the cookie domain or a subdomain of it,
+    // otherwise the auth flow is an open redirect / phishing vector.
+    def validRedirect(uri: Uri): Boolean =
+      uri.host match
+        case None    => true // relative, same-origin
+        case Some(h) => CorsMiddleware.isAllowed(h, List(cookieDomain))
 
     // Some parameter matchers. The parameter names are NOT arbitrary! They are requied by ORCID.
     object OrcidCode   extends QueryParamDecoderMatcher[String]("code")
@@ -140,13 +150,19 @@ object Routes {
 
       // Authentication Stage 1: Send the user to ORCID.
       case GET -> Root / "auth" / "v1" / "stage1" :? RedirectUri(redirectUrl) =>
-        for {
-          uri <- orcid.authenticationUri(Stage2Uri, Some(redirectUrl.toString))
-          res <- Found(Location(uri))
-        } yield res
+        if (!validRedirect(redirectUrl))
+          BadRequest("Invalid redirect URI.")
+        else
+          for {
+            uri <- orcid.authenticationUri(Stage2Uri, Some(redirectUrl.toString))
+            res <- Found(Location(uri))
+          } yield res
 
       // Authentication Stage 2: The user has returned from ORCID.
       // Insert/update a standard user, set a refresh token, and redirect to wherever the user asked to go in Stage 1.
+      case r@(GET -> Root / "auth" / "v1" / "stage2" :? OrcidCode(code) +& RedirectUri(redir)) if !validRedirect(redir) =>
+        BadRequest("Invalid redirect URI.")
+
       case r@(GET -> Root / "auth" / "v1" / "stage2" :? OrcidCode(code) +& RedirectUri(redir)) =>
         dbPool.use { db =>
           for {
@@ -177,5 +193,3 @@ object Routes {
   }
 
 }
-
-

--- a/modules/sso-service/src/main/scala/Routes.scala
+++ b/modules/sso-service/src/main/scala/Routes.scala
@@ -46,9 +46,10 @@ object Routes {
     val Stage2Uri: Uri =
       publicUri.copy(path = Path.unsafeFromString("/auth/v1/stage2"))
 
-    // Post-auth redirects come from the caller-supplied `state` value. Only allow relative URIs
-    // (same origin) or absolute URIs whose host is the cookie domain or a subdomain of it,
-    // otherwise the auth flow is an open redirect / phishing vector.
+    // Post-auth redirects come from the caller-supplied `state` value, thus it could be any domain.
+    // Only allow relative URIs (same origin) or absolute URIs whose host is the cookie domain
+    // or a subdomain of it
+    // Otherwise the auth flow is an open redirect / phishing vector.
     def validRedirect(uri: Uri): Boolean =
       uri.host match
         case None    => true // relative, same-origin

--- a/modules/sso-service/src/main/scala/ServerMiddleware.scala
+++ b/modules/sso-service/src/main/scala/ServerMiddleware.scala
@@ -11,6 +11,7 @@ import lucuma.sso.service.config.Environment
 import lucuma.sso.service.config.Environment.*
 import natchez.Trace
 import natchez.http4s.NatchezMiddleware
+import org.http4s.Headers
 import org.http4s.HttpRoutes
 import org.http4s.server.middleware.ErrorAction
 import org.typelevel.log4cats.Logger
@@ -24,17 +25,17 @@ object ServerMiddleware {
   def natchez[F[_]: Trace](implicit ev: MonadCancel[F, Throwable]): Middleware[F] =
     NatchezMiddleware.server[F]
 
-  /** A middleware that logs request and response. Headers are redacted in staging/production. */
+  /** A middleware that logs request and response. Sensitive headers are redacted outside Local. */
   def logging[F[_]: Async](
     env:          Environment,
   ): Middleware[F] =
     org.http4s.server.middleware.Logger.httpRoutes[F](
       logHeaders        = true,
       logBody           = false,
-      redactHeadersWhen = { _ =>
+      redactHeadersWhen = { h =>
         env match {
-          case Local                => false
-          case Review | Staging | Production => false // TODO: Headers.SensitiveHeaders.contains(h)
+          case Local                         => false
+          case Review | Staging | Production => Headers.SensitiveHeaders.contains(h)
         }
       }
     )

--- a/modules/sso-service/src/main/scala/ServerMiddleware.scala
+++ b/modules/sso-service/src/main/scala/ServerMiddleware.scala
@@ -6,12 +6,12 @@ package lucuma.sso.service
 import cats.*
 import cats.effect.*
 import lucuma.common.middleware.CorsMiddleware
+import lucuma.common.middleware.LoggingMiddleware
 import lucuma.sso.service.config.Config
 import lucuma.sso.service.config.Environment
 import lucuma.sso.service.config.Environment.*
 import natchez.Trace
 import natchez.http4s.NatchezMiddleware
-import org.http4s.Headers
 import org.http4s.HttpRoutes
 import org.http4s.server.middleware.ErrorAction
 import org.typelevel.log4cats.Logger
@@ -29,16 +29,10 @@ object ServerMiddleware {
   def logging[F[_]: Async](
     env:          Environment,
   ): Middleware[F] =
-    org.http4s.server.middleware.Logger.httpRoutes[F](
-      logHeaders        = true,
-      logBody           = false,
-      redactHeadersWhen = { h =>
-        env match {
-          case Local                         => false
-          case Review | Staging | Production => Headers.SensitiveHeaders.contains(h)
-        }
-      }
-    )
+    LoggingMiddleware.logging[F](revealSensitiveHeaders = env match {
+      case Local                         => true
+      case Review | Staging | Production => false
+    })
 
   /** A middleware that reports errors during requets processing. */
   def errorReporting[F[_]: MonadThrow: Logger]: Middleware[F] = routes =>

--- a/modules/sso-service/src/main/scala/ServerMiddleware.scala
+++ b/modules/sso-service/src/main/scala/ServerMiddleware.scala
@@ -29,10 +29,11 @@ object ServerMiddleware {
   def logging[F[_]: Async](
     env:          Environment,
   ): Middleware[F] =
-    LoggingMiddleware.logging[F](revealSensitiveHeaders = env match {
-      case Local                         => true
-      case Review | Staging | Production => false
-    })
+    LoggingMiddleware.logging[F](revealSensitiveHeaders = 
+      env match
+        case Local                         => true
+        case Review | Staging | Production => false
+    )
 
   /** A middleware that reports errors during requets processing. */
   def errorReporting[F[_]: MonadThrow: Logger]: Middleware[F] = routes =>

--- a/modules/sso-service/src/test/scala/CorsSuite.scala
+++ b/modules/sso-service/src/test/scala/CorsSuite.scala
@@ -21,6 +21,7 @@ object CorsSuite extends SsoSuite {
         jwtWriter = null,
         publicUri = uri"http://unused",
         cookies   = null,
+        cookieDomain = domain,
       )
     )
 
@@ -75,4 +76,3 @@ object CorsSuite extends SsoSuite {
   }
 
 }
-

--- a/modules/sso-service/src/test/scala/simulator/SsoSimulator.scala
+++ b/modules/sso-service/src/test/scala/simulator/SsoSimulator.scala
@@ -47,6 +47,7 @@ object SsoSimulator {
         jwtWriter = config.ssoJwtWriter,
         publicUri = config.publicUri,
         cookies   = CookieService[F]("lucuma.xyz", true),
+        cookieDomain = "lucuma.xyz",
       ) <+> GraphQLRoutes(
         LocalSsoClient(config.ssoJwtReader, dbPool).collect { case su: StandardUser => su },
         pool,

--- a/resource/service/src/main/scala/resource/server/http4s/ServerMiddleware.scala
+++ b/resource/service/src/main/scala/resource/server/http4s/ServerMiddleware.scala
@@ -9,6 +9,7 @@ import cats.effect.*
 import cats.syntax.all.*
 import fs2.compression.Compression
 import lucuma.common.middleware.CorsMiddleware
+import lucuma.common.middleware.LoggingMiddleware
 import org.http4s.HttpRoutes
 import org.http4s.Query
 import org.http4s.Uri
@@ -22,7 +23,6 @@ import org.http4s.otel4s.middleware.trace.server.ServerMiddleware as OtelServerM
 import org.http4s.otel4s.middleware.trace.server.ServerSpanDataProvider
 import org.http4s.server.middleware.ErrorAction
 import org.http4s.server.middleware.GZip
-import org.http4s.server.middleware.Logger as Http4sLogger
 import org.http4s.server.middleware.Metrics
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
@@ -41,10 +41,7 @@ object ServerMiddleware {
   ): F[Middleware[F]] = {
     given Logger[F] = Slf4jLogger.getLogger[F]
 
-    val logging = Http4sLogger.httpRoutes[F](
-      logHeaders = true,
-      logBody = false
-    )
+    val logging = LoggingMiddleware.logging[F]()
 
     def httpMetrics(metricsOps: MetricsOps[F]): Middleware[F] =
       routes =>


### PR DESCRIPTION
Fixes three identified security issues and adds a shared logging middleware

* The SSO server logger's `redactHeadersWhen` was a stub that returned false for every environment, so `Authorization`, `Cookie`, etc. were logged in the clear in all environments. Now redacts `Headers.SensitiveHeaders` everywhere except Local.

* The ORCID OAuth HTTP client had `logBody = true`. Those bodies could carry the ORCID client_secret and user access tokens.

*  The auth flow redirected the browser to a caller-supplied state value after login without validation — an open redirect enabling phishing on the trusted SSO origin. No risk of directly stealing a cookie or token but you could in theory do phishing this way