### PR TITLE
Correctly set coadss in all steps of acquisition sequence except FPU measuring one

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Acquisition.scala
@@ -178,13 +178,12 @@ object Acquisition:
 
       // The FPU image (first step) uses a single coadd and the fixed filter/exposure from
       // firstStepFilterAndExposure; its read mode follows from that fixed exposure time.
-      // The remaining steps use the selected filter and the ITC exposure. Only the
-      // acquisition-FPU/decker field steps use the resolved coadds (the ITC exposure count
-      // in S/N mode, else the explicit acquisition coadds); the through-slit steps keep the
-      // explicit acquisition coadds. Sky frames are generated only for Faint, at its sky
+      // Every subsequent step (field and through-slit) uses the selected filter, the ITC
+      // exposure and the resolved coadds (the ITC exposure count in S/N mode, else the
+      // explicit acquisition coadds). Sky frames are generated only for Faint, at its sky
       // offset.
       val fpuStepReadMode: GnirsReadMode = GnirsReadMode.forExposureTime(fpuStepExposureTime)
-      val fieldCoadds: PosInt            = config.acquisition.resolvedCoadds(time)
+      val acqCoadds: PosInt              = config.acquisition.resolvedCoadds(time)
 
       val skyOffsetOpt: Option[Offset] = GnirsAcquisitionMode.skyOffset.getOption(mode)
 
@@ -210,11 +209,11 @@ object Acquisition:
                               ObserveClass.Acquisition
                             )
           // The field steps switch to the acquisition decker/FPU and the selected filter,
-          // and use the ITC exposure time, read mode and field coadds.
+          // and use the ITC exposure time, read mode and acquisition coadds.
           _              <- State.modify[GnirsDynamicConfig]:
                               _.copy(
                                 exposure = acqExposureTime,
-                                coadds   = fieldCoadds,
+                                coadds   = acqCoadds,
                                 readMode = readMode,
                                 decker   = GnirsDecker.Acquisition,
                                 fpu      = GnirsFpu.Other(GnirsFpuOther.Acquisition),
@@ -223,10 +222,10 @@ object Acquisition:
           fieldSkyOpt    <- skyOffsetOpt.traverse: sky =>
                               scienceStep(TelescopeConfig(sky, Enabled), ObserveClass.Acquisition)
           field          <- scienceStep(0.arcsec, 0.arcsec, ObserveClass.Acquisition)
-          // Back to the science aperture (decker/FPU) for the through-slit steps, which revert
-          // to the explicit acquisition coadds (the ITC count is used only for the field).
+          // Back to the science aperture (decker/FPU) for the through-slit steps, keeping the
+          // acquisition coadds.
           _              <- State.modify[GnirsDynamicConfig]:
-                              _.copy(decker = specDecker, fpu = config.fpu, coadds = config.acquisition.coadds)
+                              _.copy(decker = specDecker, fpu = config.fpu)
           tSlitSkyOpt    <- skyOffsetOpt.traverse: sky =>
                               scienceStep(TelescopeConfig(sky, Enabled), ObserveClass.Acquisition)
           throughSlit    <- scienceStep(0.arcsec, 0.arcsec, ObserveClass.Acquisition)
@@ -276,17 +275,17 @@ object Acquisition:
       // acquisition templates).
       val throughExposureTime: TimeSpan = fieldExposureTime *| 2
       val ifuDecker: GnirsDecker        = GnirsDecker.forIfu(ifu)
-      val fieldCoadds: PosInt           = config.acquisition.resolvedCoadds(time)
+      val acqCoadds: PosInt             = config.acquisition.resolvedCoadds(time)
       val skyOffsetOpt: Option[Offset]  = GnirsAcquisitionMode.skyOffset.getOption(mode)
 
       eval:
         for
           // Field steps: acquisition decker/FPU, selected filter, ITC exposure and
-          // field coadds.  Faint takes a sky frame first, at its sky offset.
+          // acquisition coadds.  Faint takes a sky frame first, at its sky offset.
           _           <- State.modify[GnirsDynamicConfig]: dyn =>
                            dyn.copy(
                              exposure          = fieldExposureTime,
-                             coadds            = fieldCoadds,
+                             coadds            = acqCoadds,
                              filter            = selectedFilter,
                              acquisitionMirror = GnirsAcquisitionMirrorMode.In,
                              camera            = config.camera,
@@ -313,12 +312,11 @@ object Acquisition:
                                     )
                              s <- scienceStep(TelescopeConfig(GnirsAcquisitionMode.Faint.DefaultIfuSkyOffset, Enabled), ObserveClass.Acquisition)
                            yield s
-          // Through-IFU steps: back to the IFU decker/FPU and the explicit acquisition
-          // coadds (the ITC count is used only for the field).
+          // Through-IFU steps: back to the IFU decker/FPU, keeping the acquisition coadds.
           _           <- State.modify[GnirsDynamicConfig]:
                            _.copy(
                              exposure = throughExposureTime,
-                             coadds   = config.acquisition.coadds,
+                             coadds   = acqCoadds,
                              filter   = selectedFilter,
                              readMode = GnirsReadMode.forExposureTime(throughExposureTime),
                              decker   = ifuDecker,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirs.scala
@@ -406,12 +406,11 @@ class executionAcqGnirs extends ExecutionTestSupportForGnirs:
       yield o
 
     // In S/N mode the ITC sizes the acquisition: the fake imaging result is
-    // IntegrationTime(10s, 6), so only the acquisition-FPU/decker field steps take their
+    // IntegrationTime(10s, 6), so every step except the fixed-exposure FPU image takes its
     // coadds from the ITC exposure count (6). The FPU image (first step) always uses a
-    // single coadd, and the through-slit steps revert to the explicit acquisition coadds
-    // (default 1). The 10s × 6 = 60s integration resolves AUTO to FAINT, so a sky frame is
-    // added (6 steps): slitImage(1), fieldSky(6), field(6), field(6), throughSlitSky(1),
-    // throughSlit(1).
+    // single coadd. The 10s × 6 = 60s integration resolves AUTO to FAINT, so a sky frame is
+    // added (6 steps): slitImage(1), fieldSky(6), field(6), field(6), throughSlitSky(6),
+    // throughSlit(6).
     setup.flatMap: oid =>
       expect(
         user     = pi,
@@ -441,8 +440,8 @@ class executionAcqGnirs extends ExecutionTestSupportForGnirs:
                       { "instrumentConfig": { "coadds": 6 } },
                       { "instrumentConfig": { "coadds": 6 } },
                       { "instrumentConfig": { "coadds": 6 } },
-                      { "instrumentConfig": { "coadds": 1 } },
-                      { "instrumentConfig": { "coadds": 1 } }
+                      { "instrumentConfig": { "coadds": 6 } },
+                      { "instrumentConfig": { "coadds": 6 } }
                     ]
                   }
                 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirsIfu.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirsIfu.scala
@@ -345,10 +345,10 @@ class executionAcqGnirsIfu extends ExecutionTestSupportForGnirs:
         _ <- setAcquisitionFilter(o, "ORDER4")
       yield o
 
-    // In S/N mode the fake imaging result is IntegrationTime(10s, 6): only the field
-    // steps take their coadds from the ITC exposure count (6); the through-IFU steps
-    // revert to the explicit acquisition coadds (default 1). The 10s × 6 = 60s
-    // integration resolves AUTO to Faint (5 steps with skies).
+    // In S/N mode the fake imaging result is IntegrationTime(10s, 6): every step takes its
+    // coadds from the ITC exposure count (6) — there is no fixed-exposure FPU image in the
+    // Faint LR-IFU path. The 10s × 6 = 60s integration resolves AUTO to Faint (5 steps with
+    // skies).
     setup.flatMap: oid =>
       expect(
         user     = pi,
@@ -376,9 +376,9 @@ class executionAcqGnirsIfu extends ExecutionTestSupportForGnirs:
                     "steps": [
                       { "instrumentConfig": { "coadds": 6 } },
                       { "instrumentConfig": { "coadds": 6 } },
-                      { "instrumentConfig": { "coadds": 1 } },
-                      { "instrumentConfig": { "coadds": 1 } },
-                      { "instrumentConfig": { "coadds": 1 } }
+                      { "instrumentConfig": { "coadds": 6 } },
+                      { "instrumentConfig": { "coadds": 6 } },
+                      { "instrumentConfig": { "coadds": 6 } }
                     ]
                   }
                 }


### PR DESCRIPTION
https://app.shortcut.com/lucuma/story/9256/propagate-the-number-of-gnirs-coadds-through-the-acquisition-sequence