### PR TITLE
Send observation edit events for ghost

### DIFF
--- a/modules/service/src/main/resources/db/migration/V1205__ghost_ifu_invalidate.sql
+++ b/modules/service/src/main/resources/db/migration/V1205__ghost_ifu_invalidate.sql
@@ -1,0 +1,30 @@
+-- GHOST IFU observing-mode configuration (t_ghost_ifu) was never wired into the
+-- obscalc invalidation or observation-edit notify trigger sets.
+-- As a result, editing GHOST detector binning / read mode for example
+-- did NOT invalidate the cached ExecutionDigest in t_obscalc.
+
+-- Invalidate the obscalc cache whenever a GHOST IFU configuration row changes
+CREATE TRIGGER ghost_ifu_invalidate_trigger
+AFTER INSERT OR UPDATE OR DELETE ON t_ghost_ifu
+FOR EACH ROW
+EXECUTE FUNCTION obsid_obscalc_invalidate();
+
+-- Emit a 'ch_observation_edit' notify so clients can refresh on GHOST IFU
+-- configuration edits.
+CREATE TRIGGER ch_observation_edit_ghost_ifu_trigger
+AFTER INSERT OR UPDATE OR DELETE ON t_ghost_ifu
+FOR EACH ROW
+EXECUTE FUNCTION ch_observation_edit_associated_table_update();
+
+-- Propagate c_mode_key to t_observation so GHOST observations group correctly
+-- under observingModeGroup.  
+CREATE TRIGGER observing_mode_key_trigger
+AFTER INSERT OR DELETE OR UPDATE OF c_mode_key ON t_ghost_ifu
+FOR EACH ROW
+EXECUTE FUNCTION trigger_set_observation_mode_key();
+
+-- Initialize mode_key for existing GHOST observations.
+UPDATE t_observation AS o
+SET c_mode_key = g.c_mode_key
+FROM t_ghost_ifu g
+WHERE o.c_observation_id = g.c_observation_id;

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
@@ -38,9 +38,12 @@ trait ObservingModeSetupOperations extends DatabaseOperations { this: OdbSuite =
     )
 
   def createGhostIfuObservationAs(
-    user: User,
-    pid:  Program.Id,
-    tids: List[Target.Id]
+    user:           User,
+    pid:            Program.Id,
+    tids:           List[Target.Id],
+    resolutionMode: String         = "STANDARD",
+    redReadMode:    Option[String] = None,
+    ifu1Agitator:   Option[String] = None
   ): IO[Observation.Id] =
     createObservationWithModeAs(
       user,
@@ -49,7 +52,7 @@ trait ObservingModeSetupOperations extends DatabaseOperations { this: OdbSuite =
       s"""
         ghostIfu: {
           stepCount: 1
-          resolutionMode: STANDARD
+          resolutionMode: $resolutionMode
           red: {
             exposureTimeMode: {
               timeAndCount: {
@@ -58,6 +61,7 @@ trait ObservingModeSetupOperations extends DatabaseOperations { this: OdbSuite =
                 at: { nanometers: 500 }
               }
             }
+            ${redReadMode.fold("")(m => s"explicitReadMode: $m")}
           }
           blue: {
             exposureTimeMode: {
@@ -68,6 +72,7 @@ trait ObservingModeSetupOperations extends DatabaseOperations { this: OdbSuite =
               }
             }
           }
+          ${ifu1Agitator.fold("")(a => s"explicitIfu1Agitator: $a")}
         }
       """
     )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionPlannedTime_GhostIfu.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionPlannedTime_GhostIfu.scala
@@ -9,6 +9,10 @@ import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.model.Observation
+import lucuma.core.util.CalculationState
+import lucuma.odb.util.Codecs.observation_id
+import skunk.*
+import skunk.implicits.*
 
 
 class executionPlannedTime_GhostIfu extends ExecutionTestSupportForGhost:
@@ -265,3 +269,46 @@ class executionPlannedTime_GhostIfu extends ExecutionTestSupportForGhost:
             }
           """.asRight
       )
+
+  test("obscalc invalidates when GHOST detector binning/read mode change"):
+    def forceReady(o: Observation.Id): IO[Unit] =
+      withSession: session =>
+        session.execute(
+          sql"""
+            UPDATE t_obscalc
+               SET c_obscalc_state = 'ready' :: e_calculation_state
+             WHERE c_observation_id = $observation_id
+          """.command
+        )(o).void
+
+    def setGhostRedReadMode(o: Observation.Id): IO[Unit] =
+      withSession: session =>
+        session.execute(
+          sql"""UPDATE t_ghost_ifu SET c_red_read_mode = 'fast'
+                   WHERE c_observation_id = $observation_id""".command
+        )(o).void
+
+    def setGhostBlueBinning(o: Observation.Id): IO[Unit] =
+      withSession: session =>
+        session.execute(
+          sql"""UPDATE t_ghost_ifu SET c_blue_binning = 'four_by_four'
+                   WHERE c_observation_id = $observation_id""".command
+        )(o).void
+
+    def obscalcState(o: Observation.Id): IO[Option[CalculationState]] =
+      selectCalculationStates.map(_.get(o))
+
+    for
+      p  <- createProgram
+      t  <- createTargetWithProfileAs(pi, p)
+      o  <- createObservationWithModeAs(pi, p, List(t), GhostIfuInput)
+      _  <- forceReady(o)
+      _  <- assertIO(obscalcState(o), Some(CalculationState.Ready))
+      // red read mode: slow -> fast
+      _  <- setGhostRedReadMode(o)
+      _  <- assertIO(obscalcState(o), Some(CalculationState.Pending))
+      // blue binning: two_by_two -> four_by_four
+      _  <- forceReady(o)
+      _  <- setGhostBlueBinning(o)
+      _  <- assertIO(obscalcState(o), Some(CalculationState.Pending))
+    yield ()

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observingModeGroup_GhostIfu.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observingModeGroup_GhostIfu.scala
@@ -1,0 +1,153 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package query
+
+import cats.syntax.all.*
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.model.Program
+
+class observingModeGroup_GhostIfu extends OdbSuite with ObservingModeSetupOperations:
+
+  val pi         = TestUsers.Standard.pi(nextId, nextId)
+  val staff      = TestUsers.Standard.staff(nextId, nextId)
+  val validUsers = List(pi, staff)
+
+  private def groupQuery(pid: Program.Id): String =
+    s"""
+      query {
+        observingModeGroup(programId: ${pid.asJson}) {
+          matches {
+            observingMode {
+              ghostIfu { resolutionMode }
+            }
+            observations {
+              matches { id }
+            }
+          }
+        }
+      }
+    """
+
+  // base grouping .
+  test("GHOST observations sharing a mode should be grouped together"):
+    createProgramAs(pi).flatMap: pid =>
+      createTargetAs(pi, pid, "Biff").flatMap: tid =>
+        // Created sequentially so the ids come back in creation (== ascending) order.
+        createGhostIfuObservationAs(pi, pid, List(tid)).replicateA(2).flatMap: obs =>
+          expect(
+            user  = pi,
+            query = groupQuery(pid),
+            expected =
+              json"""
+                {
+                  "observingModeGroup" : {
+                    "matches" : [
+                      {
+                        "observingMode" : {
+                          "ghostIfu" : {
+                            "resolutionMode" : "STANDARD"
+                          }
+                        },
+                        "observations" : {
+                          "matches" : ${obs.map { id => Json.obj("id" -> id.asJson) }.asJson}
+                        }
+                      }
+                    ]
+                  }
+                }
+              """.asRight
+          )
+
+  // distinct configs form distinct groups.
+  test("GHOST observations with distinct resolution modes form distinct groups"):
+    createProgramAs(pi).flatMap: pid =>
+      createTargetAs(pi, pid, "Biff").flatMap: tid =>
+        for
+          oStandard <- createGhostIfuObservationAs(pi, pid, List(tid), resolutionMode = "STANDARD")
+          oHigh     <- createGhostIfuObservationAs(pi, pid, List(tid), resolutionMode = "HIGH")
+          _         <- expect(
+            user  = pi,
+            query = groupQuery(pid),
+            expected =
+              json"""
+                {
+                  "observingModeGroup" : {
+                    "matches" : [
+                      {
+                        "observingMode" : {
+                          "ghostIfu" : {
+                            "resolutionMode" : "HIGH"
+                          }
+                        },
+                        "observations" : {
+                          "matches" : ${List(Json.obj("id" -> oHigh.asJson)).asJson}
+                        }
+                      },
+                      {
+                        "observingMode" : {
+                          "ghostIfu" : {
+                            "resolutionMode" : "STANDARD"
+                          }
+                        },
+                        "observations" : {
+                          "matches" : ${List(Json.obj("id" -> oStandard.asJson)).asJson}
+                        }
+                      }
+                    ]
+                  }
+                }
+              """.asRight
+          )
+        yield ()
+
+  test("GHOST observations edited to share a mode should merge into one group"):
+    createProgramAs(pi).flatMap: pid =>
+      createTargetAs(pi, pid, "Biff").flatMap: tid =>
+        for
+          o1 <- createGhostIfuObservationAs(pi, pid, List(tid), resolutionMode = "STANDARD")
+          o2 <- createGhostIfuObservationAs(pi, pid, List(tid), resolutionMode = "HIGH")
+          _  <- query(
+            user  = pi,
+            query = s"""
+              mutation {
+                updateObservations(input: {
+                  SET: {
+                    observingMode: {
+                      ghostIfu: { resolutionMode: STANDARD }
+                    }
+                  }
+                  WHERE: { id: { EQ: "${o2.toString}" } }
+                }) {
+                  observations { id }
+                }
+              }
+            """
+          )
+          _  <- expect(
+            user  = pi,
+            query = groupQuery(pid),
+            expected =
+              json"""
+                {
+                  "observingModeGroup" : {
+                    "matches" : [
+                      {
+                        "observingMode" : {
+                          "ghostIfu" : {
+                            "resolutionMode" : "STANDARD"
+                          }
+                        },
+                        "observations" : {
+                          "matches" : ${List(o1, o2).map { id => Json.obj("id" -> id.asJson) }.asJson}
+                        }
+                      }
+                    ]
+                  }
+                }
+              """.asRight
+          )
+        yield ()

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEdit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/observationEdit.scala
@@ -865,6 +865,80 @@ class observationEdit extends OdbSuite with SubscriptionUtils {
       )
     } yield ()
 
+  val ghostConfigSubscription: String =
+    s"""
+      subscription {
+        observationEdit {
+          editType
+          value {
+            observingMode {
+              ghostIfu {
+                red {
+                  binning
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+  def ghostRedBinningObservationEdit(binning: String): Json =
+    json"""
+      {
+        "observationEdit": {
+          "editType": "UPDATED",
+          "value": {
+            "observingMode": {
+              "ghostIfu": {
+                "red": {
+                  "binning": $binning
+                }
+              }
+            }
+          }
+        }
+      }
+    """
+
+  def updateGhostRedBinning(user: User, oid: Observation.Id, binning: String): IO[Unit] =
+    query(
+      user = user,
+      query = s"""
+        mutation {
+          updateObservations(input: {
+            SET: {
+              observingMode: {
+                ghostIfu: {
+                  red: { explicitBinning: $binning }
+                }
+              }
+            },
+            WHERE: { id: { EQ: "$oid" } }
+          }) {
+            observations {
+              id
+            }
+          }
+        }
+      """
+    ).void
+
+  test("triggers for changing ghost ifu configuration"):
+    import Group1.pi
+
+    for {
+      pid <- createProgram(pi, "foo")
+      tid <- createTargetAs(pi, pid, "Target")
+      oid <- createGhostIfuObservationAs(pi, pid, None, tid)
+      _   <- subscriptionExpect(
+        user      = pi,
+        query     = ghostConfigSubscription,
+        mutations = Right(updateGhostRedBinning(pi, oid, "TWO_BY_TWO")),
+        expected  = List(ghostRedBinningObservationEdit("TWO_BY_TWO"))
+      )
+    } yield ()
+
   test("triggers for hard delete sends valid notification payload"):
     import Group1.{ pi, service }
     def deleteCalibrationObservation(oid: Observation.Id) =


### PR DESCRIPTION
It was discovered that we didn't get `observationEdit` events when editing some ghost fields, like binning or read mode. 

Also we need to invalidate obs clac when ghost observations change