### PR TITLE
In Gnirs acquisition S/N ITC, determine brightness and then invoke proper ITC

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ val slf4jVersion                 = "2.0.18"
 val testcontainersScalaVersion   = "0.44.1" // check test output if you attempt to update this
 val weaverVersion                = "0.13.0"
 
-ThisBuild / tlBaseVersion      := "0.85"
+ThisBuild / tlBaseVersion      := "0.86"
 ThisBuild / scalaVersion       := "3.8.4"
 ThisBuild / crossScalaVersions := Seq("3.8.4")
 ThisBuild / scalacOptions     ++= Seq("-Xmax-inlines", "50") // Hash derivation fails with default of 32

--- a/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
@@ -15,6 +15,7 @@ import lucuma.core.data.Zipper
 import lucuma.core.enums.Flamingos2Filter
 import lucuma.core.enums.GmosNorthFilter
 import lucuma.core.enums.GmosSouthFilter
+import lucuma.core.enums.GnirsAcquisitionType
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.model.Target
 import lucuma.core.util.Enumerated
@@ -176,7 +177,13 @@ object Itc:
    */
   case class Spectroscopy(
     acquisition: Zipper[Result],
-    science:     Zipper[Result]
+    science:     Zipper[Result],
+    // The GNIRS acquisition mode resolved by the ITC brightness classification.
+    // Only GNIRS long slit / IFU auto-resolution sets it; other instruments leave
+    // it None.  It pins the mode the sequence uses so it isn't re-derived (and
+    // possibly mis-classified) from the final exposure time.  See the two-pass
+    // acquisition ITC in ItcService.
+    gnirsAcqType: Option[GnirsAcquisitionType] = None
   ) extends Itc:
 
     override def dataType: Type =
@@ -190,7 +197,8 @@ object Itc:
       Eq.by: a =>
         (
           a.acquisition,
-          a.science
+          a.science,
+          a.gnirsAcqType
         )
 
   val spectroscopy: Prism[Itc, Spectroscopy] =

--- a/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
@@ -174,15 +174,13 @@ object Itc:
   /**
    * Spectroscopy results for all instruments. Spectroscopy has separate
    * acquisition and science results.
+   * 
+   * GNIRS acquisition is particular in that it also must compute the acquisition
+   * type in this layer. See the two-pass acquisition ITC in ItcService.
    */
   case class Spectroscopy(
     acquisition: Zipper[Result],
     science:     Zipper[Result],
-    // The GNIRS acquisition mode resolved by the ITC brightness classification.
-    // Only GNIRS long slit / IFU auto-resolution sets it; other instruments leave
-    // it None.  It pins the mode the sequence uses so it isn't re-derived (and
-    // possibly mis-classified) from the final exposure time.  See the two-pass
-    // acquisition ITC in ItcService.
     gnirsAcqType: Option[GnirsAcquisitionType] = None
   ) extends Itc:
 

--- a/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
@@ -119,7 +119,6 @@ trait ItcCodec:
       for
         acquisition <- c.downField("acquisition").as[Zipper[Itc.Result]]
         science     <- c.downField("spectroscopyScience").as[Zipper[Itc.Result]]
-        // Absent in rows written before the two-pass acquisition ITC → None.
         acqType     <- c.downField("gnirsAcqType").as[Option[GnirsAcquisitionType]]
       yield Itc.Spectroscopy(acquisition, science, acqType)
 

--- a/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
@@ -18,12 +18,14 @@ import lucuma.core.data.ZipperCodec
 import lucuma.core.enums.Flamingos2Filter
 import lucuma.core.enums.GmosNorthFilter
 import lucuma.core.enums.GmosSouthFilter
+import lucuma.core.enums.GnirsAcquisitionType
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.math.SignalToNoise
 import lucuma.core.math.SingleSN
 import lucuma.core.math.TotalSN
 import lucuma.core.math.Wavelength
 import lucuma.core.model.Target
+import lucuma.core.util.Enumerated
 import lucuma.core.util.TimeSpan
 import lucuma.itc.IntegrationTime
 import lucuma.itc.SignalToNoiseAt
@@ -103,12 +105,23 @@ trait ItcCodec:
     Decoder.instance:
       _.downField("spectroscopyScience").as[Zipper[Itc.Result]].map(Itc.Igrins2Spectroscopy.apply)
 
+  // GnirsAcquisitionType is a plain Enumerated; encode by tag.  Round-trips within
+  // this codec only (the value is stored in the Itc jsonb blob).
+  private given Encoder[GnirsAcquisitionType] =
+    Encoder[String].contramap(Enumerated[GnirsAcquisitionType].tag)
+
+  private given Decoder[GnirsAcquisitionType] =
+    Decoder[String].emap: s =>
+      Enumerated[GnirsAcquisitionType].fromTag(s).toRight(s"Invalid GnirsAcquisitionType: $s")
+
   given Decoder[Itc.Spectroscopy] =
     Decoder.instance: c =>
       for
         acquisition <- c.downField("acquisition").as[Zipper[Itc.Result]]
         science     <- c.downField("spectroscopyScience").as[Zipper[Itc.Result]]
-      yield Itc.Spectroscopy(acquisition, science)
+        // Absent in rows written before the two-pass acquisition ITC → None.
+        acqType     <- c.downField("gnirsAcqType").as[Option[GnirsAcquisitionType]]
+      yield Itc.Spectroscopy(acquisition, science, acqType)
 
   private def imagingScienceNemEncoder[A: Encoder](
     using Encoder[TimeSpan], Encoder[Wavelength]
@@ -170,7 +183,8 @@ trait ItcCodec:
         "itcType"             -> Itc.Type.Spectroscopy.asJson,
         "acquisition"         -> a.acquisition.asJson,
         "spectroscopyScience" -> a.science.asJson
-      )
+      // Emitted only when set, so pre-existing rows' JSON is unaffected.
+      ).deepMerge(a.gnirsAcqType.fold(Json.obj())(t => Json.obj("gnirsAcqType" -> t.asJson)))
 
   given Decoder[Itc] =
     Decoder.instance: c =>
@@ -193,6 +207,6 @@ trait ItcCodec:
       case a @ Itc.GmosSouthImaging(_)    => Encoder[Itc.GmosSouthImaging].apply(a)
       case a @ Itc.GnirsImaging(_)        => Encoder[Itc.GnirsImaging].apply(a)
       case a @ Itc.Igrins2Spectroscopy(_) => Encoder[Itc.Igrins2Spectroscopy].apply(a)
-      case a @ Itc.Spectroscopy(_, _)     => Encoder[Itc.Spectroscopy].apply(a)
+      case a @ Itc.Spectroscopy(_, _, _)  => Encoder[Itc.Spectroscopy].apply(a)
 
 object itc extends ItcCodec

--- a/modules/schema/src/test/scala/lucuma/odb/data/arb/ArbItc.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/data/arb/ArbItc.scala
@@ -12,6 +12,7 @@ import lucuma.core.data.arb.ArbZipper
 import lucuma.core.enums.Flamingos2Filter
 import lucuma.core.enums.GmosNorthFilter
 import lucuma.core.enums.GmosSouthFilter
+import lucuma.core.enums.GnirsAcquisitionType
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.math.SignalToNoise
 import lucuma.core.math.SingleSN
@@ -139,11 +140,12 @@ trait ArbItc:
       for
         a <- arbitrary[Zipper[Itc.Result]]
         s <- arbitrary[Zipper[Itc.Result]]
-      yield Itc.Spectroscopy(a, s)
+        t <- arbitrary[Option[GnirsAcquisitionType]]
+      yield Itc.Spectroscopy(a, s, t)
 
   given Cogen[Itc.Spectroscopy] =
-    Cogen[(Zipper[Itc.Result], Zipper[Itc.Result])].contramap: a =>
-      (a.acquisition, a.science)
+    Cogen[(Zipper[Itc.Result], Zipper[Itc.Result], Option[GnirsAcquisitionType])].contramap: a =>
+      (a.acquisition, a.science, a.gnirsAcqType)
 
   given Arbitrary[Itc.Igrins2Spectroscopy] =
     Arbitrary:

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
@@ -90,7 +90,11 @@ object ItcInput:
     science:     SpectroscopyParameters,
     targets:     NonEmptyList[TargetDefinition],
     blindOffset: Option[TargetDefinition],
-    signalToNoiseTargetId: Option[Target.Id]
+    signalToNoiseTargetId: Option[Target.Id],
+    // When set (GNIRS S/N mode with acquisition mode and filter both auto), the ITC
+    // resolves the acquisition mode via a brightness classification pass before the
+    // real exposure-time pass. See the two-pass acquisition ITC in ItcService.
+    gnirsAcqAutoClassify: Boolean = false
   ) extends ItcInput derives Eq:
 
     def acquisitionTargets: NonEmptyList[TargetDefinition] =
@@ -109,7 +113,8 @@ object ItcInput:
           a.acquisition.hashBytes,
           a.science.hashBytes,
           hashTargets(a.blindOffset.fold(a.targets)(_ :: a.targets)),
-          a.signalToNoiseTargetId.hashBytes
+          a.signalToNoiseTargetId.hashBytes,
+          a.gnirsAcqAutoClassify.hashBytes
         )
 
   /**
@@ -157,5 +162,5 @@ object ItcInput:
     def hashBytes(a: ItcInput): Array[Byte] =
       a match
         case in @ Imaging(_, _, _)                  => in.hashBytes
-        case in @ Spectroscopy(_, _, _, _, _)       => in.hashBytes
+        case in @ Spectroscopy(_, _, _, _, _, _)    => in.hashBytes
         case in @ ScienceOnlySpectroscopy(_, _, _)  => in.hashBytes

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
@@ -84,6 +84,11 @@ object ItcInput:
   /**
    * Spectroscopy inputs include imaging parameters (for acquisition),
    * the main spectrocopy input, and an optional blind offset target.
+   * 
+   * When `gnirsAcqAutoClassify` is set (in the case we are in GNIRS S/N mode
+   * with acquisition mode and filter both auto), the ITC resolves the
+   * acquisition mode via a brightness classification pass before the real
+   * exposure-time pass. See the two-pass acquisition ITC in ItcService.
    */
   case class Spectroscopy(
     acquisition: ImagingParameters,
@@ -91,9 +96,6 @@ object ItcInput:
     targets:     NonEmptyList[TargetDefinition],
     blindOffset: Option[TargetDefinition],
     signalToNoiseTargetId: Option[Target.Id],
-    // When set (GNIRS S/N mode with acquisition mode and filter both auto), the ITC
-    // resolves the acquisition mode via a brightness classification pass before the
-    // real exposure-time pass. See the two-pass acquisition ITC in ItcService.
     gnirsAcqAutoClassify: Boolean = false
   ) extends ItcInput derives Eq:
 

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/shared.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/shared.scala
@@ -3,9 +3,16 @@
 
 package lucuma.odb.sequence.gnirs
 
+import lucuma.core.math.SignalToNoise
 import lucuma.core.syntax.timespan.*
 import lucuma.core.util.TimeSpan
 
 // Definitions that are shared across GNIRS modes.
 val MinAcquisitionExposureTime: TimeSpan = 100.msTimeSpan  // 0.1 s; actually determined by the read mode, but this is a reasonable lower bound for all modes.
 val MaxAcquisitionExposureTime: TimeSpan = 60.secondTimeSpan
+
+// The fixed signal-to-noise used to classify the acquisition mode (Very Bright /
+// Bright / Faint) from target brightness, independent of the user's requested S/N.
+// See the two-pass acquisition ITC in ItcService.
+val AcquisitionClassificationSignalToNoise: SignalToNoise =
+  SignalToNoise.unsafeFromBigDecimalExact(BigDecimal(10))

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Acquisition.scala
@@ -18,6 +18,7 @@ import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.types.string.NonEmptyString
 import fs2.Pure
 import fs2.Stream
+import lucuma.core.enums.GnirsAcquisitionType
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsDecker
 import lucuma.core.enums.GnirsFilter
@@ -354,7 +355,11 @@ object Acquisition:
     namespace:     UUID,
     expander:      SmartGcalExpander[F, GnirsStaticConfig, GnirsDynamicConfig],
     config:        Config,
-    time:          Either[OdbError, IntegrationTime]
+    time:          Either[OdbError, IntegrationTime],
+    // The acquisition mode resolved by the ITC brightness classification, when the
+    // S/N-mode two-pass path ran. Pins the mode so it isn't re-derived from the final
+    // exposure time (see AcquisitionConfig.resolvedMode).
+    pinnedType:    Option[GnirsAcquisitionType]
   ): F[Either[OdbError, SequenceGenerator[GnirsDynamicConfig]]] =
     def sequenceError(msg: String): OdbError =
       OdbError.SequenceUnavailable(observationId, s"Could not generate a sequence for $observationId: $msg".some)
@@ -370,7 +375,7 @@ object Acquisition:
                        _.exposureTime.toNonNegMicroseconds.value > 0,
                        sequenceError("GNIRS Spectroscopy requires a positive acquisition exposure time.")
                      )
-        mode       = config.acquisition.resolvedMode(t, defaultFaintSkyOffset(config.fpu))
+        mode       = config.acquisition.resolvedMode(t, defaultFaintSkyOffset(config.fpu), pinnedType)
         selFilter <- config.acquisition
                        .selectedFilter(mode, config.centralWavelength)
                        .leftMap(sequenceError)

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Acquisition.scala
@@ -348,6 +348,9 @@ object Acquisition:
                 builder.build(NonEmptyString.unapply("Fine Adjustments"), aix, 0, repeatingAtom)
       yield Stream.emits(a0 :: as)).runA(StepTimeEstimateCalculator.Last.empty[GnirsDynamicConfig]).value
 
+  // `pinnedAcqType` is the acquisition mode resolved by the ITC brightness
+  // classification, when the S/N-mode two-pass path ran. Pins the mode so it
+  // isn't re-derived from the final exposure time (see AcquisitionConfig.resolvedMode).
   def instantiate[F[_]: Monad](
     observationId: Observation.Id,
     estimator:     StepTimeEstimateCalculator[GnirsStaticConfig, GnirsDynamicConfig],
@@ -356,10 +359,7 @@ object Acquisition:
     expander:      SmartGcalExpander[F, GnirsStaticConfig, GnirsDynamicConfig],
     config:        Config,
     time:          Either[OdbError, IntegrationTime],
-    // The acquisition mode resolved by the ITC brightness classification, when the
-    // S/N-mode two-pass path ran. Pins the mode so it isn't re-derived from the final
-    // exposure time (see AcquisitionConfig.resolvedMode).
-    pinnedType:    Option[GnirsAcquisitionType]
+    pinnedAcqType:  Option[GnirsAcquisitionType]
   ): F[Either[OdbError, SequenceGenerator[GnirsDynamicConfig]]] =
     def sequenceError(msg: String): OdbError =
       OdbError.SequenceUnavailable(observationId, s"Could not generate a sequence for $observationId: $msg".some)
@@ -375,7 +375,7 @@ object Acquisition:
                        _.exposureTime.toNonNegMicroseconds.value > 0,
                        sequenceError("GNIRS Spectroscopy requires a positive acquisition exposure time.")
                      )
-        mode       = config.acquisition.resolvedMode(t, defaultFaintSkyOffset(config.fpu), pinnedType)
+        mode       = config.acquisition.resolvedMode(t, defaultFaintSkyOffset(config.fpu), pinnedAcqType)
         selFilter <- config.acquisition
                        .selectedFilter(mode, config.centralWavelength)
                        .leftMap(sequenceError)

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Config.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Config.scala
@@ -8,6 +8,7 @@ import cats.data.NonEmptyList
 import cats.derived.*
 import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.enums.GnirsAcquisitionType
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsDecker
 import lucuma.core.enums.GnirsFilter
@@ -37,15 +38,24 @@ case class AcquisitionConfig(
 ):
 
   /**
-   * The acquisition mode: the explicit choice if set, else the default for the
-   * integration time, carrying the given sky offset when that default is Faint (the
-   * default offset differs between long slit and IFU).
+   * The acquisition mode: the explicit choice if set, else the brightness
+   * classification, carrying the given sky offset when that classification is Faint
+   * (the default offset differs between long slit and IFU).
+   *
+   * The classification is `pinnedType` when the ITC resolved it (the S/N-mode two-pass
+   * acquisition path), otherwise it is derived here from the integration time. Pinning
+   * matters because the final (user-S/N) exposure time can misclassify — e.g. a Bright
+   * target whose short exposure would otherwise read as Very Bright.
    */
-  def resolvedMode(time: IntegrationTime, defaultFaintSkyOffset: Offset): GnirsAcquisitionMode =
+  def resolvedMode(
+    time:                  IntegrationTime,
+    defaultFaintSkyOffset: Offset,
+    pinnedType:            Option[GnirsAcquisitionType] = None
+  ): GnirsAcquisitionMode =
     explicitAcqMode.getOrElse:
-      GnirsAcquisitionMode.defaultFor(time.exposureTime, resolvedCoadds(time)) match
-        case GnirsAcquisitionMode.Faint(_) => GnirsAcquisitionMode.Faint(defaultFaintSkyOffset)
-        case other                         => other
+      val tpe: GnirsAcquisitionType = pinnedType.getOrElse:
+        GnirsAcquisitionMode.defaultFor(time.exposureTime, resolvedCoadds(time)).acquisitionType
+      GnirsAcquisitionMode.forTypeAndOffset(tpe, Some(defaultFaintSkyOffset))
 
   /**
    * The selected acquisition filter: the explicit filter if set, otherwise the

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Spectroscopy.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Spectroscopy.scala
@@ -42,7 +42,8 @@ object Spectroscopy:
         SequenceGenerator.empty[GnirsDynamicConfig].asRight.pure[F]
       else Acquisition.instantiate(
              observationId, estimator, static, namespace, expander, config,
-             itc.map(_.acquisition.focus.value)
+             itc.map(_.acquisition.focus.value),
+             itc.toOption.flatMap(_.gnirsAcqType)
            )
     (for
       a <- EitherT(acquisition)

--- a/modules/service/src/main/scala/lucuma/odb/logic/GeneratorContext.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/GeneratorContext.scala
@@ -49,20 +49,20 @@ case class GeneratorContext(
     // ITC
     itcRes.foreach: itc =>
       itc match
-        case Itc.Flamingos2Imaging(m)     =>
+        case Itc.Flamingos2Imaging(m)      =>
           m.toNel.toList.foreach(addImagingResultSet)
-        case Itc.GhostIfu(r, b)           =>
+        case Itc.GhostIfu(r, b)            =>
           addResultSet(r)
           addResultSet(b)
-        case Itc.GmosNorthImaging(m)      =>
+        case Itc.GmosNorthImaging(m)       =>
           m.toNel.toList.foreach(addImagingResultSet)
-        case Itc.GmosSouthImaging(m)      =>
+        case Itc.GmosSouthImaging(m)       =>
           m.toNel.toList.foreach(addImagingResultSet)
-        case Itc.GnirsImaging(m)          =>
+        case Itc.GnirsImaging(m)           =>
           m.toNel.toList.foreach(addImagingResultSet)
-        case Itc.Igrins2Spectroscopy(sci) =>
+        case Itc.Igrins2Spectroscopy(sci)  =>
           addResultSet(sci)
-        case Itc.Spectroscopy(acq, sci)   =>
+        case Itc.Spectroscopy(acq, sci, _) =>
           addResultSet(acq)
           addResultSet(sci)
 

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -262,9 +262,10 @@ object GeneratorParamsService {
       ): Either[Error, GeneratorParams] =
 
         def spectroscopyGeneratorParams(
-          obsMode: ObservingMode,
-          acqMode: InstrumentMode,
-          sciMode: InstrumentMode
+          obsMode:              ObservingMode,
+          acqMode:              InstrumentMode,
+          sciMode:              InstrumentMode,
+          gnirsAcqAutoClassify: Boolean = false
         ): GeneratorParams =
 
           val consInput   = obsParams.constraints.toInput
@@ -281,7 +282,8 @@ object GeneratorParamsService {
                 science,
                 regularTargetInputs,
                 blindOffsetTargetInput,
-                obsParams.signalToNoiseTargetId
+                obsParams.signalToNoiseTargetId,
+                gnirsAcqAutoClassify
               )
             }
             .leftMap(MissingParamSet.fromParams)
@@ -498,6 +500,18 @@ object GeneratorParamsService {
                 wellDepth         = gn.wellDepth,
                 coadds            = gn.coadds
               )
+
+              // Two-pass acquisition ITC only when the mode and filter are both auto and
+              // we're in S/N mode: only then does the resolved filter depend on the
+              // ITC-derived exposure time (Very Bright → H2), creating the circularity.
+              val acqAutoClassify: Boolean =
+                gn.acquisition.explicitAcqMode.isEmpty &&
+                gn.acquisition.explicitFilter.isEmpty && {
+                  gn.acquisition.exposureTimeMode match
+                    case ExposureTimeMode.SignalToNoiseMode(_, _)   => true
+                    case ExposureTimeMode.TimeAndCountMode(_, _, _) => false
+                }
+
               spectroscopyGeneratorParams(
                 obsMode = gn,
                 acqMode = InstrumentMode.GnirsImaging(
@@ -508,7 +522,8 @@ object GeneratorParamsService {
                   wellDepth        = gn.wellDepth,
                   coadds           = gn.acquisition.coadds
                 ),
-                sciMode = sciMode
+                sciMode = sciMode,
+                gnirsAcqAutoClassify = acqAutoClassify
               )
 
           case ig: igrins2.longslit.Config =>

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -32,10 +32,14 @@ import lucuma.core.enums.Band
 import lucuma.core.enums.Flamingos2Filter
 import lucuma.core.enums.GmosNorthFilter
 import lucuma.core.enums.GmosSouthFilter
+import lucuma.core.enums.GnirsAcquisitionType
 import lucuma.core.enums.GnirsFilter
+import lucuma.core.math.SignalToNoise
+import lucuma.core.model.ExposureTimeMode
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Target
+import lucuma.core.model.sequence.gnirs.GnirsAcquisitionMode
 import lucuma.core.util.TimeSpan
 import lucuma.itc.AsterismIntegrationTimes
 import lucuma.itc.IntegrationTime
@@ -43,6 +47,7 @@ import lucuma.itc.ItcGhostDetector
 import lucuma.itc.TargetIntegrationTime
 import lucuma.itc.client.ClientCalculationResult
 import lucuma.itc.client.ImagingInput
+import lucuma.itc.client.ImagingParameters
 import lucuma.itc.client.InstrumentMode
 import lucuma.itc.client.ItcClient
 import lucuma.itc.client.SpectroscopyInput
@@ -52,6 +57,9 @@ import lucuma.odb.data.Md5Hash
 import lucuma.odb.data.OdbError
 import lucuma.odb.sequence.data.GeneratorParams
 import lucuma.odb.sequence.data.ItcInput
+import lucuma.odb.sequence.flamingos2
+import lucuma.odb.sequence.gmos
+import lucuma.odb.sequence.gnirs
 import lucuma.odb.sequence.syntax.hash.*
 import lucuma.odb.service.NoTransaction
 import lucuma.odb.service.Services.SuperUserAccess
@@ -280,15 +288,19 @@ object ItcService {
 
       // According to the spec we default if the target is too bright
       // https://app.shortcut.com/lucuma/story/1999/determine-exposure-time-for-acquisition-images
+      //
+      // The returned acquisition type is set only on the GNIRS S/N-mode two-pass path
+      // (see below); it pins the mode the sequence uses.
       private def safeAcquisitionCall(
-        oid:     Observation.Id,
-        input:   ImagingInput,
-        targets: NonEmptyList[ItcInput.TargetDefinition]
-      ): EitherT[F, OdbError, Zipper[Itc.Result]] =
-        def go(min: TimeSpan, max: TimeSpan): EitherT[F, OdbError, Zipper[Itc.Result]] =
+        oid:          Observation.Id,
+        input:        ImagingInput,
+        targets:      NonEmptyList[ItcInput.TargetDefinition],
+        autoClassify: Boolean
+      ): EitherT[F, OdbError, (Zipper[Itc.Result], Option[GnirsAcquisitionType])] =
+        def go(imInput: ImagingInput, min: TimeSpan, max: TimeSpan): EitherT[F, OdbError, Zipper[Itc.Result]] =
           EitherT:
             client
-              .imaging(input, useCache = false)
+              .imaging(imInput, useCache = false)
               .map: ccr =>
                 val modifiedTargetTimes =
                   ccr.targetTimes.modifyValue:
@@ -315,17 +327,48 @@ object ItcService {
                 case t =>
                   OdbError.RemoteServiceCallError(s"Error calling ITC service: ${t.getMessage}".some).asLeft.pure
 
+        def noType(z: EitherT[F, OdbError, Zipper[Itc.Result]]): EitherT[F, OdbError, (Zipper[Itc.Result], Option[GnirsAcquisitionType])] =
+          z.map((_, Option.empty[GnirsAcquisitionType]))
+
         input.mode match
           case InstrumentMode.GmosNorthImaging(_, _, _, _) |
                InstrumentMode.GmosSouthImaging(_, _, _, _) =>
-            go(lucuma.odb.sequence.gmos.MinAcquisitionExposureTime,
-               lucuma.odb.sequence.gmos.MaxAcquisitionExposureTime)
+            noType(go(input, gmos.MinAcquisitionExposureTime, gmos.MaxAcquisitionExposureTime))
           case InstrumentMode.Flamingos2Imaging(_, _, _, _) =>
-            go(lucuma.odb.sequence.flamingos2.MinAcquisitionExposureTime,
-               lucuma.odb.sequence.flamingos2.MaxAcquisitionExposureTime)
-          case InstrumentMode.GnirsImaging(_, _, _, _, _, _, _) =>
-            go(lucuma.odb.sequence.gnirs.MinAcquisitionExposureTime,
-               lucuma.odb.sequence.gnirs.MaxAcquisitionExposureTime)
+            noType(go(input, flamingos2.MinAcquisitionExposureTime, flamingos2.MaxAcquisitionExposureTime))
+          case InstrumentMode.GnirsImaging(etm, filter, camera, readMode, wellDepth, coadds, port) =>
+            val min: TimeSpan = gnirs.MinAcquisitionExposureTime
+            val max: TimeSpan = gnirs.MaxAcquisitionExposureTime
+            etm match
+              case ExposureTimeMode.SignalToNoiseMode(userSN, at) if autoClassify =>
+                // Two-pass. The acquisition mode (Very Bright / Bright / Faint) is a
+                // function of exposure time, but the exposure time depends on the filter
+                // (Very Bright images in H2) which depends on the mode — and, in S/N mode,
+                // a low requested S/N would shorten the exposure and misclassify a Bright
+                // target as Very Bright. So classify from a fixed brightness measurement
+                // (broadband filter, classification S/N) first, then compute the real
+                // exposure at the user's S/N in the mode-appropriate filter.
+                def gnirsInput(f: GnirsFilter, e: ExposureTimeMode): ImagingInput =
+                  ImagingInput.parameters
+                    .andThen(ImagingParameters.mode)
+                    .replace(InstrumentMode.GnirsImaging(e, f, camera, readMode, wellDepth, coadds, port))(input)
+
+                val classifySN:  SignalToNoise    = gnirs.AcquisitionClassificationSignalToNoise
+                val classifyEtm: ExposureTimeMode = ExposureTimeMode.SignalToNoiseMode(classifySN, at)
+                for
+                  z1                                <- go(gnirsInput(filter, classifyEtm), min, max)
+                  t1:      IntegrationTime           = z1.focus.value
+                  acqType: GnirsAcquisitionType      = GnirsAcquisitionMode.defaultFor(t1.exposureTime, t1.exposureCount).acquisitionType
+                  // Very Bright images through the acquisition filter in H2; the other
+                  // classifications keep the broadband filter (already `filter`).
+                  f2:      GnirsFilter               = if acqType === GnirsAcquisitionType.VeryBright then GnirsFilter.H2 else filter
+                  // Skip the second call when it would be identical to the first (same
+                  // filter and the user already asked for the classification S/N).
+                  z2                                <- if f2 === filter && userSN === classifySN then EitherT.pure[F, OdbError](z1)
+                                                       else go(gnirsInput(f2, etm), min, max)
+                yield (z2, acqType.some)
+              case _ =>
+                noType(go(input, min, max))
           case m                                                      =>
             EitherT.leftT:
               OdbError.InvalidObservation(oid, s"Acquisition is not supported for ${m.displayName}".some)
@@ -493,8 +536,8 @@ object ItcService {
           for
             cr  <- callSpectroscopy(sp.scienceInput)
             sci <- EitherT.fromEither(toTargetResults(sp.targets, NonEmptyList.one(cr), sp.signalToNoiseTargetId).map(_.head))
-            acq <- safeAcquisitionCall(oid, sp.acquisitionInput, sp.acquisitionTargets)
-          yield Itc.Spectroscopy(acq, sci)
+            acq <- safeAcquisitionCall(oid, sp.acquisitionInput, sp.acquisitionTargets, sp.gnirsAcqAutoClassify)
+          yield Itc.Spectroscopy(acq._1, sci, acq._2)
 
         def igrins2Spectroscopy(sp: ItcInput.ScienceOnlySpectroscopy): EitherT[F, OdbError, Itc] =
           for
@@ -505,7 +548,7 @@ object ItcService {
         (input match
           case im @ ItcInput.Imaging(_, _, _) =>
             imaging(im)
-          case sp @ ItcInput.Spectroscopy(_, _, _, _, _) =>
+          case sp @ ItcInput.Spectroscopy(_, _, _, _, _, _) =>
             spectroscopy(sp)
           case sp @ ItcInput.ScienceOnlySpectroscopy(SpectroscopyParameters(_, gh @ InstrumentMode.GhostSpectroscopy(_, _, _, _)), targets, _) =>
             ghost(gh, targets)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirsTwoPass.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirsTwoPass.scala
@@ -1,0 +1,83 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.query
+
+import cats.effect.IO
+import cats.syntax.either.*
+import cats.syntax.eq.*
+import cats.syntax.option.*
+import eu.timepit.refined.types.numeric.PosInt
+import io.circe.literal.*
+import lucuma.core.model.ExposureTimeMode
+import lucuma.core.model.Observation
+import lucuma.core.syntax.timespan.*
+import lucuma.itc.IntegrationTime
+import lucuma.itc.client.ImagingInput
+import lucuma.itc.client.InstrumentMode
+import lucuma.odb.sequence.gnirs.AcquisitionClassificationSignalToNoise
+
+// Exercises the S/N-mode two-pass acquisition ITC (both acquisition mode and filter auto).
+class executionAcqGnirsTwoPass extends ExecutionTestSupportForGnirs:
+
+  // Imaging ITC keyed on the requested S/N so the two passes return different results:
+  //   - classification pass (fixed S/N)  → 0.3s → Very Bright
+  //   - real pass          (user's S/N)  → 2s   → would classify as Bright on its own
+  // The 2s real exposure is deliberately in the Bright range: if the sequence re-derived
+  // the mode from it (the old bug) it would pick the broadband filter, so seeing H2 proves
+  // the mode was pinned to Very Bright from the classification pass.
+  override def fakeItcImagingResultFor(input: ImagingInput): Option[IntegrationTime] =
+    input.mode match
+      case InstrumentMode.GnirsImaging(ExposureTimeMode.SignalToNoiseMode(sn, _), _, _, _, _, _, _) =>
+        if sn === AcquisitionClassificationSignalToNoise then IntegrationTime(300.msTimeSpan, PosInt.unsafeFrom(1)).some
+        else                                                  IntegrationTime(2.secTimeSpan,  PosInt.unsafeFrom(3)).some
+      case _                                                                                        =>
+        none
+
+  test("S/N mode auto acquisition: classification pins Very Bright, real exposure uses H2"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGnirsLongSlitObservationAs(pi, p, t)
+        // S/N mode, acquisition mode and filter left auto ⇒ two-pass.
+        _ <- setAcquisitionSignalToNoise(o, 6, 1645)
+      yield o
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = s"""
+          query {
+            executionConfig(observationId: "$oid") {
+              gnirs {
+                acquisition {
+                  nextAtom {
+                    steps {
+                      instrumentConfig { exposure { microseconds } coadds filter }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "executionConfig": {
+              "gnirs": {
+                "acquisition": {
+                  "nextAtom": {
+                    "steps": [
+                      { "instrumentConfig": { "exposure": { "microseconds": 3000000 }, "coadds": 1, "filter": "ORDER4" } },
+                      { "instrumentConfig": { "exposure": { "microseconds": 2000000 }, "coadds": 3, "filter": "H2" } },
+                      { "instrumentConfig": { "exposure": { "microseconds": 2000000 }, "coadds": 3, "filter": "H2" } },
+                      { "instrumentConfig": { "exposure": { "microseconds": 2000000 }, "coadds": 3, "filter": "H2" } }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        """.asRight
+      )


### PR DESCRIPTION
Details here: https://app.shortcut.com/lucuma/story/9291/gnirs-acquisition-s-n-calculations-using-wrong-filter-and-read-mode

Short summary: in Gnirs we must determine the acquisition mode from the target's brightness, which in turn is determined by the exposure time. In S/N mode this is a bit of a chicken-and-egg problem so we invoke ITC twice: first with a standard S/N of 10, which avoids misclassifying the target if a low or high S/N is requested, then with that result we determine the acquisition type and then we do a proper invocation of ITC with the requested S/N.

I've been struggling to determine where to put the logic and I decided to put it in the ItcService. Here it remains nicely isolated but in turn means that the acquisition mode must be returned since it can no longer be inferred from the returned exposure time. This becomes part of the ITC layer result and is easily cached without modifying downstream logic.