### PR TITLE
Slow query improvements

### DIFF
--- a/ODB-README.md
+++ b/ODB-README.md
@@ -203,7 +203,7 @@ The instance ID and API key are found in the Grafana Cloud page under the OpenTe
 
 ## SQL Query Instrumentation
 
-The GraphQL `fetch` layer (grackle → skunk) records timing and row-count attributes on every
+The GraphQL `fetch` layer (grackle -> skunk) records timing and row-count attributes on every
 `grackle.fetch` trace span. The following optional environment variables control slow-query
 logging and large-statement dumping.
 
@@ -211,8 +211,8 @@ logging and large-statement dumping.
 
 | Variable | Required | Description |
 |---|---|---|
-| `ODB_SLOW_QUERY_THRESHOLD_MS` | No | Threshold in milliseconds. Queries slower than this are logged as `WARN` via the `lucuma-odb-slow-query` logger and flagged with `db.slow_query=true` on the `grackle.fetch` span. Defaults to `5`. |
-| `ODB_FETCH_DUMP_DIR` | No | Path to a directory. When set, SQL statements larger than 500 chars are written raw to a file in this directory and referenced from the trace/log via `db.statement_file`, instead of being truncated inline. Mainly useful for local debugging of large generated queries. |
+| `ODB_SLOW_QUERY_THRESHOLD_MS` | No | Threshold in milliseconds. Queries slower than this are logged as `WARN` via the `lucuma-odb-slow-query` logger and flagged with `db.slow_query=true` on the `grackle.fetch` span. Defaults to `5000`. |
+| `ODB_FETCH_DUMP_DIR` | No | Path to a directory. When set, SQL statements larger than 500 chars are written raw to a file in this directory and referenced from the trace/log via `db.statement_file`, instead of being truncated inline. Only useful for local debugging of large generated queries. |
 
 ## SOPS Setup for Nix Users
 

--- a/ODB-README.md
+++ b/ODB-README.md
@@ -201,6 +201,19 @@ ODB_OTEL_KEY=$(echo -n "<instance-id>:<api-key>" | base64)
 
 The instance ID and API key are found in the Grafana Cloud page under the OpenTelemetry connection page.
 
+## SQL Query Instrumentation
+
+The GraphQL `fetch` layer (grackle → skunk) records timing and row-count attributes on every
+`grackle.fetch` trace span. The following optional environment variables control slow-query
+logging and large-statement dumping.
+
+### Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `ODB_SLOW_QUERY_THRESHOLD_MS` | No | Threshold in milliseconds. Queries slower than this are logged as `WARN` via the `lucuma-odb-slow-query` logger and flagged with `db.slow_query=true` on the `grackle.fetch` span. Defaults to `5`. |
+| `ODB_FETCH_DUMP_DIR` | No | Path to a directory. When set, SQL statements larger than 500 chars are written raw to a file in this directory and referenced from the trace/log via `db.statement_file`, instead of being truncated inline. Mainly useful for local debugging of large generated queries. |
+
 ## SOPS Setup for Nix Users
 
 If using Nix flake for development, secrets are managed via SOPS:

--- a/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
@@ -40,12 +40,15 @@ import org.http4s.server.websocket.WebSocketBuilder2
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.syntax.*
+import org.typelevel.otel4s.Attribute
 import org.typelevel.otel4s.Attributes
 import org.typelevel.otel4s.trace.SpanKind
 import org.typelevel.otel4s.trace.Tracer
 import skunk.Session
 import skunk.SqlState
 
+import java.nio.file.Files
+import java.nio.file.Path as NIOPath
 import scala.concurrent.duration.*
 
 object GraphQLRoutes {
@@ -57,7 +60,7 @@ object GraphQLRoutes {
    * Construct a source of `HttpRoutes` tailored to the requesting user. Routes will be cached
    * based on the `Authorization` header and discarded when `ttl` expires.
    */
-  def apply[F[_]: {Async, Parallel, Tracer as T, Logger as L, LoggerFactory, SecureRandom}](
+  def apply[F[_]: {Async as F, Parallel, Tracer as T, Logger as L, LoggerFactory, SecureRandom}](
     gaiaClient:           GaiaClient[F],
     itcClient:            ItcClient[F],
     commitHash:           CommitHash,
@@ -124,13 +127,26 @@ object GraphQLRoutes {
                                     T.spanBuilder("graphql-query")
                                       .withSpanKind(SpanKind.Server)
                                       .build
-                                      .surround:
-                                        super.query(request, document, operationName).retryOnInvalidCursorName
-                                          .handleError(Result.InternalError.apply)
-                                          .flatTap {
-                                            case Result.InternalError(t) => error(user, s"Internal error: ${t.getClass.getSimpleName}: ${t.getMessage}", t)
-                                            case _                       => debug(user, s"Query (success).")
-                                          }
+                                      .use: span =>
+                                        F.timed(
+                                          super.query(request, document, operationName).retryOnInvalidCursorName
+                                            .handleError(Result.InternalError.apply)
+                                            .flatTap {
+                                              case Result.InternalError(t) => error(user, s"Internal error: ${t.getClass.getSimpleName}: ${t.getMessage}", t)
+                                              case _                       => debug(user, s"Query (success).")
+                                            }
+                                        ).flatMap: (elapsed, result) =>
+                                          val slow = elapsed > OdbMapping.slowQueryThreshold
+                                          val markSlow =
+                                            span.addAttribute(Attribute("graphql.slow_query", true)).whenA(slow)
+                                          val dumpGql: F[Unit] =
+                                            OdbMapping.dumpDir.filter(_ => slow).map: dir =>
+                                              F.blocking:
+                                                val hash = Integer.toHexString(document.hashCode)
+                                                val path = NIOPath.of(dir, s"odb-query-$hash.gql")
+                                                if !Files.exists(path) then {Files.writeString(path, document);()}
+                                            .getOrElse(F.unit)
+                                          markSlow *> dumpGql.as(result)
 
                                   override def subscribe(
                                     request:       Operation,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -686,26 +686,28 @@ object OdbMapping {
             L.debug("\n\n" + PrettyPrinter.query(query).render(100) + "\n") >>
             super.defaultRootCursor(query, tpe, parentCursor)
 
+          // Slow/large query instrumentation. Allocated once per mapping instance rather than
+          // on every `fetch` call.
+          private val SlowQueryLogger: Logger[F] = LF.getLoggerFromName("lucuma-odb-slow-query")
+
+          // Maybe it should be an env variable
+          private val SlowQueryThreshold = 5.millis
+          private val MaxSqlLength       = 1024
+          private val DumpThreshold      = 500
+
+          // When `ODB_FETCH_DUMP_DIR` is set, large statements are written raw to a file on that
+          // dir and a reference added to the trace via `db.statement_file`
+          private val dumpDir: Option[String] = sys.env.get("ODB_FETCH_DUMP_DIR")
+
+          private def truncateSql(s: String): String =
+            if s.length <= MaxSqlLength then s
+            else s"${s.take(MaxSqlLength)}... (${s.length - MaxSqlLength} more chars)"
+
           // Override `fetch` to log the SQL query. This is optional.
           override def fetch(fragment: AppliedFragment, codecs: List[(Boolean, Codec)]): F[Vector[Array[Any]]] = {
-            val SlowQueryLogger: Logger[F] = LF.getLoggerFromName("lucuma-odb-slow-query")
-
-            // Maybe it should be an env variable
-            val SlowQueryThreshold = 5.second
-            val MaxSqlLength       = 1024
-
             val sql = fragment.fragment.sql
 
-            def truncateSql(s: String): String =
-              if s.length <= MaxSqlLength then s
-              else s"${s.take(MaxSqlLength)}... (${s.length - MaxSqlLength} more chars)"
-
-            // When `ODB_FETCH_DUMP_DIR` is set, large statements are written raw to a file on that
-            // dir and a reference added to the trace via `db.statement_file`
-            val dumpDir = sys.env.get("ODB_FETCH_DUMP_DIR")
-
-            val DumpThreshold = 50000
-            val big           = sql.length > DumpThreshold
+            val big = sql.length > DumpThreshold
 
             // Write raw SQL to a file iff dumping is enabled and the statement is large.
             val dumpSqlToFile: F[Option[String]] =

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -81,6 +81,14 @@ object OdbMapping {
       } yield Topics(pro, obs, oc, tar, grp, cr, exe, dst)
   }
 
+  val dumpDir: Option[String] = sys.env.get("ODB_FETCH_DUMP_DIR")
+  val slowQueryThreshold: FiniteDuration =
+    sys.env
+      .get("ODB_SLOW_QUERY_THRESHOLD_MS")
+      .flatMap(_.toIntOption)
+      .map(_.millis)
+      .getOrElse(5.seconds)
+
   // Loads a GraphQL file from the classpath, relative to this Class.
   def unsafeLoadSchema(fileName: String): Schema = {
     val stream = getClass.getResourceAsStream(fileName)
@@ -689,21 +697,8 @@ object OdbMapping {
           // Slow/large query instrumentation. Allocated once per mapping instance rather than
           // on every `fetch` call.
           private val SlowQueryLogger: Logger[F] = LF.getLoggerFromName("lucuma-odb-slow-query")
-
-          // Threshold above which a query is logged as slow. Read directly from
-          // `ODB_SLOW_QUERY_THRESHOLD_MS` (milliseconds); falls back to 5ms when unset or unparseable.
-          private val SlowQueryThreshold: FiniteDuration =
-            sys.env
-              .get("ODB_SLOW_QUERY_THRESHOLD_MS")
-              .flatMap(_.toIntOption)
-              .map(_.millis)
-              .getOrElse(5.seconds)
-          private val MaxSqlLength       = 1024
-          private val DumpThreshold      = 500
-
-          // When `ODB_FETCH_DUMP_DIR` is set, large statements are written raw to a file on that
-          // dir and a reference added to the trace via `db.statement_file`
-          private val dumpDir: Option[String] = sys.env.get("ODB_FETCH_DUMP_DIR")
+          private val MaxSqlLength               = 1024
+          private val DumpThreshold              = 500
 
           private def truncateSql(s: String): String =
             if s.length <= MaxSqlLength then s
@@ -742,7 +737,7 @@ object OdbMapping {
             logQuery.flatMap: dumpPath =>
               T.span("grackle.fetch").use: span =>
                 Temporal[F].timed(super.fetch(fragment, codecs)).flatMap: (elapsed, result) =>
-                  val slowQuery = elapsed > SlowQueryThreshold
+                  val slowQuery = elapsed > slowQueryThreshold
 
                   val columnCount = codecs.size
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -698,7 +698,7 @@ object OdbMapping {
           // on every `fetch` call.
           private val SlowQueryLogger: Logger[F] = LF.getLoggerFromName("lucuma-odb-slow-query")
           private val MaxSqlLength               = 1024
-          private val DumpThreshold              = 500
+          private val DumpThreshold              = 50000
 
           private def truncateSql(s: String): String =
             if s.length <= MaxSqlLength then s

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -690,8 +690,14 @@ object OdbMapping {
           // on every `fetch` call.
           private val SlowQueryLogger: Logger[F] = LF.getLoggerFromName("lucuma-odb-slow-query")
 
-          // Maybe it should be an env variable
-          private val SlowQueryThreshold = 5.millis
+          // Threshold above which a query is logged as slow. Read directly from
+          // `ODB_SLOW_QUERY_THRESHOLD_MS` (milliseconds); falls back to 5ms when unset or unparseable.
+          private val SlowQueryThreshold: FiniteDuration =
+            sys.env
+              .get("ODB_SLOW_QUERY_THRESHOLD_MS")
+              .flatMap(_.toIntOption)
+              .map(_.millis)
+              .getOrElse(5.seconds)
           private val MaxSqlLength       = 1024
           private val DumpThreshold      = 500
 

--- a/odb-sparse-checkout
+++ b/odb-sparse-checkout
@@ -22,5 +22,6 @@
 /modules/sso-backend-client/
 /modules/sso-frontend-client/
 /modules/otel/
+/modules/common-middleware/
 /project/
 /test-cert/


### PR DESCRIPTION
A few niceties for slow queries, esentially we can override the time with an obs variable and we can now write the graphql query and sql query to a file for debugging. This is only really useful for local development