### PR TITLE
Fix flaky imaging guideEnvironment tests

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -900,7 +900,13 @@ trait DatabaseOperations { this: OdbSuite =>
     createObservationWithSpatialOffsets(user, pid, ObservingModeType.Flamingos2Imaging, ImageQuality.Preset.PointEight, None, tids*)
 
   def createGnirsImagingObservationAs(user: User, pid: Program.Id, tids: Target.Id*): IO[Observation.Id] =
-    createObservationWithSpatialOffsets(user, pid, ObservingModeType.GnirsImaging, ImageQuality.Preset.PointEight, None, tids*)
+    createGnirsImagingObservationAs(user, pid, None, tids*)
+
+  // The spiral dither generator's seed is always pinned so the generated science
+  // offsets — and hence AGS guide-star/pos-angle selection — are deterministic. An
+  // explicit `seed` overrides the DefaultImagingDitherSeed; `None` uses the default.
+  def createGnirsImagingObservationAs(user: User, pid: Program.Id, seed: Option[Long], tids: Target.Id*): IO[Observation.Id] =
+    createObservationWithSpatialOffsets(user, pid, ObservingModeType.GnirsImaging, ImageQuality.Preset.PointEight, seed.map(_.toString), tids*)
 
   def createGnirsLongSlitObservationAs(user: User, pid: Program.Id, tids: Target.Id*): IO[Observation.Id] =
     createObservationWithSpatialOffsets(user, pid, ObservingModeType.GnirsLongSlit, ImageQuality.Preset.PointEight, None, tids*)
@@ -1250,6 +1256,27 @@ trait DatabaseOperations { this: OdbSuite =>
         }"""
 
 
+  // Test-support default seed for imaging spatial-dither offset generators. Some
+  // imaging modes (GNIRS, Flamingos-2) default to a *randomly*-seeded spiral when
+  // no variant is specified, which makes the generated science offsets — and hence
+  // AGS pos-angle selection — non-deterministic across runs. We pin the seed here
+  // so every imaging observation these helpers create is reproducible.
+  val DefaultImagingDitherSeed: Long = 0L
+
+  // A grouped variant with a fixed-seed spiral offset generator of the given size,
+  // reproducing each imaging mode's default variant but with a deterministic seed.
+  private def pinnedSpiralVariant(sizeArcsec: Int, seed: String = DefaultImagingDitherSeed.toString): String =
+    s"""variant: {
+              grouped: {
+                offsets: {
+                  spiral: {
+                    size: { arcseconds: $sizeArcsec }
+                    seed: $seed
+                  }
+                }
+              }
+            }"""
+
   private def observingModeObject(observingMode: ObservingModeType): String =
     observingMode match
       case e: ExchangeObservingModeType =>
@@ -1262,12 +1289,13 @@ trait DatabaseOperations { this: OdbSuite =>
         }"""
 
       case ObservingModeType.Flamingos2Imaging =>
-        """{
+        s"""{
           flamingos2Imaging: {
             filters: [
               { filter: Y },
               { filter: J }
             ]
+            ${pinnedSpiralVariant(30)}
           }
         }"""
       case ObservingModeType.Flamingos2LongSlit =>
@@ -1323,13 +1351,14 @@ trait DatabaseOperations { this: OdbSuite =>
           }
         }"""
       case ObservingModeType.GnirsImaging =>
-        """{
+        s"""{
           gnirsImaging: {
             camera: SHORT_BLUE
             filters: [
               { filter: J },
               { filter: ORDER4 }
             ]
+            ${pinnedSpiralVariant(10)}
           }
         }"""
       case ObservingModeType.GnirsLongSlit =>
@@ -1522,13 +1551,19 @@ trait DatabaseOperations { this: OdbSuite =>
           }
         }"""
       case ObservingModeType.GnirsImaging =>
-        """{
+        // For imaging, `offsets` (when present) carries an explicit spiral dither
+        // seed; otherwise we fall back to the pinned default. Either way the seed is
+        // fixed so the generated science offsets — and hence AGS pos-angle selection
+        // — are deterministic (the server-side default seed is random).
+        val seed = offsets.getOrElse(DefaultImagingDitherSeed.toString)
+        s"""{
           gnirsImaging: {
             camera: SHORT_BLUE
             filters: [
               { filter: J },
               { filter: ORDER4 }
             ]
+            ${pinnedSpiralVariant(10, seed)}
           }
         }"""
       case ObservingModeType.GnirsLongSlit =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironmentGnirs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/guideEnvironmentGnirs.scala
@@ -111,7 +111,10 @@ class guideEnvironmentGnirs extends ExecutionTestSupportForGnirs
       expect(pi, guideEnvironmentQuery(oid), expected = gnirsPwfs2Result("V1647 Orionis"))
 
   // GNIRS imaging guides with PWFS2, like the long slit. The PWFS patrol field and
-  // the 20" protected radius are shared, so AGS selects the same star.
+  // the 20" protected radius are shared, so AGS selects the same star. The imaging
+  // field is symmetric under a 180 degree flip, so 90 and 270 are equally valid and
+  // the random spiral dither breaks the tie; the test-support layer pins the dither
+  // seed (DefaultImagingDitherSeed) so the resulting angle is deterministic.
   test("imaging sidereal target - AGS picks best star with PWFS2"):
     val setup: IO[Observation.Id] =
       for
@@ -122,7 +125,7 @@ class guideEnvironmentGnirs extends ExecutionTestSupportForGnirs
       yield o
 
     setup.flatMap: oid =>
-      expect(pi, guideEnvironmentQuery(oid), expected = gnirsPwfs2Result("V1647 Orionis"))
+      expect(pi, guideEnvironmentQuery(oid), expected = gnirsPwfs2Result("V1647 Orionis", BigDecimal("90.000000")))
 
   // GNIRS IFU guides with PWFS2, like the long slit, and selects the same star. Its
   // small science area shifts the optimal position angle (240 vs the long slit's 270).


### PR DESCRIPTION
The random generation of offsets for group imaging invariants was changing the vignetting for each run, sometimes selecting a different position angle. They now use an explicit seed for the random generation in the tests.