### PR TITLE
Shortcut 6776: calibrationRole in WhereObservation

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -18693,6 +18693,11 @@ input WhereObservation {
   Matches on the observation workflow state.
   """
   workflow: WhereCalculatedObservationWorkflow
+
+  """
+  Matches the calibration role.
+  """
+  calibrationRole: WhereOptionEqCalibrationRole
 }
 
 """

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereObservation.scala
@@ -9,6 +9,7 @@ import cats.syntax.all.*
 import grackle.Path
 import grackle.Predicate
 import grackle.Predicate.*
+import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.enums.ScienceBand
@@ -81,6 +82,7 @@ object WhereObservation {
     val ObservingModeTypeBinding = observingModeTypeBinding(enumeratedBinding[ObservingModeType])
     val SiteBinding = siteBinding(enumeratedBinding[Site])
     val WorkflowBinding = WhereCalculatedObservationWorkflow.binding(path / "workflow")
+    val CalibrationRoleBinding = WhereOptionEq.binding[CalibrationRole](path / "calibrationRole", enumeratedBinding[CalibrationRole])
 
     lazy val WhereObservationBinding = binding(path)
     ObjectFieldsBinding.rmap {
@@ -96,10 +98,11 @@ object WhereObservation {
         InstrumentBinding.Option("instrument", rInstrument),
         ObservingModeTypeBinding.Option("observingModeType", rObservingModeType),
         SiteBinding.Option("site", rSite),
-        WorkflowBinding.Option("workflow", rWorkflow)
+        WorkflowBinding.Option("workflow", rWorkflow),
+        CalibrationRoleBinding.Option("calibrationRole", rCalibrationRole)
       ) =>
-        (rAND, rOR, rNOT, rId, rRef, rProgram, rSubtitle, rScienceBand, rInstrument, rObservingModeType, rSite, rWorkflow).parMapN {
-          (AND, OR, NOT, id, ref, program, subtitle, scienceBand, instrument, observingModeType, site, workflow) =>
+        (rAND, rOR, rNOT, rId, rRef, rProgram, rSubtitle, rScienceBand, rInstrument, rObservingModeType, rSite, rWorkflow, rCalibrationRole).parMapN {
+          (AND, OR, NOT, id, ref, program, subtitle, scienceBand, instrument, observingModeType, site, workflow, calibrationRole) =>
             and(List(
               AND.map(and),
               OR.map(or),
@@ -112,7 +115,8 @@ object WhereObservation {
               instrument,
               observingModeType,
               site,
-              workflow
+              workflow,
+              calibrationRole
             ).flatten)
         }
     }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observations.scala
@@ -9,6 +9,7 @@ import cats.syntax.all.*
 import io.circe.Json
 import io.circe.literal.*
 import io.circe.syntax.*
+import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.enums.ScienceBand
 import lucuma.core.enums.TimeAccountingCategory
@@ -1104,5 +1105,27 @@ class observations extends OdbSuite with ObservingModeSetupOperations {
                 )
               )
     yield ()
+
+  test("select by calibration role"):
+    for
+      pid  <- createProgramAs(pi3)
+      tid  <- createTargetWithProfileAs(pi3, pid)
+      oid1 <- createObservationAs(pi3, pid, tid)
+      oid2 <- createObservationAs(pi3, pid, tid)
+      _    <- setObservationCalibrationRole(List(oid2), CalibrationRole.Twilight)
+      oid3 <- createObservationAs(pi3, pid, tid)
+      _    <- setObservationCalibrationRole(List(oid3), CalibrationRole.SpectroPhotometric)
+      pidF  = s"""program: { id: { EQ: "$pid" } }"""
+      twi  <- observationsWhere(pi3, s"""$pidF, calibrationRole: { EQ: TWILIGHT }""")
+      spec <- observationsWhere(pi3, s"""$pidF, calibrationRole: { EQ: SPECTROPHOTOMETRIC }""")
+      in   <- observationsWhere(pi3, s"""$pidF, calibrationRole: { IN: [ TWILIGHT, SPECTROPHOTOMETRIC ] }""")
+      none <- observationsWhere(pi3, s"""$pidF, calibrationRole: { IS_NULL: true }""")
+      any  <- observationsWhere(pi3, s"""$pidF, calibrationRole: { IS_NULL: false }""")
+    yield
+      assertEquals(twi, List(oid2))
+      assertEquals(spec, List(oid3))
+      assertEquals(in, List(oid2, oid3))
+      assertEquals(none, List(oid1))
+      assertEquals(any, List(oid2, oid3))
 
 }


### PR DESCRIPTION
Adds `calibrationRole` to `WhereObservation`, as we do for targets.