### PR TITLE
Makes the itc version dependent only on itc code changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -491,6 +491,17 @@ lazy val itcModel = crossProject(JVMPlatform, JSPlatform)
     )
   )
 
+lazy val itcSourceHash = taskKey[String]("hash of itc service and model scala sources")
+ThisBuild / itcSourceHash / fileInputs +=
+  (itcService / baseDirectory).value.toGlob / "src" / "main" / "scala" / ** / "*.scala"
+ThisBuild / itcSourceHash / fileInputs +=
+  (LocalRootProject / baseDirectory).value.toGlob / "itc" / "model" / "src" / "main" / "scala" / ** / "*.scala"
+ThisBuild / itcSourceHash := {
+  val files  = itcSourceHash.inputFiles.filter(_.toString.endsWith(".scala")).sorted.map(_.toFile)
+  val hashes = files.map(Hash(_))
+  Hash.toHex(Hash(hashes.toArray.flatten))
+}
+
 lazy val ocslibHash = taskKey[String]("hash of ocslib and graphql schema")
 ThisBuild / ocslibHash / fileInputs += (itcService / baseDirectory).value.toGlob / "ocslib" / "*.jar"
 ThisBuild / ocslibHash / fileInputs += (itcService / Compile / resourceDirectory).value.toGlob / "graphql" / "*.graphql"
@@ -592,6 +603,7 @@ lazy val itcService = project
       sbtVersion,
       git.gitHeadCommit,
       "buildDateTime" -> System.currentTimeMillis(),
+      itcSourceHash,
       ocslibHash,
       ocsGitHash,
       ocsGitBranch,

--- a/itc/service/src/main/scala/lucuma/itc/service/ItcMapping.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/ItcMapping.scala
@@ -96,9 +96,9 @@ object ItcMapping extends ItcCacheOrRemote with Version {
   def calculateImagingIntegrationTime[F[
     _
   ]: MonadThrow: Parallel: Logger: CustomSed.Resolver: Tracer](
-    cache:       BinaryEffectfulCache[F],
-    itc:         Itc[F],
-    config:      Config
+    cache:  BinaryEffectfulCache[F],
+    itc:    Itc[F],
+    config: Config
   )(asterismRequest: AsterismImagingTimeRequest): F[Result[CalculationResult]] =
     Tracer[F]
       .span("process imaging_targets_parallel")
@@ -192,9 +192,9 @@ object ItcMapping extends ItcCacheOrRemote with Version {
             s"Error calculating spectroscopy integration time and graph for input: $asterismRequest"
 
   def apply[F[_]: Sync: Logger: Parallel: Tracer: CustomSed.Resolver](
-    cache:       BinaryEffectfulCache[F],
-    itc:         Itc[F],
-    config:      Config
+    cache:  BinaryEffectfulCache[F],
+    itc:    Itc[F],
+    config: Config
   ): F[Mapping[F]] =
     loadSchema[F].map { loadedSchema =>
       new CirceMapping[F] {

--- a/itc/service/src/main/scala/lucuma/itc/service/ItcMapping.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/ItcMapping.scala
@@ -33,10 +33,8 @@ object ItcMapping extends ItcCacheOrRemote with Version {
   def loadSchema[F[_]: ApplicativeThrow: Logger]: F[Schema] =
     SchemaStitcher.load("graphql/itc.graphql")
 
-  def versions[F[_]: Applicative](
-    environment: ExecutionEnvironment
-  ): F[Result[ItcVersions]] =
-    Result(ItcVersions(version(environment).value, BuildInfo.ocslibHash.some)).pure[F]
+  def versions[F[_]: Applicative]: F[Result[ItcVersions]] =
+    Result(ItcVersions(version.value, BuildInfo.ocslibHash.some)).pure[F]
 
   private val buildError: Throwable => Error =
     case SourceTooBright(hw)      => Error.SourceTooBright(hw)
@@ -67,7 +65,6 @@ object ItcMapping extends ItcCacheOrRemote with Version {
   def calculateSpectroscopyIntegrationTime[F[
     _
   ]: MonadThrow: Parallel: Logger: CustomSed.Resolver: Tracer](
-    environment:     ExecutionEnvironment,
     cache:           BinaryEffectfulCache[F],
     itc:             Itc[F],
     config:          Config
@@ -88,7 +85,7 @@ object ItcMapping extends ItcCacheOrRemote with Version {
           .span("build spectroscopy_result")
           .surround:
             CalculationResult(
-              ItcVersions(version(environment).value, BuildInfo.ocslibHash.some),
+              ItcVersions(version.value, BuildInfo.ocslibHash.some),
               AsterismIntegrationTimeOutcomes(targetOutcomes)
             ).toResult.pure[F]
       .onError: t =>
@@ -99,7 +96,6 @@ object ItcMapping extends ItcCacheOrRemote with Version {
   def calculateImagingIntegrationTime[F[
     _
   ]: MonadThrow: Parallel: Logger: CustomSed.Resolver: Tracer](
-    environment: ExecutionEnvironment,
     cache:       BinaryEffectfulCache[F],
     itc:         Itc[F],
     config:      Config
@@ -129,7 +125,7 @@ object ItcMapping extends ItcCacheOrRemote with Version {
           .span("build imaging_result")
           .surround:
             CalculationResult(
-              ItcVersions(version(environment).value, BuildInfo.ocslibHash.some),
+              ItcVersions(version.value, BuildInfo.ocslibHash.some),
               AsterismIntegrationTimeOutcomes(targetOutcomes)
             ).toResult.pure[F]
       .onError: t =>
@@ -166,7 +162,6 @@ object ItcMapping extends ItcCacheOrRemote with Version {
   def spectroscopyIntegrationTimeAndGraphs[F[
     _
   ]: MonadThrow: Parallel: Logger: CustomSed.Resolver: Tracer](
-    environment:     ExecutionEnvironment,
     cache:           BinaryEffectfulCache[F],
     itc:             Itc[F],
     config:          Config
@@ -188,7 +183,7 @@ object ItcMapping extends ItcCacheOrRemote with Version {
           .span("build time_and_graphs_result")
           .surround:
             SpectroscopyTimeAndGraphsResult(
-              ItcVersions(version(environment).value, BuildInfo.ocslibHash.some),
+              ItcVersions(version.value, BuildInfo.ocslibHash.some),
               AsterismTimeAndGraphsOutcomes(targetTimesAndGraphs)
             ).toResult.pure[F]
       .onError: t =>
@@ -197,7 +192,6 @@ object ItcMapping extends ItcCacheOrRemote with Version {
             s"Error calculating spectroscopy integration time and graph for input: $asterismRequest"
 
   def apply[F[_]: Sync: Logger: Parallel: Tracer: CustomSed.Resolver](
-    environment: ExecutionEnvironment,
     cache:       BinaryEffectfulCache[F],
     itc:         Itc[F],
     config:      Config
@@ -220,13 +214,13 @@ object ItcMapping extends ItcCacheOrRemote with Version {
             ObjectMapping(
               tpe = QueryType,
               fieldMappings = List(
-                RootEffect.computeEncodable("versions")((_, _) => versions(environment)),
+                RootEffect.computeEncodable("versions")((_, _) => versions),
                 RootEffect.computeEncodable("spectroscopy") { (_, env) =>
                   env
                     .getR[SpectroscopyInput]("input")
                     .flatMap(AsterismSpectroscopyTimeRequest.fromInput)
                     .flatTraverse:
-                      calculateSpectroscopyIntegrationTime[F](environment, cache, itc, config)
+                      calculateSpectroscopyIntegrationTime[F](cache, itc, config)
                     .toGraphQLErrors
                 },
                 RootEffect.computeEncodable("imaging") { (_, env) =>
@@ -234,7 +228,7 @@ object ItcMapping extends ItcCacheOrRemote with Version {
                     .getR[ImagingInput]("input")
                     .flatMap(AsterismImagingTimeRequest.fromInput)
                     .flatTraverse:
-                      calculateImagingIntegrationTime(environment, cache, itc, config)
+                      calculateImagingIntegrationTime(cache, itc, config)
                     .toGraphQLErrors
                 },
                 RootEffect.computeEncodable("spectroscopyIntegrationTimeAndGraphs") { (_, env) =>
@@ -245,7 +239,7 @@ object ItcMapping extends ItcCacheOrRemote with Version {
                         .fromInput(input)
                         .map((_, input.significantFigures))
                     .flatTraverse: (tr, fig) =>
-                      spectroscopyIntegrationTimeAndGraphs(environment, cache, itc, config)(tr, fig)
+                      spectroscopyIntegrationTimeAndGraphs(cache, itc, config)(tr, fig)
                     .toGraphQLErrors
                 }
               )

--- a/itc/service/src/main/scala/lucuma/itc/service/Main.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/Main.scala
@@ -29,7 +29,6 @@ import lucuma.itc.legacy.FLocalItc
 import lucuma.itc.legacy.ItcImpl
 import lucuma.itc.legacy.LocalItc
 import lucuma.itc.service.config.*
-import lucuma.itc.service.config.ExecutionEnvironment.*
 import lucuma.otel.OtelSetup
 import natchez.Trace
 import org.http4s.*
@@ -172,7 +171,7 @@ object Main extends IOApp with ItcCacheOrRemote {
       _                          <- Resource.eval(checkVersionToPurge[F](cache))
       customSedResolver          <- CustomSedOdbAttachmentResolver[F](cfg.odbBaseUrl, cfg.odbServiceToken)
       given CustomSed.Resolver[F] = CustomSedCachedResolver(customSedResolver, cache, CustomSedTTL)
-      mapping                    <- Resource.eval(ItcMapping[F](cfg.environment, cache, itc, cfg))
+      mapping                    <- Resource.eval(ItcMapping[F](cache, itc, cfg))
       otelMiddleware             <- Resource.eval(OtelServerMiddleware.builder[F](spanDataProvider).build)
       metricsOps                 <- Resource.eval(OtelMetrics.serverMetricsOps[F]())
     yield wsb =>
@@ -219,7 +218,7 @@ object Main extends IOApp with ItcCacheOrRemote {
   def server(cfg: Config)(using Logger[IO]): Resource[IO, ExitCode] =
     for
       _                       <- Resource.eval(banner[IO](cfg))
-      otel                    <- OtelSetup.resource(ServiceName, version(Local).value, cfg.otel)
+      otel                    <- OtelSetup.resource(ServiceName, version.value, cfg.otel)
       given Trace[IO]          = otel.trace
       given Tracer[IO]         = otel.tracer
       given Meter[IO]          = otel.meter

--- a/itc/service/src/main/scala/lucuma/itc/service/Version.scala
+++ b/itc/service/src/main/scala/lucuma/itc/service/Version.scala
@@ -5,28 +5,13 @@ package lucuma.itc.service
 
 import buildinfo.BuildInfo
 import eu.timepit.refined.types.string.NonEmptyString
-import lucuma.itc.service.config.*
-
-import java.time.Instant
-import java.time.ZoneId
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 
 trait Version:
   val gitHash = BuildInfo.gitHeadCommit
 
-  val versionDateFormatter: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneId.from(ZoneOffset.UTC))
-
-  val versionDateTimeFormatter: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(ZoneId.from(ZoneOffset.UTC))
-
-  def version(environment: ExecutionEnvironment): NonEmptyString =
-    val instant = Instant.ofEpochMilli(BuildInfo.buildDateTime)
-    NonEmptyString.unsafeFrom(
-      environment match
-        case ExecutionEnvironment.Local => versionDateTimeFormatter.format(instant)
-        case _                          =>
-          versionDateFormatter.format(instant) +
-            "-" + gitHash.map(_.take(7)).getOrElse("NONE")
-    )
+  // The reported server version is a content hash of the ITC service and model
+  // Scala sources (see the `itcSourceHash` task in build.sbt). This way it only
+  // changes when the ITC code actually changes, avoiding needless invalidation of
+  // the ODB's cached ITC results (which are truncated whenever this version changes).
+  def version: NonEmptyString =
+    NonEmptyString.unsafeFrom(BuildInfo.itcSourceHash)

--- a/itc/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/client/WiringSuite.scala
@@ -85,9 +85,7 @@ import lucuma.itc.SeriesDataType
 import lucuma.itc.SignalToNoiseAt
 import lucuma.itc.TargetIntegrationTime
 import lucuma.itc.TargetIntegrationTimeOutcome
-import lucuma.itc.service.ItcMapping.versionDateTimeFormatter
 
-import java.time.Instant
 import scala.collection.immutable.SortedMap
 
 val atWavelength = Wavelength.fromIntNanometers(600).get
@@ -103,7 +101,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.GmosSpectroscopyInputData,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -126,7 +124,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.GmosMosSpectroscopyInputData,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -149,7 +147,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.GmosSouthMosSpectroscopyInputData,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -172,7 +170,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.Flamingos2SpectroscopyInputData,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -195,7 +193,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.Igrins2SpectroscopyInputData,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -218,7 +216,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.GhostSpectroscopyInputData,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -241,7 +239,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.GmosImagingInputData,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -264,7 +262,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.Flamingos2ImagingInputData,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -291,7 +289,7 @@ class WiringSuite extends ClientSuite:
       toITC,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -314,7 +312,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.GnirsImagingInputData,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -341,7 +339,7 @@ class WiringSuite extends ClientSuite:
       toITC,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -364,7 +362,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.GraphInput,
       SpectroscopyIntegrationTimeAndGraphsResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismTimeAndGraphsResult(
@@ -441,7 +439,7 @@ class WiringSuite extends ClientSuite:
       toTC,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -464,7 +462,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.SpectroscopyEmissionLinesInput,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -496,7 +494,7 @@ class WiringSuite extends ClientSuite:
       toTC,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -519,7 +517,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.GmosSpectroscopyExactValuesInputData,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -542,7 +540,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.GmosImagingExactValuesInputData,
       ClientCalculationResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismIntegrationTimeOutcomes:
@@ -565,7 +563,7 @@ class WiringSuite extends ClientSuite:
       WiringSuite.GraphExactValuesInput,
       SpectroscopyIntegrationTimeAndGraphsResult(
         ItcVersions(
-          versionDateTimeFormatter.format(Instant.ofEpochMilli(buildinfo.BuildInfo.buildDateTime)),
+          buildinfo.BuildInfo.itcSourceHash,
           BuildInfo.ocslibHash.some
         ),
         AsterismTimeAndGraphsResult(

--- a/itc/tests/src/test/scala/lucuma/itc/tests/util.scala
+++ b/itc/tests/src/test/scala/lucuma/itc/tests/util.scala
@@ -66,7 +66,7 @@ def routesForWsb(
 
   for
     cache  <- RedisEffectfulCache[IO](new NoOpRedis[IO, Array[Byte], Array[Byte]]())
-    itcMap <- ItcMapping[IO](ExecutionEnvironment.Local, cache, itc, testConfig)
+    itcMap <- ItcMapping[IO](cache, itc, testConfig)
   yield (wsb: WebSocketBuilder2[IO]) =>
     Routes.forService(_ => IO.pure(GraphQLService(itcMap).some), wsb)
 

--- a/modules/service/src/main/resources/db/migration/V1208__itc_version_update_ready_only.sql
+++ b/modules/service/src/main/resources/db/migration/V1208__itc_version_update_ready_only.sql
@@ -8,14 +8,19 @@ BEGIN
   IF (OLD.c_version IS DISTINCT FROM NEW.c_version OR OLD.c_data IS DISTINCT FROM NEW.c_data) THEN
     TRUNCATE t_itc_result;
 
-    -- Reset to pending, but only for observations in the 'ready' workflow state.
+    -- Reset to pending, but only for observations in the 'ready' workflow state or non-executed
+    -- ones with itc errors.
     UPDATE t_obscalc SET
       c_last_invalidation = NOW(),
       c_failure_count     = 0,
       c_retry_at          = NULL,
       c_obscalc_state     = 'pending'
     WHERE c_obscalc_state IN ('ready', 'retry')
-      AND c_workflow_state = 'ready';
+      AND c_workflow_state NOT IN ('inactive', 'ongoing', 'completed')
+      AND (
+            c_workflow_state = 'ready'
+            OR c_workflow_validations @> '[{"code": "ITC_ERROR"}]'::jsonb
+          );
   END IF;
   RETURN NEW;
 END;

--- a/modules/service/src/main/resources/db/migration/V1208__itc_version_update_ready_only.sql
+++ b/modules/service/src/main/resources/db/migration/V1208__itc_version_update_ready_only.sql
@@ -1,0 +1,22 @@
+-- When the ITC version changes, reset obscalc. Previously this reset every
+-- workflow state except inactive, ongoing and completed. Limit it to the
+-- 'ready' workflow state only.
+CREATE OR REPLACE FUNCTION itc_version_update()
+  RETURNS trigger AS $$
+BEGIN
+  NEW.c_last_update = NOW();
+  IF (OLD.c_version IS DISTINCT FROM NEW.c_version OR OLD.c_data IS DISTINCT FROM NEW.c_data) THEN
+    TRUNCATE t_itc_result;
+
+    -- Reset to pending, but only for observations in the 'ready' workflow state.
+    UPDATE t_obscalc SET
+      c_last_invalidation = NOW(),
+      c_failure_count     = 0,
+      c_retry_at          = NULL,
+      c_obscalc_state     = 'pending'
+    WHERE c_obscalc_state IN ('ready', 'retry')
+      AND c_workflow_state = 'ready';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
Also, only invalidate ready observations when the itc version changes.