### PR TITLE
Shortcut 9377: move time accounting

### DIFF
--- a/modules/obscalc/obscalc-flow.md
+++ b/modules/obscalc/obscalc-flow.md
@@ -137,6 +137,7 @@ flowchart TD
     T --> S2[storeResult]
     S2 --> CK{c_last_invalidation == pending.lastInvalidation?}
     CK -->|no| BP[state = pending — recompute]
+    CK -->|yes, a visit still time-accounting-dirty| RT2[state = retry — TA recompute failed]
     CK -->|yes, error is RemoteServiceCallError| RT[state = retry, bump failure_count, set retry_at]
     CK -->|yes, otherwise| RD[state = ready]
 ```
@@ -151,7 +152,7 @@ flowchart TD
 
 ### Result Storage Guard
 
-`storeResult` (`ObscalcService.scala:286`) locks the row and re-reads `c_last_invalidation`. If it changed during calculation, the result is *still* written but the state is forced back to `pending` so the next pickup re-runs against the newer inputs.
+`storeResult` (`ObscalcService.scala:286`) locks the row and re-reads `c_last_invalidation`. If it changed during calculation, the result is *still* written but the state is forced back to `pending` so the next pickup re-runs against the newer inputs. It also checks whether any of the observation's visits is still time-accounting-dirty (a recompute that failed): if so — and `c_last_invalidation` is unchanged — the state is forced to `retry` so the time-accounting update is attempted again. See [`time-accounting-flow.md`](../service/time-accounting-flow.md).
 
 ### Retry Backoff
 

--- a/modules/obscalc/obscalc-flow.md
+++ b/modules/obscalc/obscalc-flow.md
@@ -152,7 +152,7 @@ flowchart TD
 
 ### Result Storage Guard
 
-`storeResult` (`ObscalcService.scala:286`) locks the row and re-reads `c_last_invalidation`. If it changed during calculation, the result is *still* written but the state is forced back to `pending` so the next pickup re-runs against the newer inputs. It also checks whether any of the observation's visits is still time-accounting-dirty (a recompute that failed): if so — and `c_last_invalidation` is unchanged — the state is forced to `retry` so the time-accounting update is attempted again. See [`time-accounting-flow.md`](../service/time-accounting-flow.md).
+`storeResult` (`ObscalcService.scala:286`) locks the row and re-reads `c_last_invalidation`. If it changed during calculation, the result is *still* written but the state is forced back to `pending` so the next pickup re-runs against the newer inputs. It also checks whether any of the observation's visits is still time-accounting-dirty (a recompute that failed): if so — and `c_last_invalidation` is unchanged — the state is forced to `retry` so the time-accounting update is attempted again. See [`time-accounting-flow.md`](time-accounting-flow.md).
 
 ### Retry Backoff
 

--- a/modules/obscalc/src/main/scala/lucuma/odb/obscalc/Main.scala
+++ b/modules/obscalc/src/main/scala/lucuma/odb/obscalc/Main.scala
@@ -189,11 +189,23 @@ object CalcMain extends MainParams:
           Logger[F].debug(s"Loaded PendingCalc ${pc.observationId}. Last invalidated at ${pc.lastInvalidation}.")
         .parEvalMapUnordered(connectionsLimit): pc =>
           T.span("obscalc.calculate").surround:
-            services.useNonTransactionally:
-              requireServiceAccessOrThrow:
-                obscalcService
-                  .calculateAndUpdate(pc)
-                  .tupleLeft(pc)
+            for
+              // Recompute time accounting for the observation's visits in its
+              // own transaction, independent of the ITC/digest calculation so an
+              // ITC failure can never stall or revert it.  A no-op if the
+              // observation has no visits.  Best effort: a failure here must not
+              // take down the daemon nor block the obscalc calculation.
+              _ <- T.span("obscalc.timeAccounting").surround:
+                     services
+                       .useTransactionally:
+                         requireServiceAccessOrThrow:
+                           timeAccountingService.updateAll(pc.observationId)
+                       .handleErrorWith: t =>
+                         Logger[F].warn(t)(s"Time accounting update failed for ${pc.observationId}")
+              r <- services.useNonTransactionally:
+                     requireServiceAccessOrThrow:
+                       obscalcService.calculateAndUpdate(pc)
+            yield (pc, r)
         .evalTap: (pc, meta) =>
           Logger[F].debug(s"Stored obscalc result for ${pc.observationId}. Current status: $meta.")
         .void

--- a/modules/obscalc/time-accounting-flow.md
+++ b/modules/obscalc/time-accounting-flow.md
@@ -14,7 +14,7 @@ when events arrive. An execution event only marks the affected visit dirty; the
 worker picks the observation up and recomputes the dirty visits. This keeps the
 event-ingestion path (from the "Observe" application) cheap.
 
-See [`obscalc-flow.md`](../obscalc/obscalc-flow.md) for the worker/daemon
+See [`obscalc-flow.md`](obscalc-flow.md) for the worker/daemon
 machinery this rides on.
 
 ## Where it lives

--- a/modules/service/src/main/resources/db/migration/V1210__async_time_accounting.sql
+++ b/modules/service/src/main/resources/db/migration/V1210__async_time_accounting.sql
@@ -1,0 +1,81 @@
+-- Time accounting moves off the execution-event hot path and into the obscalc
+-- worker, which recomputes it asynchronously.
+
+-- 1. Stop invalidating obscalc on t_visit UPDATE.  obscalc reads nothing from
+--    t_visit, so the UPDATE branch never produced a meaningful recalculation --
+--    it only fired because the old synchronous time-accounting update wrote
+--    t_visit on every event.  Now that the worker writes the time-accounting
+--    columns back to t_visit (both the result columns and the markers below),
+--    keeping the UPDATE branch would create a feedback loop.  The INSERT branch
+--    is still wanted (refresh obscalc when a visit is recorded, see V1085) as is
+--    DELETE.
+DROP TRIGGER visit_invalidate_trigger ON t_visit;
+
+CREATE TRIGGER visit_invalidate_trigger
+  AFTER INSERT OR DELETE ON t_visit
+  FOR EACH ROW EXECUTE FUNCTION obsid_obscalc_invalidate();
+
+-- 2. Time-accounting-specific invalidation tracking, PER VISIT.  These are
+--    bumped ONLY on the specific visit that received an execution event or a
+--    dataset QA-state change -- the only two things that alter a visit's charge.
+--    The worker recomputes a visit only when c_ta_invalidation > c_ta_update, so:
+--      * obscalc invalidations unrelated to time accounting (target/mode edits,
+--        a migration that blanket-sets observations to 'pending') recompute
+--        nothing; and
+--      * an event or QA change in one visit never reprices any OTHER visit of
+--        the observation -- in particular it cannot silently rewrite a closed,
+--        already-corrected visit with a newly-deployed algorithm.
+--    Existing visits get equal timestamps (not dirty), preserving their stored
+--    history until a genuine change to that visit occurs.
+ALTER TABLE t_visit
+  ADD COLUMN c_ta_invalidation timestamp NOT NULL DEFAULT now(),
+  ADD COLUMN c_ta_update       timestamp NOT NULL DEFAULT now();
+
+-- Mark a single visit's time accounting dirty and invalidate obscalc so the
+-- worker picks the observation up (and the digest/workflow refresh too).
+-- Updating t_visit here does not re-fire visit_invalidate_trigger (INSERT/DELETE
+-- only), so there is no feedback loop.
+CREATE PROCEDURE invalidate_visit_time_accounting(
+  visit_id       d_visit_id,
+  observation_id d_observation_id
+) LANGUAGE plpgsql AS $$
+BEGIN
+  UPDATE t_visit SET c_ta_invalidation = now() WHERE c_visit_id = visit_id;
+  CALL invalidate_obscalc(observation_id);
+END;
+$$;
+
+-- 3. Recording an execution event invalidates that event's visit's time
+--    accounting.  This replaces the old synchronous per-event time-accounting
+--    update (removed from ExecutionEventService).  AFTER INSERT fires only for
+--    genuinely inserted rows, so idempotency-key replays (INSERT ... ON CONFLICT
+--    DO UPDATE) do not re-trigger it.
+CREATE FUNCTION event_time_accounting_invalidate()
+  RETURNS trigger AS $$
+BEGIN
+  CALL invalidate_visit_time_accounting(NEW.c_visit_id, NEW.c_observation_id);
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER event_time_accounting_invalidate_trigger
+  AFTER INSERT ON t_execution_event
+  FOR EACH ROW EXECUTE FUNCTION event_time_accounting_invalidate();
+
+-- 4. A dataset QA-state change (Pass/null <-> Fail/Usable) adds or removes a QA
+--    discount, changing the charge for the dataset's -- possibly already closed
+--    -- visit.  Invalidate that visit's time accounting (which also invalidates
+--    obscalc, as this trigger already did).
+CREATE OR REPLACE FUNCTION dataset_qa_state_invalidate()
+  RETURNS TRIGGER AS $$
+BEGIN
+  IF (OLD.c_qa_state IS DISTINCT FROM NEW.c_qa_state) AND (
+    ((OLD.c_qa_state IS NULL OR OLD.c_qa_state = 'Pass') AND (NEW.c_qa_state IN ('Fail', 'Usable')))
+    OR
+    ((OLD.c_qa_state IN ('Fail', 'Usable')) AND (NEW.c_qa_state IS NULL OR NEW.c_qa_state = 'Pass'))
+  ) THEN
+    CALL invalidate_visit_time_accounting(NEW.c_visit_id, NEW.c_observation_id);
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
@@ -6,7 +6,6 @@ package lucuma.odb.service
 import cats.effect.Concurrent
 import cats.syntax.applicative.*
 import cats.syntax.applicativeError.*
-import cats.syntax.apply.*
 import cats.syntax.flatMap.*
 import cats.syntax.functor.*
 import cats.syntax.option.*
@@ -127,17 +126,9 @@ object ExecutionEventService:
             case _                        => ().pure
 
         ResultT(insert)
-          .flatMap: (eid, time, vid, wasInserted) =>
+          .flatMap: (eid, time, _, wasInserted) =>
             if wasInserted then
-              // A note about the visit id.  Datasets have a visit id which is
-              // NOT NULL.  They are assigned via a BEFORE trigger on t_dataset.
-              // At the time of the insert, the dataset's step's atom must have
-              // been assigned already or the insert is rejected.  So, by the
-              // time we're getting events for a dataset, we know the associated
-              // atom has a visit.
-              ResultT.liftF:
-                setDatasetTime(time) *>
-                timeAccountingService.update(vid).as(eid)
+              ResultT.liftF(setDatasetTime(time).as(eid))
             else
               ResultT.pure(eid)
           .value
@@ -158,11 +149,7 @@ object ExecutionEventService:
                 invalidVisit.asFailureF
 
         ResultT(insert)
-          .flatMap: (eid, wasInserted) =>
-            if wasInserted then
-              ResultT.liftF(timeAccountingService.update(input.visitId).as(eid))
-            else
-              ResultT.pure(eid)
+          .map((eid, _) => eid)
           .value
 
       override def insertSlewEvent(
@@ -177,8 +164,7 @@ object ExecutionEventService:
         (for
           v <- ResultT(visitService.lookupOrInsertForSlew(input.observationId, none))
           e <- ResultT(insert(v))
-          (eid, wasInserted) = e
-          _ <- ResultT.liftF(timeAccountingService.update(v)).whenA(wasInserted)
+          (eid, _) = e
         yield eid).value
 
       override def insertStepEvent(
@@ -200,11 +186,7 @@ object ExecutionEventService:
               case SqlState.ForeignKeyViolation(_) => invalidStep.asFailureF
 
         ResultT(insert)
-          .flatMap: (eid, wasInserted) =>
-            if wasInserted then
-              ResultT.liftF(timeAccountingService.update(input.visitId).as(eid))
-            else
-              ResultT.pure(eid)
+          .map((eid, _) => eid)
           .value
 
       override def selectSequenceEvents(

--- a/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ExecutionEventService.scala
@@ -101,7 +101,7 @@ object ExecutionEventService:
         def invalidDataset: OdbError.InvalidDataset =
           OdbError.InvalidDataset(input.datasetId, Some(s"Dataset '${input.datasetId.show}' not found"))
 
-        val insert: F[Result[(Id, Timestamp, Visit.Id, Boolean)]] =
+        val insert: F[Result[(Id, Timestamp, Boolean)]] =
           session
             .option(Statements.InsertDatasetEvent)(input)
             .map(_.toResult(invalidDataset.asProblem))
@@ -126,7 +126,7 @@ object ExecutionEventService:
             case _                        => ().pure
 
         ResultT(insert)
-          .flatMap: (eid, time, _, wasInserted) =>
+          .flatMap: (eid, time, wasInserted) =>
             if wasInserted then
               ResultT.liftF(setDatasetTime(time).as(eid))
             else
@@ -236,7 +236,7 @@ object ExecutionEventService:
           c_visit_id = $visit_id
       """.query(timestamp_interval.opt)
 
-    val InsertDatasetEvent: Query[AddDatasetEventInput, (Id, Timestamp, Visit.Id, Boolean)] =
+    val InsertDatasetEvent: Query[AddDatasetEventInput, (Id, Timestamp, Boolean)] =
       sql"""
         INSERT INTO t_execution_event (
           c_event_type,
@@ -272,9 +272,8 @@ object ExecutionEventService:
         RETURNING
           c_execution_event_id,
           c_received,
-          c_visit_id,
           xmax = 0 AS inserted
-      """.query(execution_event_id *: core_timestamp *: visit_id *: bool)
+      """.query(execution_event_id *: core_timestamp *: bool)
          .contramap(in => (in.datasetId, in.datasetStage, in.idempotencyKey, in.datasetId))
 
     val InsertSequenceEvent: Query[AddSequenceEventInput, (Id, Boolean)] =

--- a/modules/service/src/main/scala/lucuma/odb/service/ObscalcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObscalcService.scala
@@ -290,7 +290,13 @@ object ObscalcService:
       )(using ServiceAccess, Transaction[F]): F[Option[Obscalc.Meta]] =
         for
           lu <- session.option(Statements.SelectLastInvalidationForUpdate)(pending.observationId)
-          ns  = lu.map(lastUpdate => if lastUpdate === pending.lastInvalidation then expected else CalculationState.Pending)
+          ns  = lu.map: (lastInvalidation, timeAccountingDirty) =>
+                  // Re-invalidated during the calculation: go back to 'pending'.
+                  if lastInvalidation =!= pending.lastInvalidation then CalculationState.Pending
+                  // The obscalc result is fine but time accounting didn't get
+                  // updated (its recompute failed); retry so it is attempted again.
+                  else if timeAccountingDirty                      then CalculationState.Retry
+                  else                                                  expected
           af  = ns.map(newState => Statements.storeResult(pending, result, newState))
           m  <- af.traverse(f => session.unique(f.fragment.query(Statements.obscalc_meta))(f.argument))
         yield m
@@ -586,13 +592,23 @@ object ObscalcService:
         sql"c_workflow_validations = ${_observation_validation}"(r.workflow.validationErrors)
       )
 
-    val SelectLastInvalidationForUpdate: Query[Observation.Id, Timestamp] =
+    // Along with the last invalidation timestamp, reports whether any of the
+    // observation's visits still has dirty time accounting (its recompute failed
+    // or did not complete) so that the entry can be retried rather than left
+    // 'ready' with stale data.
+    val SelectLastInvalidationForUpdate: Query[Observation.Id, (Timestamp, Boolean)] =
       sql"""
-        SELECT c_last_invalidation
-        FROM t_obscalc
-        WHERE c_observation_id = $observation_id
+        SELECT
+          o.c_last_invalidation,
+          EXISTS (
+            SELECT 1 FROM t_visit v
+            WHERE v.c_observation_id  = o.c_observation_id
+              AND v.c_ta_invalidation > v.c_ta_update
+          )
+        FROM t_obscalc o
+        WHERE o.c_observation_id = $observation_id
         FOR UPDATE
-      """.query(core_timestamp)
+      """.query(core_timestamp *: bool)
 
     def storeResult(
       pending:  Obscalc.PendingCalc,

--- a/modules/service/src/main/scala/lucuma/odb/service/TimeAccountingService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/TimeAccountingService.scala
@@ -50,6 +50,15 @@ trait TimeAccountingService[F[_]] {
   )(using Transaction[F], Services.ServiceAccess): F[Unit]
 
   /**
+   * Updates the time accounting data for every visit of the given observation.
+   * A no-op for observations that have no visits (i.e., that haven't begun
+   * executing).
+   */
+  def updateAll(
+    observationId: Observation.Id
+  )(using Transaction[F], Services.ServiceAccess): F[Unit]
+
+  /**
    * Adds a manual time charge correction.
    */
   def addCorrection(
@@ -139,6 +148,23 @@ object TimeAccountingService {
         visitId: Visit.Id
       )(using Transaction[F], Services.ServiceAccess): F[Unit] =
         Update(visitId).run
+
+      override def updateAll(
+        observationId: Observation.Id
+      )(using Transaction[F], Services.ServiceAccess): F[Unit] =
+        // Recompute only the visits that were actually invalidated (received an
+        // execution event or a dataset QA-state change) since their last update.
+        // Visits with no relevant change -- including closed, already-corrected
+        // visits of the same observation -- are left untouched, so an unrelated
+        // obscalc invalidation (or an event in a different visit) never reprices
+        // them.  We record the invalidation timestamp we observed (not `now()`)
+        // so that an invalidation arriving during the recompute leaves the visit
+        // dirty for the next pass.
+        session.execute(SelectDirtyVisits)(observationId).flatMap:
+          _.traverse_ { (visitId, invalidation) =>
+            update(visitId) *>
+            session.execute(MarkVisitTimeAccountingUpdated)(invalidation, visitId).void
+          }
 
       case class Update(visitId: Visit.Id)(using Transaction[F]) {
         lazy val run: F[Unit] =
@@ -350,6 +376,27 @@ object TimeAccountingService {
            f.programTime,
            v
          )}
+
+    // The observation's visits that are "dirty" (invalidated since their last
+    // update), each with the invalidation timestamp to record once recomputed.
+    val SelectDirtyVisits: Query[Observation.Id, (Visit.Id, Timestamp)] =
+      sql"""
+        SELECT
+          c_visit_id,
+          c_ta_invalidation
+        FROM
+          t_visit
+        WHERE
+          c_observation_id  = $observation_id AND
+          c_ta_invalidation > c_ta_update
+      """.query(visit_id *: core_timestamp)
+
+    val MarkVisitTimeAccountingUpdated: Command[(Timestamp, Visit.Id)] =
+      sql"""
+        UPDATE t_visit
+           SET c_ta_update = $core_timestamp
+         WHERE c_visit_id = $visit_id
+      """.command
 
     val SelectObservationId: Query[Visit.Id, Observation.Id] =
       sql"""

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -116,6 +116,9 @@ trait DatabaseOperations { this: OdbSuite =>
               .map(_.map(_.meta.lastInvalidation).getOrElse(Timestamp.Min))
 
         when.flatMap: t =>
+          // Mirror the obscalc daemon: recompute time accounting first (clearing
+          // its dirty marker) so the calculation can settle to 'ready'.
+          services.transactionally(timeAccountingService.updateAll(oid)) *>
           srv.calculateAndUpdate(Obscalc.PendingCalc(pid, oid, t))
     .void
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/timeAccounting.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/timeAccounting.scala
@@ -40,6 +40,7 @@ import lucuma.core.model.sequence.Step
 import lucuma.core.model.sequence.TimeChargeCorrection
 import lucuma.core.syntax.string.*
 import lucuma.core.syntax.timespan.*
+import lucuma.core.util.CalculationState
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import lucuma.core.util.TimestampInterval
@@ -488,6 +489,65 @@ class timeAccounting extends OdbSuite with DatabaseOperations with ExecutionTest
       e.fold(insertSlewEvent(pid), insertSequenceEvent(pid), insertAtomEvent(pid), insertStepEvent(pid), insertDatasetEvent(pid))
     }
 
+  // The obscalc calculation state for an observation, if a row exists.
+  def obscalcState(oid: Observation.Id): IO[Option[CalculationState]] =
+    withSession: s =>
+      s.option(sql"""
+        SELECT c_obscalc_state
+        FROM t_obscalc
+        WHERE c_observation_id = $observation_id
+      """.query(calculation_state))(oid)
+
+  // Forces the obscalc entry into the 'ready' state so that a subsequent
+  // invalidation (e.g. by recording an execution event) is observable.
+  def setObscalcReady(pid: Program.Id, oid: Observation.Id): IO[Unit] =
+    withSession: s =>
+      s.execute(sql"""
+        INSERT INTO t_obscalc (c_program_id, c_observation_id, c_obscalc_state)
+        VALUES ($program_id, $observation_id, 'ready' :: e_calculation_state)
+        ON CONFLICT ON CONSTRAINT t_obscalc_pkey
+          DO UPDATE SET c_obscalc_state = 'ready' :: e_calculation_state
+      """.command)(pid, oid).void
+
+  // Mirrors what the obscalc worker (obscalc/Main.scala) does for time
+  // accounting: recompute it for all of the observation's visits.
+  def runTimeAccounting(oid: Observation.Id): IO[Unit] =
+    withServices(serviceUser): s =>
+      s.session.transaction.use: xa =>
+        s.timeAccountingService.updateAll(oid)(using xa)
+
+  // The stored (final) program time summed over an observation's visits.
+  def finalProgramTime(oid: Observation.Id): IO[TimeSpan] =
+    withSession: s =>
+      s.unique(sql"""
+        SELECT COALESCE(SUM(c_final_program_time), '0'::interval)
+        FROM t_visit
+        WHERE c_observation_id = $observation_id
+      """.query(time_span))(oid)
+
+  // The stored (final) program time for a single visit.
+  def visitFinalProgramTime(vid: Visit.Id): IO[TimeSpan] =
+    withSession: s =>
+      s.unique(sql"""
+        SELECT c_final_program_time FROM t_visit WHERE c_visit_id = $visit_id
+      """.query(time_span))(vid)
+
+  // Overwrites the stored final program time for a visit, standing in for a
+  // value written by some previous run/algorithm.
+  def setFinalProgramTime(vid: Visit.Id, ts: TimeSpan): IO[Unit] =
+    withSession: s =>
+      s.execute(sql"""
+        UPDATE t_visit SET c_final_program_time = $time_span WHERE c_visit_id = $visit_id
+      """.command)((ts, vid)).void
+
+  // An obscalc invalidation NOT related to time accounting.
+  def invalidateObscalc(oid: Observation.Id): IO[Unit] =
+    withSession(_.execute(sql"CALL invalidate_obscalc($observation_id)".command)(oid).void)
+
+  // A time-accounting-relevant invalidation of a specific visit.
+  def invalidateTimeAccounting(vid: Visit.Id, oid: Observation.Id): IO[Unit] =
+    withSession(_.execute(sql"CALL invalidate_visit_time_accounting($visit_id, $observation_id)".command)((vid, oid)).void)
+
   test("timeChargeInvoice (no events)") {
     recordVisit(pi, serviceUser, mode, visitTime, 1, 1, 1, 0).flatMap { v =>
       expect(pi, invoiceQuery(v.oid), invoiceExected(TimeCharge.Invoice.Empty, Nil))
@@ -512,6 +572,105 @@ class timeAccounting extends OdbSuite with DatabaseOperations with ExecutionTest
       _ <- expect(pi, invoiceQuery(v.oid), invoiceExected(invoice, Nil))
     } yield ()
 
+  }
+
+  test("timeChargeInvoice (computed asynchronously by the obscalc worker)") {
+    // Same scenario as "no discounts", but exercising the async path end to end:
+    // recording events must invalidate obscalc (so the worker picks the
+    // observation up) WITHOUT computing time accounting synchronously, and the
+    // worker's recompute (updateAll) must then produce the expected charge.
+    val events = List(
+      (SequenceCommand.Start, t00),
+      (SequenceCommand.Stop,  t10)
+    )
+
+    for {
+      v  <- recordVisit(pi, serviceUser, mode, visitTime, 1, 1, 1, 9000)
+
+      // Establish a known 'ready' baseline so the event's invalidation is visible.
+      _  <- setObscalcReady(v.pid, v.oid)
+      _  <- assertIO(obscalcState(v.oid), CalculationState.Ready.some)
+
+      // Recording the events must invalidate obscalc (-> pending) ...
+      es  = events.map { (c, t) => SequenceEvent(EventId, t, v.oid, v.vid, none, c) }
+      _  <- insertEvents(v.pid, es)
+      _  <- assertIO(obscalcState(v.oid), CalculationState.Pending.some)
+
+      // ... but must NOT have updated time accounting synchronously.
+      _  <- assertIO(finalProgramTime(v.oid), 0.sec)
+
+      // The worker recomputes time accounting for the observation's visits.
+      _  <- runTimeAccounting(v.oid)
+      _  <- assertIO(finalProgramTime(v.oid), 10.sec)
+    } yield ()
+  }
+
+  test("time accounting is not recomputed on an unrelated obscalc invalidation") {
+    // The crux of the async design: a closed visit's stored charge must only be
+    // recomputed when something time-accounting-relevant changed -- never merely
+    // because obscalc was invalidated for an unrelated reason (a target/mode
+    // edit, or a migration that blanket-sets observations to 'pending').
+    val events = List(
+      (SequenceCommand.Start, t00),
+      (SequenceCommand.Stop,  t10)
+    )
+
+    val bogus = 999.sec
+
+    for {
+      v <- recordVisit(pi, serviceUser, mode, visitTime, 1, 1, 1, 9100)
+      es = events.map { (c, t) => SequenceEvent(EventId, t, v.oid, v.vid, none, c) }
+      _ <- insertEvents(v.pid, es)
+
+      // The worker computes the real charge.
+      _ <- runTimeAccounting(v.oid)
+      _ <- assertIO(finalProgramTime(v.oid), 10.sec)
+
+      // Stand in a value from some previous algorithm, then invalidate obscalc
+      // for a reason unrelated to time accounting.
+      _ <- setFinalProgramTime(v.vid, bogus)
+      _ <- invalidateObscalc(v.oid)
+      _ <- runTimeAccounting(v.oid)
+      // Not time-accounting-dirty: the stored value is left exactly as it was.
+      _ <- assertIO(finalProgramTime(v.oid), bogus)
+
+      // A time-accounting-relevant invalidation does force the recompute.
+      _ <- invalidateTimeAccounting(v.vid, v.oid)
+      _ <- runTimeAccounting(v.oid)
+      _ <- assertIO(finalProgramTime(v.oid), 10.sec)
+    } yield ()
+  }
+
+  test("an execution event in one visit does not reprice another visit") {
+    // The corrections-integrity guarantee: recompute is scoped to the visit that
+    // changed.  An event in a new visit must not re-derive (and thus silently
+    // alter) a different, already-closed visit of the same observation.
+    val events = List(
+      (SequenceCommand.Start, t00),
+      (SequenceCommand.Stop,  t10)
+    )
+
+    val bogus = 999.sec
+
+    for {
+      // Visit 1 executes and its charge is computed.
+      v1 <- recordVisit(pi, serviceUser, mode, visitTime, 1, 1, 1, 9200)
+      _  <- insertEvents(v1.pid, events.map { (c, t) => SequenceEvent(EventId, t, v1.oid, v1.vid, none, c) })
+      _  <- runTimeAccounting(v1.oid)
+      _  <- assertIO(visitFinalProgramTime(v1.vid), 10.sec)
+
+      // Stand in a staff-corrected / previous-algorithm value for the now-closed
+      // visit 1.
+      _  <- setFinalProgramTime(v1.vid, bogus)
+
+      // Later, a second visit of the SAME observation receives events.
+      v2 <- recordVisitAs(serviceUser, v1.oid)
+      _  <- insertEvents(v1.pid, events.map { (c, t) => SequenceEvent(EventId, t, v1.oid, v2, none, c) })
+      _  <- runTimeAccounting(v1.oid)
+
+      // Only visit 2 was recomputed; visit 1's stored value is left untouched.
+      _  <- assertIO(visitFinalProgramTime(v1.vid), bogus)
+    } yield ()
   }
 
   test("timeChargeInvoice (daylight discount)") {

--- a/modules/service/src/test/scala/lucuma/odb/service/ObscalcServiceSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/ObscalcServiceSuite.scala
@@ -17,6 +17,7 @@ import lucuma.core.model.Observation
 import lucuma.core.model.ObservationValidation
 import lucuma.core.model.ObservationWorkflow
 import lucuma.core.model.Program
+import lucuma.core.model.Visit
 import lucuma.core.model.sequence.CategorizedTime
 import lucuma.core.model.sequence.ExecutionDigest
 import lucuma.core.model.sequence.SequenceDigest
@@ -34,6 +35,7 @@ import lucuma.odb.util.Codecs.calculation_state
 import lucuma.odb.util.Codecs.core_timestamp
 import lucuma.odb.util.Codecs.observation_id
 import lucuma.odb.util.Codecs.program_id
+import lucuma.odb.util.Codecs.visit_id
 import skunk.*
 import skunk.implicits.*
 
@@ -94,6 +96,19 @@ trait ObscalcServiceSuiteSupport extends ExecutionTestSupportForGmos:
       """.command
 
       session.execute(up)(o).void
+
+  // Marks a visit's time accounting dirty (c_ta_invalidation > c_ta_update)
+  // without touching t_obscalc.c_last_invalidation -- the state left behind when
+  // a time accounting recompute fails.
+  def markVisitTimeAccountingDirty(v: Visit.Id): IO[Unit] =
+    withSession: session =>
+      val up: Command[Visit.Id] = sql"""
+        UPDATE t_visit
+        SET c_ta_invalidation = c_ta_update + interval '1 second'
+        WHERE c_visit_id = $visit_id
+      """.command
+
+      session.execute(up)(v).void
 
   def calculationState(o: Observation.Id): IO[CalculationState] =
     withSession: session =>
@@ -320,6 +335,26 @@ class ObscalcServiceSuite extends ObscalcServiceSuiteSupport:
         calculateAndUpdate(lst.head) *> selectStates
 
     assertIO(res.map(_.values.toList.head), CalculationState.Retry)
+
+  test("still-dirty time accounting at obscalc finish -> retry"):
+    setup.flatMap: (p, o) =>
+      val pc = Obscalc.PendingCalc(p, o, randomTime)
+      for
+        v <- recordVisitAs(serviceUser, o)
+        // Baseline: no visit is dirty, so a successful calculation leaves the
+        // entry 'ready'.
+        _ <- insert(pc)
+        _ <- calculateAndUpdate(pc)
+        _ <- assertIO(calculationState(o), CalculationState.Ready)
+
+        // A visit's time accounting recompute failed (dirty, but
+        // c_last_invalidation unchanged).  Finishing the obscalc calculation
+        // must not leave the entry 'ready' -- it goes to 'retry' so the
+        // recompute is attempted again.
+        _ <- markVisitTimeAccountingDirty(v)
+        _ <- calculateAndUpdate(pc)
+        _ <- assertIO(calculationState(o), CalculationState.Retry)
+      yield ()
 
   test("insert visit sets state to pending"):
     val states = for

--- a/modules/service/time-accounting-flow.md
+++ b/modules/service/time-accounting-flow.md
@@ -112,21 +112,21 @@ sequenceDiagram
     participant Obs as Observe app
     participant Event as ExecutionEventService
     participant DB as PostgreSQL
-    participant Trig as event_time_accounting_invalidate()
+    participant Trig as event trigger
     participant Daemon as Obscalc Daemon
     participant TA as TimeAccountingService.updateAll
     participant Calc as ObscalcService.calculateAndUpdate
 
-    Obs->>Event: addStepEvent / addDatasetEvent / …
-    Event->>DB: INSERT t_execution_event   (cheap; no recompute)
+    Obs->>Event: addStepEvent / addDatasetEvent
+    Event->>DB: INSERT t_execution_event, cheap, no recompute
     DB->>Trig: AFTER INSERT
-    Trig->>DB: UPDATE t_visit SET c_ta_invalidation = now()  (that visit)
-    Trig->>DB: CALL invalidate_obscalc(observation)  → t_obscalc 'pending'
-    DB-->>Daemon: NOTIFY ch_obscalc_update (pending)
-    Daemon->>TA: updateAll(oid) — own transaction
-    TA->>DB: recompute each DIRTY visit; set its c_ta_update
-    Daemon->>Calc: calculateAndUpdate(oid) — ITC / digest / workflow
-    Calc->>DB: storeResult → 'ready' (or 'retry' if a visit is still dirty)
+    Trig->>DB: UPDATE t_visit c_ta_invalidation = now, for that visit
+    Trig->>DB: CALL invalidate_obscalc, t_obscalc becomes pending
+    DB-->>Daemon: NOTIFY ch_obscalc_update, pending
+    Daemon->>TA: updateAll in its own transaction
+    TA->>DB: recompute each DIRTY visit, set its c_ta_update
+    Daemon->>Calc: calculateAndUpdate, ITC / digest / workflow
+    Calc->>DB: storeResult ready, or retry if a visit still dirty
 ```
 
 Key point: `updateAll` runs in **its own transaction, before and independent of**

--- a/modules/service/time-accounting-flow.md
+++ b/modules/service/time-accounting-flow.md
@@ -1,0 +1,220 @@
+# Time Accounting Flow
+
+## Overview
+
+Time accounting is the record of how much observing time an execution consumed
+and how it was charged. It is computed **per visit** and stored on `t_visit`
+(`c_raw_*` and `c_final_*` interval columns), plus a set of discount rows in
+`t_time_charge_discount`. It is *derived* data: a function of the visit's
+execution events, its datasets' QA state, manual staff corrections, and the
+observing night.
+
+It is recomputed **asynchronously by the obscalc worker** rather than inline
+when events arrive. An execution event only marks the affected visit dirty; the
+worker picks the observation up and recomputes the dirty visits. This keeps the
+event-ingestion path (from the "Observe" application) cheap.
+
+See [`obscalc-flow.md`](../obscalc/obscalc-flow.md) for the worker/daemon
+machinery this rides on.
+
+## Where it lives
+
+| Concern | Location |
+|---|---|
+| Compute a visit's invoice, write `t_visit` + discounts | `TimeAccountingService.update(visitId)` |
+| Recompute all *dirty* visits of an observation | `TimeAccountingService.updateAll(observationId)` |
+| Manual staff correction | `TimeAccountingService.addCorrection(visitId, …)` (synchronous) |
+| Record an execution event (marks a visit dirty) | `ExecutionEventService` insert methods |
+| Drive the recompute in the worker | obscalc daemon `Main.scala` `calcAndUpdateStream` |
+| Retry decision when a recompute fails | `ObscalcService.storeResult` |
+| Triggers, markers, procedures | migration `V1210__async_time_accounting.sql` |
+
+## What causes time accounting to update
+
+**Exactly two things change a visit's charge**, and each is scoped to a single
+visit:
+
+1. **An execution event** is recorded for the visit (`t_execution_event`, which
+   has `c_visit_id NOT NULL`).
+2. **A dataset's QA state** crosses `Pass`/null ↔ `Fail`/`Usable`
+   (`t_dataset`, also `c_visit_id NOT NULL`) — this adds or removes a QA
+   discount for the visit that contains the dataset.
+
+Both go through `invalidate_visit_time_accounting(visit_id, observation_id)`,
+which:
+
+- `UPDATE t_visit SET c_ta_invalidation = now()` for **that visit only**, and
+- `CALL invalidate_obscalc(observation_id)` so the worker picks the observation
+  up (and the obscalc digest/workflow refresh too).
+
+Manual corrections are handled **synchronously** in `addCorrection` (staff, rare)
+and do **not** go through this path — they write the correction row and adjust
+`t_visit` immediately.
+
+## The per-visit dirty markers
+
+`t_visit` carries two timestamps:
+
+| Column | Meaning |
+|---|---|
+| `c_ta_invalidation` | Bumped to `now()` when this visit is invalidated (event / QA change). |
+| `c_ta_update` | Set to the invalidation value that was just recomputed. |
+
+A visit is **dirty** iff `c_ta_invalidation > c_ta_update`.
+`updateAll(observationId)` selects only the observation's dirty visits,
+recomputes each with `update(visitId)`, and sets that visit's `c_ta_update` to
+the invalidation timestamp it observed.
+
+Existing visits (at migration time) get equal default timestamps → not dirty →
+never recomputed until a genuine change occurs.
+
+## Why NOT recompute otherwise-unchanged visits
+
+This is the central design invariant, and it is deliberate.
+
+Time accounting is derived, but its stored values are also **acted on by
+humans**: staff review the automated numbers and enter manual corrections, and a
+program's charged time is a real accounting figure. Consider:
+
+1. Visit V1 executes early in the semester; its charge is computed and staff add
+   manual correction entries after reviewing it.
+2. Months pass. The time-accounting **algorithm is changed** in a deploy.
+3. A new visit V2 of the *same observation* begins executing.
+
+If recomputing were scoped to the *observation* (recompute-all-visits), every
+event in V2 would re-derive V1 as well — under the **new** algorithm. The
+correction rows survive (they're reapplied from `t_time_charge_correction`), but
+the base they sit on drifts, so V1's stored final charge silently changes away
+from the value staff reviewed and approved. That is worse than losing the
+corrections outright: it looks authoritative but no longer matches the human
+decision.
+
+Scoping the recompute to the **visit that actually changed** prevents this: V2's
+events touch only V2; V1 is inviolate unless *it* receives an event or a QA
+change. Recompute is fine when a human is actively making a relevant change
+(even a post-deploy QA correction re-prices with the new algorithm — someone is
+in the loop expecting it); the danger is only an *unrelated* trigger silently
+picking up an algorithm change.
+
+Two corollaries fall out of per-visit scoping:
+
+- **Unrelated obscalc invalidations don't touch time accounting.** A target/mode
+  edit, or a migration that blanket-sets observations to `pending`, invalidates
+  obscalc but marks no visit dirty, so `updateAll` is a no-op. (This is why the
+  markers are on `t_visit`, not `t_obscalc`.)
+- **QA changes are handled correctly** even on an old, closed visit, because the
+  QA trigger marks *that* visit dirty.
+
+## Flow
+
+```mermaid
+sequenceDiagram
+    participant Obs as Observe app
+    participant Event as ExecutionEventService
+    participant DB as PostgreSQL
+    participant Trig as event_time_accounting_invalidate()
+    participant Daemon as Obscalc Daemon
+    participant TA as TimeAccountingService.updateAll
+    participant Calc as ObscalcService.calculateAndUpdate
+
+    Obs->>Event: addStepEvent / addDatasetEvent / …
+    Event->>DB: INSERT t_execution_event   (cheap; no recompute)
+    DB->>Trig: AFTER INSERT
+    Trig->>DB: UPDATE t_visit SET c_ta_invalidation = now()  (that visit)
+    Trig->>DB: CALL invalidate_obscalc(observation)  → t_obscalc 'pending'
+    DB-->>Daemon: NOTIFY ch_obscalc_update (pending)
+    Daemon->>TA: updateAll(oid) — own transaction
+    TA->>DB: recompute each DIRTY visit; set its c_ta_update
+    Daemon->>Calc: calculateAndUpdate(oid) — ITC / digest / workflow
+    Calc->>DB: storeResult → 'ready' (or 'retry' if a visit is still dirty)
+```
+
+Key point: `updateAll` runs in **its own transaction, before and independent of**
+`calculateAndUpdate`. Time accounting is pure DB work; the ITC/digest calculation
+can hit a remote service and fail. Keeping them separate means an ITC failure can
+never stall or revert a time-accounting recompute.
+
+## Interaction subtleties
+
+### Retry when a recompute fails
+
+`updateAll` is best-effort in the daemon (errors are logged and swallowed). If it
+fails, the visit stays dirty (`c_ta_update` was never advanced). To avoid
+orphaning that dirty state, `storeResult` checks whether **any** visit of the
+observation is still dirty when the obscalc calculation finishes, and if so sets
+the entry to `retry` (with the normal exponential backoff) instead of `ready` —
+so the poll picks it up again and `updateAll` is retried.
+
+### Failure vs. concurrent event — retry vs. pending
+
+`storeResult` decides the final state in this order:
+
+```
+if c_last_invalidation changed since pickup      → pending   (re-invalidated during calc)
+else if any visit still dirty                    → retry     (a recompute failed)
+else                                             → ready
+```
+
+The ordering matters. A real event bumps **both** the visit's
+`c_ta_invalidation` *and* `t_obscalc.c_last_invalidation` (the latter via
+`invalidate_obscalc`). So an event that arrives *during* the calculation trips
+the `pending` check first — it is correctly treated as "re-invalidated", not as a
+failure. The `retry` branch is reached only when a visit is dirty **and**
+`c_last_invalidation` is unchanged, which happens exclusively when `updateAll`
+itself failed.
+
+### Race safety
+
+`updateAll` records `c_ta_update` = the `c_ta_invalidation` value it *observed*,
+never `now()`. So if a new event bumps `c_ta_invalidation` while a recompute is
+in flight, the visit is left dirty for the next pass rather than being marked
+clean at a stale value — no lost update, regardless of commit order.
+
+### No feedback loop
+
+`updateAll` writes back to `t_visit` (both the result columns and `c_ta_update`).
+`visit_invalidate_trigger` fires only on `INSERT`/`DELETE` of `t_visit`
+(narrowed from `INSERT OR UPDATE OR DELETE` in V1210), so these `UPDATE`s do not
+re-invalidate obscalc.
+
+## What a recompute actually computes
+
+`update(visitId)` rebuilds the visit's `TimeAccountingState` from **all** of its
+events, then applies discounts and corrections to produce the invoice:
+
+- **No-data discount** — visit has no datasets → whole charge discounted.
+- **Daylight discount** — time outside the night's nautical twilight.
+- **Overlap discount** — the portion overlapping another chargeable visit at the
+  same site.
+- **QA discount** — atoms whose datasets failed QA.
+- **Corrections** — staff `Add`/`Subtract` entries from `t_time_charge_correction`
+  are reapplied on top (so corrections survive a recompute; only the base they
+  apply to reflects the current algorithm).
+
+Final charge = raw execution time − discounts, then corrected.
+
+## Known limitation: cross-visit overlap
+
+The overlap discount makes one visit's charge depend on *another* visit. Per-visit
+scoping only recomputes the visit that received an event/QA change, so if an
+earlier visit is **open but no longer receiving events** while a new visit
+overlaps it, the earlier visit will not be re-marked and could miss an overlap
+adjustment. This is accepted: overlapping visits realistically both receive
+events while concurrent (so both get marked and recomputed), and the alternative
+— whole-observation recompute — reintroduces the corrected-history problem above,
+which is worse.
+
+## Readers
+
+The stored `t_visit` values are read by GraphQL query paths only (never in a
+write/execution path), so eventual consistency is safe:
+
+- `Visit.timeChargeInvoice` — `TimeChargeInvoiceMapping` over `VisitTable`
+  (`executionTime`/`finalCharge` are the stored `c_raw_*`/`c_final_*` columns;
+  discounts/corrections from their tables). **Stored, not recomputed on read.**
+- `Observation.execution` time charge — `ExecutionMapping` via
+  `timeAccountingService.selectObservations` (sums the visits).
+- `Program` banded time — `ProgramMapping` via `selectProgram`.
+
+obscalc itself does **not** read time accounting, so there is no dependency
+cycle in that direction.


### PR DESCRIPTION
Moves time accounting updates from execution event handling into the (asynchronous) Obscalc service.  A couple of salutary consequences:

* most importantly, event handling won't be slowed by a synchronous time accounting update
* but also, multiple consecutive updates coalesce in some cases

This turned out to be more ~complicated~ subtle than I expected.  In particular, we don't want to recompute time accounting for existing visits unless something explicitly triggers it: an execution event or a QA state change.  Otherwise, every time we change the time accounting algorithm all the existing time charges and careful manual corrections made by the staff would be compromised.  This PR adds a couple of time accounting timestamp fields to `t_visit` used to detect explicit updates and prevent that situation.