### PR TITLE
Setting selected sn target not working when

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/AsterismService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AsterismService.scala
@@ -220,8 +220,15 @@ object AsterismService {
                 val missing = observationIds.toList.filterNot(present.toSet)
                 missing match
                   case Nil =>
-                    val af = Statements.setSignalToNoiseTarget(programId, observationIds, tid)
-                    session.prepareR(af.fragment.command).use(_.execute(af.argument)).as(Result.unit)
+                    // Clear existing SN targets first, then set the chosen one. A single
+                    // UPDATE that flips multiple rows can transiently violate the partial
+                    // unique index i_asterism_single_sn_target: 
+                    val clear = Statements.clearSignalToNoiseTargets(programId, observationIds)
+                    val set   = Statements.applySignalToNoiseFlags(programId, observationIds.map(_ -> tid))
+                    for
+                      _ <- session.prepareR(clear.fragment.command).use(_.execute(clear.argument))
+                      _ <- session.prepareR(set.fragment.command).use(_.execute(set.argument))
+                    yield Result.unit
                   case bad =>
                     OdbError.InvalidArgument(
                       s"Signal-to-noise target ${tid.show} is not in the asterism of observation(s): ${bad.map(_.show).mkString(", ")}.".some
@@ -394,18 +401,6 @@ object AsterismService {
         programIdEqual(programId)                                                   |+|
         void" AND " |+| observationIdIn(observationIds)                             |+|
         void" AND c_is_signal_to_noise_target"
-
-    // Sets the flag on the chosen target and clears it from all others for the
-    // given observations, in a single statement (safe w.r.t. the single-target
-    // partial unique index).
-    def setSignalToNoiseTarget(
-      programId:      Program.Id,
-      observationIds: NonEmptyList[Observation.Id],
-      targetId:       Target.Id
-    ): AppliedFragment =
-      sql"UPDATE t_asterism_target SET c_is_signal_to_noise_target = (c_target_id = $target_id) WHERE "(targetId) |+|
-        programIdEqual(programId)                                                                                 |+|
-        void" AND " |+| observationIdIn(observationIds)
 
     def observationsWithTarget(
       programId:      Program.Id,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/explicitSignalToNoiseTarget.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/explicitSignalToNoiseTarget.scala
@@ -5,7 +5,6 @@ package lucuma.odb.graphql
 package mutation
 
 import cats.effect.IO
-import cats.syntax.foldable.*
 import cats.syntax.option.*
 import cats.syntax.show.*
 import io.circe.Json
@@ -463,8 +462,7 @@ class explicitSignalToNoiseTarget extends OdbSuite:
       _     <- IO(assertEquals(obs, List(oid)))
     yield ()
 
-  // Reproduction for the unique-violation (SQLSTATE 23505) on
-  // i_asterism_single_sn_target. `setSignalToNoiseTarget`
+  // Reproduction for the unique-violation on i_asterism_single_sn_target.
   test("switching the SN target from the later target to the earlier one does not raise 23505"):
     for
       pid <- createProgramAs(pi)
@@ -476,21 +474,3 @@ class explicitSignalToNoiseTarget extends OdbSuite:
       _   <- setSnTarget(oid, t0.some) // switch to the earlier target: 23505 today
       _   <- assertSnTarget(oid, t0.some)
     yield ()
-
-  test("repeatedly switching the SN target back and forth never violates the unique index"):
-    val switches = 25
-    for
-      pid <- createProgramAs(pi)
-      t0  <- createTargetAs(pi, pid, "Larry")
-      t1  <- createTargetAs(pi, pid, "Curly")
-      oid <- createObservationAs(pi, pid, t0, t1)
-      _   <- setSnTarget(oid, t1.some)
-      // Alternate t1 -> t0 -> t1 -> ... ; each switch leaves the old row
-      // flagged while the new one is being flagged.
-      _   <- List.range(0, switches).traverse_ { i =>
-               setSnTarget(oid, (if (i % 2 == 0) t0 else t1).some)
-             }
-      // switches=25: last index is 24 (even) -> t0
-      _   <- assertSnTarget(oid, t0.some)
-    yield ()
-

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/explicitSignalToNoiseTarget.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/explicitSignalToNoiseTarget.scala
@@ -5,6 +5,7 @@ package lucuma.odb.graphql
 package mutation
 
 import cats.effect.IO
+import cats.syntax.foldable.*
 import cats.syntax.option.*
 import cats.syntax.show.*
 import io.circe.Json
@@ -461,3 +462,35 @@ class explicitSignalToNoiseTarget extends OdbSuite:
       obs   <- observationsWhere(pi, s"""program: { id: { EQ: "${pid.show}" } }""")
       _     <- IO(assertEquals(obs, List(oid)))
     yield ()
+
+  // Reproduction for the unique-violation (SQLSTATE 23505) on
+  // i_asterism_single_sn_target. `setSignalToNoiseTarget`
+  test("switching the SN target from the later target to the earlier one does not raise 23505"):
+    for
+      pid <- createProgramAs(pi)
+      t0  <- createTargetAs(pi, pid, "Larry")
+      t1  <- createTargetAs(pi, pid, "Curly")
+      oid <- createObservationAs(pi, pid, t0, t1)
+      _   <- setSnTarget(oid, t1.some) // flag the later target
+      _   <- assertSnTarget(oid, t1.some)
+      _   <- setSnTarget(oid, t0.some) // switch to the earlier target: 23505 today
+      _   <- assertSnTarget(oid, t0.some)
+    yield ()
+
+  test("repeatedly switching the SN target back and forth never violates the unique index"):
+    val switches = 25
+    for
+      pid <- createProgramAs(pi)
+      t0  <- createTargetAs(pi, pid, "Larry")
+      t1  <- createTargetAs(pi, pid, "Curly")
+      oid <- createObservationAs(pi, pid, t0, t1)
+      _   <- setSnTarget(oid, t1.some)
+      // Alternate t1 -> t0 -> t1 -> ... ; each switch leaves the old row
+      // flagged while the new one is being flagged.
+      _   <- List.range(0, switches).traverse_ { i =>
+               setSnTarget(oid, (if (i % 2 == 0) t0 else t1).some)
+             }
+      // switches=25: last index is 24 (even) -> t0
+      _   <- assertSnTarget(oid, t0.some)
+    yield ()
+


### PR DESCRIPTION
While trying to support this feature on explore I got an error when setting the SN target if one already exists, in the form of
```
   Duplicate key value violates unique constraint "i_asterism_single_sn_target".                                                       
   Key (c_program_id, c_observation_id)=(p-11b9, o-4cee) already exists. 
```

The fx was to split the operation into two statements in the same transaction, reusing existing fragments:                                          
                                                                                                                                       
 1. `clearSignalToNoiseTargets` — set all SN flags false for the observations.                                                           
 2. `applySignalToNoiseFlags` — set exactly the chosen target true.   