### PR TITLE
Exchange observations default to Defined, not Completed

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -508,17 +508,13 @@ object ObservationWorkflowService {
             case Undefined  => List(Inactive)
             case Unapproved => List(Inactive)
             case Defined    =>
+              // Exchange observations run at Keck/Subaru, not Gemini; they have no
+              // Ready/Ongoing/Completed lifecycle, so Inactive is the only transition.
               List(Inactive) ++
-                Option.when((!info.isOpportunity) && (info.isAccepted || !info.tpe.hasProposal))(Ready) ++
-                Option.when(info.isExchange)(Completed)
-            case Ready      =>
-              List(Inactive, validationStatus) ++
-                Option.when(canUpdateExecutionState)(Ongoing) ++
-                Option.when(info.isExchange)(Completed)
+                Option.when((!info.isExchange) && (!info.isOpportunity) && (info.isAccepted || !info.tpe.hasProposal))(Ready)
+            case Ready      => List(Inactive, validationStatus) ++ Option.when(canUpdateExecutionState)(Ongoing)
             case Ongoing    => List(Completed) ++ Option.when(canUpdateExecutionState)(Ready)
-            case Completed  =>
-              if info.isExchange then List(Defined)            // exchange: allow revert (un-complete)
-              else if info.isDeclaredComplete then List(Ongoing) else Nil
+            case Completed  => if info.isDeclaredComplete then List(Ongoing) else Nil
 
         (state, allowedTransitions)
 
@@ -786,21 +782,6 @@ object ObservationWorkflowService {
                     // Same for everyone
                     case (Ongoing, Completed) =>
                       updateDeclaredState(oid, Some(Completed))
-                        .as(Result(w.copy(state = state)))
-
-                    // Exchange observations: declare complete directly from Defined/Ready
-                    // (there is no Ready/Ongoing lifecycle at Gemini), and allow reverting.
-                    case (Defined, Completed) =>
-                      updateDeclaredState(oid, Some(Completed))
-                        .as(Result(w.copy(state = state)))
-
-                    case (Ready, Completed) =>
-                      updateUserState(oid, None) >>
-                      updateDeclaredState(oid, Some(Completed))
-                        .as(Result(w.copy(state = state)))
-
-                    case (Completed, Defined) =>
-                      updateDeclaredState(oid, None)
                         .as(Result(w.copy(state = state)))
 
                     // Same for everyone; note that this needs to be the last case

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -170,6 +170,9 @@ case class ObservationValidationInfo(
       case _: VisitorObservingModeType => true
       case _ => false
 
+  def isExchange: Boolean =
+    observingMode.exists(_.isExchange)
+
   lazy val cfpMidpoint: Option[Timestamp] =
     for
       s  <- site
@@ -504,10 +507,18 @@ object ObservationWorkflowService {
             case Inactive   => List(executionState.getOrElse(validationStatus))
             case Undefined  => List(Inactive)
             case Unapproved => List(Inactive)
-            case Defined    => List(Inactive) ++ Option.when((!info.isOpportunity) && (info.isAccepted || !info.tpe.hasProposal))(Ready)
-            case Ready      => List(Inactive, validationStatus) ++ Option.when(canUpdateExecutionState)(Ongoing)
+            case Defined    =>
+              List(Inactive) ++
+                Option.when((!info.isOpportunity) && (info.isAccepted || !info.tpe.hasProposal))(Ready) ++
+                Option.when(info.isExchange)(Completed)
+            case Ready      =>
+              List(Inactive, validationStatus) ++
+                Option.when(canUpdateExecutionState)(Ongoing) ++
+                Option.when(info.isExchange)(Completed)
             case Ongoing    => List(Completed) ++ Option.when(canUpdateExecutionState)(Ready)
-            case Completed  => if info.isDeclaredComplete then List(Ongoing) else Nil
+            case Completed  =>
+              if info.isExchange then List(Defined)            // exchange: allow revert (un-complete)
+              else if info.isDeclaredComplete then List(Ongoing) else Nil
 
         (state, allowedTransitions)
 
@@ -524,7 +535,7 @@ object ObservationWorkflowService {
         // Here are our simple validators
 
         val generatorValidator: Validator = info =>
-          if info.isVisitor then ObservationValidationMap.empty
+          if info.isVisitor || info.isExchange then ObservationValidationMap.empty
           else info.generatorParams.foldMap:
             case Left(error)                                          => ObservationValidationMap.singleton(error.toObsValidation)
             case Right(GeneratorParams(Left(m), _, _, _, _, _, _, _)) => ObservationValidationMap.singleton(m.toObsValidation)
@@ -572,7 +583,7 @@ object ObservationWorkflowService {
             else ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.invalidScienceBand(b)))
 
         val itcValidator: Validator = info =>
-          if hasItc(info.oid) || info.isVisitor then ObservationValidationMap.empty
+          if hasItc(info.oid) || info.isVisitor || info.isExchange then ObservationValidationMap.empty
           else ObservationValidationMap.singleton(ObservationValidation.itc("ITC results are not present."))
 
         // V magnitudes are used by Observe to set the GHOST slit viewing
@@ -627,7 +638,7 @@ object ObservationWorkflowService {
 
         val toCheck: List[ObservationValidationInfo] =
           science.values.toList.filter: info =>
-            info.isAccepted && prelimV.get(info.oid).forall(_.isEmpty)
+            info.isAccepted && !info.isExchange && prelimV.get(info.oid).forall(_.isEmpty)
 
         val configValidations: ResultT[F, Map[Observation.Id, ObservationValidationMap]] =
           NonEmptyList
@@ -709,7 +720,7 @@ object ObservationWorkflowService {
           errs  <- validateObsDefinition(infos, _ => itc.isDefined)
           exec = exec0.filter:
             case a: DeclaredExecutionState => true // always ok
-            case _ => !infos.get(oid).exists(_.isVisitor) // otherwise discard the state if it's a visitor
+            case _ => !infos.get(oid).exists(i => i.isVisitor || i.isExchange) // otherwise discard the state if it's a visitor or exchange
           wfExec = exec.flatMap[ExecutionState](ces => ces.workflowExecutionState)
           execs  = wfExec.fold[Map[Observation.Id, ExecutionState]](Map.empty)(es => Map(oid -> es))
           wfs    = computeWorkflows(infos, errs, execs)
@@ -775,6 +786,21 @@ object ObservationWorkflowService {
                     // Same for everyone
                     case (Ongoing, Completed) =>
                       updateDeclaredState(oid, Some(Completed))
+                        .as(Result(w.copy(state = state)))
+
+                    // Exchange observations: declare complete directly from Defined/Ready
+                    // (there is no Ready/Ongoing lifecycle at Gemini), and allow reverting.
+                    case (Defined, Completed) =>
+                      updateDeclaredState(oid, Some(Completed))
+                        .as(Result(w.copy(state = state)))
+
+                    case (Ready, Completed) =>
+                      updateUserState(oid, None) >>
+                      updateDeclaredState(oid, Some(Completed))
+                        .as(Result(w.copy(state = state)))
+
+                    case (Completed, Defined) =>
+                      updateDeclaredState(oid, None)
                         .as(Result(w.copy(state = state)))
 
                     // Same for everyone; note that this needs to be the last case

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setObservationWorkflowState.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setObservationWorkflowState.scala
@@ -8,6 +8,8 @@ package mutation
 import cats.effect.IO
 import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.enums.ExchangeObservingModeType
+import lucuma.core.enums.KeckInstrument
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.model.ConfigurationRequest
 import lucuma.core.model.Observation
@@ -374,6 +376,56 @@ class setObservationWorkflowState
       _   <- assertIO(queryObservationWorkflowState(oid), Ongoing)
       _   <- interceptOdbError(setObservationWorkflowState(pi, oid, Ready)):
               case OdbError.InvalidWorkflowTransition(Ongoing, Ready, _) => () // expected
+    yield ()
+
+  // Exchange observations run at Keck/Subaru, not Gemini, so there is no
+  // Ready/Ongoing execution lifecycle. They default to Defined and add Completed
+  // (a declared-complete state) to the normal transition set.
+  private def createExchangeKeckObs(accepted: Boolean): IO[(Program.Id, Observation.Id)] =
+    for
+      cid <- createKeckCallForProposalsAs(staff, instruments = List(KeckInstrument.Hires))
+      pid <- createProgramWithNonPartnerPi(pi, "Exchange")
+      _   <- query(pi, s"""
+               mutation {
+                 createProposal(input: {
+                   programId: "$pid"
+                   SET: { category: GALACTIC_OTHER, callId: "$cid", keck: { partnerSplits: [{ partner: US, percent: 100 }] } }
+                 }) { proposal { category } }
+               }
+             """)
+      _   <- addCoisAs(pi, pid).whenA(accepted)
+      _   <- setProposalStatus(staff, pid, "ACCEPTED").whenA(accepted)
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createExchangeModeObservationAs(pi, pid, ExchangeObservingModeType.ExchangeKeck, tid)
+      _   <- runObscalcUpdate(pid, oid)
+    yield (pid, oid)
+
+  test("[Exchange]     Defined    <-> Inactive, Completed (proposal not accepted)"):
+    for
+      po        <- createExchangeKeckObs(accepted = false)
+      (pid, oid) = po
+      _         <- assertIO(queryObservationWorkflowState(oid), Defined)
+      _         <- testTransitions(pid, oid, Defined, Inactive, Completed)
+    yield ()
+
+  test("[Exchange]     Defined    <-> Inactive, Ready, Completed (proposal accepted)"):
+    for
+      po        <- createExchangeKeckObs(accepted = true)
+      (pid, oid) = po
+      _         <- assertIO(queryObservationWorkflowState(oid), Defined)
+      _         <- testTransitions(pid, oid, Defined, Inactive, Ready, Completed)
+    yield ()
+
+  test("[Exchange]     Completed  <-> Defined (PI can declare complete and revert)"):
+    for
+      po        <- createExchangeKeckObs(accepted = false)
+      (pid, oid) = po
+      _         <- assertIO(queryObservationWorkflowState(oid), Defined)
+      _         <- setObservationWorkflowState(pi, oid, Completed)
+      _         <- runObscalcUpdate(pid, oid)
+      _         <- assertIO(queryObservationWorkflowState(oid), Completed)
+      // From Completed the only transition is back to Defined; everything else is illegal.
+      _         <- testTransitions(pid, oid, Completed, Defined)
     yield ()
 
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setObservationWorkflowState.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setObservationWorkflowState.scala
@@ -400,32 +400,22 @@ class setObservationWorkflowState
       _   <- runObscalcUpdate(pid, oid)
     yield (pid, oid)
 
-  test("[Exchange]     Defined    <-> Inactive, Completed (proposal not accepted)"):
+  test("[Exchange]     Defined    <-> Inactive (proposal not accepted)"):
     for
       po        <- createExchangeKeckObs(accepted = false)
       (pid, oid) = po
       _         <- assertIO(queryObservationWorkflowState(oid), Defined)
-      _         <- testTransitions(pid, oid, Defined, Inactive, Completed)
+      _         <- testTransitions(pid, oid, Defined, Inactive)
     yield ()
 
-  test("[Exchange]     Defined    <-> Inactive, Ready, Completed (proposal accepted)"):
+  // Exchange has no Ready/Completed lifecycle: even when the proposal is accepted,
+  // Ready must not be offered (a normal accepted observation would offer it).
+  test("[Exchange]     Defined    <-> Inactive (proposal accepted)"):
     for
       po        <- createExchangeKeckObs(accepted = true)
       (pid, oid) = po
       _         <- assertIO(queryObservationWorkflowState(oid), Defined)
-      _         <- testTransitions(pid, oid, Defined, Inactive, Ready, Completed)
-    yield ()
-
-  test("[Exchange]     Completed  <-> Defined (PI can declare complete and revert)"):
-    for
-      po        <- createExchangeKeckObs(accepted = false)
-      (pid, oid) = po
-      _         <- assertIO(queryObservationWorkflowState(oid), Defined)
-      _         <- setObservationWorkflowState(pi, oid, Completed)
-      _         <- runObscalcUpdate(pid, oid)
-      _         <- assertIO(queryObservationWorkflowState(oid), Completed)
-      // From Completed the only transition is back to Defined; everything else is illegal.
-      _         <- testTransitions(pid, oid, Completed, Defined)
+      _         <- testTransitions(pid, oid, Defined, Inactive)
     yield ()
 
 }


### PR DESCRIPTION
Exchange observations (Keck/Subaru) were automatically showing a Completed workflow status because the digest calculator defaults their execution state to Completed, and execution state overrides everything in the workflow computation. This also masked underlying validation errors.

Handle exchange like visitor observations: ignore the digest's default Completed in getCalculatedWorkflow and exempt exchange from the generator, ITC, and configuration-request validators so the state lands on Defined. Add Completed (declared-complete) to the Defined/Ready transition set and allow reverting Completed -> Defined; Ready is kept for now, Ongoing is naturally excluded. The PI can mark Completed since access control only requires write access plus a valid transition.