### PR TITLE
Fix GNIRS acquisition type leaking user acquisition ExposureTimeMode

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -501,16 +501,14 @@ object GeneratorParamsService {
                 coadds            = gn.coadds
               )
 
-              // Two-pass acquisition ITC only when the mode and filter are both auto and
-              // we're in S/N mode: only then does the resolved filter depend on the
-              // ITC-derived exposure time (Very Bright → H2), creating the circularity.
+              // Two-pass acquisition ITC whenever the acquisition mode and filter are
+              // both auto: only then does the resolved filter depend on the ITC-derived
+              // brightness classification (Very Bright → H2), creating the circularity.
+              // This holds for both S/N and time-and-count acquisition ETMs — the
+              // classification must not depend on the user's acquisition ETM.
               val acqAutoClassify: Boolean =
                 gn.acquisition.explicitAcqMode.isEmpty &&
-                gn.acquisition.explicitFilter.isEmpty && {
-                  gn.acquisition.exposureTimeMode match
-                    case ExposureTimeMode.SignalToNoiseMode(_, _)   => true
-                    case ExposureTimeMode.TimeAndCountMode(_, _, _) => false
-                }
+                gn.acquisition.explicitFilter.isEmpty
 
               spectroscopyGeneratorParams(
                 obsMode = gn,

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -340,21 +340,24 @@ object ItcService {
             val min: TimeSpan = gnirs.MinAcquisitionExposureTime
             val max: TimeSpan = gnirs.MaxAcquisitionExposureTime
             etm match
-              case ExposureTimeMode.SignalToNoiseMode(userSN, at) if autoClassify =>
+              case _ if autoClassify =>
                 // Two-pass. The acquisition mode (Very Bright / Bright / Faint) is a
                 // function of exposure time, but the exposure time depends on the filter
                 // (Very Bright images in H2) which depends on the mode — and, in S/N mode,
                 // a low requested S/N would shorten the exposure and misclassify a Bright
                 // target as Very Bright. So classify from a fixed brightness measurement
                 // (broadband filter, classification S/N) first, then compute the real
-                // exposure at the user's S/N in the mode-appropriate filter.
+                // exposure at the user's ETM in the mode-appropriate filter. The
+                // classification must not depend on the user's acquisition ETM, so it
+                // always runs at the classification S/N — the user ETM's own wavelength
+                // (`etm.at`, present on both S/N and time-and-count modes) locates it.
                 def gnirsInput(f: GnirsFilter, e: ExposureTimeMode): ImagingInput =
                   ImagingInput.parameters
                     .andThen(ImagingParameters.mode)
                     .replace(InstrumentMode.GnirsImaging(e, f, camera, readMode, wellDepth, coadds, port))(input)
 
                 val classifySN:  SignalToNoise    = gnirs.AcquisitionClassificationSignalToNoise
-                val classifyEtm: ExposureTimeMode = ExposureTimeMode.SignalToNoiseMode(classifySN, at)
+                val classifyEtm: ExposureTimeMode = ExposureTimeMode.SignalToNoiseMode(classifySN, etm.at)
                 for
                   z1                                <- go(gnirsInput(filter, classifyEtm), min, max)
                   t1:      IntegrationTime           = z1.focus.value
@@ -362,9 +365,14 @@ object ItcService {
                   // Very Bright images through the acquisition filter in H2; the other
                   // classifications keep the broadband filter (already `filter`).
                   f2:      GnirsFilter               = if acqType === GnirsAcquisitionType.VeryBright then GnirsFilter.H2 else filter
-                  // Skip the second call when it would be identical to the first (same
-                  // filter and the user already asked for the classification S/N).
-                  z2                                <- if f2 === filter && userSN === classifySN then EitherT.pure[F, OdbError](z1)
+                  // Skip the second call only when it would be identical to the first:
+                  // same filter and the user's ETM is itself the classification S/N
+                  // request. Time-and-count always needs the second call (the first ran
+                  // at the classification S/N, not the user's time/count).
+                  skip:    Boolean                   = f2 === filter && (etm match
+                                                         case ExposureTimeMode.SignalToNoiseMode(sn, _) => sn === classifySN
+                                                         case _                                         => false)
+                  z2                                <- if skip then EitherT.pure[F, OdbError](z1)
                                                        else go(gnirsInput(f2, etm), min, max)
                 yield (z2, acqType.some)
               case _ =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirsTwoPassTimeAndCount.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirsTwoPassTimeAndCount.scala
@@ -1,0 +1,89 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.query
+
+import cats.effect.IO
+import cats.syntax.either.*
+import cats.syntax.eq.*
+import cats.syntax.option.*
+import eu.timepit.refined.types.numeric.PosInt
+import io.circe.literal.*
+import lucuma.core.model.ExposureTimeMode
+import lucuma.core.model.Observation
+import lucuma.core.syntax.timespan.*
+import lucuma.itc.IntegrationTime
+import lucuma.itc.client.ImagingInput
+import lucuma.itc.client.InstrumentMode
+import lucuma.odb.sequence.gnirs.AcquisitionClassificationSignalToNoise
+
+// Exercises the time-and-count two-pass acquisition ITC (both acquisition mode and
+// filter auto). The classification pass must run at the fixed classification S/N even
+// though the user's acquisition ETM is time-and-count — otherwise the acquisition type
+// leaks from the user's exposure (the reported bug).
+class executionAcqGnirsTwoPassTimeAndCount extends ExecutionTestSupportForGnirs:
+
+  // Imaging ITC:
+  //   - classification pass (fixed S/N)  → 0.3s → Very Bright
+  //   - real pass (user's time-and-count) → echoes the user's 2s / 3 count
+  // The 2s real exposure is deliberately in the Bright range: if the sequence re-derived
+  // the mode from it (the bug) it would pick the broadband filter, so seeing H2 proves
+  // the mode was pinned to Very Bright from the classification pass.
+  override def fakeItcImagingResultFor(input: ImagingInput): Option[IntegrationTime] =
+    input.mode match
+      case InstrumentMode.GnirsImaging(ExposureTimeMode.SignalToNoiseMode(sn, _), _, _, _, _, _, _) =>
+        // Only the classification pass runs in S/N mode here; it uses the classification S/N.
+        if sn === AcquisitionClassificationSignalToNoise then IntegrationTime(300.msTimeSpan, PosInt.unsafeFrom(1)).some
+        else                                                  none
+      case InstrumentMode.GnirsImaging(ExposureTimeMode.TimeAndCountMode(time, count, _), _, _, _, _, _, _) =>
+        IntegrationTime(time, count).some
+      case _                                                                                        =>
+        none
+
+  test("time-and-count mode auto acquisition: classification pins Very Bright, real exposure uses H2"):
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGnirsLongSlitObservationAs(pi, p, t)
+        // Time-and-count mode, acquisition mode and filter left auto ⇒ two-pass.
+        _ <- setAcquisitionTimeAndCount(o, 2, 3, 1645)
+      yield o
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = s"""
+          query {
+            executionConfig(observationId: "$oid") {
+              gnirs {
+                acquisition {
+                  nextAtom {
+                    steps {
+                      instrumentConfig { exposure { microseconds } filter }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "executionConfig": {
+              "gnirs": {
+                "acquisition": {
+                  "nextAtom": {
+                    "steps": [
+                      { "instrumentConfig": { "exposure": { "microseconds": 3000000 }, "filter": "ORDER4" } },
+                      { "instrumentConfig": { "exposure": { "microseconds": 2000000 }, "filter": "H2" } },
+                      { "instrumentConfig": { "exposure": { "microseconds": 2000000 }, "filter": "H2" } },
+                      { "instrumentConfig": { "exposure": { "microseconds": 2000000 }, "filter": "H2" } }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        """.asRight
+      )


### PR DESCRIPTION
The GNIRS acquisition brightness classification (Very Bright / Bright / Faint) must be determined by a fixed ITC classification pass (S/N=10), independent of the user's acquisition ExposureTimeMode. Previously that pass only ran in SignalToNoiseMode; in TimeAndCountMode it was skipped and the type was re-derived from the user's own acquisition exposure x coadds, so two otherwise-identical observations classified differently and picked different acquisition filters.

Run the two-pass classification for both ETM types. ExposureTimeMode.at is present on both SignalToNoiseMode and TimeAndCountMode, so the classification pass reads etm.at uniformly - no wavelength threading needed. The skip-pass-2 optimization now only short-circuits when the user's ETM is itself the classification S/N request.