### PR TITLE
Make some calibrations steps optional

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/SmartGcalExpander.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/SmartGcalExpander.scala
@@ -4,9 +4,11 @@
 package lucuma.odb.sequence
 
 import cats.Applicative
+import cats.Functor
 import cats.data.NonEmptyList
 import cats.syntax.applicative.*
 import cats.syntax.either.*
+import cats.syntax.functor.*
 import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.SmartGcalType
 import lucuma.core.model.sequence.StepConfig
@@ -40,6 +42,16 @@ trait SmartGcalExpander[F[_], S, D]:
     static: S,
     atom:   ProtoAtom[ProtoStep[D]]
   ): F[Either[String, ProtoAtom[ProtoStep[D]]]]
+
+  /**
+   * Expands a single step, best-effort.  Like `expandStep`, but a missing
+   * SmartGcal mapping yields no steps instead of an error.
+   */
+  def expandStepBestEffort(
+    static: S,
+    step:   ProtoStep[D]
+  )(using Functor[F]): F[List[ProtoStep[D]]] =
+    expandStep(static, step).map(_.fold(_ => List.empty, _.toList))
 
 
 object SmartGcalExpander:

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/SmartGcalExpander.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/SmartGcalExpander.scala
@@ -47,7 +47,7 @@ trait SmartGcalExpander[F[_], S, D]:
    * Expands a single step, best-effort.  Like `expandStep`, but a missing
    * SmartGcal mapping yields no steps instead of an error.
    */
-  def expandStepBestEffort(
+  def expandStepOptional(
     static: S,
     step:   ProtoStep[D]
   )(using Functor[F]): F[List[ProtoStep[D]]] =

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Science.scala
@@ -130,7 +130,7 @@ object Science:
         // The flat is required, but the arc is best-effort
         for
           fs <- EitherT(expander.expandStep(static, flat))
-          rs <- EitherT.liftF(expander.expandStepBestEffort(static, arc))
+          rs <- EitherT.liftF(expander.expandStepOptional(static, arc))
         yield StepDefinition(a0, b0, b1, a1, fs.map(adjustReadMode) ++ rs.map(adjustReadMode))
 
     object PreDef:

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/longslit/Science.scala
@@ -127,10 +127,11 @@ object Science:
           val mode = Flamingos2ReadMode.forExposureTime(f2.value.exposure)
           f2.copy(value = f2.value.copy(readMode = mode, reads = mode.readCount))
 
+        // The flat is required, but the arc is best-effort
         for
           fs <- EitherT(expander.expandStep(static, flat))
-          rs <- EitherT(expander.expandStep(static, arc))
-        yield StepDefinition(a0, b0, b1, a1, fs.map(adjustReadMode) ::: rs.map(adjustReadMode))
+          rs <- EitherT.liftF(expander.expandStepBestEffort(static, arc))
+        yield StepDefinition(a0, b0, b1, a1, fs.map(adjustReadMode) ++ rs.map(adjustReadMode))
 
     object PreDef:
 

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
@@ -117,7 +117,7 @@ object Science:
           // The flat is required, but the arc is best-effort
           for
             fs <- EitherT(expander.expandStep(static, flat))
-            as <- EitherT.liftF(expander.expandStepBestEffort(static, arc))
+            as <- EitherT.liftF(expander.expandStepOptional(static, arc))
           yield StepDefinition(scienceSteps, (fs.map(adjustReadMode) ++ as.map(adjustReadMode)).some)
 
     object PreDef:

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
@@ -116,8 +116,10 @@ object Science:
         cals.fold(EitherT.pure(StepDefinition(scienceSteps, none))): (flat, arc) =>
           for
             fs <- EitherT(expander.expandStep(static, flat))
-            rs <- EitherT(expander.expandStep(static, arc))
-          yield StepDefinition(scienceSteps, (fs.map(adjustReadMode) ::: rs.map(adjustReadMode)).some)
+            // The flat is required, but the arc is optional
+            ar <- EitherT.liftF(expander.expandStep(static, arc))
+            arcSteps = ar.toOption.toList.flatMap(_.toList).map(adjustReadMode)
+          yield StepDefinition(scienceSteps, (fs.map(adjustReadMode) ++ arcSteps).some)
 
     object PreDef:
 

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
@@ -114,12 +114,11 @@ object Science:
           s.copy(value = s.value.copy(readMode = GnirsReadMode.forExposureTime(s.value.exposure)))
 
         cals.fold(EitherT.pure(StepDefinition(scienceSteps, none))): (flat, arc) =>
+          // The flat is required, but the arc is best-effort
           for
             fs <- EitherT(expander.expandStep(static, flat))
-            // The flat is required, but the arc is optional
-            ar <- EitherT.liftF(expander.expandStep(static, arc))
-            arcSteps = ar.toOption.toList.flatMap(_.toList).map(adjustReadMode)
-          yield StepDefinition(scienceSteps, (fs.map(adjustReadMode) ++ arcSteps).some)
+            as <- EitherT.liftF(expander.expandStepBestEffort(static, arc))
+          yield StepDefinition(scienceSteps, (fs.map(adjustReadMode) ++ as.map(adjustReadMode)).some)
 
     object PreDef:
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForFlamingos2.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForFlamingos2.scala
@@ -58,6 +58,14 @@ trait ExecutionTestSupportForFlamingos2 extends ExecutionTestSupport:
       Flamingos2Fpu.LongSlit2.some
     )
 
+  // R=3000 grism + Y filter has a flat but no arc in smart gcal tables
+  val f2_key_R3K_Y: Flamingos2.TableKey =
+    Flamingos2.TableKey(
+      Flamingos2Disperser.R3000.some,
+      Flamingos2Filter.Y,
+      Flamingos2Fpu.LongSlit1.some
+    )
+
   val f2_flat_JH1 =
     SmartGcalValue(
       Gcal(
@@ -94,7 +102,8 @@ trait ExecutionTestSupportForFlamingos2 extends ExecutionTestSupport:
         Flamingos2.TableRow(PosLong.unsafeFrom(1), f2_key_JH1, f2_flat_JH1),
         Flamingos2.TableRow(PosLong.unsafeFrom(1), f2_key_JH1, f2_arc_JH1),
         Flamingos2.TableRow(PosLong.unsafeFrom(1), f2_key_JH2, f2_flat_JH1),
-        Flamingos2.TableRow(PosLong.unsafeFrom(1), f2_key_JH2, f2_arc_JH1)
+        Flamingos2.TableRow(PosLong.unsafeFrom(1), f2_key_JH2, f2_arc_JH1),
+        Flamingos2.TableRow(PosLong.unsafeFrom(1), f2_key_R3K_Y, f2_flat_JH1)
       )
 
     servicesFor(pi /* doesn't matter*/).map(_(s)).use: services =>
@@ -332,4 +341,3 @@ trait ExecutionTestSupportForFlamingos2 extends ExecutionTestSupport:
       _ <- addEndStepEvent(s, v)
       _ <- runObscalcUpdate(p, o)
     yield o
-

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGnirs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGnirs.scala
@@ -60,8 +60,8 @@ trait ExecutionTestSupportForGnirs extends ExecutionTestSupport:
       GnirsWellDepth.Shallow
     )
 
-  // a thermal-IR (L/M-band) long-camera GNIRS spectroscopy setup — 0.05"/pix, D10,
-  // MIRROR, 2.8-4.2 µm, 0.20" slit, DEEP.
+  // a thermal-IR (L/M-band) long-camera GNIRS spectroscopy setup
+  // 0.05"/pix, D10, MIRROR, 2.8-4.2 µm, 0.20" slit, DEEP.
   //
   // It has a flat but no arc, mirroring the real tables where arcs stop at ~2.5 µm.
   // Used to verify the sequence still generates without arcs.
@@ -135,7 +135,6 @@ trait ExecutionTestSupportForGnirs extends ExecutionTestSupport:
           Gnirs.TableRow(PosLong.unsafeFrom(1), gnirsSmartKey(ps).copy(fpu = GnirsFpu.Spectroscopy.Ifu(ifuFpu(ps))), gnirsSmartArc)
         )
       ::: List(
-        // o-57a1: flat only, no arc.
         Gnirs.TableRow(PosLong.unsafeFrom(1), gnirsThermalIrKey, gnirsSmartFlat)
       )
 
@@ -225,10 +224,6 @@ trait ExecutionTestSupportForGnirs extends ExecutionTestSupport:
     ).void
 
 
-  /**
-   * configure gnirs with thermal-IR (L/M-band) long-camera setup — 0.05"/pix (LONG_BLUE), D10,
-   * MIRROR, 0.20" slit, 3.3 µm.
-   */
   def configureGnirsThermalIr(oid: Observation.Id): IO[Unit] =
     query(
       pi,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGnirs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGnirs.scala
@@ -60,6 +60,24 @@ trait ExecutionTestSupportForGnirs extends ExecutionTestSupport:
       GnirsWellDepth.Shallow
     )
 
+  // a thermal-IR (L/M-band) long-camera GNIRS spectroscopy setup — 0.05"/pix, D10,
+  // MIRROR, 2.8-4.2 µm, 0.20" slit, DEEP.
+  //
+  // It has a flat but no arc, mirroring the real tables where arcs stop at ~2.5 µm.
+  // Used to verify the sequence still generates without arcs.
+  private val gnirsThermalIrKey: Gnirs.TableKey =
+    Gnirs.TableKey(
+      GnirsPixelScale.PixelScale_0_05,
+      GnirsGrating.D10,
+      GnirsPrism.Mirror,
+      BoundedInterval.unsafeOpenUpper(
+        Wavelength.fromIntNanometers(2800).get,
+        Wavelength.fromIntNanometers(4200).get
+      ),
+      GnirsFpu.Spectroscopy.Slit(GnirsFpuSlit.LongSlit_0_20),
+      GnirsWellDepth.Deep
+    )
+
   val gnirsSmartFlat: SmartGcalValue.Legacy =
     SmartGcalValue(
       Gcal(
@@ -116,6 +134,10 @@ trait ExecutionTestSupportForGnirs extends ExecutionTestSupport:
           Gnirs.TableRow(PosLong.unsafeFrom(1), gnirsSmartKey(ps).copy(fpu = GnirsFpu.Spectroscopy.Ifu(ifuFpu(ps))), gnirsSmartFlat),
           Gnirs.TableRow(PosLong.unsafeFrom(1), gnirsSmartKey(ps).copy(fpu = GnirsFpu.Spectroscopy.Ifu(ifuFpu(ps))), gnirsSmartArc)
         )
+      ::: List(
+        // o-57a1: flat only, no arc.
+        Gnirs.TableRow(PosLong.unsafeFrom(1), gnirsThermalIrKey, gnirsSmartFlat)
+      )
 
     prior >>
       servicesFor(pi /* doesn't matter */).map(_(s)).use: services =>
@@ -191,6 +213,36 @@ trait ExecutionTestSupportForGnirs extends ExecutionTestSupport:
                       at:    { nanometers: $atNm }
                     }
                   }
+                }
+              }
+            }
+            WHERE: { id: { EQ: "$oid" } }
+          }) {
+            observations { id }
+          }
+        }
+      """
+    ).void
+
+
+  /**
+   * configure gnirs with thermal-IR (L/M-band) long-camera setup — 0.05"/pix (LONG_BLUE), D10,
+   * MIRROR, 0.20" slit, 3.3 µm.
+   */
+  def configureGnirsThermalIr(oid: Observation.Id): IO[Unit] =
+    query(
+      pi,
+      s"""
+        mutation {
+          updateObservations(input: {
+            SET: {
+              observingMode: {
+                gnirsSpectroscopy: {
+                  camera: LONG_BLUE
+                  explicitGrating: D10
+                  slit: { fpu: LONG_SLIT_0_20 }
+                  centralWavelength: { nanometers: 3300 }
+                  explicitWellDepth: DEEP
                 }
               }
             }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciFlamingos2.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciFlamingos2.scala
@@ -179,6 +179,36 @@ class executionSciFlamingos2 extends ExecutionTestSupportForFlamingos2:
           ).asLeft
       )
 
+  test("[f2] R=3000 + Y filter yields flat-only calibrations, no arc"):
+    // R=3000 + Y filter has a flat but no arc in the smart gcal tables (the arc
+    // lamps don't reach the Y-band edge).
+    // The sequence must still generate — with a flat and no arc.
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationWithModeAs(
+               pi,
+               p,
+               List(t),
+               """
+                 flamingos2LongSlit: {
+                   disperser: R3000
+                   filter: Y
+                   fpu: LONG_SLIT_1
+                 }
+               """
+             )
+      yield o
+
+    setup.flatMap: oid =>
+      query(pi, flamingos2ScienceQuery(oid)).map: js =>
+        val arcs     = js.findAllByKey("arcs")
+        val continua = js.findAllByKey("continuum")
+        assert(arcs.nonEmpty) // no arc
+        assert(arcs.forall(_.asArray.exists(_.isEmpty)))
+        assert(continua.exists(!_.isNull)) // flat present
+
   test("simple generation - unsplittable"):
     val setup: IO[Observation.Id] =
       for

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciFlamingos2.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciFlamingos2.scala
@@ -182,7 +182,7 @@ class executionSciFlamingos2 extends ExecutionTestSupportForFlamingos2:
   test("[f2] R=3000 + Y filter yields flat-only calibrations, no arc"):
     // R=3000 + Y filter has a flat but no arc in the smart gcal tables (the arc
     // lamps don't reach the Y-band edge).
-    // The sequence must still generate — with a flat and no arc.
+    // The sequence must still generate with a flat and no arc.
     val setup: IO[Observation.Id] =
       for
         p <- createProgram

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
@@ -89,8 +89,8 @@ class executionSciGnirsLongSlit extends ExecutionTestSupportForGnirs:
           ).asRight
       )
 
-  // thermal-IR (L/M-band) long-camera config — 0.05"/pix (LONG_BLUE), D10, MIRROR, 0.20" slit,
-  // 3.3 µm.
+  // thermal-IR (L/M-band) long-camera config 
+  // 0.05"/pix (LONG_BLUE), D10, MIRROR, 0.20" slit, 3.3 µm.
   // This config has a flat but no arc in the smart gcal tables.
   val ThermalIrSnapshot: GnirsDynamicSnapshot =
     GnirsDynamicSnapshot(
@@ -111,10 +111,8 @@ class executionSciGnirsLongSlit extends ExecutionTestSupportForGnirs:
     )
 
   test("[gnirs] thermal-IR config yields flat-only calibrations, no arc"):
-    // Thermal-IR (L/M-band) configs have a flat but no arc in the smart gcal
-    // tables.
-    // The sequence must still generate: the arc is best-effort and is
-    // omitted when there's no arc mapping.
+    // Thermal-IR (L/M-band) configs have a flat but no arc in the smart gcal tables.
+    // The sequence must still generate, the arc is optional
     val setup: IO[Observation.Id] =
       for
         oid <- gnirsObs

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
@@ -89,6 +89,62 @@ class executionSciGnirsLongSlit extends ExecutionTestSupportForGnirs:
           ).asRight
       )
 
+  // thermal-IR (L/M-band) long-camera config — 0.05"/pix (LONG_BLUE), D10, MIRROR, 0.20" slit,
+  // 3.3 µm.
+  // This config has a flat but no arc in the smart gcal tables.
+  val ThermalIrSnapshot: GnirsDynamicSnapshot =
+    GnirsDynamicSnapshot(
+      exposureTime        = ExposureTime,
+      coadds              = 1,
+      centralWavelengthNm = BigDecimal("3300.000"),
+      filter              = "ORDER3",
+      decker              = "LONG_CAM_LONG_SLIT",
+      fpuSlit             = Some("LONG_SLIT_0_20"),
+      fpuOther            = None,
+      fpuIfu              = None,
+      prism               = Some("MIRROR"),
+      grating             = Some("D10"),
+      mirrorWavelengthNm  = Some(BigDecimal("3300.000")),
+      camera              = "LONG_BLUE",
+      focus               = None,
+      readMode            = "FAINT"
+    )
+
+  test("[gnirs] thermal-IR config yields flat-only calibrations, no arc"):
+    // Thermal-IR (L/M-band) configs have a flat but no arc in the smart gcal
+    // tables.
+    // The sequence must still generate: the arc is best-effort and is
+    // omitted when there's no arc mapping.
+    val setup: IO[Observation.Id] =
+      for
+        oid <- gnirsObs
+        _   <- configureGnirsThermalIr(oid)
+      yield oid
+
+    // The flat, with no trailing arc, taken at the last (long-camera) offset.
+    val flatOnlyCalAtom: Json =
+      gnirsExpectedCalAtom(ThermalIrSnapshot, 0, -1, 20.secondTimeSpan, 2, 1, 10.secondTimeSpan, 3, 0)
+
+    setup.flatMap: oid =>
+      expect(
+        user     = pi,
+        query    = gnirsScienceQuery(oid),
+        expected =
+          Json.obj(
+            "executionConfig" -> Json.obj(
+              "gnirs" -> Json.obj(
+                "science" -> Json.obj(
+                  "nextAtom" -> gnirsExpectedScienceAtom(ThermalIrSnapshot,
+                    (0, -1, Enabled), (0, 5, Enabled), (0, 5, Enabled), (0, -1, Enabled)
+                  ),
+                  "possibleFuture" -> List(flatOnlyCalAtom).asJson,
+                  "hasMore"        -> false.asJson
+                )
+              )
+            )
+          ).asRight
+      )
+
   test("[gnirs] short camera default offsets, exposureCount=3 -> 1 cycle of 4, unsplittable"):
     for
       o <- gnirsObs


### PR DESCRIPTION
Some configurations have a flat but no arc in the smart GCal tables, the arc lamps don't span every wavelength. Sequence generation required both a flat and an arc, so these configs failed with missing Smart GCAL mapping.

This was initially reported for gnirs but also f2 suffers the same fate

After discussing with science it is correct not to have arc steps and only flats, thus they now become optional.
