### PR TITLE
Dedup observation ids in getAsterisms to avoid parameter-limit overflow

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/AsterismService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AsterismService.scala
@@ -270,7 +270,12 @@ object AsterismService {
       override def getAsterisms(
         oids: List[Observation.Id]
       )(using SuperUserAccess): F[Map[Observation.Id, List[(Target.Id, Target)]]] =
-        NonEmptyList.fromList(oids) match
+        // Dedup the ids before building the `IN (...)` list. Callers (e.g. the
+        // configurationRequests/applicableObservations effect batching) may pass the
+        // same observation many times; without dedup the bind-parameter count can
+        // exceed Postgres's 32767 limit. The result Map is keyed by observation id,
+        // so deduping is behavior-preserving. Mirrors `getSiteAndExplicitBaseCoordinates`.
+        NonEmptyList.fromList(oids.distinct) match
           case None      => Map.empty.pure[F]
           case Some(nel) =>
             val enc = observation_id.nel(nel)


### PR DESCRIPTION
The configurationRequests/applicableObservations query batches asterism lookups across all observation cursors. Because the same observation can appear many times, getAsterisms could build an IN (...) list exceeding Postgres's 32767 parameter limit, throwing TooManyParametersException.

Deduplicate the ids before building the IN list (as the sibling getSiteAndExplicitBaseCoordinates already does). The result Map is keyed by observation id, so this is behavior-preserving.


Claude-Session: https://claude.ai/code/session_012fsjch1SEYuMXC4KBJKWoq