### PR TITLE
Fix observeClass for imaging sky/dither steps

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/imaging/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/flamingos2/imaging/Science.scala
@@ -72,7 +72,7 @@ object Science:
           _   <- setFilter(filter, integrationTime.exposureTime)
           sky <- skyOffsets
                    .traverse: offset =>
-                     scienceStep(offset, ObserveClass.NightCal)
+                     scienceStep(offset, ObserveClass.Science)
           obj <- offsets.take(integrationTime.exposureCount.value)
                    .traverse: offset =>
                      scienceStep(offset, ObserveClass.Science)
@@ -109,7 +109,7 @@ object Science:
         skyList.traverse: (filter, offset) =>
           for
             _ <- setFilter(filter, filterTimes(filter).exposureTime)
-            s <- scienceStep(offset, ObserveClass.NightCal)
+            s <- scienceStep(offset, ObserveClass.Science)
           yield s
 
       // number of groups of interleaved filters

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/imaging/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gmos/imaging/Science.scala
@@ -87,7 +87,7 @@ object Science:
           _   <- setFilter(filter, integrationTime.exposureTime)
           sky <- skyOffsets
                    .traverse: offset =>
-                     scienceStep(offset, ObserveClass.NightCal)
+                     scienceStep(offset, ObserveClass.Science)
           obj <- offsets.take(integrationTime.exposureCount.value)
                    .traverse: offset =>
                      scienceStep(offset, ObserveClass.Science)
@@ -124,7 +124,7 @@ object Science:
         skyList.traverse: (filter, offset) =>
           for
             _ <- setFilter(filter, filterTimes(filter).exposureTime)
-            s <- scienceStep(offset, ObserveClass.NightCal)
+            s <- scienceStep(offset, ObserveClass.Science)
           yield s
 
       // number of groups of interleaved filters

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/imaging/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/imaging/Science.scala
@@ -79,7 +79,7 @@ object Science:
           _   <- setFilter(config, filter, integrationTime.exposureTime)
           sky <- skyOffsets
                    .traverse: offset =>
-                     scienceStep(offset, ObserveClass.NightCal)
+                     scienceStep(offset, ObserveClass.Science)
           obj <- offsets.take(integrationTime.exposureCount.value)
                    .traverse: offset =>
                      scienceStep(offset, ObserveClass.Science)
@@ -116,7 +116,7 @@ object Science:
         skyList.traverse: (filter, offset) =>
           for
             _ <- setFilter(config, filter, filterTimes(filter).exposureTime)
-            s <- scienceStep(offset, ObserveClass.NightCal)
+            s <- scienceStep(offset, ObserveClass.Science)
           yield s
 
       // number of groups of interleaved filters

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciFlamingos2Imaging.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciFlamingos2Imaging.scala
@@ -53,22 +53,34 @@ class executionSciFlamingos2Imaging extends ExecutionTestSupportForFlamingos2:
       Flamingos2ReadMode.Faint.readCount
     )
 
-  private def sciAtom(filter: Flamingos2Filter, exposureTime: TimeSpan, p: Int = 0, q: Int = 0): Json =
+  private def sciStep(
+    filter:       Flamingos2Filter,
+    exposureTime: TimeSpan,
+    p:            Int            = 0,
+    q:            Int            = 0,
+    guiding:      StepGuideState = StepGuideState.Enabled
+  ): Json =
+    json"""
+      {
+        "instrumentConfig": ${flamingos2ExpectedInstrumentConfig(imagingDynamic(filter, exposureTime))},
+        "stepConfig": { "stepType": "SCIENCE" },
+        "telescopeConfig": ${expectedTelescopeConfig(p, q, guiding)},
+        "observeClass": "SCIENCE",
+        "breakpoint": "DISABLED"
+      }
+    """
+
+  private def sciAtomOf(steps: Json*): Json =
     json"""
       {
         "description": null,
         "observeClass": "SCIENCE",
-        "steps": [
-          {
-            "instrumentConfig": ${flamingos2ExpectedInstrumentConfig(imagingDynamic(filter, exposureTime))},
-            "stepConfig": { "stepType": "SCIENCE" },
-            "telescopeConfig": ${expectedTelescopeConfig(p, q, StepGuideState.Enabled)},
-            "observeClass": "SCIENCE",
-            "breakpoint": "DISABLED"
-          }
-        ]
+        "steps": ${steps.toList.asJson}
       }
     """
+
+  private def sciAtom(filter: Flamingos2Filter, exposureTime: TimeSpan, p: Int = 0, q: Int = 0): Json =
+    sciAtomOf(sciStep(filter, exposureTime, p, q))
 
   private def expectedScience(atoms: List[Json]): Json =
     json"""
@@ -157,6 +169,91 @@ class executionSciFlamingos2Imaging extends ExecutionTestSupportForFlamingos2:
         sciAtom(Flamingos2Filter.J, 20.secondTimeSpan),
         sciAtom(Flamingos2Filter.Y, 10.secondTimeSpan),
         sciAtom(Flamingos2Filter.J, 20.secondTimeSpan)
+      )
+
+    setup.flatMap: oid =>
+      expect(pi, flamingos2ScienceQuery(oid, 100.some), expectedScience(atoms).asRight)
+
+  // Two guide-disabled sky positions, shared across filters.  Sky steps must be
+  // observeClass SCIENCE (not NIGHT_CAL) even though guiding is disabled.
+  private val skyOffsetsInput: String =
+    s"""
+      skyOffsets: {
+        enumerated: {
+          values: [
+            { offset: { p: { arcseconds: 10 }, q: { arcseconds: 10 } }, guiding: DISABLED },
+            { offset: { p: { arcseconds: 20 }, q: { arcseconds: 20 } }, guiding: DISABLED }
+          ]
+        }
+      }
+    """
+
+  private def skyPair(filter: Flamingos2Filter, t: TimeSpan): List[Json] =
+    List(
+      sciStep(filter, t, 10, 10, StepGuideState.Disabled),
+      sciStep(filter, t, 20, 20, StepGuideState.Disabled)
+    )
+
+  test("grouped, no offsets, sky"):
+    val mode =
+      s"""
+        flamingos2Imaging: {
+          variant: { grouped: { skyCount: 2, $skyOffsetsInput } }
+          filters: [ { filter: Y }, { filter: J } ]
+        }
+      """
+
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationWithModeAs(pi, p, List(t), mode)
+      yield o
+
+    // One atom per filter: sky, sky, object exposures, sky, sky.
+    def mkAtom(filter: Flamingos2Filter, t: TimeSpan, count: Int): Json =
+      sciAtomOf((skyPair(filter, t) ++ List.fill(count)(sciStep(filter, t)) ++ skyPair(filter, t))*)
+
+    val atoms =
+      List(
+        mkAtom(Flamingos2Filter.Y, 10.secondTimeSpan, 2),
+        mkAtom(Flamingos2Filter.J, 20.secondTimeSpan, 3)
+      )
+
+    setup.flatMap: oid =>
+      expect(pi, flamingos2ScienceQuery(oid, 100.some), expectedScience(atoms).asRight)
+
+  test("interleaved, no offsets, sky"):
+    val mode =
+      s"""
+        flamingos2Imaging: {
+          variant: { interleaved: { skyCount: 2, $skyOffsetsInput } }
+          filters: [ { filter: Y }, { filter: J } ]
+        }
+      """
+
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationWithModeAs(pi, p, List(t), mode)
+      yield o
+
+    val Y = Flamingos2Filter.Y
+    val J = Flamingos2Filter.J
+    val ty = 10.secondTimeSpan
+    val tj = 20.secondTimeSpan
+
+    // Each atom is bracketed by the same guide-disabled sky steps (forward at
+    // the head, reversed at the tail), with the interleaved object exposures in
+    // between.  groupCount = min(2, 3) = 2, so there are two atoms.
+    val skyHead = skyPair(Y, ty) ++ skyPair(J, tj)
+    val skyTail = skyPair(J, tj).reverse ++ skyPair(Y, ty).reverse
+
+    val atoms =
+      List(
+        sciAtomOf((skyHead ++ List(sciStep(Y, ty), sciStep(J, tj), sciStep(J, tj)) ++ skyTail)*),
+        sciAtomOf((skyHead ++ List(sciStep(Y, ty), sciStep(J, tj)) ++ skyTail)*)
       )
 
     setup.flatMap: oid =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGmosNorthImaging.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGmosNorthImaging.scala
@@ -402,12 +402,12 @@ class executionSciGmosNorthImaging extends ExecutionTestSupportForGmos:
     def mkAtom(f: GmosNorthFilter, t: IntegrationTime): Json =
       gnAtom(
         (
-          Step(f, t).withOffset(0, 0).withClass(ObserveClass.NightCal) ::
-          Step(f, t).withOffset(1, 1).withClass(ObserveClass.NightCal) ::
+          Step(f, t).withOffset(0, 0).withClass(ObserveClass.Science) ::
+          Step(f, t).withOffset(1, 1).withClass(ObserveClass.Science) ::
           List.fill(t.exposureCount.value)(Step(f, t)).appendedAll:
             List(
-              Step(f, t).withOffset(0, 0).withClass(ObserveClass.NightCal),
-              Step(f, t).withOffset(1, 1).withClass(ObserveClass.NightCal)
+              Step(f, t).withOffset(0, 0).withClass(ObserveClass.Science),
+              Step(f, t).withOffset(1, 1).withClass(ObserveClass.Science)
             )
         )*
       )
@@ -541,17 +541,17 @@ class executionSciGmosNorthImaging extends ExecutionTestSupportForGmos:
 
     val oneGroup: Json =
       gnAtom(
-        Step(GmosNorthFilter.GPrime, Time120x06).withOffset(100, 100).withClass(ObserveClass.NightCal),
-        Step(GmosNorthFilter.GPrime, Time120x06).withOffset(200, 200).withClass(ObserveClass.NightCal),
-        Step(GmosNorthFilter.IPrime, Time060x12).withOffset(100, 100).withClass(ObserveClass.NightCal),
-        Step(GmosNorthFilter.IPrime, Time060x12).withOffset(200, 200).withClass(ObserveClass.NightCal),
+        Step(GmosNorthFilter.GPrime, Time120x06).withOffset(100, 100).withClass(ObserveClass.Science),
+        Step(GmosNorthFilter.GPrime, Time120x06).withOffset(200, 200).withClass(ObserveClass.Science),
+        Step(GmosNorthFilter.IPrime, Time060x12).withOffset(100, 100).withClass(ObserveClass.Science),
+        Step(GmosNorthFilter.IPrime, Time060x12).withOffset(200, 200).withClass(ObserveClass.Science),
         Step(GmosNorthFilter.GPrime, Time120x06),
         Step(GmosNorthFilter.IPrime, Time060x12),
         Step(GmosNorthFilter.IPrime, Time060x12),
-        Step(GmosNorthFilter.IPrime, Time060x12).withOffset(200, 200).withClass(ObserveClass.NightCal),
-        Step(GmosNorthFilter.IPrime, Time060x12).withOffset(100, 100).withClass(ObserveClass.NightCal),
-        Step(GmosNorthFilter.GPrime, Time120x06).withOffset(200, 200).withClass(ObserveClass.NightCal),
-        Step(GmosNorthFilter.GPrime, Time120x06).withOffset(100, 100).withClass(ObserveClass.NightCal),
+        Step(GmosNorthFilter.IPrime, Time060x12).withOffset(200, 200).withClass(ObserveClass.Science),
+        Step(GmosNorthFilter.IPrime, Time060x12).withOffset(100, 100).withClass(ObserveClass.Science),
+        Step(GmosNorthFilter.GPrime, Time120x06).withOffset(200, 200).withClass(ObserveClass.Science),
+        Step(GmosNorthFilter.GPrime, Time120x06).withOffset(100, 100).withClass(ObserveClass.Science),
       )
 
     val json: List[Json] = List.fill(6)(oneGroup)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsImaging.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsImaging.scala
@@ -11,6 +11,7 @@ import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.enums.GnirsReadMode
+import lucuma.core.enums.StepGuideState
 import lucuma.core.model.Observation
 import lucuma.core.syntax.string.*
 import lucuma.core.syntax.timespan.*
@@ -35,35 +36,47 @@ class executionSciGnirsImaging extends ExecutionTestSupportForGnirs:
           case _                  => none
       case _                                       => none
 
-  private def sciAtom(filter: GnirsFilter, exposureTime: TimeSpan, p: Int = 0, q: Int = 0): Json =
+  private def sciStep(
+    filter:       GnirsFilter,
+    exposureTime: TimeSpan,
+    p:            Int            = 0,
+    q:            Int            = 0,
+    guiding:      StepGuideState = StepGuideState.Enabled
+  ): Json =
+    json"""
+      {
+        "instrumentConfig": {
+          "exposure":             { "seconds": ${exposureTime.toSeconds} },
+          "coadds":               1,
+          "centralWavelength":    { "nanometers": ${filter.centralWavelength.toNanometers.value.value} },
+          "filter":               ${filter.tag.toScreamingSnakeCase.asJson},
+          "decker":               "ACQUISITION",
+          "fpuSlit":              null,
+          "fpuOther":             "ACQUISITION",
+          "fpuIfu":               null,
+          "acquisitionMirrorOut": null,
+          "camera":               "SHORT_BLUE",
+          "focusMotorSteps":      null,
+          "readMode":             ${GnirsReadMode.forExposureTime(exposureTime).tag.toScreamingSnakeCase.asJson}
+        },
+        "stepConfig": { "stepType": "SCIENCE" },
+        "telescopeConfig": ${expectedTelescopeConfig(p, q, guiding)},
+        "observeClass": "SCIENCE",
+        "breakpoint": "DISABLED"
+      }
+    """
+
+  private def sciAtomOf(steps: Json*): Json =
     json"""
       {
         "description": null,
         "observeClass": "SCIENCE",
-        "steps": [
-          {
-            "instrumentConfig": {
-              "exposure":             { "seconds": ${exposureTime.toSeconds} },
-              "coadds":               1,
-              "centralWavelength":    { "nanometers": ${filter.centralWavelength.toNanometers.value.value} },
-              "filter":               ${filter.tag.toScreamingSnakeCase.asJson},
-              "decker":               "ACQUISITION",
-              "fpuSlit":              null,
-              "fpuOther":             "ACQUISITION",
-              "fpuIfu":               null,
-              "acquisitionMirrorOut": null,
-              "camera":               "SHORT_BLUE",
-              "focusMotorSteps":      null,
-              "readMode":             ${GnirsReadMode.forExposureTime(exposureTime).tag.toScreamingSnakeCase.asJson}
-            },
-            "stepConfig": { "stepType": "SCIENCE" },
-            "telescopeConfig": ${expectedTelescopeConfig(p, q, lucuma.core.enums.StepGuideState.Enabled)},
-            "observeClass": "SCIENCE",
-            "breakpoint": "DISABLED"
-          }
-        ]
+        "steps": ${steps.toList.asJson}
       }
     """
+
+  private def sciAtom(filter: GnirsFilter, exposureTime: TimeSpan, p: Int = 0, q: Int = 0): Json =
+    sciAtomOf(sciStep(filter, exposureTime, p, q))
 
   private def expectedScience(atoms: List[Json]): Json =
     json"""
@@ -126,6 +139,93 @@ class executionSciGnirsImaging extends ExecutionTestSupportForGnirs:
     val atoms =
       List.fill(3)(sciAtom(GnirsFilter.Order4, 25.secondTimeSpan)) ++
       List.fill(2)(sciAtom(GnirsFilter.J, 10.secondTimeSpan))
+
+    setup.flatMap: oid =>
+      expect(pi, gnirsScienceQuery(oid, 100.some), expectedScience(atoms).asRight)
+
+  // Two guide-disabled sky positions, shared across filters.  Sky steps must be
+  // observeClass SCIENCE (not NIGHT_CAL) even though guiding is disabled.
+  private val skyOffsetsInput: String =
+    s"""
+      skyOffsets: {
+        enumerated: {
+          values: [
+            { offset: { p: { arcseconds: 10 }, q: { arcseconds: 10 } }, guiding: DISABLED },
+            { offset: { p: { arcseconds: 20 }, q: { arcseconds: 20 } }, guiding: DISABLED }
+          ]
+        }
+      }
+    """
+
+  private def skyPair(filter: GnirsFilter, t: TimeSpan): List[Json] =
+    List(
+      sciStep(filter, t, 10, 10, StepGuideState.Disabled),
+      sciStep(filter, t, 20, 20, StepGuideState.Disabled)
+    )
+
+  test("grouped, no offsets, sky"):
+    val mode =
+      s"""
+        gnirsImaging: {
+          camera: SHORT_BLUE
+          variant: { grouped: { skyCount: 2, $skyOffsetsInput } }
+          filters: [ { filter: J }, { filter: ORDER4 } ]
+        }
+      """
+
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationWithModeAs(pi, p, List(t), mode)
+      yield o
+
+    // One atom per filter: sky, sky, object exposures, sky, sky.
+    def mkAtom(filter: GnirsFilter, t: TimeSpan, count: Int): Json =
+      sciAtomOf((skyPair(filter, t) ++ List.fill(count)(sciStep(filter, t)) ++ skyPair(filter, t))*)
+
+    val atoms =
+      List(
+        mkAtom(GnirsFilter.J, 10.secondTimeSpan, 2),
+        mkAtom(GnirsFilter.Order4, 25.secondTimeSpan, 3)
+      )
+
+    setup.flatMap: oid =>
+      expect(pi, gnirsScienceQuery(oid, 100.some), expectedScience(atoms).asRight)
+
+  test("interleaved, no offsets, sky"):
+    val mode =
+      s"""
+        gnirsImaging: {
+          camera: SHORT_BLUE
+          variant: { interleaved: { skyCount: 2, $skyOffsetsInput } }
+          filters: [ { filter: J }, { filter: ORDER4 } ]
+        }
+      """
+
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationWithModeAs(pi, p, List(t), mode)
+      yield o
+
+    val fj = GnirsFilter.J
+    val fh = GnirsFilter.Order4
+    val tj = 10.secondTimeSpan
+    val th = 25.secondTimeSpan
+
+    // Each atom is bracketed by the same guide-disabled sky steps (forward at
+    // the head, reversed at the tail), with the interleaved object exposures in
+    // between.  groupCount = min(2, 3) = 2, so there are two atoms.
+    val skyHead = skyPair(fj, tj) ++ skyPair(fh, th)
+    val skyTail = skyPair(fh, th).reverse ++ skyPair(fj, tj).reverse
+
+    val atoms =
+      List(
+        sciAtomOf((skyHead ++ List(sciStep(fj, tj), sciStep(fh, th), sciStep(fh, th)) ++ skyTail)*),
+        sciAtomOf((skyHead ++ List(sciStep(fj, tj), sciStep(fh, th)) ++ skyTail)*)
+      )
 
     setup.flatMap: oid =>
       expect(pi, gnirsScienceQuery(oid, 100.some), expectedScience(atoms).asRight)


### PR DESCRIPTION
For imaging observations (GMOS, GNIRS, Flamingos2), the sky/dither steps were generated with ObserveClass.NightCal even though their step type is Science. These are the guiding-disabled steps, so recorded steps ended up with c_observe_class = nightCal while c_step_type = science.

Sky/dither frames are part of the science observation and should be ObserveClass.Science. Both Science and NightCal charge to ChargeClass.Program, so time accounting is unchanged; the fix corrects the calibration flag and proprietary-period handling for these frames.

Add grouped-sky and interleaved-sky coverage to the GNIRS and Flamingos2 execution suites (using genuinely guide-disabled sky offsets) and update the existing GMOS imaging expectations.


Claude-Session: https://claude.ai/code/session_012oJFeh7Ehb9AzgdbKHRj1K