### PR TITLE
Shortcut 9429: deadlock

### DIFF
--- a/modules/obscalc/time-accounting-flow.md
+++ b/modules/obscalc/time-accounting-flow.md
@@ -179,51 +179,70 @@ re-invalidate obscalc.
 
 ### Locking (deadlock avoidance)
 
-Recording an execution event touches three rows via triggers — `t_observation`,
-`t_obscalc` (`invalidate_obscalc`), and `t_visit` (the invalidation marker) — so
-concurrent writers need both a consistent **order** and the right lock **mode**.
-Get either wrong and you get deadlocks.
+Recording an execution event touches three rows via triggers —
+`t_observation_execution` (the mutex), `t_obscalc` (`invalidate_obscalc`), and
+`t_visit` (the invalidation marker) — so concurrent writers need both a
+consistent **order** and the right lock **mode**. Get either wrong and you get
+deadlocks.
+
+#### The mutex: `t_observation_execution`
+
+Every observation has exactly one row in `t_observation_execution`, created with
+the observation. It carries `c_step_execution_order` and serves as **the** lock
+for observation-scoped execution state. Take it through the helper:
+
+```sql
+PERFORM lock_observation_execution(observation_id);
+```
+
+It is deliberately *not* `t_observation`. Locking the observation row meant
+serializing against every unrelated edit of that observation (any `UPDATE` of a
+non-key column takes the same mode), and the counter living there meant every
+step event wrote the widest, most-read, 46-times-FK-referenced row in the schema
+— a dead tuple per step. Locking a row whose only job is this invariant costs
+neither. Nothing FK-references `t_observation_execution`, so its rows are never
+`KEY SHARE`-locked by child inserts and the mutex is a clean acquisition rather
+than an upgrade.
 
 #### Order
 
 Acquire in this order, always:
 
 ```
-t_observation  →  t_obscalc  →  t_visit
+t_observation_execution  →  t_obscalc  →  t_visit
 ```
 
-`invalidate_visit_time_accounting` takes the observation lock itself rather than
-relying on another trigger having done it, so the order holds no matter which
-trigger fires first (Postgres fires triggers in **name** order, which is not a
-thing to depend on):
+`invalidate_visit_time_accounting` takes the mutex itself rather than relying on
+another trigger having done it, so the order holds no matter which trigger fires
+first (Postgres fires triggers in **name** order, which is not a thing to depend
+on):
 
 ```sql
-PERFORM 1 FROM t_observation WHERE c_observation_id = observation_id FOR NO KEY UPDATE;
+PERFORM lock_observation_execution(observation_id);
 CALL invalidate_obscalc(observation_id);
 UPDATE t_visit SET c_ta_invalidation = now() WHERE c_visit_id = visit_id;
 ```
 
 **Why the order matters even though these writers already serialize on the
-observation lock.** They serialize only against *each other*, and plenty of
-writers never take that lock at all: `invalidate_obscalc` reads `t_observation`
-unlocked and goes straight to `t_obscalc` (11 triggers reach it that way, via
-`obsid_obscalc_invalidate`), and the obscalc worker locks `t_obscalc` and writes
-`t_visit` without ever touching `t_observation`. Those are safe today only because
-each takes **one** of the three rows — it can block someone without wanting
-anything back. The order is the rule that keeps that true: a path claiming
-`t_obscalc` and *then* reaching for the observation would deadlock against every
-observation-first path, and the observation lock cannot prevent it because such a
-path never participates in it.
+mutex.** They serialize only against *each other*, and plenty of writers never
+take it at all: `invalidate_obscalc` goes straight to `t_obscalc` (11 triggers
+reach it that way, via `obsid_obscalc_invalidate`), and the obscalc worker locks
+`t_obscalc` and writes `t_visit` without ever touching the mutex. Those are safe
+today only because each takes **one** of the three rows — it can block someone
+without wanting anything back. The order is the rule that keeps that true: a path
+claiming `t_obscalc` and *then* reaching for the mutex would deadlock against
+every mutex-first path, and the mutex cannot prevent it because such a path never
+participates in it.
 
-Note also that the observation lock is **per observation**. A transaction spanning
-several observations is not serialized against another spanning the same set, so
+Note also that the mutex is **per observation**. A transaction spanning several
+observations is not serialized against another spanning the same set, so
 multi-observation work needs its own deterministic ordering (lock them in a fixed
 order, e.g. by id).
 
 #### Mode: `FOR NO KEY UPDATE`, never `FOR UPDATE`
 
-This is the part that is easy to get wrong, and the reason these locks look
-weaker than you might expect.
+This is the part that is easy to get wrong, and it is *also* why the mutex was
+moved off `t_observation` rather than merely weakened.
 
 **46 tables FK-reference `t_observation`.** Inserting a row into any of them —
 `t_execution_event`, `t_visit`, `t_atom`, `t_dataset`,
@@ -240,47 +259,54 @@ invisible in the code.
 | **NO KEY UPDATE** | **ok** | conflict | conflict | conflict |
 | **UPDATE** | **conflict** | conflict | conflict | conflict |
 
-So a trigger taking `FOR UPDATE` on the observation is *upgrading* a lock that
-every concurrent child insert also holds. `FOR KEY SHARE` is self-compatible, so
+So a trigger taking `FOR UPDATE` on the observation was *upgrading* a lock that
+every concurrent child insert also held. `FOR KEY SHARE` is self-compatible, so
 several transactions hold it at once, then each blocks upgrading — deadlock, and
 no amount of ordering discipline in the trigger can prevent it, because the FK
-lock was taken before the trigger existed to have an opinion.
+lock is taken before any trigger exists to have an opinion.
 
-`FOR NO KEY UPDATE` conflicts with **itself**, so these writers still serialize
-against each other exactly as needed — but it does not conflict with the FK's
-`KEY SHARE`, so it can never deadlock against a concurrent insert:
+Two consequences, and both still bind:
 
-```
-A: holds KEY SHARE(obs), wants NO KEY UPDATE → B holds only KEY SHARE → GRANTED
-B: holds KEY SHARE(obs), wants NO KEY UPDATE → conflicts with A's     → waits → proceeds
-```
-
-It is also cheaper: while a `FOR UPDATE` is held, *every* child-row insert for
-that observation blocks. Under `FOR NO KEY UPDATE` those inserts proceed freely
-and only the trigger bodies serialize.
+- **Never take `FOR UPDATE` on a row other tables FK-reference** unless you
+  genuinely mean to block their inserts. `FOR NO KEY UPDATE` conflicts with
+  itself — which is the entire requirement for a mutex — while staying compatible
+  with the FK's `KEY SHARE`.
+- **Prefer a row nothing FK-references at all.** That is what
+  `t_observation_execution` is. Its rows are never `KEY SHARE`-locked, so the
+  mutex is a fresh acquisition, not an upgrade, and it cannot false-share with
+  ordinary observation edits.
 
 #### What each lock is actually for
 
-Keeping these straight is what makes the mode choice obvious:
+Keeping these straight is what makes the choices above obvious:
 
 | Lock | Taken by | Protects |
 |---|---|---|
-| `FOR KEY SHARE` (implicit) | the INSERT's FK check | the observation's *key* — stops it being deleted or key-updated while a child row referencing it is written |
-| `FOR NO KEY UPDATE` (explicit) | the trigger/procedure | the *trigger bodies* — stops them interleaving |
+| `FOR KEY SHARE` on `t_observation` (implicit) | the INSERT's FK check | the observation's *key* — stops it being deleted or key-updated while a child row referencing it is written |
+| `FOR NO KEY UPDATE` on `t_observation_execution` (explicit) | `lock_observation_execution` | the *trigger bodies* — stops them interleaving |
 
-They do different jobs, and the implicit one gives you **no** mutual exclusion —
-it is the weakest mode and is self-compatible. The explicit `PERFORM` is doing all
-the serialization work; it is not redundant. Drop it from
+They do different jobs on different rows, and the implicit one gives you **no**
+mutual exclusion — it is the weakest mode and is self-compatible. The explicit
+lock is doing all the serialization work; it is not redundant. Drop it from
 `update_execution_information_for_step_event` and its
 `IF NOT EXISTS … INSERT INTO t_step_execution` becomes a check-then-act race
 (`c_step_id` is that table's primary key, so the loser gets a unique violation).
 
+A corollary worth knowing: `lock_observation_execution` locks nothing if the row
+is missing, which would mean *silently* no mutual exclusion. That is why the row
+is created with the observation and why the helper self-heals rather than
+assuming.
+
 #### Rules for new code
 
-1. Take the locks in the canonical order above.
-2. Use **`FOR NO KEY UPDATE`** to serialize writers on a row that other tables
-   FK-reference. Reach for `FOR UPDATE` only if you genuinely need to block child
-   inserts or to change a referenced key column — and say why in a comment.
+1. To serialize observation-scoped execution work, call
+   **`lock_observation_execution(observation_id)`** — first, before `t_obscalc`
+   or `t_visit`. Don't invent a second mutex; a mutex only works if everyone
+   agrees on it.
+2. If you must lock some *other* row that tables FK-reference, use
+   **`FOR NO KEY UPDATE`**. Reach for `FOR UPDATE` only if you genuinely need to
+   block child inserts or to change a referenced key column — and say why in a
+   comment.
 3. An `AFTER` trigger can never establish lock ordering on the parent row, because
    the FK lock precedes it. If you need the parent locked first, do it in a
    `BEFORE` trigger or in application code before the insert.
@@ -289,6 +315,8 @@ the serialization work; it is not redundant. Drop it from
    c_instrument)` unique key) takes `FOR UPDATE` implicitly, and so conflicts with
    every child insert. That is unavoidable, but worth knowing when a bulk
    observation update starts deadlocking.
+5. The step-execution counter lives on `t_observation_execution`, not
+   `t_observation` (V1227 dropped the old column). Increment it under the mutex.
 
 ## What a recompute actually computes
 

--- a/modules/obscalc/time-accounting-flow.md
+++ b/modules/obscalc/time-accounting-flow.md
@@ -177,37 +177,118 @@ clean at a stale value — no lost update, regardless of commit order.
 (narrowed from `INSERT OR UPDATE OR DELETE` in V1210), so these `UPDATE`s do not
 re-invalidate obscalc.
 
-### Lock ordering (deadlock avoidance)
+### Locking (deadlock avoidance)
 
-Recording an execution event touches three rows via triggers: `t_observation`
-(`update_execution_information_for_step_event` takes it `FOR UPDATE`), `t_obscalc`
-(`invalidate_obscalc`), and `t_visit` (the invalidation marker). Every code path
-that touches these must acquire them in **one consistent order** or concurrent
-transactions deadlock. The order is:
+Recording an execution event touches three rows via triggers — `t_observation`,
+`t_obscalc` (`invalidate_obscalc`), and `t_visit` (the invalidation marker) — so
+concurrent writers need both a consistent **order** and the right lock **mode**.
+Get either wrong and you get deadlocks.
+
+#### Order
+
+Acquire in this order, always:
 
 ```
 t_observation  →  t_obscalc  →  t_visit
 ```
 
-`invalidate_visit_time_accounting` enforces this **itself**, so it does not depend
-on trigger firing order:
+`invalidate_visit_time_accounting` takes the observation lock itself rather than
+relying on another trigger having done it, so the order holds no matter which
+trigger fires first (Postgres fires triggers in **name** order, which is not a
+thing to depend on):
 
 ```sql
-PERFORM 1 FROM t_observation WHERE c_observation_id = observation_id FOR UPDATE; -- t_observation
-CALL invalidate_obscalc(observation_id);                                        -- t_obscalc
-UPDATE t_visit SET c_ta_invalidation = now() WHERE c_visit_id = visit_id;        -- t_visit
+PERFORM 1 FROM t_observation WHERE c_observation_id = observation_id FOR NO KEY UPDATE;
+CALL invalidate_obscalc(observation_id);
+UPDATE t_visit SET c_ta_invalidation = now() WHERE c_visit_id = visit_id;
 ```
 
-Because the procedure locks `t_observation` first regardless of when it runs, the
-order can't invert even if the trigger fires before `update_execution_information_*`
-(which also locks `t_observation` first) — and it survives renaming or adding
-triggers.
+**Why the order matters even though these writers already serialize on the
+observation lock.** They serialize only against *each other*, and plenty of
+writers never take that lock at all: `invalidate_obscalc` reads `t_observation`
+unlocked and goes straight to `t_obscalc` (11 triggers reach it that way, via
+`obsid_obscalc_invalidate`), and the obscalc worker locks `t_obscalc` and writes
+`t_visit` without ever touching `t_observation`. Those are safe today only because
+each takes **one** of the three rows — it can block someone without wanting
+anything back. The order is the rule that keeps that true: a path claiming
+`t_obscalc` and *then* reaching for the observation would deadlock against every
+observation-first path, and the observation lock cannot prevent it because such a
+path never participates in it.
 
-This was a real production deadlock (V1210 named the trigger `event_…`, which
-Postgres fires in **name** order — *before* `update_execution_…` — so an event
-insert locked `t_obscalc` before `t_observation`, the reverse of `recordVisit`
-and observation edits). Fixed in V1211 with the explicit ordering above. **If you
-add another path that touches these tables, take the locks in this same order.**
+Note also that the observation lock is **per observation**. A transaction spanning
+several observations is not serialized against another spanning the same set, so
+multi-observation work needs its own deterministic ordering (lock them in a fixed
+order, e.g. by id).
+
+#### Mode: `FOR NO KEY UPDATE`, never `FOR UPDATE`
+
+This is the part that is easy to get wrong, and the reason these locks look
+weaker than you might expect.
+
+**46 tables FK-reference `t_observation`.** Inserting a row into any of them —
+`t_execution_event`, `t_visit`, `t_atom`, `t_dataset`,
+`t_sequence_materialization`, … — makes PostgreSQL take a **`FOR KEY SHARE`**
+lock on the referenced `t_observation` row to enforce the foreign key. This
+happens as part of the INSERT, **before any `AFTER` trigger runs**, and it is
+invisible in the code.
+
+`FOR UPDATE` is the **only** mode that conflicts with `FOR KEY SHARE`:
+
+| requested ↓ / held → | KEY SHARE | SHARE | NO KEY UPDATE | UPDATE |
+|---|---|---|---|---|
+| **KEY SHARE** | ok | ok | ok | **conflict** |
+| **NO KEY UPDATE** | **ok** | conflict | conflict | conflict |
+| **UPDATE** | **conflict** | conflict | conflict | conflict |
+
+So a trigger taking `FOR UPDATE` on the observation is *upgrading* a lock that
+every concurrent child insert also holds. `FOR KEY SHARE` is self-compatible, so
+several transactions hold it at once, then each blocks upgrading — deadlock, and
+no amount of ordering discipline in the trigger can prevent it, because the FK
+lock was taken before the trigger existed to have an opinion.
+
+`FOR NO KEY UPDATE` conflicts with **itself**, so these writers still serialize
+against each other exactly as needed — but it does not conflict with the FK's
+`KEY SHARE`, so it can never deadlock against a concurrent insert:
+
+```
+A: holds KEY SHARE(obs), wants NO KEY UPDATE → B holds only KEY SHARE → GRANTED
+B: holds KEY SHARE(obs), wants NO KEY UPDATE → conflicts with A's     → waits → proceeds
+```
+
+It is also cheaper: while a `FOR UPDATE` is held, *every* child-row insert for
+that observation blocks. Under `FOR NO KEY UPDATE` those inserts proceed freely
+and only the trigger bodies serialize.
+
+#### What each lock is actually for
+
+Keeping these straight is what makes the mode choice obvious:
+
+| Lock | Taken by | Protects |
+|---|---|---|
+| `FOR KEY SHARE` (implicit) | the INSERT's FK check | the observation's *key* — stops it being deleted or key-updated while a child row referencing it is written |
+| `FOR NO KEY UPDATE` (explicit) | the trigger/procedure | the *trigger bodies* — stops them interleaving |
+
+They do different jobs, and the implicit one gives you **no** mutual exclusion —
+it is the weakest mode and is self-compatible. The explicit `PERFORM` is doing all
+the serialization work; it is not redundant. Drop it from
+`update_execution_information_for_step_event` and its
+`IF NOT EXISTS … INSERT INTO t_step_execution` becomes a check-then-act race
+(`c_step_id` is that table's primary key, so the loser gets a unique violation).
+
+#### Rules for new code
+
+1. Take the locks in the canonical order above.
+2. Use **`FOR NO KEY UPDATE`** to serialize writers on a row that other tables
+   FK-reference. Reach for `FOR UPDATE` only if you genuinely need to block child
+   inserts or to change a referenced key column — and say why in a comment.
+3. An `AFTER` trigger can never establish lock ordering on the parent row, because
+   the FK lock precedes it. If you need the parent locked first, do it in a
+   `BEFORE` trigger or in application code before the insert.
+4. Note that an `UPDATE` of a *referenced key* column (e.g.
+   `t_observation.c_instrument`, part of the FK'd `(c_observation_id,
+   c_instrument)` unique key) takes `FOR UPDATE` implicitly, and so conflicts with
+   every child insert. That is unavoidable, but worth knowing when a bulk
+   observation update starts deadlocking.
 
 ## What a recompute actually computes
 

--- a/modules/service/src/main/resources/db/migration/V1227__weaken_observation_lock_mode.sql
+++ b/modules/service/src/main/resources/db/migration/V1227__weaken_observation_lock_mode.sql
@@ -1,0 +1,244 @@
+-- Root-cause fix for the deadlock class that produced V1212 and V1217, replacing
+-- the "acquire the strong lock first" approach with "don't take a lock that strong
+-- in the first place."
+--
+-- WHY THIS WORKS
+--
+-- The execution-information triggers need mutual exclusion only among THEMSELVES:
+-- one ongoing step per observation, and a serialized c_step_execution_order
+-- increment.  They were written with FOR UPDATE, which is the strongest row lock
+-- and -- critically -- the ONLY mode that conflicts with FOR KEY SHARE:
+--
+--   requested \ held | KEY SHARE | SHARE | NO KEY UPDATE | UPDATE
+--   KEY SHARE        |    ok     |  ok   |      ok       |  CONFLICT
+--   NO KEY UPDATE    |    ok     | CONF  |    CONFLICT   |  CONFLICT
+--   UPDATE           | CONFLICT  | CONF  |    CONFLICT   |  CONFLICT
+--
+-- FOR KEY SHARE is exactly what PostgreSQL takes on t_observation to enforce the
+-- foreign key of every child row inserted (t_execution_event, t_visit, t_atom,
+-- t_dataset, t_sequence_materialization, ... -- 46 tables reference it).  So
+-- FOR UPDATE was the one choice guaranteed to fight the FK machinery, on the most
+-- referenced row in the schema.
+--
+-- FOR NO KEY UPDATE still conflicts with itself, so the triggers serialize
+-- exactly as before -- the invariant is preserved.  But it does NOT conflict with
+-- FOR KEY SHARE, so the upgrade KEY SHARE -> NO KEY UPDATE can never deadlock:
+--
+--   A: holds KEY SHARE(obs), wants NO KEY UPDATE -> B holds only KEY SHARE -> GRANTED
+--   B: holds KEY SHARE(obs), wants NO KEY UPDATE -> conflicts with A's -> waits -> proceeds
+--
+-- No cycle, and no ordering discipline required.  This is why the approach scales:
+-- V1217 must be repeated for every FK-bearing child table (and for every one added
+-- in future), whereas weakening the mode fixes all of them at once.
+--
+-- SECONDARY BENEFIT
+--
+-- While a FOR UPDATE was held, EVERY insert of ANY child row for that observation
+-- blocked -- a throughput cost nobody was measuring.  Under FOR NO KEY UPDATE
+-- those inserts proceed freely; only the trigger bodies serialize.
+
+-- 1. The BEFORE INSERT trigger from V1217 is no longer needed: there is no longer
+--    an upgrade to lose a race on.  (Harmless if left in place, but it takes an
+--    unnecessary exclusive lock on every event insert, which is the very
+--    contention this migration removes.)
+DROP TRIGGER IF EXISTS lock_observation_for_execution_event_trigger ON t_execution_event;
+DROP FUNCTION IF EXISTS lock_observation_for_execution_event();
+
+-- 2. Step / dataset events.  Body identical to V1100 except the lock mode.
+CREATE OR REPLACE FUNCTION update_execution_information_for_step_event()
+  RETURNS TRIGGER AS $$
+DECLARE
+  sequence_type    e_sequence_type;
+  step_stage_state d_tag;
+  new_order        integer;
+BEGIN
+
+  -- What is the sequence type we're working with?
+  SELECT c_sequence_type INTO STRICT sequence_type
+  FROM t_atom
+  WHERE c_atom_id = NEW.c_atom_id;
+
+  -- What is the execution state according to the step stage? (For step events,
+  -- otherwise this is NULL.)
+  SELECT s.c_execution_state
+  INTO step_stage_state
+  FROM t_step_stage_execution_state s
+  WHERE s.c_step_stage = NEW.c_step_stage;
+
+  -- Serialize with the other execution-information writers.
+  --
+  -- FOR NO KEY UPDATE rather than FOR UPDATE: the INSERT INTO t_execution_event
+  -- that fired this AFTER trigger has already taken a FOR KEY SHARE lock on this
+  -- very t_observation row, enforcing t_execution_event.c_observation_id's
+  -- foreign key.  FOR UPDATE is the only mode that conflicts with FOR KEY SHARE,
+  -- so requesting it here would be upgrading against a lock other concurrent
+  -- inserts hold too -- the deadlock this migration removes. NO KEY UPDATE
+  -- conflicts with itself, so these writers still serialize.
+  PERFORM 1 FROM t_observation WHERE c_observation_id = NEW.c_observation_id FOR NO KEY UPDATE;
+
+  -- Ensure only one ongoing step in this observation.
+  UPDATE t_step_execution se
+     SET c_execution_state = 'abandoned'
+   WHERE c_observation_id = NEW.c_observation_id
+     AND c_step_id       <> NEW.c_step_id
+     AND c_execution_state = 'ongoing';
+
+  IF NOT EXISTS (
+    SELECT 1 FROM t_step_execution WHERE c_step_id = NEW.c_step_id
+  ) THEN
+
+    UPDATE t_observation
+       SET c_step_execution_order = c_step_execution_order + 1
+     WHERE c_observation_id = NEW.c_observation_id
+    RETURNING c_step_execution_order INTO new_order;
+
+    INSERT INTO t_step_execution (
+      c_step_id,
+      c_observation_id,
+      c_sequence_type,
+      c_visit_id,
+      c_execution_state,
+      c_execution_order,
+      c_first_event_time,
+      c_last_event_time
+    )
+    VALUES (
+      NEW.c_step_id,
+      NEW.c_observation_id,
+      sequence_type,
+      NEW.c_visit_id,
+      COALESCE(step_stage_state, 'ongoing'), -- born ongoing
+      new_order,
+      NEW.c_received,
+      NEW.c_received
+    );
+
+  ELSE
+
+    UPDATE t_step_execution e
+    SET
+      c_visit_id         = NEW.c_visit_id, -- we include the visit in order to fail (in validate_step_execution_update()) if it has changed
+      c_first_event_time = least(e.c_first_event_time,   NEW.c_received),
+      c_last_event_time  = greatest(e.c_last_event_time, NEW.c_received),
+      c_execution_state  =
+        CASE
+          -- If cur state (cs) in a terminal execution state, we stay there.
+          WHEN cs.c_terminal THEN e.c_execution_state
+
+          -- If new state (ns) is a terminal state, go ahead
+          WHEN ns.c_terminal THEN step_stage_state
+
+          -- Otherwise we're executing
+          ELSE 'ongoing'
+        END
+    FROM t_step_execution_state cs
+    LEFT JOIN t_step_execution_state ns ON ns.c_tag = step_stage_state
+    WHERE e.c_step_id = NEW.c_step_id
+      AND cs.c_tag    = e.c_execution_state;
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3. Sequence (abort) events.
+CREATE OR REPLACE FUNCTION update_execution_information_for_sequence_event()
+  RETURNS TRIGGER AS $$
+BEGIN
+
+  IF NEW.c_sequence_command = 'abort' THEN
+
+    PERFORM 1 FROM t_observation WHERE c_observation_id = NEW.c_observation_id FOR NO KEY UPDATE;
+
+    UPDATE t_step_execution se
+    SET c_execution_state = 'abandoned'
+    WHERE se.c_observation_id = NEW.c_observation_id
+      AND se.c_execution_state = 'ongoing';
+
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 4. Visit recording.
+CREATE OR REPLACE FUNCTION update_execution_information_for_visit()
+  RETURNS TRIGGER AS $$
+BEGIN
+
+  PERFORM 1 FROM t_observation WHERE c_observation_id = NEW.c_observation_id FOR NO KEY UPDATE;
+
+  UPDATE t_step_execution se
+  SET c_execution_state = 'abandoned'
+  WHERE se.c_execution_state = 'ongoing'
+    AND se.c_visit_id <> NEW.c_visit_id;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 5. Time-accounting invalidation (V1212).  The lock here exists purely to pin the
+--    canonical order t_observation -> t_obscalc -> t_visit; NO KEY UPDATE pins it
+--    just as well against the other writers, all of which now take at least that
+--    mode.
+CREATE OR REPLACE PROCEDURE invalidate_visit_time_accounting(
+  visit_id       d_visit_id,
+  observation_id d_observation_id
+) LANGUAGE plpgsql AS $$
+BEGIN
+  PERFORM 1 FROM t_observation WHERE c_observation_id = observation_id FOR NO KEY UPDATE;
+  CALL invalidate_obscalc(observation_id);
+  UPDATE t_visit SET c_ta_invalidation = now() WHERE c_visit_id = visit_id;
+END;
+$$;
+
+-- 6. Sequence regeneration.
+--
+--    The argument that NO KEY UPDATE suffices: every path that could interfere
+--    already takes at least NO KEY UPDATE on the same observation row, so they
+--    still mutually exclude.  A competing sequence regeneration calls this
+--    procedure itself; a competing execution event goes through
+--    update_execution_information_for_step_event (which creates the
+--    t_step_execution rows this procedure's NOT EXISTS checks read).  What is
+--    given up is blocking inserts into child tables that take no explicit lock at
+--    all (t_dataset, t_atom_digest, ...), none of which this procedure reads.
+CREATE OR REPLACE PROCEDURE abandon_ongoing_and_delete_unexecuted_steps(
+  p_observation_id d_observation_id,
+  p_sequence_type  e_sequence_type
+) AS $$
+BEGIN
+
+  PERFORM 1 FROM t_observation WHERE c_observation_id = p_observation_id FOR NO KEY UPDATE;
+
+  -- Abandon ongoing steps.
+  UPDATE t_step_execution se
+     SET c_execution_state = 'abandoned'
+   WHERE se.c_execution_state = 'ongoing'
+     AND se.c_observation_id = p_observation_id
+     AND se.c_sequence_type  = p_sequence_type;
+
+  -- Delete steps that have no execution information (i.e., unexecuted steps)
+  DELETE FROM t_step s
+  USING t_atom a
+  WHERE s.c_atom_id = a.c_atom_id
+    AND a.c_observation_id = p_observation_id
+    AND a.c_sequence_type  = p_sequence_type
+    AND NOT EXISTS (
+      SELECT 1 FROM t_step_execution se WHERE se.c_step_id = s.c_step_id
+    );
+
+  -- Delete atoms with no (executed) steps -- all unexecuted steps have been deleted
+  -- so only executed steps remain.
+  DELETE FROM t_atom a
+  WHERE a.c_observation_id = p_observation_id
+    AND a.c_sequence_type  = p_sequence_type
+    AND NOT EXISTS (
+      SELECT 1
+        FROM t_step s
+        JOIN t_step_execution se USING (c_step_id)
+       WHERE s.c_atom_id = a.c_atom_id
+    );
+
+END;
+$$ LANGUAGE plpgsql;

--- a/modules/service/src/main/resources/db/migration/V1227__weaken_observation_lock_mode.sql
+++ b/modules/service/src/main/resources/db/migration/V1227__weaken_observation_lock_mode.sql
@@ -1,8 +1,12 @@
--- Root-cause fix for the deadlock class that produced V1212 and V1217, replacing
--- the "acquire the strong lock first" approach with "don't take a lock that strong
--- in the first place."
+-- Root-cause fix for the deadlock class that produced V1212 and V1217.  Two
+-- changes, in order of importance:
 --
--- WHY THIS WORKS
+--   1. Stop taking a lock mode that fights the FK machinery -- "don't take a lock
+--      that strong in the first place" instead of "acquire the strong lock first".
+--   2. Move the mutex (and the c_step_execution_order counter) off t_observation
+--      onto a dedicated per-observation row.  See 1b below.
+--
+-- WHY (1) WORKS
 --
 -- The execution-information triggers need mutual exclusion only among THEMSELVES:
 -- one ongoing step per observation, and a serialized c_step_execution_order
@@ -44,7 +48,147 @@
 DROP TRIGGER IF EXISTS lock_observation_for_execution_event_trigger ON t_execution_event;
 DROP FUNCTION IF EXISTS lock_observation_for_execution_event();
 
--- 2. Step / dataset events.  Body identical to V1100 except the lock mode.
+-- 1b. Move the mutex (and its counter) off t_observation entirely.
+--
+-- t_observation was only ever a convenient anchor: the invariant being protected
+-- lives in t_step_execution, not in the observation row.  Two costs came with
+-- that choice:
+--
+--   * FALSE SHARING.  NO KEY UPDATE conflicts with itself, and an ordinary
+--     UPDATE of any non-key observation column takes exactly that mode.  So
+--     editing an observation's title or mode params contended with step-event
+--     processing, and vice versa, for no reason.
+--
+--   * WRITE CHURN ON THE HOTTEST ROW.  c_step_execution_order lived on
+--     t_observation, so every new step UPDATEd the widest, most-read,
+--     46-times-FK-referenced row in the schema just to bump a counter -- one
+--     dead tuple per step, with the attendant bloat and vacuum pressure.
+--
+-- Both go away by giving each observation a dedicated row whose only job is to
+-- carry the execution counter and serve as the execution mutex.  Nothing
+-- FK-references this table, so its rows are never KEY SHARE'd by child inserts
+-- and the mutex is a clean, uncontended acquisition rather than an upgrade.
+--
+-- The canonical lock order becomes:
+--
+--     t_observation_execution  ->  t_obscalc  ->  t_visit
+--
+-- and t_observation is no longer locked or written by event processing at all.
+CREATE TABLE t_observation_execution (
+  c_observation_id       d_observation_id PRIMARY KEY
+                           REFERENCES t_observation (c_observation_id) ON DELETE CASCADE,
+  c_step_execution_order integer NOT NULL DEFAULT 0
+);
+
+-- Carry every existing observation's counter forward.
+INSERT INTO t_observation_execution (c_observation_id, c_step_execution_order)
+SELECT c_observation_id, c_step_execution_order FROM t_observation;
+
+-- The old column is now dead.  Drop it so any lingering reference fails loudly
+-- rather than silently reading a stale zero.  Nothing FK-references or reads it
+-- (no Scala reference; only v_observation surfaces it, implicitly via `SELECT
+-- o.*`), and nothing is layered on v_observation -- so this is the same
+-- DROP VIEW / recreate cycle every migration that touches the view already does.
+-- Because the view is `SELECT o.*`, recreating it after the column is gone drops
+-- the column from the view automatically.  View body copied verbatim from V1206.
+DROP VIEW v_observation;
+
+ALTER TABLE t_observation DROP COLUMN c_step_execution_order;
+
+CREATE VIEW v_observation AS
+  SELECT o.*,
+  CASE WHEN o.c_explicit_ra              IS NOT NULL THEN o.c_observation_id END AS c_explicit_base_id,
+  CASE WHEN o.c_air_mass_min             IS NOT NULL THEN o.c_observation_id END AS c_air_mass_id,
+  CASE WHEN o.c_hour_angle_min           IS NOT NULL THEN o.c_observation_id END AS c_hour_angle_id,
+  CASE WHEN o.c_observing_mode_type      IS NOT NULL THEN o.c_observation_id END AS c_observing_mode_id,
+  CASE WHEN o.c_spec_wavelength          IS NOT NULL THEN o.c_observation_id END AS c_spec_wavelength_id,
+  CASE WHEN o.c_spec_wavelength_coverage IS NOT NULL THEN o.c_observation_id END AS c_spec_wavelength_coverage_id,
+  CASE WHEN o.c_spec_focal_plane_angle   IS NOT NULL THEN o.c_observation_id END AS c_spec_focal_plane_angle_id,
+  CASE WHEN o.c_img_minimum_fov          IS NOT NULL THEN o.c_observation_id END AS c_img_minimum_fov_id,
+  CASE WHEN o.c_observation_duration     IS NOT NULL THEN o.c_observation_id END AS c_observation_duration_id,
+  CASE WHEN o.c_orig_est_setup_count     IS NOT NULL THEN o.c_observation_id END AS c_original_estimate_id,
+  CASE WHEN o.c_science_mode = 'imaging'::d_tag      THEN o.c_observation_id END AS c_imaging_mode_id,
+  CASE WHEN o.c_science_mode = 'spectroscopy'::d_tag THEN o.c_observation_id END AS c_spectroscopy_mode_id,
+  c.c_active_start::timestamp + (c.c_active_end::timestamp - c.c_active_start::timestamp) * 0.5 AS c_reference_time,
+  EXISTS (
+    SELECT 1
+    FROM t_sequence_materialization m
+    WHERE m.c_observation_id = o.c_observation_id
+      AND m.c_sequence_type = 'science'::e_sequence_type
+  ) AS c_science_sequence_is_materialized,
+  EXISTS (
+    SELECT 1
+    FROM t_sequence_materialization m
+    WHERE m.c_observation_id = o.c_observation_id
+      AND m.c_sequence_type = 'acquisition'::e_sequence_type
+  ) AS c_acquisition_sequence_is_materialized,
+  -- Scalar subquery: at most one flagged target per observation is guaranteed
+  -- by the partial unique index i_asterism_single_sn_target. No LIMIT here on
+  -- purpose -- if that invariant were ever violated, PostgreSQL raises "more
+  -- than one row returned by a subquery used as an expression", surfacing the
+  -- bug rather than hiding it.
+  (
+    SELECT a.c_target_id
+    FROM t_asterism_target a
+    WHERE a.c_observation_id = o.c_observation_id
+      AND a.c_is_signal_to_noise_target
+  ) AS c_signal_to_noise_target_id
+  FROM t_observation o
+  LEFT JOIN t_proposal p on p.c_program_id = o.c_program_id
+  LEFT JOIN t_cfp c on p.c_cfp_id = c.c_cfp_id;
+
+
+-- Every observation gets its execution row at creation, so the mutex always has
+-- something to lock.
+CREATE FUNCTION create_observation_execution()
+  RETURNS trigger AS $$
+BEGIN
+  INSERT INTO t_observation_execution (c_observation_id)
+  VALUES (NEW.c_observation_id)
+  ON CONFLICT DO NOTHING;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER create_observation_execution_trigger
+  AFTER INSERT ON t_observation
+  FOR EACH ROW EXECUTE FUNCTION create_observation_execution();
+
+-- THE mutex.  Every writer of observation-scoped execution information takes
+-- this, first, and holds it to commit.
+--
+-- FOR NO KEY UPDATE rather than FOR UPDATE: nothing FK-references this table
+-- today so the two would behave identically, but the weaker mode is what is
+-- actually needed (it conflicts with itself, which is the whole requirement) and
+-- it stays correct if something ever does reference it.
+--
+-- The row is created with the observation, so the NOT FOUND branch should be
+-- dead.  It exists because a missing row would otherwise mean "locked nothing"
+-- -- silently no mutual exclusion, the worst possible failure for a mutex.  The
+-- INSERT ... SELECT is deliberate: if the observation itself is gone (deleted
+-- calibrations), it inserts nothing and the whole call is a harmless no-op,
+-- matching invalidate_obscalc's behaviour rather than raising a FK violation.
+CREATE FUNCTION lock_observation_execution(p_observation_id d_observation_id)
+  RETURNS void AS $$
+BEGIN
+  PERFORM 1 FROM t_observation_execution
+   WHERE c_observation_id = p_observation_id
+     FOR NO KEY UPDATE;
+
+  IF NOT FOUND THEN
+    INSERT INTO t_observation_execution (c_observation_id)
+    SELECT c_observation_id FROM t_observation WHERE c_observation_id = p_observation_id
+    ON CONFLICT DO NOTHING;
+
+    PERFORM 1 FROM t_observation_execution
+     WHERE c_observation_id = p_observation_id
+       FOR NO KEY UPDATE;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 2. Step / dataset events.  Body identical to V1100 except for how the mutex is
+--    taken and where the execution-order counter lives.
 CREATE OR REPLACE FUNCTION update_execution_information_for_step_event()
   RETURNS TRIGGER AS $$
 DECLARE
@@ -65,16 +209,11 @@ BEGIN
   FROM t_step_stage_execution_state s
   WHERE s.c_step_stage = NEW.c_step_stage;
 
-  -- Serialize with the other execution-information writers.
-  --
-  -- FOR NO KEY UPDATE rather than FOR UPDATE: the INSERT INTO t_execution_event
-  -- that fired this AFTER trigger has already taken a FOR KEY SHARE lock on this
-  -- very t_observation row, enforcing t_execution_event.c_observation_id's
-  -- foreign key.  FOR UPDATE is the only mode that conflicts with FOR KEY SHARE,
-  -- so requesting it here would be upgrading against a lock other concurrent
-  -- inserts hold too -- the deadlock this migration removes. NO KEY UPDATE
-  -- conflicts with itself, so these writers still serialize.
-  PERFORM 1 FROM t_observation WHERE c_observation_id = NEW.c_observation_id FOR NO KEY UPDATE;
+  -- Serialize with the other execution-information writers.  Note this locks
+  -- t_observation_execution, NOT t_observation: the INSERT INTO t_execution_event
+  -- that fired this trigger already holds FOR KEY SHARE on the observation row,
+  -- and taking a conflicting mode on it is the deadlock this migration removes.
+  PERFORM lock_observation_execution(NEW.c_observation_id);
 
   -- Ensure only one ongoing step in this observation.
   UPDATE t_step_execution se
@@ -87,7 +226,7 @@ BEGIN
     SELECT 1 FROM t_step_execution WHERE c_step_id = NEW.c_step_id
   ) THEN
 
-    UPDATE t_observation
+    UPDATE t_observation_execution
        SET c_step_execution_order = c_step_execution_order + 1
      WHERE c_observation_id = NEW.c_observation_id
     RETURNING c_step_execution_order INTO new_order;
@@ -149,7 +288,7 @@ BEGIN
 
   IF NEW.c_sequence_command = 'abort' THEN
 
-    PERFORM 1 FROM t_observation WHERE c_observation_id = NEW.c_observation_id FOR NO KEY UPDATE;
+    PERFORM lock_observation_execution(NEW.c_observation_id);
 
     UPDATE t_step_execution se
     SET c_execution_state = 'abandoned'
@@ -167,7 +306,7 @@ CREATE OR REPLACE FUNCTION update_execution_information_for_visit()
   RETURNS TRIGGER AS $$
 BEGIN
 
-  PERFORM 1 FROM t_observation WHERE c_observation_id = NEW.c_observation_id FOR NO KEY UPDATE;
+  PERFORM lock_observation_execution(NEW.c_observation_id);
 
   UPDATE t_step_execution se
   SET c_execution_state = 'abandoned'
@@ -179,15 +318,14 @@ END;
 $$ LANGUAGE plpgsql;
 
 -- 5. Time-accounting invalidation (V1212).  The lock here exists purely to pin the
---    canonical order t_observation -> t_obscalc -> t_visit; NO KEY UPDATE pins it
---    just as well against the other writers, all of which now take at least that
---    mode.
+--    canonical order t_observation_execution -> t_obscalc -> t_visit.  It must be
+--    the SAME mutex the other writers take, or the ordering guarantee is empty.
 CREATE OR REPLACE PROCEDURE invalidate_visit_time_accounting(
   visit_id       d_visit_id,
   observation_id d_observation_id
 ) LANGUAGE plpgsql AS $$
 BEGIN
-  PERFORM 1 FROM t_observation WHERE c_observation_id = observation_id FOR NO KEY UPDATE;
+  PERFORM lock_observation_execution(observation_id);
   CALL invalidate_obscalc(observation_id);
   UPDATE t_visit SET c_ta_invalidation = now() WHERE c_visit_id = visit_id;
 END;
@@ -196,8 +334,8 @@ $$;
 -- 6. Sequence regeneration.
 --
 --    The argument that NO KEY UPDATE suffices: every path that could interfere
---    already takes at least NO KEY UPDATE on the same observation row, so they
---    still mutually exclude.  A competing sequence regeneration calls this
+--    takes the same t_observation_execution mutex, so they still mutually
+--    exclude.  A competing sequence regeneration calls this
 --    procedure itself; a competing execution event goes through
 --    update_execution_information_for_step_event (which creates the
 --    t_step_execution rows this procedure's NOT EXISTS checks read).  What is
@@ -209,7 +347,7 @@ CREATE OR REPLACE PROCEDURE abandon_ongoing_and_delete_unexecuted_steps(
 ) AS $$
 BEGIN
 
-  PERFORM 1 FROM t_observation WHERE c_observation_id = p_observation_id FOR NO KEY UPDATE;
+  PERFORM lock_observation_execution(p_observation_id);
 
   -- Abandon ongoing steps.
   UPDATE t_step_execution se


### PR DESCRIPTION
This PR addresses the execution deadlocks we're seeing in testing (again). Fundamentally the issue is the mutual-exclusion serialization surrounding execution event handling, visit recording, and sequence regeneration. Before, we grabbed the strongest lock available (`FOR UPDATE`) on the observation in question. This conflicts with even the foreign-key validation that fires when inserting any row referencing that observation. [#2722](https://github.com/gemini-hlsw/lucuma-odb/issues/2722) and [#2733](https://github.com/gemini-hlsw/lucuma-odb/issues/2733) both tried to solve it by grabbing the `FOR UPDATE` lock earlier in the process, but I think that missed the point. Instead — and either change alone would resolve the deadlock:

* Move the step execution order and the lock to a separate table created for this purpose, avoiding any conflict on `t_observation`.
* Weaken the lock to `FOR NO KEY UPDATE` so FK validation proceeds regardless of whether the lock is held. This may not be strictly necessary now that it isn't `t_observation` itself being locked, but it's the correct locking level for this task.

Claude generated some fairly verbose comments in the migration itself, and I think that file (`V1227`) is sufficient for reviewing.