### PR TITLE
retry 'Interrupted system call' failures

### DIFF
--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/concurrentInsertDeadlock.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/concurrentInsertDeadlock.scala
@@ -17,14 +17,33 @@ class concurrentInsertDeadlock extends OdbSuite:
   val pi = TestUsers.Standard.pi(nextId, nextId)
   lazy val validUsers = List(pi)
 
+  // Under this test's deliberately high concurrency, a backend's file `open()`
+  // can be interrupted by a signal on the CI container filesystem (EINTR).
+  // Postgres 15 surfaces that as a XX000 internal error ("Could not open file
+  // ...: Interrupted system call") in mdopenfork rather than retrying it. It is a
+  // transient infrastructure hiccup, unrelated to what this test guards, so we
+  // retry it a few times. A genuine regression -- a deadlock (40P01) or a
+  // resource-limit violation (LU001) -- carries different text, does not match,
+  // and still fails the test loudly.
+  private def isTransientOpenIntr(t: Throwable): Boolean =
+    LazyList.iterate(Option(t))(_.flatMap(e => Option(e.getCause).filterNot(_ eq e)))
+      .takeWhile(_.isDefined)
+      .flatten
+      .exists(e => Option(e.getMessage).exists(_.contains("Interrupted system call")))
+
+  private def retryingTransient[A](io: IO[A], remaining: Int = 3): IO[A] =
+    io.handleErrorWith:
+      case t if remaining > 0 && isTransientOpenIntr(t) => retryingTransient(io, remaining - 1)
+      case t                                            => IO.raiseError(t)
+
   test("concurrent observations into one program"):
     createProgramAs(pi).flatMap: pid =>
-      List.range(0, 16).parTraverse_(_ => createObservationAs(pi, pid))
+      List.range(0, 16).parTraverse_(_ => retryingTransient(createObservationAs(pi, pid)))
 
   test("concurrent groups into one program"):
     createProgramAs(pi).flatMap: pid =>
-      List.range(0, 16).parTraverse_(_ => createGroupAs(pi, pid))
+      List.range(0, 16).parTraverse_(_ => retryingTransient(createGroupAs(pi, pid)))
 
   test("concurrent targets into one program"):
     createProgramAs(pi).flatMap: pid =>
-      List.range(0, 16).parTraverse_(_ => createTargetAs(pi, pid))
+      List.range(0, 16).parTraverse_(_ => retryingTransient(createTargetAs(pi, pid)))


### PR DESCRIPTION
There's an issue with the `concurrentInsertDeadlock` test that bites us on occasion in CI.  The failure is accompanied by an "Interrupted system call" Postgres exception that I don't believe that it is related to deadlocks but rather to the CI environment itself.  A retry, when the test fails with this message should bypass the problem.