### PR TITLE
Add GNIRS imaging acquisition sequences

### DIFF
--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
@@ -65,11 +65,24 @@ object ItcInput:
   case class Imaging(
     science: NonEmptyList[ImagingParameters],
     targets: NonEmptyList[TargetDefinition],
-    signalToNoiseTargetId: Option[Target.Id]
+    signalToNoiseTargetId: Option[Target.Id],
+    // GNIRS imaging has an acquisition sequence sized by its own ITC pass; other
+    // imaging modes have none.  When `gnirsAcqAutoClassify` is set, the ITC resolves
+    // the acquisition brightness type via a classification pass before the real
+    // exposure-time pass.  See the two-pass acquisition ITC in ItcService.
+    acquisition:          Option[ImagingParameters] = None,
+    gnirsAcqAutoClassify: Boolean                   = false
   ) extends ItcInput derives Eq:
 
     def scienceInput: NonEmptyList[ImagingInput] =
       science.map(ImagingInput(_, targets.map(_.input)))
+
+    // Imaging has no blind offset, so the acquisition uses the science targets.
+    def acquisitionTargets: NonEmptyList[TargetDefinition] =
+      targets
+
+    def acquisitionInput: Option[ImagingInput] =
+      acquisition.map(ImagingInput(_, acquisitionTargets.map(_.input)))
 
   object Imaging:
     given HashBytes[Imaging] with
@@ -79,6 +92,8 @@ object ItcInput:
           bld.addAll(params.hashBytes)
         bld.addAll(hashTargets(a.targets))
         bld.addAll(a.signalToNoiseTargetId.hashBytes)
+        bld.addAll(a.acquisition.hashBytes)
+        bld.addAll(a.gnirsAcqAutoClassify.hashBytes)
         bld.result()
 
   /**
@@ -163,6 +178,6 @@ object ItcInput:
   given HashBytes[ItcInput] with
     def hashBytes(a: ItcInput): Array[Byte] =
       a match
-        case in @ Imaging(_, _, _)                  => in.hashBytes
+        case in @ Imaging(_, _, _, _, _)            => in.hashBytes
         case in @ Spectroscopy(_, _, _, _, _, _)    => in.hashBytes
         case in @ ScienceOnlySpectroscopy(_, _, _)  => in.hashBytes

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
@@ -61,15 +61,16 @@ object ItcInput:
   /**
    * ImagingInputs per-filter (as contained in the IntrumentMode in
    * ImagingParameters).
+
+   * GNIRS imaging has an acquisition sequence sized by its own ITC pass; other
+   * imaging modes have none.  When `gnirsAcqAutoClassify` is set, the ITC resolves
+   * the acquisition brightness type via a classification pass before the real
+   * exposure-time pass.  See the two-pass acquisition ITC in ItcService.
    */
   case class Imaging(
     science: NonEmptyList[ImagingParameters],
     targets: NonEmptyList[TargetDefinition],
     signalToNoiseTargetId: Option[Target.Id],
-    // GNIRS imaging has an acquisition sequence sized by its own ITC pass; other
-    // imaging modes have none.  When `gnirsAcqAutoClassify` is set, the ITC resolves
-    // the acquisition brightness type via a classification pass before the real
-    // exposure-time pass.  See the two-pass acquisition ITC in ItcService.
     acquisition:          Option[ImagingParameters] = None,
     gnirsAcqAutoClassify: Boolean                   = false
   ) extends ItcInput derives Eq:

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/imaging/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/imaging/Acquisition.scala
@@ -1,0 +1,189 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence
+package gnirs
+package imaging
+
+import cats.Monad
+import cats.Order
+import cats.data.NonEmptyList
+import cats.data.State
+import cats.syntax.applicative.*
+import cats.syntax.option.*
+import cats.syntax.traverse.*
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.NonEmptyString
+import fs2.Pure
+import fs2.Stream
+import lucuma.core.enums.GnirsAcquisitionType
+import lucuma.core.enums.GnirsCamera
+import lucuma.core.enums.GnirsDecker
+import lucuma.core.enums.GnirsFilter
+import lucuma.core.enums.GnirsFpuOther
+import lucuma.core.enums.GnirsReadMode
+import lucuma.core.enums.ObserveClass
+import lucuma.core.enums.SequenceType
+import lucuma.core.enums.StepGuideState.Disabled
+import lucuma.core.math.Offset
+import lucuma.core.math.syntax.int.*
+import lucuma.core.model.Observation
+import lucuma.core.model.sequence.Atom
+import lucuma.core.model.sequence.TelescopeConfig
+import lucuma.core.model.sequence.gnirs.GnirsAcquisitionMirrorMode
+import lucuma.core.model.sequence.gnirs.GnirsAcquisitionMode
+import lucuma.core.model.sequence.gnirs.GnirsDynamicConfig
+import lucuma.core.model.sequence.gnirs.GnirsFpu
+import lucuma.core.model.sequence.gnirs.GnirsStaticConfig
+import lucuma.core.util.TimeSpan
+import lucuma.itc.IntegrationTime
+import lucuma.odb.data.OdbError
+import lucuma.odb.sequence.data.ProtoStep
+import lucuma.odb.sequence.imaging.ImagingSequence
+import lucuma.odb.sequence.util.AtomBuilder
+import lucuma.refined.*
+
+import java.util.UUID
+
+/**
+ * GNIRS imaging acquisition sequence generation. Because the GNIRS imaging field of
+ * view is small, an acquisition is used to center the target: an offset image where
+ * the observer measures the "keyhole" center, followed by an image on the target.
+ *
+ * There are three brightness types (classified by the ITC exactly as for spectroscopy):
+ *
+ *   - Very Bright: offset (10,0) field image in H (Order4) with the fixed per-camera
+ *     exposure, then an on-target (0,0) image in the narrow-band H2 with the ITC exposure.
+ *   - Bright: offset (10,0) field image in the first science filter with the fixed
+ *     per-camera exposure, then an on-target (0,0) image in the same filter with the ITC
+ *     exposure.
+ *   - Faint: offset (0,10) field image (for keyhole measurement and sky subtraction) and
+ *     an on-target (0,0) image, both in the first science filter, both with the ITC
+ *     exposure.
+ *
+ * As with spectroscopy, an "Initial Acquisition" atom (field image + on-target image) is
+ * followed by [[RepeatingAtomCount]] "Fine Adjustments" atoms, each a single on-target image.
+ */
+object Acquisition:
+
+  val RepeatingAtomCount: Int = 10
+
+  private val SingleCoadd: PosInt = 1.refined
+
+  case class Steps(
+    fieldImage: ProtoStep[GnirsDynamicConfig],
+    onTarget:   ProtoStep[GnirsDynamicConfig]
+  ):
+    // The on-target image carries a breakpoint so the observer can pause to apply the
+    // centering measured on the field image.
+    val initialAtom: NonEmptyList[ProtoStep[GnirsDynamicConfig]] =
+      NonEmptyList.of(fieldImage, onTarget.withBreakpoint)
+
+    val repeatingAtom: NonEmptyList[ProtoStep[GnirsDynamicConfig]] =
+      NonEmptyList.of(onTarget)
+
+  private object StepComputer extends GnirsSequenceState:
+
+    def compute(
+      camera:      GnirsCamera,
+      acqType:     GnirsAcquisitionType,
+      firstFilter: GnirsFilter,
+      time:        IntegrationTime
+    ): Steps =
+      val acqExposureTime: TimeSpan = time.exposureTime
+      // In S/N mode the ITC exposure count is the acquisition coadds.
+      val acqCoadds: PosInt         = time.exposureCount
+      // The fixed per-camera keyhole exposure (short 3s, long 15s).
+      val camExposureTime: TimeSpan = keyholeExposureTime(camera)
+
+      // The field/keyhole image: filter, exposure and coadds depend on the brightness type.
+      // Very Bright / Bright use the fixed camera exposure and a single coadd; Faint uses the
+      // ITC exposure and coadds (it doubles as a sky frame). The offset is (0,10) for Faint,
+      // else (10,0).
+      val (fieldFilter, fieldExposureTime, fieldCoadds, fieldOffset): (GnirsFilter, TimeSpan, PosInt, Offset) =
+        acqType match
+          case GnirsAcquisitionType.VeryBright =>
+            (GnirsFilter.Order4, camExposureTime, SingleCoadd, Offset(Offset.P(10.arcsec), Offset.Q(0.arcsec)))
+          case GnirsAcquisitionType.Bright     =>
+            (firstFilter,        camExposureTime, SingleCoadd, Offset(Offset.P(10.arcsec), Offset.Q(0.arcsec)))
+          case GnirsAcquisitionType.Faint      =>
+            (firstFilter,        acqExposureTime, acqCoadds,   Offset(Offset.P(0.arcsec),  Offset.Q(10.arcsec)))
+
+      // The on-target image always uses the ITC exposure and coadds. Very Bright images
+      // through H2 (its exposure comes from the H2 ITC pass); the others use the first filter.
+      val onTargetFilter: GnirsFilter =
+        acqType match
+          case GnirsAcquisitionType.VeryBright => GnirsFilter.H2
+          case _                               => firstFilter
+
+      eval:
+        for
+          _          <- State.modify[GnirsDynamicConfig]: dyn =>
+                          dyn.copy(
+                            exposure          = fieldExposureTime,
+                            coadds            = fieldCoadds,
+                            filter            = fieldFilter,
+                            acquisitionMirror = GnirsAcquisitionMirrorMode.In,
+                            camera            = camera,
+                            readMode          = GnirsReadMode.forExposureTime(fieldExposureTime),
+                            decker            = GnirsDecker.Acquisition,
+                            fpu               = GnirsFpu.Other(GnirsFpuOther.Acquisition)
+                          )
+          fieldImage <- scienceStep(TelescopeConfig(fieldOffset, Disabled), ObserveClass.Acquisition)
+          _          <- State.modify[GnirsDynamicConfig]:
+                          _.copy(
+                            exposure = acqExposureTime,
+                            coadds   = acqCoadds,
+                            filter   = onTargetFilter,
+                            readMode = GnirsReadMode.forExposureTime(acqExposureTime)
+                          )
+          onTarget   <- scienceStep(0.arcsec, 0.arcsec, ObserveClass.Acquisition)
+        yield Steps(fieldImage, onTarget)
+
+  private class Generator(
+    builder:       AtomBuilder[GnirsDynamicConfig],
+    initialAtom:   NonEmptyList[ProtoStep[GnirsDynamicConfig]],
+    repeatingAtom: NonEmptyList[ProtoStep[GnirsDynamicConfig]]
+  ) extends SequenceGenerator[GnirsDynamicConfig]:
+
+    override val generate: Stream[Pure, Atom[GnirsDynamicConfig]] =
+      (for
+        a0 <- builder.build(NonEmptyString.unapply("Initial Acquisition"), 0, 0, initialAtom)
+        as <- (1 to RepeatingAtomCount).toList.traverse: aix =>
+                builder.build(NonEmptyString.unapply("Fine Adjustments"), aix, 0, repeatingAtom)
+      yield Stream.emits(a0 :: as)).runA(StepTimeEstimateCalculator.Last.empty[GnirsDynamicConfig]).value
+
+  // `pinnedAcqType` is the acquisition mode resolved by the ITC brightness classification
+  // (the two-pass acquisition ITC). When present it pins the type rather than re-deriving
+  // it from the final exposure time.
+  def instantiate[F[_]: Monad](
+    observationId: Observation.Id,
+    estimator:     StepTimeEstimateCalculator[GnirsStaticConfig, GnirsDynamicConfig],
+    static:        GnirsStaticConfig,
+    namespace:     UUID,
+    config:        Config,
+    time:          Either[OdbError, IntegrationTime],
+    pinnedAcqType: Option[GnirsAcquisitionType]
+  ): F[Either[OdbError, SequenceGenerator[GnirsDynamicConfig]]] =
+    def sequenceError(msg: String): OdbError =
+      OdbError.SequenceUnavailable(observationId, s"Could not generate a sequence for $observationId: $msg".some)
+
+    val builder: AtomBuilder[GnirsDynamicConfig] =
+      AtomBuilder.instantiate(estimator, static, namespace, SequenceType.Acquisition)
+
+    // The first filter in the sequence: the wavelength-first filter under the variant's
+    // ordering — the same ordering GeneratorParamsService used for the ITC classification.
+    given Order[GnirsFilter] = ImagingSequence.wavelengthOrder(config.variant)(_.centralWavelength)
+    val firstFilter: GnirsFilter = config.filters.map(_.filter).sorted.head
+
+    (for
+      t <- time.filterOrElse(
+             _.exposureTime.toNonNegMicroseconds.value > 0,
+             sequenceError("GNIRS Imaging requires a positive acquisition exposure time.")
+           )
+    yield
+      val acqType: GnirsAcquisitionType =
+        pinnedAcqType.getOrElse(GnirsAcquisitionMode.defaultFor(t.exposureTime, t.exposureCount).acquisitionType)
+      val steps: Steps = StepComputer.compute(config.camera, acqType, firstFilter, t)
+      Generator(builder, steps.initialAtom, steps.repeatingAtom): SequenceGenerator[GnirsDynamicConfig]
+    ).pure[F]

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/imaging/Imaging.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/imaging/Imaging.scala
@@ -8,8 +8,11 @@ package imaging
 import cats.data.EitherT
 import cats.effect.Sync
 import fs2.Pure
+import lucuma.core.enums.GnirsAcquisitionType
+import lucuma.core.model.Observation
 import lucuma.core.model.sequence.gnirs.GnirsDynamicConfig
 import lucuma.core.model.sequence.gnirs.GnirsStaticConfig
+import lucuma.itc.IntegrationTime
 import lucuma.odb.data.ItcScience.GnirsImaging
 import lucuma.odb.data.OdbError
 import lucuma.odb.sequence.data.StreamingExecutionConfig
@@ -19,22 +22,37 @@ import java.util.UUID
 object Imaging:
 
   private def instantiate[F[_]: Sync](
-    static:  GnirsStaticConfig,
-    science: F[Either[OdbError, SequenceGenerator[GnirsDynamicConfig]]]
+    observationId:  Observation.Id,
+    estimator:      StepTimeEstimateCalculator[GnirsStaticConfig, GnirsDynamicConfig],
+    static:         GnirsStaticConfig,
+    namespace:      UUID,
+    config:         Config,
+    acquisitionItc: Either[OdbError, IntegrationTime],
+    pinnedAcqType:  Option[GnirsAcquisitionType],
+    science:        F[Either[OdbError, SequenceGenerator[GnirsDynamicConfig]]]
   ): F[Either[OdbError, StreamingExecutionConfig[Pure, GnirsStaticConfig, GnirsDynamicConfig]]] =
-    EitherT(science)
-      // Note acquisition is empty for imaging
-      .map(s => StreamingExecutionConfig(static, SequenceGenerator.empty.generate, s.generate))
-      .value
+    (for
+      a <- EitherT(Acquisition.instantiate(observationId, estimator, static, namespace, config, acquisitionItc, pinnedAcqType))
+      s <- EitherT(science)
+    yield StreamingExecutionConfig(static, a.generate, s.generate)).value
 
   def gnirs[F[_]: Sync](
-    estimator:  StepTimeEstimateCalculator[GnirsStaticConfig, GnirsDynamicConfig],
-    namespace:  UUID,
-    config:     Config,
-    scienceItc: Either[OdbError, GnirsImaging]
+    observationId:  Observation.Id,
+    estimator:      StepTimeEstimateCalculator[GnirsStaticConfig, GnirsDynamicConfig],
+    namespace:      UUID,
+    config:         Config,
+    acquisitionItc: Either[OdbError, IntegrationTime],
+    pinnedAcqType:  Option[GnirsAcquisitionType],
+    scienceItc:     Either[OdbError, GnirsImaging]
   ): F[Either[OdbError, StreamingExecutionConfig[Pure, GnirsStaticConfig, GnirsDynamicConfig]]] =
     val static = config.staticConfig
     instantiate(
+      observationId,
+      estimator,
       static,
+      namespace,
+      config,
+      acquisitionItc,
+      pinnedAcqType,
       Science.gnirs(estimator, static, namespace, config, scienceItc)
     )

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/shared.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/shared.scala
@@ -3,6 +3,9 @@
 
 package lucuma.odb.sequence.gnirs
 
+import cats.syntax.eq.*
+import lucuma.core.enums.GnirsCamera
+import lucuma.core.enums.GnirsPixelScale
 import lucuma.core.math.SignalToNoise
 import lucuma.core.syntax.timespan.*
 import lucuma.core.util.TimeSpan
@@ -10,6 +13,13 @@ import lucuma.core.util.TimeSpan
 // Definitions that are shared across GNIRS modes.
 val MinAcquisitionExposureTime: TimeSpan = 100.msTimeSpan  // 0.1 s; actually determined by the read mode, but this is a reasonable lower bound for all modes.
 val MaxAcquisitionExposureTime: TimeSpan = 60.secondTimeSpan
+
+// The fixed, single-coadd exposure time for the initial "keyhole"/field image of an
+// acquisition, as a function of the camera: 15s for the long cameras (0.05"/pix) and
+// 3s for the short cameras (0.15"/pix). This is the H-band value the spectroscopy
+// acquisition falls back to, reused as-is for imaging acquisitions.
+def keyholeExposureTime(camera: GnirsCamera): TimeSpan =
+  if camera.pixelScale === GnirsPixelScale.PixelScale_0_05 then 15.secTimeSpan else 3.secTimeSpan
 
 // The fixed signal-to-noise used to classify the acquisition mode (Very Bright /
 // Bright / Faint) from target brightness, independent of the user's requested S/N.

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Acquisition.scala
@@ -11,7 +11,6 @@ import cats.data.NonEmptyList
 import cats.data.State
 import cats.syntax.applicative.*
 import cats.syntax.either.*
-import cats.syntax.eq.*
 import cats.syntax.option.*
 import cats.syntax.traverse.*
 import eu.timepit.refined.types.numeric.PosInt
@@ -99,7 +98,7 @@ object Acquisition:
   ): Either[String, (GnirsFilter, TimeSpan)] =
     // "Use H": image the FPU in H (Order4) at the camera's H exposure (short 3s, long 15s).
     val useH: (GnirsFilter, TimeSpan) =
-      (GnirsFilter.Order4, if camera.pixelScale === GnirsPixelScale.PixelScale_0_05 then 15.secTimeSpan else 3.secTimeSpan)
+      (GnirsFilter.Order4, keyholeExposureTime(camera))
     (mode, selectedFilter, camera.pixelScale) match
       case (_, GnirsFilter.PAH, GnirsPixelScale.PixelScale_0_15)    =>
         s"PAH acquisition filter cannot be used with short camera".asLeft

--- a/modules/sequence/src/test/scala/lucuma/odb/sequence/data/arb/ArbItcInput.scala
+++ b/modules/sequence/src/test/scala/lucuma/odb/sequence/data/arb/ArbItcInput.scala
@@ -36,10 +36,14 @@ trait ArbItcInput:
         ct <- Gen.choose(1, 10)
         ts <- List.range(1L, ct + 1L).traverse(genTargetDefinition)
         sn <- Gen.option(Gen.oneOf(ts.map(_.targetId)))
+        aq <- arbitrary[Option[ImagingParameters]]
+        ac <- arbitrary[Boolean]
       yield ItcInput.Imaging(
         NonEmptyList.fromListUnsafe(ss),
         NonEmptyList.fromListUnsafe(ts),
-        sn
+        sn,
+        aq,
+        ac
       )
 
   given Arbitrary[ItcInput.Spectroscopy] =

--- a/modules/service/src/main/scala/lucuma/odb/logic/GeneratorStreaming.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/GeneratorStreaming.scala
@@ -384,8 +384,10 @@ object GeneratorStreaming:
         import lucuma.odb.sequence.gnirs.imaging.Imaging
         (for
           cfg <- extractMode(ObservingMode.GnirsImagingName, context)(_.asGnirsImaging)
+          acq  = acquisitionTime(context.oid, context.itcRes)
+          typ  = gnirsAcqType(context.itcRes)
           itc  = requireImagingItc(ObservingMode.GnirsImagingName, context.oid, context.itcRes, ItcScience.gnirsImaging.getOption)
-          gen <- EitherT(Imaging.gnirs(calculator.gnirsStep, context.namespace, cfg, itc))
+          gen <- EitherT(Imaging.gnirs(context.oid, calculator.gnirsStep, context.namespace, cfg, acq, typ, itc))
           res <- collapseIfNecessary(context, gen)
         yield res).value
 

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -57,6 +57,7 @@ import lucuma.odb.sequence.flamingos2
 import lucuma.odb.sequence.ghost
 import lucuma.odb.sequence.gnirs
 import lucuma.odb.sequence.igrins2
+import lucuma.odb.sequence.imaging.ImagingSequence
 import lucuma.odb.sequence.visitor
 import lucuma.odb.util.Codecs.*
 import skunk.*
@@ -363,11 +364,33 @@ object GeneratorParamsService {
                 )
               )
 
+            // The acquisition images the field in the first (wavelength-ordered) science
+            // filter to classify the target brightness at the classification S/N; the
+            // two-pass acquisition ITC then resolves the type (Very Bright / Bright /
+            // Faint) and re-images through H2 for Very Bright.  Fully auto, so it always
+            // classifies (`gnirsAcqAutoClassify = true`).
+            val firstFilter: GnirsFilter =
+              given Order[GnirsFilter] = ImagingSequence.wavelengthOrder(gnm.variant)(_.centralWavelength)
+              fs.map(_.filter).sorted.head
+
+            val acquisition =
+              ImagingParameters(
+                obsParams.constraints.toInput,
+                InstrumentMode.GnirsImaging(
+                  exposureTimeMode = ExposureTimeMode.SignalToNoiseMode(gnirs.AcquisitionClassificationSignalToNoise, firstFilter.centralWavelength),
+                  filter           = firstFilter,
+                  camera           = gnm.camera,
+                  readMode         = GnirsReadMode.Bright,
+                  wellDepth        = gnm.wellDepth,
+                  coadds           = gnm.coadds
+                )
+              )
+
             val itcInput =
               obsParams
                 .targets
                 .traverse(itcTargetParams)
-                .map(ItcInput.Imaging(inputs, _, obsParams.signalToNoiseTargetId))
+                .map(ItcInput.Imaging(inputs, _, obsParams.signalToNoiseTargetId, acquisition.some, gnirsAcqAutoClassify = true))
                 .leftMap(MissingParamSet.fromParams)
                 .toEither
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -647,22 +647,33 @@ object ItcService {
             )
 
         def imaging(im: ItcInput.Imaging): EitherT[F, OdbError, Itc] =
-          im.science.head.mode match
-            case InstrumentMode.Flamingos2Imaging(_, _, _, _) =>
-              callRemoteImagingItc(oid, im, Imaging.Flamingos2Imaging)
+          val science: EitherT[F, OdbError, Itc] =
+            im.science.head.mode match
+              case InstrumentMode.Flamingos2Imaging(_, _, _, _) =>
+                callRemoteImagingItc(oid, im, Imaging.Flamingos2Imaging)
 
-            case InstrumentMode.GmosNorthImaging(_, _, _, _) =>
-              callRemoteImagingItc(oid, im, Imaging.GmosNorthImaging)
+              case InstrumentMode.GmosNorthImaging(_, _, _, _) =>
+                callRemoteImagingItc(oid, im, Imaging.GmosNorthImaging)
 
-            case InstrumentMode.GmosSouthImaging(_, _, _, _) =>
-              callRemoteImagingItc(oid, im, Imaging.GmosSouthImaging)
+              case InstrumentMode.GmosSouthImaging(_, _, _, _) =>
+                callRemoteImagingItc(oid, im, Imaging.GmosSouthImaging)
 
-            case InstrumentMode.GnirsImaging(_, _, _, _, _, _, _) =>
-              callRemoteImagingItc(oid, im, Imaging.GnirsImaging)
+              case InstrumentMode.GnirsImaging(_, _, _, _, _, _, _) =>
+                callRemoteImagingItc(oid, im, Imaging.GnirsImaging)
 
-            case m                                     =>
-              EitherT.leftT:
-                OdbError.InvalidObservation(oid, s"Imaging ITC lookup is not supported for ${m.displayName}.".some)
+              case m                                     =>
+                EitherT.leftT:
+                  OdbError.InvalidObservation(oid, s"Imaging ITC lookup is not supported for ${m.displayName}.".some)
+
+          // GNIRS imaging has its own acquisition sequence, sized by a dedicated ITC pass;
+          // other imaging modes have none (`acquisitionInput` is empty for them).
+          im.acquisitionInput match
+            case None        => science
+            case Some(input) =>
+              for
+                sci <- science
+                acq <- acquisitionResult(oid, input, im.acquisitionTargets, im.gnirsAcqAutoClassify)
+              yield sci.copy(acquisition = acq)
 
         def spectroscopy(sp: ItcInput.Spectroscopy): EitherT[F, OdbError, Itc] =
           for
@@ -678,7 +689,7 @@ object ItcService {
           yield Itc(ItcAcquisition.NotApplicable, ItcScience.Spectroscopy(sci))
 
         (input match
-          case im @ ItcInput.Imaging(_, _, _) =>
+          case im @ ItcInput.Imaging(_, _, _, _, _) =>
             imaging(im)
           case sp @ ItcInput.Spectroscopy(_, _, _, _, _, _) =>
             spectroscopy(sp)
@@ -737,9 +748,14 @@ object ItcService {
                 safeAcquisitionCall(oid, sp.acquisitionInput, sp.acquisitionTargets, sp.gnirsAcqAutoClassify)
                   .map((z, t) => ItcAcquisition.Available(z, t): ItcAcquisition)
 
-              // Imaging has no acquisition sequence.
-              case ItcInputDerivation.Ready(_: ItcInput.Imaging)                 =>
-                NotApplicable
+              // GNIRS imaging has an acquisition sequence; other imaging modes don't
+              // (`acquisitionInput` is empty for them).
+              case ItcInputDerivation.Ready(im: ItcInput.Imaging)                =>
+                im.acquisitionInput match
+                  case None        => NotApplicable
+                  case Some(input) =>
+                    safeAcquisitionCall(oid, input, im.acquisitionTargets, im.gnirsAcqAutoClassify)
+                      .map((z, t) => ItcAcquisition.Available(z, t): ItcAcquisition)
 
               // GHOST and IGRINS-2 spectroscopy have no acquisition sequence.
               case ItcInputDerivation.Ready(_: ItcInput.ScienceOnlySpectroscopy) =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirsImaging.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirsImaging.scala
@@ -1,0 +1,183 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.query
+
+import cats.effect.IO
+import cats.syntax.either.*
+import cats.syntax.eq.*
+import cats.syntax.option.*
+import io.circe.Json
+import io.circe.literal.*
+import io.circe.syntax.*
+import lucuma.core.enums.GnirsFilter
+import lucuma.core.enums.GnirsReadMode
+import lucuma.core.enums.StepGuideState
+import lucuma.core.model.ExposureTimeMode
+import lucuma.core.model.Observation
+import lucuma.core.syntax.string.*
+import lucuma.core.syntax.timespan.*
+import lucuma.core.util.TimeSpan
+import lucuma.itc.IntegrationTime
+import lucuma.itc.client.ImagingInput
+import lucuma.itc.client.InstrumentMode
+import lucuma.odb.sequence.gnirs.AcquisitionClassificationSignalToNoise
+import lucuma.odb.sequence.gnirs.imaging.Acquisition.RepeatingAtomCount
+import lucuma.refined.*
+
+// GNIRS imaging acquisition. The brightness type (Very Bright / Bright / Faint) is
+// classified from a fixed S/N=10 ITC pass on the first (wavelength-ordered) imaging
+// filter, exactly as for spectroscopy.
+class executionAcqGnirsImaging extends ExecutionTestSupportForGnirs:
+
+  // The acquisition ITC keys on the (fixed) classification S/N and the filter:
+  //   - first-filter classification pass sizes the exposure and picks the type;
+  //   - Very Bright additionally re-images the target through H2.
+  // Different first filters drive different types across the tests:
+  //   J  → 2s × 3 = 6s   → Bright
+  //   K  → 30s × 1 = 30s → Faint
+  //   Y  → 0.3s × 1      → Very Bright (with an H2 pass of 2s × 3)
+  override def fakeItcImagingResultFor(input: ImagingInput): Option[IntegrationTime] =
+    input.mode match
+      case InstrumentMode.GnirsImaging(ExposureTimeMode.SignalToNoiseMode(sn, _), filter, _, _, _, _, _)
+          if sn === AcquisitionClassificationSignalToNoise =>
+        filter match
+          case GnirsFilter.J  => IntegrationTime(2.secTimeSpan,  3.refined).some
+          case GnirsFilter.K  => IntegrationTime(30.secTimeSpan, 1.refined).some
+          case GnirsFilter.Y  => IntegrationTime(300.msTimeSpan, 1.refined).some
+          case GnirsFilter.H2 => IntegrationTime(2.secTimeSpan,  3.refined).some
+          case _              => none
+      case _ => none
+
+  private val AcqStepsQuery: String =
+    s"""
+      description
+      observeClass
+      steps {
+        instrumentConfig {
+          exposure { microseconds }
+          coadds
+          filter
+          decker
+          fpuOther
+          camera
+          readMode
+        }
+        telescopeConfig {
+          offset { p { arcseconds } q { arcseconds } }
+          guiding
+        }
+        observeClass
+        breakpoint
+      }
+    """
+
+  private def gnirsAcqImagingQuery(oid: Observation.Id): String =
+    executionConfigQuery(oid, "gnirs", "acquisition", AcqStepsQuery, None)
+
+  private def readMode(t: TimeSpan): String =
+    GnirsReadMode.forExposureTime(t).tag.toScreamingSnakeCase
+
+  private def acqStep(
+    exposure:   TimeSpan,
+    coadds:     Int,
+    filter:     GnirsFilter,
+    camera:     String,
+    p:          Int,
+    q:          Int,
+    guiding:    StepGuideState,
+    breakpoint: String = "DISABLED"
+  ): Json =
+    json"""
+      {
+        "instrumentConfig": {
+          "exposure":  { "microseconds": ${exposure.toMicroseconds} },
+          "coadds":    $coadds,
+          "filter":    ${filter.tag.toScreamingSnakeCase.asJson},
+          "decker":    "ACQUISITION",
+          "fpuOther":  "ACQUISITION",
+          "camera":    ${camera.asJson},
+          "readMode":  ${readMode(exposure).asJson}
+        },
+        "telescopeConfig": ${expectedTelescopeConfig(p, q, guiding)},
+        "observeClass": "ACQUISITION",
+        "breakpoint":   ${breakpoint.asJson}
+      }
+    """
+
+  // The expected acquisition: an "Initial Acquisition" atom (field image + on-target,
+  // the on-target carrying a breakpoint), then RepeatingAtomCount "Fine Adjustments"
+  // atoms, each a single on-target image. `onTargetBreak` is the on-target with its
+  // breakpoint enabled; `onTarget` is the same step without a breakpoint.
+  private def expectedAcquisition(field: Json, onTargetBreak: Json, onTarget: Json): Json =
+    val fineAdjustment =
+      json"""{ "description": "Fine Adjustments", "observeClass": "ACQUISITION", "steps": [ $onTarget ] }"""
+    json"""
+      {
+        "executionConfig": {
+          "gnirs": {
+            "acquisition": {
+              "nextAtom": {
+                "description": "Initial Acquisition",
+                "observeClass": "ACQUISITION",
+                "steps": [ $field, $onTargetBreak ]
+              },
+              "possibleFuture": ${List.fill(RepeatingAtomCount)(fineAdjustment).asJson},
+              "hasMore": false
+            }
+          }
+        }
+      }
+    """
+
+  // The on-target step, with and without an enabled breakpoint (for the initial atom
+  // and the repeating "Fine Adjustments" atoms respectively).
+  private def onTargetSteps(exposure: TimeSpan, coadds: Int, filter: GnirsFilter, camera: String): (Json, Json) =
+    (acqStep(exposure, coadds, filter, camera, 0, 0, StepGuideState.Enabled, "ENABLED"),
+     acqStep(exposure, coadds, filter, camera, 0, 0, StepGuideState.Enabled))
+
+  private def imagingObs(camera: String, filter: String): IO[Observation.Id] =
+    val mode =
+      s"""
+        gnirsImaging: {
+          camera: $camera
+          filters: [ { filter: $filter } ]
+        }
+      """
+    for
+      p <- createProgram
+      t <- createTargetWithProfileAs(pi, p)
+      o <- createObservationWithModeAs(pi, p, List(t), mode)
+    yield o
+
+  test("Bright: field image in first filter (fixed short-camera exposure), on-target in first filter"):
+    // First filter J classifies as Bright (6s). Field image: (10,0), J, 3s, 1 coadd.
+    // On-target: (0,0), J, 2s (ITC), 3 coadds.
+    val field                     = acqStep(3.secTimeSpan, 1, GnirsFilter.J, "SHORT_BLUE", 10, 0, StepGuideState.Disabled)
+    val (onTargetBreak, onTarget) = onTargetSteps(2.secTimeSpan, 3, GnirsFilter.J, "SHORT_BLUE")
+    imagingObs("SHORT_BLUE", "J").flatMap: oid =>
+      expect(pi, gnirsAcqImagingQuery(oid), expectedAcquisition(field, onTargetBreak, onTarget).asRight)
+
+  test("Very Bright: field image in H (Order4), on-target in H2"):
+    // First filter Y classifies as Very Bright (0.3s). Field image: (10,0), H (Order4),
+    // 3s, 1 coadd. On-target: (0,0), H2, 2s (H2 ITC pass), 3 coadds.
+    val field                     = acqStep(3.secTimeSpan, 1, GnirsFilter.Order4, "SHORT_BLUE", 10, 0, StepGuideState.Disabled)
+    val (onTargetBreak, onTarget) = onTargetSteps(2.secTimeSpan, 3, GnirsFilter.H2, "SHORT_BLUE")
+    imagingObs("SHORT_BLUE", "Y").flatMap: oid =>
+      expect(pi, gnirsAcqImagingQuery(oid), expectedAcquisition(field, onTargetBreak, onTarget).asRight)
+
+  test("Faint: both images in first filter with the ITC exposure, field offset (0,10)"):
+    // First filter K classifies as Faint (30s). Field/keyhole image: (0,10), K, 30s
+    // (ITC), 1 coadd. On-target: (0,0), K, 30s, 1 coadd.
+    val field                     = acqStep(30.secTimeSpan, 1, GnirsFilter.K, "SHORT_BLUE", 0, 10, StepGuideState.Disabled)
+    val (onTargetBreak, onTarget) = onTargetSteps(30.secTimeSpan, 1, GnirsFilter.K, "SHORT_BLUE")
+    imagingObs("SHORT_BLUE", "K").flatMap: oid =>
+      expect(pi, gnirsAcqImagingQuery(oid), expectedAcquisition(field, onTargetBreak, onTarget).asRight)
+
+  test("Long camera uses a 15s keyhole exposure"):
+    // Same Bright classification as the short-camera case, but the long camera's fixed
+    // keyhole exposure is 15s (vs 3s short).
+    val field                     = acqStep(15.secTimeSpan, 1, GnirsFilter.J, "LONG_BLUE", 10, 0, StepGuideState.Disabled)
+    val (onTargetBreak, onTarget) = onTargetSteps(2.secTimeSpan, 3, GnirsFilter.J, "LONG_BLUE")
+    imagingObs("LONG_BLUE", "J").flatMap: oid =>
+      expect(pi, gnirsAcqImagingQuery(oid), expectedAcquisition(field, onTargetBreak, onTarget).asRight)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsImaging.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsImaging.scala
@@ -230,7 +230,9 @@ class executionSciGnirsImaging extends ExecutionTestSupportForGnirs:
     setup.flatMap: oid =>
       expect(pi, gnirsScienceQuery(oid, 100.some), expectedScience(atoms).asRight)
 
-  test("acquisition sequence is empty"):
+  // The acquisition sequence itself is asserted in detail in executionAcqGnirsImaging;
+  // here we just confirm it is now generated (no longer null).
+  test("acquisition sequence is generated"):
     val mode =
       s"""
         gnirsImaging: {
@@ -247,13 +249,5 @@ class executionSciGnirsImaging extends ExecutionTestSupportForGnirs:
       yield o
 
     setup.flatMap: oid =>
-      expect(pi, gnirsAcquisitionQuery(oid),
-        json"""
-          {
-            "executionConfig": {
-              "gnirs": {
-                "acquisition": null
-              }
-            }
-          }
-        """.asRight)
+      query(pi, gnirsAcquisitionQuery(oid)).map: json =>
+        assert(json.hcursor.downFields("executionConfig", "gnirs", "acquisition").focus.exists(!_.isNull))


### PR DESCRIPTION
GNIRS imaging previously generated no acquisition sequence. Because the imaging field of view is small, add an acquisition to center the target: an offset keyhole image followed by an on-target image.

Like spectroscopy, there are three brightness types (Very Bright / Bright / Faint), classified from a fixed S/N=10 ITC pass on the first (wavelength- ordered) imaging filter. The acquisition is fully auto-computed, so no DB or GraphQL schema changes are needed.

- sequence: new gnirs/imaging/Acquisition.scala generator; combine it with science in Imaging.scala; add a shared keyholeExposureTime helper (3s short / 15s long) reused by spectroscopy's useH; add optional acquisition + gnirsAcqAutoClassify to ItcInput.Imaging.
- service: build the acquisition ITC input for GNIRS imaging in GeneratorParamsService; compute the imaging acquisition ITC in ItcService (imaging calc + callRemoteAcquisition); thread the acquisition time/type into Imaging.gnirs from GeneratorStreaming.
- tests: new executionAcqGnirsImaging suite (three types + both cameras); update the executionSciGnirsImaging empty-acquisition test.


Claude-Session: https://claude.ai/code/session_01GWeEBsbkS1N7dtKShK7YoQ