### PR TITLE
Make the ITC legacy tests actually assert

### DIFF
--- a/.github/workflows/legacy-tests.yml
+++ b/.github/workflows/legacy-tests.yml
@@ -12,13 +12,16 @@ on:
 
 jobs:
   legacy-tests:
-    name: ITC Legacy Tests
+    name: ITC Legacy Tests (shard ${{ matrix.shard }})
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     strategy:
+      # One shard failing should not cancel the others; we want the full picture.
+      fail-fast: false
       matrix:
         java: [temurin@25]
         scala: [3]
+        shard: [0, 1, 2, 3, 4, 5]
     steps:
       - name: Checkout code
         uses: nschloe/action-cached-lfs-checkout@v1
@@ -37,7 +40,12 @@ jobs:
           java-version: 25
           cache: sbt
 
+      # Sharding is handled by sbt-test-shards (auto-enabled on every project), which reads
+      # these two variables and filters the suites by name hash. Keep TEST_SHARD_COUNT in step
+      # with the `shard` matrix above.
       - name: Run Legacy ITC Tests
         env:
           RUN_LEGACY_TESTS: true
+          TEST_SHARD_COUNT: 6
+          TEST_SHARD: ${{ matrix.shard }}
         run: sbt -v -J-Xmx6g itcLegacyTests/test

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/CommonITCLegacySuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/CommonITCLegacySuite.scala
@@ -32,11 +32,13 @@ import lucuma.itc.service.ItcObservingConditions
 import lucuma.itc.service.Main.ReverseClassLoader
 import lucuma.itc.service.ObservingMode
 import lucuma.itc.service.TargetData
+import munit.Location
 import munit.Tag
 
 import java.io.File
 import java.io.FileFilter
 import scala.collection.immutable.SortedMap
+import scala.concurrent.duration.*
 
 object LegacyITCTest extends Tag("LegacyItcTest")
 
@@ -46,6 +48,11 @@ import munit.CatsEffectSuite
  * This is a common trait for tests of the legacy ITC code
  */
 trait CommonITCLegacySuite extends CatsEffectSuite:
+
+  // Each of these tests makes one real (and slow) call into the legacy ITC per enum value, and
+  // some of those enums are large — StellarLibrarySpectrum alone has 158. The default 30s is not
+  // enough now that the assertions actually run.
+  override def munitIOTimeout: Duration = 15.minutes
 
   // Common validation functions
   def containsValidResults(r: IntegrationTimeRemoteResult): Boolean =
@@ -57,23 +64,59 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
   def containsValidResultsWithSNAt(r: IntegrationTimeRemoteResult): Boolean =
     containsValidResults(r) && r.signalToNoiseAt.isDefined
 
-  def allowedErrors(err: List[String]) =
-    err.exists(_.contains("Invalid S/N")) || err.exists(_.contains("do not overlap")) ||
-      err.exists(_.contains("Unsupported configuration")) ||
-      err.exists(_.contains("Unsupported calculation method")) ||
-      err.exists(_.matches("Configuration would require \\d* exposures")) ||
-      err.exists(_.contains("target is too bright")) ||
-      err.exists(_.contains("Signal = 0")) ||
-      err.exists(_.contains("Redshifted SED")) ||
-      err.exists(_.contains("Wavelength"))
+  /**
+   * Messages the legacy ITC produces when a configuration simply is not calculable, rather than
+   * because something is wrong.
+   *
+   * The wording is not consistent across instruments: REL-4806 rewrote the messages in GmosRecipe
+   * but left GnirsRecipe and Flamingos2Recipe on the older phrasing, so both forms are listed here.
+   */
+  private val notCalculablePatterns: List[String] = List(
+    "do not overlap",
+    "Unsupported configuration",
+    "Unsupported calculation method",
+    "target is too bright",
+    // GNIRS / Flamingos2 wording
+    "Configuration would require",
+    // GMOS wording, since REL-4806
+    "Insufficient signal at",
+    "exposures required for this configuration",
+    // No read mode satisfies the configuration, e.g. GNIRS imaging with the Order1 / PAH filters
+    "Could not find best read mode"
+  )
 
-  def allowedErrorsWithLargeSN(err: List[String]) =
-    err.exists(_.contains("Invalid S/N")) || err.exists(_.contains("do not overlap")) ||
-      err.exists(_.contains("Unsupported configuration")) ||
-      err.exists(_.contains("Unsupported calculation method")) ||
-      err.exists(_.matches("Configuration would require \\d* exposures")) ||
-      err.exists(_.contains("target is too bright")) ||
-      err.exists(_.contains("Invalid SignalToNoise value"))
+  // "Signal = 0" is GNIRS/Flamingos2; "Signal is <= 0" is the shared ExposureTimeCalculator.
+  private val noSignalPatterns: List[String] = List("Signal = 0", "Signal is <= 0")
+
+  def allowedErrors(err: List[String]): Boolean =
+    val patterns = notCalculablePatterns ++ noSignalPatterns ++ List("Redshifted SED", "Wavelength")
+    err.exists(e => patterns.exists(e.contains))
+
+  def allowedErrorsWithLargeSN(err: List[String]): Boolean =
+    val patterns = notCalculablePatterns :+ "Invalid SignalToNoise value"
+    err.exists(e => patterns.exists(e.contains))
+
+  /**
+   * Runs `run` for every value and fails listing every value whose result was not acceptable, each
+   * paired with why it was rejected.
+   *
+   * Always iterate with this rather than `foreach`: `assertIOBoolean` returns an `IO`, which
+   * `foreach` discards, silently turning the assertion into a no-op.
+   */
+  def assertAllValid[A](
+    values:      List[A],
+    errorCheck:  List[String] => Boolean = allowedErrors,
+    resultCheck: IntegrationTimeRemoteResult => Boolean = containsValidResults
+  )(run: A => IO[Either[List[String], IntegrationTimeRemoteResult]])(using Location): IO[Unit] =
+    values
+      .traverse: a =>
+        run(a).map:
+          case Left(errs) if !errorCheck(errs) =>
+            (a -> s"disallowed error: ${errs.mkString("; ")}").some
+          case Right(r) if !resultCheck(r)     => (a -> s"unacceptable result: $r").some
+          case _                               => none
+      .map(_.flattenOption)
+      .map(assertEquals(_, List.empty[(A, String)]))
 
   // Initialize the local ITC
   lazy val localItc = {
@@ -130,6 +173,13 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
     ifu match
       case GnirsFpuIfu.LowResolution  => GnirsCamera.ShortBlue
       case GnirsFpuIfu.HighResolution => GnirsCamera.LongBlue
+
+  // The 10 l/mm grating is only usable with a long camera (Gnirs.java rejects it on the
+  // 0.15"/pix short camera), so pair it up rather than leaving it untested.
+  def gnirsCameraForGrating(grating: GnirsGrating, default: GnirsCamera): GnirsCamera =
+    grating match
+      case GnirsGrating.D10 => GnirsCamera.LongBlue
+      case _                => default
 
   // Common telescope details - this will be used in tests
   def telescope = ItcTelescopeDetails(
@@ -352,42 +402,38 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
   // Common test implementations
   def testConditions(name: String, params: ItcParameters): Unit =
     test(s"$name - image quality".tag(LegacyITCTest)):
-      Enumerated[ImageQuality.Preset].all.foreach: iq =>
-        val result = localItc
+      assertAllValid(Enumerated[ImageQuality.Preset].all): iq =>
+        localItc
           .calculate(
             params
               .copy(conditions = params.conditions.copy(iq = iq.toImageQuality.toArcSeconds))
               .asJson
               .noSpaces
           )
-        assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
     test(s"$name - cloud extinction".tag(LegacyITCTest)):
-      Enumerated[CloudExtinction.Preset].all.foreach: ce =>
-        val result = localItc
+      assertAllValid(Enumerated[CloudExtinction.Preset].all): ce =>
+        localItc
           .calculate(
             params
               .copy(conditions = params.conditions.copy(cc = ce.toCloudExtinction.toVegaMagnitude))
               .asJson
               .noSpaces
           )
-        assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
     test(s"$name - water vapor".tag(LegacyITCTest)):
-      Enumerated[WaterVapor].all.foreach: wv =>
-        val result = localItc
+      assertAllValid(Enumerated[WaterVapor].all): wv =>
+        localItc
           .calculate(
             params.copy(conditions = params.conditions.copy(wv = wv)).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
     test(s"$name - sky background".tag(LegacyITCTest)):
-      Enumerated[SkyBackground].all.foreach: sb =>
-        val result = localItc
+      assertAllValid(Enumerated[SkyBackground].all): sb =>
+        localItc
           .calculate(
             params.copy(conditions = params.conditions.copy(sb = sb)).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   def testSEDs(
     name:        String,
@@ -397,8 +443,8 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
   ): Unit =
     test(s"$name - stellar library spectrum".tag(LegacyITCTest)):
       assume(runStellar, "Skip stellar library spectrum test")
-      Enumerated[StellarLibrarySpectrum].all.foreach: f =>
-        val result = localItc
+      assertAllValid(Enumerated[StellarLibrarySpectrum].all): f =>
+        localItc
           .calculate(
             bodySED(
               baseParams.source,
@@ -408,12 +454,11 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
               UnnormalizedSED.StellarLibrary(f)
             ).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
     test(s"$name - cool star".tag(LegacyITCTest)):
       assume(runCoolStar, "Skip cool star test")
-      Enumerated[CoolStarTemperature].all.foreach: f =>
-        val result = localItc
+      assertAllValid(Enumerated[CoolStarTemperature].all): f =>
+        localItc
           .calculate(
             bodySED(
               baseParams.source,
@@ -423,11 +468,10 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
               UnnormalizedSED.CoolStarModel(f)
             ).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
     test(s"$name - galaxy spectrum".tag(LegacyITCTest)):
-      Enumerated[GalaxySpectrum].all.foreach: f =>
-        val result = localItc
+      assertAllValid(Enumerated[GalaxySpectrum].all): f =>
+        localItc
           .calculate(
             bodySED(
               baseParams.source,
@@ -437,11 +481,10 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
               UnnormalizedSED.Galaxy(f)
             ).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
     test(s"$name - planet spectrum".tag(LegacyITCTest)):
-      Enumerated[PlanetSpectrum].all.foreach: f =>
-        val result = localItc
+      assertAllValid(Enumerated[PlanetSpectrum].all): f =>
+        localItc
           .calculate(
             bodySED(
               baseParams.source,
@@ -451,11 +494,10 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
               UnnormalizedSED.Planet(f)
             ).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
     test(s"$name - quasar spectrum".tag(LegacyITCTest)):
-      Enumerated[QuasarSpectrum].all.foreach: f =>
-        val result = localItc
+      assertAllValid(Enumerated[QuasarSpectrum].all): f =>
+        localItc
           .calculate(
             bodySED(
               baseParams.source,
@@ -465,11 +507,10 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
               UnnormalizedSED.Quasar(f)
             ).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
     test(s"$name - hii region spectrum".tag(LegacyITCTest)):
-      Enumerated[HIIRegionSpectrum].all.foreach: f =>
-        val result = localItc
+      assertAllValid(Enumerated[HIIRegionSpectrum].all): f =>
+        localItc
           .calculate(
             bodySED(
               baseParams.source,
@@ -479,11 +520,10 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
               UnnormalizedSED.HIIRegion(f)
             ).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
     test(s"$name - planetary nebula spectrum".tag(LegacyITCTest)):
-      Enumerated[PlanetaryNebulaSpectrum].all.foreach: f =>
-        val result = localItc
+      assertAllValid(Enumerated[PlanetaryNebulaSpectrum].all): f =>
+        localItc
           .calculate(
             bodySED(
               baseParams.source,
@@ -493,7 +533,6 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
               UnnormalizedSED.PlanetaryNebula(f)
             ).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   def testUserDefinedSED(name: String, baseParams: ItcParameters): Unit =
     test(s"$name - user defined SED".tag(LegacyITCTest)):
@@ -522,8 +561,8 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
     errorCheck: List[String] => Boolean = allowedErrors
   ): Unit =
     test(s"$name - brightness integrated units".tag(LegacyITCTest)):
-      Brightness.Integrated.all.toList.foreach: f =>
-        val result = localItc
+      assertAllValid(Brightness.Integrated.all.toList, errorCheck = errorCheck): f =>
+        localItc
           .calculate(
             bodyIntMagUnits(
               baseParams.source,
@@ -533,11 +572,10 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
               f.withValueTagged(BrightnessValue.unsafeFrom(5))
             ).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(errorCheck, containsValidResults)))
 
     test(s"$name - surface units".tag(LegacyITCTest)):
-      Brightness.Surface.all.toList.foreach: f =>
-        val result = localItc
+      assertAllValid(Brightness.Surface.all.toList, errorCheck = errorCheck): f =>
+        localItc
           .calculate(
             bodySurfaceMagUnits(
               baseParams.source,
@@ -547,11 +585,10 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
               f.withValueTagged(BrightnessValue.unsafeFrom(5))
             ).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(errorCheck, containsValidResults)))
 
     test(s"$name - gaussian units".tag(LegacyITCTest)):
-      Brightness.Integrated.all.toList.foreach: f =>
-        val result = localItc
+      assertAllValid(Brightness.Integrated.all.toList, errorCheck = errorCheck): f =>
+        localItc
           .calculate(
             bodyIntGaussianMagUnits(
               baseParams.source,
@@ -561,12 +598,11 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
               f.withValueTagged(BrightnessValue.unsafeFrom(5))
             ).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(errorCheck, containsValidResults)))
 
   def testPowerAndBlackbody(name: String, baseParams: ItcParameters): Unit =
     test(s"$name - power law".tag(LegacyITCTest)):
-      List(-10, 0, 10).foreach: f =>
-        val result = localItc
+      assertAllValid(List(-10, 0, 10)): f =>
+        localItc
           .calculate(
             bodyPowerLaw(
               baseParams.source,
@@ -576,4 +612,3 @@ trait CommonITCLegacySuite extends CatsEffectSuite:
               f
             ).asJson.noSpaces
           )
-        assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCFlamingos2Suite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCFlamingos2Suite.scala
@@ -3,7 +3,6 @@
 
 package lucuma.itc.legacy
 
-import cats.syntax.traverse.*
 import io.circe.syntax.*
 import lucuma.core.enums.*
 import lucuma.core.util.Enumerated
@@ -36,8 +35,8 @@ trait LegacyITCFlamingos2Suite extends CommonITCLegacySuite:
   def title: String
 
   test(s"$title - Flamingos2 filter".tag(LegacyITCTest)):
-    Enumerated[Flamingos2Filter].all.traverse: f =>
-      val result = localItc
+    assertAllValid(Enumerated[Flamingos2Filter].all): f =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition,
                    obs,
@@ -45,19 +44,17 @@ trait LegacyITCFlamingos2Suite extends CommonITCLegacySuite:
                    analysisMethod
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test(s"$title - Flamingos2 fpu".tag(LegacyITCTest).tag(F2FpuTest)):
-    Enumerated[Flamingos2Fpu].all.traverse: f =>
-      val result = localItc
+    assertAllValid(Enumerated[Flamingos2Fpu].all): f =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition, obs, observingModeWithFpu(f)).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test(s"$title - Flamingos2 read mode".tag(LegacyITCTest).tag(F2ReadModeTest)):
-    Enumerated[Flamingos2ReadMode].all.traverse: rm =>
-      val result = localItc
+    assertAllValid(Enumerated[Flamingos2ReadMode].all): rm =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition,
                    obs,
@@ -65,7 +62,6 @@ trait LegacyITCFlamingos2Suite extends CommonITCLegacySuite:
                    analysisMethod
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   // Testing observing conditions
   testConditions(title, baseParams)

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGmosImgExpTimeSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGmosImgExpTimeSuite.scala
@@ -66,12 +66,11 @@ class LegacyITCGmosImgExpTimeSuite extends CommonITCLegacySuite:
   )
 
   test("gmos north filter".tag(LegacyITCTest)):
-    Enumerated[GmosNorthFilter].all.foreach: f =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosNorthFilter].all): f =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition, obs, gmosNConf.copy(filter = f)).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   // GMOS South filter testing
   val gmosSConf = ObservingMode.ImagingMode.GmosSouth(
@@ -87,12 +86,11 @@ class LegacyITCGmosImgExpTimeSuite extends CommonITCLegacySuite:
   )
 
   test("gmos south filter".tag(LegacyITCTest)):
-    Enumerated[GmosSouthFilter].all.foreach: f =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosSouthFilter].all): f =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition, obs, gmosSConf.copy(filter = f)).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   // Testing various SEDs
   testSEDs("GMOS imaging TxC", baseParams)

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGmosImgSignalToNoiseSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGmosImgSignalToNoiseSuite.scala
@@ -64,12 +64,11 @@ class LegacyITCGmosImgSignalToNoiseSuite extends CommonITCLegacySuite:
   )
 
   test("gmos north filter".tag(LegacyITCTest)):
-    Enumerated[GmosNorthFilter].all.foreach: f =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosNorthFilter].all): f =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition, obs, gmosNConf.copy(filter = f)).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   // GMOS South filter testing
   val gmosSConf = ObservingMode.ImagingMode.GmosSouth(
@@ -85,12 +84,11 @@ class LegacyITCGmosImgSignalToNoiseSuite extends CommonITCLegacySuite:
   )
 
   test("gmos south filter".tag(LegacyITCTest)):
-    Enumerated[GmosSouthFilter].all.foreach: f =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosSouthFilter].all): f =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition, obs, gmosSConf.copy(filter = f)).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   // Testing various SEDs
   testSEDs("GMOS imaging TxC S/N", baseParams, false, false)

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGmosSpecExpTimeSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGmosSpecExpTimeSuite.scala
@@ -80,8 +80,8 @@ class LegacyITCGmosSpecExpTimeSuite extends CommonITCLegacySuite:
   )
 
   test("gmos north grating".tag(LegacyITCTest)):
-    Enumerated[GmosNorthGrating].all.foreach: d =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosNorthGrating].all): d =>
+      localItc
         .calculate(
           bodyConf(
             sourceDefinition,
@@ -89,11 +89,10 @@ class LegacyITCGmosSpecExpTimeSuite extends CommonITCLegacySuite:
             gnConf.copy(disperser = d)
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gmos north filter".tag(LegacyITCTest)):
-    Enumerated[GmosNorthFilter].all.foreach: f =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosNorthFilter].all): f =>
+      localItc
         .calculate(
           bodyConf(
             sourceDefinition,
@@ -101,11 +100,10 @@ class LegacyITCGmosSpecExpTimeSuite extends CommonITCLegacySuite:
             gnConf.copy(filter = f.some)
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gmos north fpu".tag(LegacyITCTest)):
-    Enumerated[GmosNorthFpu].all.foreach: f =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosNorthFpu].all): f =>
+      localItc
         .calculate(
           bodyConf(
             sourceDefinition,
@@ -114,11 +112,10 @@ class LegacyITCGmosSpecExpTimeSuite extends CommonITCLegacySuite:
             if (f.isIFU) ifuAnalysisMethod else lsAnalysisMethod
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gmos north mos custom slit width".tag(LegacyITCTest)):
-    Enumerated[GmosCustomSlitWidth].all.foreach: w =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosCustomSlitWidth].all): w =>
+      localItc
         .calculate(
           bodyConf(
             sourceDefinition,
@@ -126,7 +123,6 @@ class LegacyITCGmosSpecExpTimeSuite extends CommonITCLegacySuite:
             gnConf.copy(fpu = GmosNorthFpuParam(GmosFpuMask.Custom(ToBeDefined, w)))
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   // GMOS South grating configuration testing
   val gsConf = ObservingMode.SpectroscopyMode.GmosSouth(
@@ -146,8 +142,8 @@ class LegacyITCGmosSpecExpTimeSuite extends CommonITCLegacySuite:
   )
 
   test("gmos south grating".tag(LegacyITCTest)):
-    Enumerated[GmosSouthGrating].all.foreach: d =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosSouthGrating].all): d =>
+      localItc
         .calculate(
           bodyConf(
             sourceDefinition,
@@ -155,11 +151,10 @@ class LegacyITCGmosSpecExpTimeSuite extends CommonITCLegacySuite:
             gsConf.copy(disperser = d)
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gmos south filter".tag(LegacyITCTest)):
-    Enumerated[GmosSouthFilter].all.foreach: f =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosSouthFilter].all): f =>
+      localItc
         .calculate(
           bodyConf(
             sourceDefinition,
@@ -167,11 +162,10 @@ class LegacyITCGmosSpecExpTimeSuite extends CommonITCLegacySuite:
             gsConf.copy(filter = f.some)
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gmos south fpu".tag(LegacyITCTest)):
-    Enumerated[GmosSouthFpu].all.foreach: f =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosSouthFpu].all): f =>
+      localItc
         .calculate(
           bodyConf(
             sourceDefinition,
@@ -180,11 +174,10 @@ class LegacyITCGmosSpecExpTimeSuite extends CommonITCLegacySuite:
             if (f.isIFU) ifuAnalysisMethod else lsAnalysisMethod
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gmos south mos custom slit width".tag(LegacyITCTest)):
-    Enumerated[GmosCustomSlitWidth].all.foreach: w =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosCustomSlitWidth].all): w =>
+      localItc
         .calculate(
           bodyConf(
             sourceDefinition,
@@ -192,7 +185,6 @@ class LegacyITCGmosSpecExpTimeSuite extends CommonITCLegacySuite:
             gsConf.copy(fpu = GmosSouthFpuParam(GmosFpuMask.Custom(ToBeDefined, w)))
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   // Testing various SEDs
   testSEDs("GMOS spectroscopy TxC", baseParams)

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGmosSpecSignalToNoiseSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGmosSpecSignalToNoiseSuite.scala
@@ -74,24 +74,22 @@ class LegacyITCGmosSpecSignalToNoiseSuite extends CommonITCLegacySuite:
   )
 
   test("gmos north grating".tag(LegacyITCTest)):
-    Enumerated[GmosNorthGrating].all.foreach: d =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosNorthGrating].all): d =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition, obs, gnConf.copy(disperser = d)).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gmos north filter".tag(LegacyITCTest)):
-    Enumerated[GmosNorthFilter].all.foreach: f =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosNorthFilter].all): f =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition, obs, gnConf.copy(filter = f.some)).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gmos north fpu".tag(LegacyITCTest)):
-    Enumerated[GmosNorthFpu].all.foreach: f =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosNorthFpu].all): f =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition,
                    obs,
@@ -99,11 +97,10 @@ class LegacyITCGmosSpecSignalToNoiseSuite extends CommonITCLegacySuite:
                    analysis = if (f.isIFU) ifuAnalysisMethod else lsAnalysisMethod
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gmos north mos custom slit width".tag(LegacyITCTest)):
-    Enumerated[GmosCustomSlitWidth].all.foreach: w =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosCustomSlitWidth].all): w =>
+      localItc
         .calculate(
           bodyConf(
             sourceDefinition,
@@ -111,7 +108,6 @@ class LegacyITCGmosSpecSignalToNoiseSuite extends CommonITCLegacySuite:
             gnConf.copy(fpu = GmosNorthFpuParam(GmosFpuMask.Custom(ToBeDefined, w)))
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   val gsConf = ObservingMode.SpectroscopyMode.GmosSouth(
     Wavelength.decimalNanometers.getOption(600).get,
@@ -129,24 +125,22 @@ class LegacyITCGmosSpecSignalToNoiseSuite extends CommonITCLegacySuite:
   )
 
   test("gmos south grating".tag(LegacyITCTest)):
-    Enumerated[GmosSouthGrating].all.foreach: d =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosSouthGrating].all): d =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition, obs, gsConf.copy(disperser = d)).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gmos south filter".tag(LegacyITCTest)):
-    Enumerated[GmosSouthFilter].all.foreach: f =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosSouthFilter].all): f =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition, obs, gsConf.copy(filter = f.some)).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gmos south fpu".tag(LegacyITCTest)):
-    Enumerated[GmosSouthFpu].all.foreach: f =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosSouthFpu].all): f =>
+      localItc
         .calculate(
           bodyConf(sourceDefinition,
                    obs,
@@ -154,11 +148,10 @@ class LegacyITCGmosSpecSignalToNoiseSuite extends CommonITCLegacySuite:
                    analysis = if (f.isIFU) ifuAnalysisMethod else lsAnalysisMethod
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gmos south mos custom slit width".tag(LegacyITCTest)):
-    Enumerated[GmosCustomSlitWidth].all.foreach: w =>
-      val result = localItc
+    assertAllValid(Enumerated[GmosCustomSlitWidth].all): w =>
+      localItc
         .calculate(
           bodyConf(
             sourceDefinition,
@@ -166,7 +159,6 @@ class LegacyITCGmosSpecSignalToNoiseSuite extends CommonITCLegacySuite:
             gsConf.copy(fpu = GmosSouthFpuParam(GmosFpuMask.Custom(ToBeDefined, w)))
           ).asJson.noSpaces
         )
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   // Testing various SEDs
   testSEDs("GMOS spectroscopy S/N", baseParams)

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsImgExpTimeSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsImgExpTimeSuite.scala
@@ -54,28 +54,24 @@ class LegacyITCGnirsImgExpTimeSuite extends CommonITCLegacySuite:
     assertIOBoolean(result.map(_.fold(_ => false, containsValidResults)))
 
   test("gnirs imaging filter".tag(LegacyITCTest)):
-    Enumerated[GnirsFilter].all.foreach: f =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsFilter].all): f =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(filter = f)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs imaging camera".tag(LegacyITCTest)):
-    Enumerated[GnirsCamera].all.foreach: c =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsCamera].all): c =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(camera = c)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs imaging read mode".tag(LegacyITCTest)):
-    Enumerated[GnirsReadMode].all.foreach: r =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsReadMode].all): r =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(readMode = r)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs imaging well depth".tag(LegacyITCTest)):
-    Enumerated[GnirsWellDepth].all.foreach: w =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsWellDepth].all): w =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(wellDepth = w)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   testConditions("GNIRS imaging S/N", baseParams)
 

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsImgSignalToNoiseSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsImgSignalToNoiseSuite.scala
@@ -52,28 +52,24 @@ class LegacyITCGnirsImgSignalToNoiseSuite extends CommonITCLegacySuite:
     assertIOBoolean(result.map(_.fold(_ => false, containsValidResults)))
 
   test("gnirs imaging filter".tag(LegacyITCTest)):
-    Enumerated[GnirsFilter].all.foreach: f =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsFilter].all): f =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(filter = f)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs imaging camera".tag(LegacyITCTest)):
-    Enumerated[GnirsCamera].all.foreach: c =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsCamera].all): c =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(camera = c)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs imaging read mode".tag(LegacyITCTest)):
-    Enumerated[GnirsReadMode].all.foreach: r =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsReadMode].all): r =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(readMode = r)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs imaging well depth".tag(LegacyITCTest)):
-    Enumerated[GnirsWellDepth].all.foreach: w =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsWellDepth].all): w =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(wellDepth = w)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   testConditions("GNIRS imaging integration time", baseParams)
 

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecExpTimeSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecExpTimeSuite.scala
@@ -61,62 +61,58 @@ class LegacyITCGnirsSpecExpTimeSuite extends CommonITCLegacySuite:
   override def instrument = ItcInstrumentDetails(gnirs)
 
   test("gnirs grating".tag(LegacyITCTest)):
-    Enumerated[GnirsGrating].all.foreach: g =>
-      val result = localItc.calculate:
-        bodyConf(sourceDefinition, obs, gnirs.copy(grating = g)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
+    assertAllValid(Enumerated[GnirsGrating].all): g =>
+      localItc.calculate:
+        bodyConf(
+          sourceDefinition,
+          obs,
+          gnirs.copy(grating = g, camera = gnirsCameraForGrating(g, gnirs.camera))
+        ).asJson.noSpaces
 
   test("gnirs filter".tag(LegacyITCTest)):
-    Enumerated[GnirsFilter].all.foreach: f =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsFilter].all): f =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(filter = f)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs camera".tag(LegacyITCTest)):
-    Enumerated[GnirsCamera].all.foreach: c =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsCamera].all): c =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(camera = c)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs prism".tag(LegacyITCTest)):
-    Enumerated[GnirsPrism].all.foreach: p =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsPrism].all): p =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(prism = p)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs read mode".tag(LegacyITCTest)):
-    Enumerated[GnirsReadMode].all.foreach: r =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsReadMode].all): r =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(readMode = r)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs slit width".tag(LegacyITCTest)):
-    Enumerated[GnirsFpuSlit].all.foreach: s =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsFpuSlit].all): s =>
+      localItc.calculate:
         bodyConf(sourceDefinition,
                  obs,
                  gnirs.copy(fpu = GnirsFpu.Spectroscopy.Slit(s))
         ).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
-  // Note `traverse_`, not `foreach`: `assertIOBoolean` returns an IO, and `foreach` discards it,
-  // which would make the assertion a no-op.
   test("gnirs IFU".tag(LegacyITCTest)):
-    Enumerated[GnirsFpuIfu].all.traverse_ { ifu =>
+    assertAllValid(
+      Enumerated[GnirsFpuIfu].all,
+      resultCheck = containsValidResultsWithSNAt
+    ): ifu =>
       val ifuMode = gnirs.copy(
         fpu = GnirsFpu.Spectroscopy.Ifu(ifu),
         camera = gnirsCameraForIfu(ifu)
       )
-      val result  = localItc.calculate:
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, ifuMode, gnirsIfuAnalysisMethod).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResultsWithSNAt)))
-    }
 
   test("gnirs well depth".tag(LegacyITCTest)):
-    Enumerated[GnirsWellDepth].all.foreach: w =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsWellDepth].all): w =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(wellDepth = w)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   testConditions("GNIRS spectroscopy S/N", baseParams)
 

--- a/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecSignalToNoiseSuite.scala
+++ b/itc/legacy-tests/src/test/scala/lucuma/itc/legacy/LegacyITCGnirsSpecSignalToNoiseSuite.scala
@@ -3,7 +3,6 @@
 
 package lucuma.itc.legacy
 
-import cats.syntax.all.*
 import eu.timepit.refined.types.numeric.PosInt
 import io.circe.syntax.*
 import lucuma.core.enums.GnirsCamera
@@ -78,63 +77,60 @@ class LegacyITCGnirsSpecSignalToNoiseSuite extends CommonITCLegacySuite:
   // The S/N at the requested wavelength is asserted explicitly: the OCS GnirsRecipe IFU
   // branch used to hardcode an empty signalToNoiseAt, which left the S/N column of the
   // Explore spectroscopy modes table blank for GNIRS IFU rows in time-and-count mode.
-  // Note `traverse_`, not `foreach`: `assertIOBoolean` returns an IO, and `foreach` discards it,
-  // which would make the assertion a no-op.
   test("gnirs IFU".tag(LegacyITCTest)):
-    Enumerated[GnirsFpuIfu].all.traverse_ { ifu =>
+    assertAllValid(
+      Enumerated[GnirsFpuIfu].all,
+      errorCheck = _ => false,
+      resultCheck = containsValidResultsWithSNAt
+    ): ifu =>
       val ifuMode = gnirs.copy(
         fpu = GnirsFpu.Spectroscopy.Ifu(ifu),
         camera = gnirsCameraForIfu(ifu)
       )
-      val result  = localItc.calculate:
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, ifuMode, gnirsIfuAnalysisMethod).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(_ => false, containsValidResultsWithSNAt)))
-    }
 
   test("gnirs grating".tag(LegacyITCTest)):
-    Enumerated[GnirsGrating].all.foreach: g =>
-      val result = localItc.calculate:
-        bodyConf(sourceDefinition, obs, gnirs.copy(grating = g)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
+    assertAllValid(Enumerated[GnirsGrating].all): g =>
+      localItc.calculate:
+        bodyConf(
+          sourceDefinition,
+          obs,
+          gnirs.copy(grating = g, camera = gnirsCameraForGrating(g, gnirs.camera))
+        ).asJson.noSpaces
 
   test("gnirs filter".tag(LegacyITCTest)):
-    Enumerated[GnirsFilter].all.foreach: f =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsFilter].all): f =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(filter = f)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs camera".tag(LegacyITCTest)):
-    Enumerated[GnirsCamera].all.foreach: c =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsCamera].all): c =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(camera = c)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs prism".tag(LegacyITCTest)):
-    Enumerated[GnirsPrism].all.foreach: p =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsPrism].all): p =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(prism = p)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs read mode".tag(LegacyITCTest)):
-    Enumerated[GnirsReadMode].all.foreach: r =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsReadMode].all): r =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(readMode = r)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs slit width".tag(LegacyITCTest)):
-    Enumerated[GnirsFpuSlit].all.foreach: s =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsFpuSlit].all): s =>
+      localItc.calculate:
         bodyConf(sourceDefinition,
                  obs,
                  gnirs.copy(fpu = GnirsFpu.Spectroscopy.Slit(s))
         ).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   test("gnirs well depth".tag(LegacyITCTest)):
-    Enumerated[GnirsWellDepth].all.foreach: w =>
-      val result = localItc.calculate:
+    assertAllValid(Enumerated[GnirsWellDepth].all): w =>
+      localItc.calculate:
         bodyConf(sourceDefinition, obs, gnirs.copy(wellDepth = w)).asJson.noSpaces
-      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))
 
   testConditions("GNIRS spectroscopy integration time", baseParams)
 


### PR DESCRIPTION
Every looping test in these suites iterated with `foreach`:

    Enumerated[GnirsFpuIfu].all.foreach: ifu =>
      val result = localItc.calculate(...)
      assertIOBoolean(result.map(_.fold(allowedErrors, containsValidResults)))

`assertIOBoolean` returns an `IO`, and `foreach` expects `Unit`, so the `IO`
was discarded and never run. The assertion was a no-op and the test passed
unconditionally. That is how the GNIRS IFU signal-to-noise gap went unnoticed:
the "gnirs IFU" test passed against both the broken and the fixed OCS jars.

This affected 53 sites. Fifteen were in the shared generators (testConditions,
testSEDs, testBrightnessUnits, testPowerAndBlackbody), which twelve suites call,
so roughly 180 test instances were asserting nothing.

Replaces the pattern with an `assertAllValid` helper that runs the body for
every value and fails listing every value that was rejected along with why.
Collecting all offenders rather than failing fast matters here: this is the
first time the assertions have run, so a single run has to be a triage pass.
The three `.traverse:` sites in LegacyITCFlamingos2Suite were already correct
but are folded in too, so only one idiom remains to copy.

Turning the assertions on surfaced nine failures, all now resolved:

- Seven were stale `allowedErrors` patterns. OCS 41f8bdd14 (REL-4806) rewrote
  GmosRecipe's messages to "Insufficient signal at N nm" and "N exposures
  required for this configuration", but the list still matched the old wording.
  Note GnirsRecipe and Flamingos2Recipe were left on the older phrasing, so
  both forms are needed. Dropped "Invalid S/N", which matches nothing in either
  the OCS or this repo any more.
- Two were a bad fixture: the GNIRS 10 l/mm grating cannot be used with the
  0.15"/pix short camera. Added `gnirsCameraForGrating`, mirroring the existing
  `gnirsCameraForIfu`, so D10 is exercised rather than excused.
- One was GNIRS imaging with the Order1 / PAH filters reporting "Could not find
  best read mode", accepted as a legitimate rejection.

Also raises munitIOTimeout. These tests previously did nothing but build JSON
strings; they now make around 3000 real ITC calls per run, and the largest
single test (158 StellarLibrarySpectrum values) exceeded the 30s default. The
legacy-tests workflow will go from seconds to roughly twenty minutes.

Full suite: 301 tests, 0 failed, 299 passed, 2 skipped.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q8HPfo5nknxUYmpQkYZVnb