### PR TITLE
Email notification of proposal submission

### DIFF
--- a/ODB-README.md
+++ b/ODB-README.md
@@ -154,6 +154,20 @@ Two more config variables are required:
 - INVITATION_SENDER_EMAIL - this should be some user in the MAILGUN_DOMAIN. For example `explore@mail.odb-dev.lucuma.xyz`. This will be the sender of the invitation emails.
 - EXPLORE_URL - The url of the Explore instance for this version of the ODB. For example `https://explore-dev.lucuma.xyz`. This is used to put a link to explore in the invitation emails.
 
+### Proposal notification emails
+
+When a proposal is submitted, a notification is sent to an address that depends on the type of the
+proposal. Each address is read from its own variable, falling back to `PROPOSAL_EMAIL_DEFAULT` when
+that variable is not set. If neither is set, the odb will fail when loading the configuration.
+
+- PROPOSAL_EMAIL_DEFAULT - used for any of the variables below that is not set.
+- By call for proposals type: PROPOSAL_EMAIL_DEMO_SCIENCE, PROPOSAL_EMAIL_DIRECTORS_TIME,
+  PROPOSAL_EMAIL_FAST_TURNAROUND, PROPOSAL_EMAIL_LARGE_PROGRAM, PROPOSAL_EMAIL_POOR_WEATHER,
+  PROPOSAL_EMAIL_SYSTEM_VERIFICATION
+- By exchange partner: PROPOSAL_EMAIL_KECK, PROPOSAL_EMAIL_SUBARU
+- By partner: PROPOSAL_EMAIL_AR, PROPOSAL_EMAIL_BR, PROPOSAL_EMAIL_CA, PROPOSAL_EMAIL_CL,
+  PROPOSAL_EMAIL_KR, PROPOSAL_EMAIL_UH, PROPOSAL_EMAIL_US
+
 To run the odb locally, the environment variables in this section must be set or the odb will fail when
 loading the configuration. Here is the complete list with some example values.
 
@@ -162,6 +176,7 @@ loading the configuration. Here is the complete list with some example values.
 - MAILGUN_WEBHOOK_SIGNING_KEY=<Any string> (Can be anything, since webhooks won't be received locally)
 - INVITATION_SENDER_EMAIL=explore@mail.odb-dev.lucuma.xyz
 - EXPLORE_URL=https://explore-dev.lucuma.xyz
+- PROPOSAL_EMAIL_DEFAULT=noreply@gemini.edu (The per-type variables are all optional)
 
 Mailgun sets other variables in the Heroku app, but they are for things we are not using.
 

--- a/flake.nix
+++ b/flake.nix
@@ -105,6 +105,10 @@ yMvjw3Rl9GQnMoTGYsNsunNy4Q==
               value = "noreply@gemini.edu";
             }
             {
+              name = "PROPOSAL_EMAIL_DEFAULT";
+              value = "noreply@gemini.edu";
+            }
+            {
               name = "EXPLORE_URL";
               value = "https://explore-dev.lucuma.xyz";
             }

--- a/modules/service/src/main/scala/lucuma/odb/Config.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Config.scala
@@ -22,6 +22,9 @@ import lucuma.catalog.simbad.SEDDataLoader
 import lucuma.catalog.telluric.TelluricTargetsClient
 import lucuma.common.middleware.TracingMiddleware
 import lucuma.core.data.EmailAddress
+import lucuma.core.enums.ExchangePartner
+import lucuma.core.enums.GeminiCallForProposalsType
+import lucuma.core.enums.Partner
 import lucuma.core.model.Program
 import lucuma.core.model.User
 import lucuma.core.util.Gid
@@ -274,7 +277,8 @@ object Config:
     domain:            NonEmptyString,
     webhookSigningKey: NonEmptyString,
     invitationFrom:    EmailAddress,
-    exploreUrl:        Uri
+    exploreUrl:        Uri,
+    proposalEmails:    ProposalEmails
   ):
     // add to environment?
     lazy val baseUri        = uri"https://api.mailgun.net/v3"
@@ -287,12 +291,96 @@ object Config:
       envOrProp("MAILGUN_DOMAIN").as[NonEmptyString],
       envOrProp("MAILGUN_WEBHOOK_SIGNING_KEY").as[NonEmptyString],
       envOrProp("INVITATION_SENDER_EMAIL").as[EmailAddress],
-      envOrProp("EXPLORE_URL").as[Uri]
+      envOrProp("EXPLORE_URL").as[Uri],
+      ProposalEmails.fromCiris
     ).parMapN(Email.apply)
 
-    private given ConfigDecoder[String, EmailAddress] =
-      ConfigDecoder[String].mapOption("Email Address"): s =>
-        EmailAddress.from(s).toOption
+  /**
+   * Addresses that are notified when a proposal is submitted, in addition to the PI. Which
+   * address is used depends on the type of the proposal: the call for proposals type for Gemini
+   * proposals, the exchange partner for Keck and Subaru proposals, and the partner for the NGOs.
+   */
+  case class ProposalEmails(
+    demoScience:        EmailAddress,
+    directorsTime:      EmailAddress,
+    fastTurnaround:     EmailAddress,
+    largeProgram:       EmailAddress,
+    poorWeather:        EmailAddress,
+    systemVerification: EmailAddress,
+    subaru:             EmailAddress,
+    keck:               EmailAddress,
+    ar:                 EmailAddress,
+    br:                 EmailAddress,
+    ca:                 EmailAddress,
+    cl:                 EmailAddress,
+    kr:                 EmailAddress,
+    uh:                 EmailAddress,
+    us:                 EmailAddress
+  ):
+
+    /**
+     * The address for a Gemini call for proposals type, if any. There is no address for the
+     * regular semester (classical and queue) proposals.
+     */
+    def forCfpType(cfpType: GeminiCallForProposalsType): Option[EmailAddress] =
+      cfpType match
+        case GeminiCallForProposalsType.DemoScience        => demoScience.some
+        case GeminiCallForProposalsType.DirectorsTime      => directorsTime.some
+        case GeminiCallForProposalsType.FastTurnaround     => fastTurnaround.some
+        case GeminiCallForProposalsType.LargeProgram       => largeProgram.some
+        case GeminiCallForProposalsType.PoorWeather        => poorWeather.some
+        case GeminiCallForProposalsType.SystemVerification => systemVerification.some
+        case GeminiCallForProposalsType.RegularSemester    => none
+
+    def forExchangePartner(partner: ExchangePartner): EmailAddress =
+      partner match
+        case ExchangePartner.Keck   => keck
+        case ExchangePartner.Subaru => subaru
+
+    def forPartner(partner: Partner): EmailAddress =
+      partner match
+        case Partner.AR => ar
+        case Partner.BR => br
+        case Partner.CA => ca
+        case Partner.CL => cl
+        case Partner.KR => kr
+        case Partner.UH => uh
+        case Partner.US => us
+
+  object ProposalEmails:
+
+    /** A `ProposalEmails` where every address is the same, as if only the default were set. */
+    def uniform(address: EmailAddress): ProposalEmails =
+      ProposalEmails(
+        address, address, address, address, address,
+        address, address, address, address, address,
+        address, address, address, address, address
+      )
+
+    // Falls back to PROPOSAL_EMAIL_DEFAULT if the specific variable is not set. Note that `or`
+    // only falls back when the value is missing, so a malformed address remains an error.
+    private def address(suffix: String): ConfigValue[Effect, EmailAddress] =
+      envOrProp(s"PROPOSAL_EMAIL_$suffix")
+        .or(envOrProp("PROPOSAL_EMAIL_DEFAULT"))
+        .as[EmailAddress]
+
+    lazy val fromCiris: ConfigValue[Effect, ProposalEmails] = (
+      address("DEMO_SCIENCE"),
+      address("DIRECTORS_TIME"),
+      address("FAST_TURNAROUND"),
+      address("LARGE_PROGRAM"),
+      address("POOR_WEATHER"),
+      address("SYSTEM_VERIFICATION"),
+      address("SUBARU"),
+      address("KECK"),
+      address("AR"),
+      address("BR"),
+      address("CA"),
+      address("CL"),
+      address("KR"),
+      address("UH"),
+      address("US")
+    ).parMapN(ProposalEmails.apply)
 
   case class HttpClient(
     timeout:            Duration,
@@ -310,6 +398,10 @@ object Config:
         .as[Duration]
         .default(60.seconds) // 60s is Ember's default
     ).parMapN(HttpClient.apply)
+
+  private given ConfigDecoder[String, EmailAddress] =
+    ConfigDecoder[String].mapOption("Email Address"): s =>
+      EmailAddress.from(s).toOption
 
   private given ConfigDecoder[String, PublicKey] =
     ConfigDecoder[String].mapOption("Public Key"): s =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ProposalView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ProposalView.scala
@@ -21,8 +21,6 @@ trait ProposalView[F[_]] extends BaseMapping[F]:
     // those rows, so the placeholder is never rendered or discriminated upon.
     val ScienceSubtype  = col("c_gemini_science_subtype", science_subtype)
 
-    val Title           = col("c_title",    text_nonempty.opt)
-    val Abstract        = col("c_abstract", text_nonempty.opt)
     val Category        = col("c_category", tag.opt)
 
     val TooActivation   = col("c_too_activation", too_activation)

--- a/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
@@ -15,6 +15,7 @@ import grackle.syntax.*
 import lucuma.core.data.EmailAddress
 import lucuma.core.enums.ConsiderForBand3
 import lucuma.core.enums.ExchangePartner
+import lucuma.core.enums.GeminiCallForProposalsType
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.Observatory
 import lucuma.core.enums.Partner
@@ -233,6 +234,10 @@ object ProposalService {
         val subaruProposalType: Option[SubaruCallForProposalsType] =
           cfp.flatMap(_.subaruProposalType)
 
+        // The Gemini call type, which is empty for an external (Keck/Subaru) proposal.
+        val geminiCallType: Option[GeminiCallForProposalsType] =
+          cfp.flatMap(_.gemini).map(_.callType)
+
         val isPastDeadline: Option[Boolean] =
           deadline.map(_ < currentTime)
 
@@ -418,12 +423,41 @@ object ProposalService {
               } yield ()).value
             )
 
+        // Addresses notified when a proposal is submitted, in addition to the PI.  An
+        // external (Keck/Subaru) proposal has no Gemini call type and is not announced.
+        // Duplicates are removed because several of the configured addresses may be the
+        // same, in particular when they all fall back to PROPOSAL_EMAIL_DEFAULT.
+        private lazy val notificationRecipients: List[EmailAddress] =
+          geminiCallType.toList.flatMap {
+            case GeminiCallForProposalsType.RegularSemester =>
+              // A regular semester proposal requests time either from an exchange partner
+              // or from the Gemini partners named in its splits, never both.
+              exchangePartner.fold(
+                requestedPartners.toList.sortBy(_.tag).map(emailConfig.proposalEmails.forPartner)
+              )(p => List(emailConfig.proposalEmails.forExchangePartner(p)))
+            case callType                                   =>
+              emailConfig.proposalEmails.forCfpType(callType).toList
+          }.distinct
+
+        private val notificationSubject: NonEmptyString =
+          NonEmptyString.unsafeFrom("Proposal Received")
+
+        private val notificationText: NonEmptyString =
+          NonEmptyString.unsafeFrom("A new proposal has been received")
+
+        def sendNotificationEmails(pid: Program.Id)(using Transaction[F]): F[Result[Unit]] =
+          notificationRecipients
+            .traverse(a => ResultT(sendEmailHelper(pid, a, notificationSubject, notificationText, none)))
+            .void
+            .value
+
         def sendEmail(
           pid: Program.Id,
           newStatus: ProposalStatus
          )(using Transaction[F]): F[Result[Unit]] =
-          // There might be other emails in the future
-          if newStatus === ProposalStatus.Submitted then sendSubmissionEmail(pid)
+          // There might be emails for other status changes in the future
+          if newStatus === ProposalStatus.Submitted then
+            (ResultT(sendSubmissionEmail(pid)) *> ResultT(sendNotificationEmails(pid))).value
           else Result.unit.pure
 
       }

--- a/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
@@ -16,6 +16,7 @@ import lucuma.core.data.EmailAddress
 import lucuma.core.enums.ConsiderForBand3
 import lucuma.core.enums.ExchangePartner
 import lucuma.core.enums.GeminiCallForProposalsType
+import lucuma.core.enums.Instrument
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.Observatory
 import lucuma.core.enums.Partner
@@ -31,6 +32,9 @@ import lucuma.core.model.Program
 import lucuma.core.model.ProposalReference
 import lucuma.core.model.Semester
 import lucuma.core.model.User
+import lucuma.core.model.sequence.CategorizedTimeRange
+import lucuma.core.util.CalculatedValue
+import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import lucuma.itc.client.ItcClient
 import lucuma.odb.Config
@@ -184,6 +188,32 @@ object ProposalService {
 
   }
 
+  /** Stand-in for a value that the proposal doesn't have. */
+  private val Missing: String = "<Missing>"
+
+  /** Stand-in for a list that has no elements. */
+  private val Empty: String = "None"
+
+  private def orMissing(s: Option[String]): String =
+    s.map(_.trim).filter(_.nonEmpty).getOrElse(Missing)
+
+  /**
+   * The observing time requested for a program, in decimal hours.  A single value is
+   * given when the minimum and maximum agree.  The calculation state is ignored: a
+   * stale estimate is still the best one available.
+   */
+  private[odb] def timeRequestedText(cv: Option[CalculatedValue[CategorizedTimeRange]]): String =
+    def hours(t: TimeSpan): String = f"${t.toHours}%.2f"
+
+    cv.map(_.value).filter(_.max.programTime.toMicroseconds > 0L) match
+      case None                                               => "Not available"
+      case Some(r) if r.min.programTime === r.max.programTime => s"${hours(r.max.programTime)} hours"
+      case Some(r)                                            => s"${hours(r.min.programTime)} - ${hours(r.max.programTime)} hours"
+
+  /** Escapes the characters that would otherwise be markup in an html message. */
+  private[odb] def escapeHtml(s: String): String =
+    s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
   /** Construct a `ProposalService` using the specified `Session`. */
   def instantiate[F[_]: Concurrent](emailConfig: Config.Email)(using Services[F]): ProposalService[F] =
     new ProposalService[F] {
@@ -208,13 +238,17 @@ object ProposalService {
         status:            ProposalStatus,
         hasProposal:       Boolean,
         piEmailStr:        Option[NonEmptyString],
+        piName:            Option[String],
         title:             Option[NonEmptyString],
+        description:       Option[String],
         reference:         Option[ProposalReference],
         semester:          Option[Semester],
         scienceSubtype:    Option[ScienceSubtype],
         splitsSum:         Long,
         availablePartners: Set[Partner],
         requestedPartners: Set[Partner],
+        coiNames:          List[String],
+        instruments:       List[Instrument],
         proprietary:       NonNegInt,
         currentTime:       Timestamp,
         deadline:          Option[Timestamp],
@@ -240,6 +274,36 @@ object ProposalService {
 
         val isPastDeadline: Option[Boolean] =
           deadline.map(_ < currentTime)
+
+        // Descriptions of the proposal for the emails sent upon submission.  A missing
+        // value is reported rather than left blank, as in the PI submission email.
+        val typeText: String =
+          scienceSubtype.fold(Missing)(_.title)
+
+        val titleText: String =
+          title.fold(Missing)(_.value)
+
+        val cfpTitleText: String =
+          cfpTitle.fold(Missing)(_.value)
+
+        val piNameText: String =
+          orMissing(piName)
+
+        val abstractText: String =
+          orMissing(description)
+
+        // The observatory the PI is associated with, which is Gemini unless the time
+        // request is on behalf of an exchange partner community.
+        val piObservatory: String =
+          exchangePartner.fold("Gemini Observatory"):
+            case ExchangePartner.Keck   => "Keck Observatory"
+            case ExchangePartner.Subaru => "Subaru Observatory"
+
+        val coiNamesText: String =
+          if coiNames.isEmpty then Empty else coiNames.mkString(", ")
+
+        val instrumentsText: String =
+          if instruments.isEmpty then Empty else instruments.map(_.longName).sorted.mkString(", ")
 
         val piEmailAddress: Option[EmailAddress] =
           piEmailStr.flatMap(nes =>
@@ -374,15 +438,15 @@ object ProposalService {
         )
 
         private def htmlSubmissionEmail(newReference: ProposalReference): NonEmptyString = NonEmptyString.unsafeFrom(
-          s"""Hello,<br/>
-          <br/>
+          s"""|Hello,<br/>
+          |<br/>
           |Thanks for submitting a Gemini proposal!<br/>
           |<br/>
           |This email confirms that your proposal was received on ${formatDate(currentTime)} at ${formatTime(currentTime)} UT.<br/>
           |<br/>
-          |Call for Proposals: ${cfpTitle.getOrElse("<Missing>")}<br/>
+          |Call for Proposals: ${escapeHtml(cfpTitleText)}<br/>
           |Proposal Id: <a href="${programUrl(newReference)}">${newReference.label}</a><br/>
-          |Proposal Title: ${title.getOrElse("<Missing>")}<br/>
+          |Proposal Title: ${escapeHtml(titleText)}<br/>
           |<br/>
           |This proposal may be revised until the CfP deadline on ${deadline.fold("<Missing>")(formatDate)} at ${deadline.fold("<Missing>")(formatTime)} UT.<br/>
           |<br/>
@@ -414,13 +478,10 @@ object ProposalService {
               .send(pid, emailConfig.invitationFrom, recipient, subject, text, html)
               .map(_ => Result.unit)
 
-        def sendSubmissionEmail(pid: Program.Id)(using Transaction[F]): F[Result[Unit]] =
+        def sendSubmissionEmail(pid: Program.Id, newReference: ProposalReference)(using Transaction[F]): F[Result[Unit]] =
           piEmailAddress // this has already been validated, so we should have one
             .fold(Result.unit.pure)(email =>
-              (for {
-                newReference <- ResultT(getNewReference(pid))
-                _            <- ResultT(sendEmailHelper(pid, email, emailSubject(newReference), textSubmissionEmail(newReference), htmlSubmissionEmail(newReference).some))
-              } yield ()).value
+              sendEmailHelper(pid, email, emailSubject(newReference), textSubmissionEmail(newReference), htmlSubmissionEmail(newReference).some)
             )
 
         // Addresses notified when a proposal is submitted, in addition to the PI.  An
@@ -439,17 +500,54 @@ object ProposalService {
               emailConfig.proposalEmails.forCfpType(callType).toList
           }.distinct
 
-        private val notificationSubject: NonEmptyString =
-          NonEmptyString.unsafeFrom("Proposal Received")
+        private def notificationSubject(newReference: ProposalReference): NonEmptyString =
+          NonEmptyString.unsafeFrom(s"New $typeText proposal received: ${newReference.label}")
 
-        private val notificationText: NonEmptyString =
-          NonEmptyString.unsafeFrom("A new proposal has been received")
+        private def notificationText(
+          newReference: ProposalReference,
+          timeRequested: Option[CalculatedValue[CategorizedTimeRange]]
+        ): NonEmptyString = NonEmptyString.unsafeFrom(
+          s"""|A new $typeText proposal has been received:
+              |Id: ${newReference.label}
+              |URL: ${programUrl(newReference)}
+              |Title: $titleText
+              |PI: $piNameText ($piObservatory)
+              |CoIs: $coiNamesText
+              |Request: ${timeRequestedText(timeRequested)}
+              |Instruments: $instrumentsText
+              |Abstract: $abstractText""".stripMargin
+        )
 
-        def sendNotificationEmails(pid: Program.Id)(using Transaction[F]): F[Result[Unit]] =
-          notificationRecipients
-            .traverse(a => ResultT(sendEmailHelper(pid, a, notificationSubject, notificationText, none)))
-            .void
-            .value
+        private def notificationHtml(
+          newReference: ProposalReference,
+          timeRequested: Option[CalculatedValue[CategorizedTimeRange]]
+        ): NonEmptyString = NonEmptyString.unsafeFrom(
+          s"""|A new $typeText proposal has been received:<br/>
+              |Id: ${newReference.label}<br/>
+              |URL: <a href="${programUrl(newReference)}">${programUrl(newReference)}</a><br/>
+              |Title: ${escapeHtml(titleText)}<br/>
+              |PI: ${escapeHtml(piNameText)} ($piObservatory)<br/>
+              |CoIs: ${escapeHtml(coiNamesText)}<br/>
+              |Request: ${timeRequestedText(timeRequested)}<br/>
+              |Instruments: $instrumentsText<br/>
+              |Abstract: ${escapeHtml(abstractText)}""".stripMargin
+        )
+
+        def sendNotificationEmails(pid: Program.Id, newReference: ProposalReference)(using Transaction[F]): F[Result[Unit]] =
+          notificationRecipients match
+            case Nil        => Result.unit.pure
+            case recipients =>
+              (for {
+                timeRequested <- ResultT.liftF(timeEstimateService.estimateProgramRange(pid))
+                _             <- recipients.traverse: a =>
+                                   ResultT(sendEmailHelper(
+                                     pid,
+                                     a,
+                                     notificationSubject(newReference),
+                                     notificationText(newReference, timeRequested),
+                                     notificationHtml(newReference, timeRequested).some
+                                   ))
+              } yield ()).value
 
         def sendEmail(
           pid: Program.Id,
@@ -457,7 +555,11 @@ object ProposalService {
          )(using Transaction[F]): F[Result[Unit]] =
           // There might be emails for other status changes in the future
           if newStatus === ProposalStatus.Submitted then
-            (ResultT(sendSubmissionEmail(pid)) *> ResultT(sendNotificationEmails(pid))).value
+            (for {
+              newReference <- ResultT(getNewReference(pid))
+              _            <- ResultT(sendSubmissionEmail(pid, newReference))
+              _            <- ResultT(sendNotificationEmails(pid, newReference))
+            } yield ()).value
           else Result.unit.pure
 
       }
@@ -466,11 +568,11 @@ object ProposalService {
         val parts: Decoder[Set[Partner]] =
           _partner.map(_.toList.toSet)
 
-        val coNames: Decoder[List[Option[NonEmptyString]]] =
-          _text.map(_.toList.map(n => NonEmptyString.from(n).toOption))
+        val instrumentList: Decoder[List[Instrument]] =
+          _instrument.map(_.toList)
 
         val codec: Decoder[ProposalContext] =
-          (proposal_status *: bool *: varchar_nonempty.opt *: text_nonempty.opt *: proposal_reference.opt *: semester.opt *: science_subtype.opt *: int8 *: parts *: parts *: int4_nonneg *: core_timestamp *: core_timestamp.opt *: text_nonempty.opt *: CallForProposalsService.Statements.cfp_properties.opt *: consider_for_band_3.opt *: exchange_partner.opt *: observatory.opt).to[ProposalContext]
+          (proposal_status *: bool *: varchar_nonempty.opt *: text.opt *: text_nonempty.opt *: text.opt *: proposal_reference.opt *: semester.opt *: science_subtype.opt *: int8 *: parts *: parts *: text_list *: instrumentList *: int4_nonneg *: core_timestamp *: core_timestamp.opt *: text_nonempty.opt *: CallForProposalsService.Statements.cfp_properties.opt *: consider_for_band_3.opt *: exchange_partner.opt *: observatory.opt).to[ProposalContext]
 
         def lookup(pid: Program.Id): F[Result[ProposalContext]] =
           val af = Statements.selectProposalContext(user, pid)
@@ -901,7 +1003,9 @@ object ProposalService {
           prog.c_proposal_status,
           prop.c_program_id IS NOT NULL,
           pi.c_email,
+          pi.c_display_name,
           prog.c_name,
+          prog.c_description,
           prog.c_proposal_reference,
           prog.c_semester,
           prog.c_science_subtype,
@@ -927,6 +1031,26 @@ object ProposalService {
             (SELECT ARRAY_AGG(DISTINCT c_partner) FROM t_partner_split WHERE c_program_id = prog.c_program_id AND c_percent > 0),
             '{}'
           ) AS c_requested_partners,
+          COALESCE(
+            (SELECT ARRAY_AGG(pu.c_display_name ORDER BY pu.c_display_name)
+             FROM v_program_user pu
+             WHERE pu.c_program_id = prog.c_program_id
+               AND pu.c_role IN ('coi', 'coi_ro')
+               AND pu.c_display_name IS NOT NULL
+            ),
+            '{}'
+          ) AS c_coi_names,
+          COALESCE(
+            (SELECT ARRAY_AGG(DISTINCT obs.c_instrument)
+             FROM t_observation obs
+             WHERE obs.c_program_id = prog.c_program_id
+               AND obs.c_existence = 'present'
+               AND obs.c_workflow_user_state IS DISTINCT FROM 'inactive'
+               AND obs.c_calibration_role IS NULL
+               AND obs.c_instrument IS NOT NULL
+            ),
+            '{}'
+          ) AS c_instruments,
           prog.c_goa_proprietary,
           LOCALTIMESTAMP,
           COALESCE(

--- a/modules/service/src/test/scala/lucuma/odb/ProposalEmailsConfigSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/ProposalEmailsConfigSuite.scala
@@ -1,0 +1,105 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb
+
+import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.std.Semaphore
+import cats.syntax.all.*
+import lucuma.core.data.EmailAddress
+import lucuma.core.enums.ExchangePartner
+import lucuma.core.enums.GeminiCallForProposalsType
+import lucuma.core.enums.Partner
+import munit.CatsEffectSuite
+
+/**
+ * Tests for the `PROPOSAL_EMAIL_*` configuration. `Config.envOrProp` falls back to system
+ * properties, so the values can be set here without touching the environment. Note that a real
+ * environment variable takes precedence over a system property, so the tests are skipped
+ * entirely when any `PROPOSAL_EMAIL_*` variable is set in the environment (as it is in the nix
+ * dev shell).
+ */
+class ProposalEmailsConfigSuite extends CatsEffectSuite {
+
+  private val Suffixes: List[String] =
+    List(
+      "DEMO_SCIENCE", "DIRECTORS_TIME", "FAST_TURNAROUND", "LARGE_PROGRAM", "POOR_WEATHER",
+      "SYSTEM_VERIFICATION", "SUBARU", "KECK", "AR", "BR", "CA", "CL", "KR", "UH", "US"
+    )
+
+  private val sem = ResourceSuiteLocalFixture(
+    "semaphore",
+    Resource.eval(Semaphore[IO](1L))
+  )
+
+  override def munitFixtures = List(sem)
+
+  private def key(suffix: String): String =
+    s"PROPOSAL_EMAIL_$suffix"
+
+  private def address(suffix: String): EmailAddress =
+    EmailAddress.unsafeFrom(s"${suffix.toLowerCase}@gemini.edu")
+
+  private def putSystemProperty(key: String, value: String): IO[Unit] =
+    IO(System.getProperties().put(key, value)).void
+
+  private def removeSystemProperty(key: String): IO[Unit] =
+    IO(System.getProperties().remove(key)).void
+
+  private val reset: IO[Unit] =
+    (key("DEFAULT") :: Suffixes.map(key)).traverse_(removeSystemProperty)
+
+  private def withProperties(props: (String, String)*)(use: IO[Unit]): IO[Unit] =
+    // Not in an IO, so that munit sees the assumption violation and skips the test.
+    assume(!sys.env.keys.exists(_.startsWith("PROPOSAL_EMAIL_")), "PROPOSAL_EMAIL_* set in environment")
+    sem().permit.use: _ =>
+      (reset *> props.toList.traverse_(putSystemProperty) *> use).guarantee(reset)
+
+  private val Default: EmailAddress =
+    EmailAddress.unsafeFrom("default@gemini.edu")
+
+  test("all specific variables set"):
+    withProperties(Suffixes.map(s => (key(s), address(s).value.value))*):
+      Config.ProposalEmails.fromCiris.load[IO].map: pe =>
+        assertEquals(pe.forCfpType(GeminiCallForProposalsType.DemoScience),        address("DEMO_SCIENCE").some)
+        assertEquals(pe.forCfpType(GeminiCallForProposalsType.DirectorsTime),      address("DIRECTORS_TIME").some)
+        assertEquals(pe.forCfpType(GeminiCallForProposalsType.FastTurnaround),     address("FAST_TURNAROUND").some)
+        assertEquals(pe.forCfpType(GeminiCallForProposalsType.LargeProgram),       address("LARGE_PROGRAM").some)
+        assertEquals(pe.forCfpType(GeminiCallForProposalsType.PoorWeather),        address("POOR_WEATHER").some)
+        assertEquals(pe.forCfpType(GeminiCallForProposalsType.SystemVerification), address("SYSTEM_VERIFICATION").some)
+        assertEquals(pe.forCfpType(GeminiCallForProposalsType.RegularSemester),    none)
+        assertEquals(pe.forExchangePartner(ExchangePartner.Keck),                  address("KECK"))
+        assertEquals(pe.forExchangePartner(ExchangePartner.Subaru),                address("SUBARU"))
+        Partner.values.toList.foreach: p =>
+          assertEquals(pe.forPartner(p), address(p.abbreviation))
+
+  test("default only"):
+    withProperties((key("DEFAULT"), Default.value.value)):
+      Config.ProposalEmails.fromCiris.load[IO].map: pe =>
+        assertEquals(pe, Config.ProposalEmails.uniform(Default))
+
+  test("specific variable overrides the default"):
+    withProperties(
+      (key("DEFAULT"), Default.value.value),
+      (key("KECK"),    address("KECK").value.value)
+    ):
+      Config.ProposalEmails.fromCiris.load[IO].map: pe =>
+        assertEquals(pe.forExchangePartner(ExchangePartner.Keck),   address("KECK"))
+        assertEquals(pe.forExchangePartner(ExchangePartner.Subaru), Default)
+        assertEquals(pe.forPartner(Partner.US),                     Default)
+
+  test("nothing set is an error"):
+    withProperties():
+      Config.ProposalEmails.fromCiris.load[IO].attempt.map: e =>
+        assert(e.isLeft, "Expected the configuration load to fail.")
+
+  test("malformed address is an error, even with a default"):
+    withProperties(
+      (key("DEFAULT"), Default.value.value),
+      (key("KECK"),    "not an email address")
+    ):
+      Config.ProposalEmails.fromCiris.load[IO].attempt.map: e =>
+        assert(e.isLeft, "Expected the configuration load to fail.")
+
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -3016,6 +3016,20 @@ trait DatabaseOperations { this: OdbSuite =>
       .use(_.prepareR(query).use(_.stream(pid, chunkSize = 1024).compile.toList))
   }
 
+  // The subject, text and html of the emails sent to a recipient for a program.
+  def getEmailMessages(pid: Program.Id, recipient: EmailAddress): IO[List[(String, String, Option[String])]] = {
+    val query =
+      sql"""
+        select c_subject, c_text_message, c_html_message
+        from t_email
+        where c_program_id = $program_id and c_recipient_email = $email_address
+        order by c_original_time
+      """.query(text_nonempty *: text_nonempty *: text_nonempty.opt)
+    FMain.databasePoolResource[IO](databaseConfig).flatten
+      .use(_.prepareR(query).use(_.stream((pid, recipient), chunkSize = 1024).compile.toList))
+      .map(_.map((s, t, h) => (s.value, t.value, h.map(_.value))))
+  }
+
   def getEmailStatusesByAddress(address: NonEmptyString): IO[List[EmailStatus]] = {
     val query = sql"select c_status from t_email where c_recipient_email = $text_nonempty".query(email_status)
     FMain.databasePoolResource[IO](databaseConfig).flatten

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -3007,6 +3007,15 @@ trait DatabaseOperations { this: OdbSuite =>
       .use(_.prepareR(query).use(_.unique(id)))
   }
 
+  // The recipients of all the emails sent for a program, in address order.
+  def getEmailRecipients(pid: Program.Id): IO[List[EmailAddress]] = {
+    val query =
+      sql"select c_recipient_email from t_email where c_program_id = $program_id order by c_recipient_email"
+        .query(email_address)
+    FMain.databasePoolResource[IO](databaseConfig).flatten
+      .use(_.prepareR(query).use(_.stream(pid, chunkSize = 1024).compile.toList))
+  }
+
   def getEmailStatusesByAddress(address: NonEmptyString): IO[List[EmailStatus]] = {
     val query = sql"select c_status from t_email where c_recipient_email = $text_nonempty".query(email_status)
     FMain.databasePoolResource[IO](databaseConfig).flatten

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -394,7 +394,8 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
       domain            = "gpp.com".refined,
       webhookSigningKey = "webhookKey".refined,
       invitationFrom    = EmailAddress.unsafeFrom("explore@gpp.com"),
-      exploreUrl        = uri"https://explore.gemini.edu/"
+      exploreUrl        = uri"https://explore.gemini.edu/",
+      proposalEmails    = Config.ProposalEmails.uniform(EmailAddress.unsafeFrom("proposals@gpp.com"))
     )
 
   val simbadClient: IO[SimbadClient[IO]] =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/email/emailWebhookRoutes.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/email/emailWebhookRoutes.scala
@@ -32,7 +32,8 @@ class emailWebhookRoutes extends OdbSuite {
       domain            = "gpp.com".refined,
       webhookSigningKey = "55484a8372da2cf84445b8a65d674511".refined,
       invitationFrom    = EmailAddress.unsafeFrom("explore@gpp.com"),
-      exploreUrl = Uri.fromString("https://nonsense.kom").toOption.get
+      exploreUrl = Uri.fromString("https://nonsense.kom").toOption.get,
+      proposalEmails    = Config.ProposalEmails.uniform(EmailAddress.unsafeFrom("proposals@gpp.com"))
     )
 
   private given logger: Logger[IO] = Slf4jLogger.getLogger[IO]

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatusEmailTime.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatusEmailTime.scala
@@ -1,0 +1,66 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package mutation
+
+import cats.syntax.option.*
+import lucuma.core.data.EmailAddress
+import lucuma.core.enums.GeminiCallForProposalsType
+import lucuma.core.enums.Partner
+import lucuma.odb.Config
+import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
+import lucuma.refined.*
+import org.http4s.implicits.*
+
+// The notification email for a proposal with a real observation, which is the only
+// way to exercise a non-empty time request and instrument list.
+class setProposalStatusEmailTime extends ExecutionTestSupportForGmos {
+
+  override val httpRequestHandler = invitationEmailRequestHandler
+
+  private val proposalAddress: EmailAddress =
+    EmailAddress.unsafeFrom("us@gemini.edu")
+
+  override def emailConfig: Config.Email =
+    Config.Email(
+      apiKey            = "apiKey".refined,
+      domain            = "gpp.com".refined,
+      webhookSigningKey = "webhookKey".refined,
+      invitationFrom    = EmailAddress.unsafeFrom("explore@gpp.com"),
+      exploreUrl        = uri"https://explore.gemini.edu/",
+      proposalEmails    = Config.ProposalEmails.uniform(proposalAddress)
+    )
+
+  test("✓ the request and instruments come from the program's observations") {
+    for {
+      cid <- createGeminiCallForProposalsAs(staff, GeminiCallForProposalsType.RegularSemester)
+      pid <- createProgramWithNonPartnerPi(pi, "Timed Proposal")
+      tid <- createTargetWithProfileAs(pi, pid)
+      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
+      _   <- runObscalcUpdate(pid, oid)
+      _   <- addProposal(pi, pid, cid.some)
+      _   <- addPartnerSplits(pi, pid, partnerSplits = List((Partner.US, 100)))
+      _   <- addCoisAs(pi, pid, List(Partner.US))
+      _   <- submitProposal(pi, pid)
+      ms  <- getEmailMessages(pid, proposalAddress)
+    } yield {
+      val (_, text, html) = ms.head
+      assertEquals(ms.size, 1)
+      assertEquals(lineOf(text, "Instruments"), "Instruments: GMOS North")
+      assertEquals(lineOf(html.get, "Instruments"), "Instruments: GMOS North<br/>")
+
+      // The figure follows from the sequence estimate, so only its shape is checked.
+      val request = lineOf(text, "Request")
+      assert(
+        request.matches("""Request: \d+\.\d{2}( - \d+\.\d{2})? hours"""),
+        s"Unexpected request line: $request"
+      )
+    }
+  }
+
+  private def lineOf(message: String, label: String): String =
+    message.linesIterator.find(_.startsWith(s"$label:")).getOrElse(s"<no $label line in: $message>")
+
+}

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatusEmails.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatusEmails.scala
@@ -10,8 +10,12 @@ import cats.syntax.option.*
 import lucuma.core.data.EmailAddress
 import lucuma.core.enums.GeminiCallForProposalsType
 import lucuma.core.enums.Partner
+import lucuma.core.enums.ProgramUserRole
 import lucuma.core.model.CallForProposals
 import lucuma.core.model.Program
+import lucuma.core.model.ProgramUser
+import lucuma.core.model.ProposalReference
+import lucuma.core.model.UserProfile
 import lucuma.odb.Config
 import lucuma.refined.*
 import org.http4s.implicits.*
@@ -161,6 +165,80 @@ class setProposalStatusEmails extends OdbSuite {
       _   <- assertRecipients(pid, List(piAddress, address("us")))
     } yield ()
   }
+
+  test("✓ the notification message names the proposal, the investigators and the request") {
+    val expectedText = (ref: ProposalReference) =>
+      s"""|A new Queue proposal has been received:
+          |Id: ${ref.label}
+          |URL: https://explore.gemini.edu/${ref.label}
+          |Title: Ann & Bob's Big Adventure
+          |PI: Petra Ito (Gemini Observatory)
+          |CoIs: Ann Coi, Zoe CoiRO
+          |Request: Not available
+          |Instruments: None
+          |Abstract: A study of <interesting> things.""".stripMargin
+
+    val expectedHtml = (ref: ProposalReference) =>
+      s"""|A new Queue proposal has been received:<br/>
+          |Id: ${ref.label}<br/>
+          |URL: <a href="https://explore.gemini.edu/${ref.label}">https://explore.gemini.edu/${ref.label}</a><br/>
+          |Title: Ann &amp; Bob's Big Adventure<br/>
+          |PI: Petra Ito (Gemini Observatory)<br/>
+          |CoIs: Ann Coi, Zoe CoiRO<br/>
+          |Request: Not available<br/>
+          |Instruments: None<br/>
+          |Abstract: A study of &lt;interesting&gt; things.""".stripMargin
+
+    for {
+      cid <- geminiCall(GeminiCallForProposalsType.RegularSemester)
+      pid <- createProgramWithNonPartnerPi(pi, "Ann & Bob's Big Adventure")
+      _   <- setProgramDescription(pid, "A study of <interesting> things.")
+      pu  <- piProgramUserIdAs(pi, pid)
+      _   <- setCreditName(pu, "Petra Ito")
+      _   <- addProgramUserAs(pi, pid, ProgramUserRole.Coi, preferred = creditName("Ann Coi"))
+      _   <- addProgramUserAs(pi, pid, ProgramUserRole.CoiRO, preferred = creditName("Zoe CoiRO"))
+      _   <- addProposal(pi, pid, cid.some)
+      _   <- addPartnerSplits(pi, pid, partnerSplits = List((Partner.US, 100)))
+      ref <- submitProposal(pi, pid)
+      ms  <- getEmailMessages(pid, address("us"))
+    } yield assertEquals(
+      ms,
+      List((s"New Queue proposal received: ${ref.label}", expectedText(ref), expectedHtml(ref).some))
+    )
+  }
+
+  private def creditName(name: String): UserProfile =
+    UserProfile(givenName = none, familyName = none, creditName = name.some, email = none)
+
+  private def setCreditName(puid: ProgramUser.Id, name: String): IO[Unit] =
+    query(
+      user  = pi,
+      query = s"""
+        mutation {
+          updateProgramUsers(input: {
+            WHERE: { id: { EQ: "$puid" } }
+            SET: { preferredProfile: { creditName: "$name" } }
+          }) {
+            programUsers { id }
+          }
+        }
+      """
+    ).void
+
+  private def setProgramDescription(pid: Program.Id, description: String): IO[Unit] =
+    query(
+      user  = pi,
+      query = s"""
+        mutation {
+          updatePrograms(input: {
+            WHERE: { id: { EQ: "$pid" } }
+            SET: { description: "$description" }
+          }) {
+            programs { id }
+          }
+        }
+      """
+    ).void
 
   // An external (Subaru) proposal apportions its time across Gemini partners, so it
   // carries its splits directly.  There is no `addProposal` variant for one.

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatusEmails.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatusEmails.scala
@@ -1,0 +1,191 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+
+package mutation
+
+import cats.effect.IO
+import cats.syntax.option.*
+import lucuma.core.data.EmailAddress
+import lucuma.core.enums.GeminiCallForProposalsType
+import lucuma.core.enums.Partner
+import lucuma.core.model.CallForProposals
+import lucuma.core.model.Program
+import lucuma.odb.Config
+import lucuma.refined.*
+import org.http4s.implicits.*
+
+// Tests the notification emails that are sent, in addition to the PI confirmation
+// email, when a proposal is submitted.
+class setProposalStatusEmails extends OdbSuite {
+
+  val pi    = TestUsers.Standard.pi(1, 101)
+  val staff = TestUsers.Standard.staff(4, 104)
+
+  val validUsers = List(pi, staff)
+
+  override val httpRequestHandler = invitationEmailRequestHandler
+
+  private def address(name: String): EmailAddress =
+    EmailAddress.unsafeFrom(s"$name@gemini.edu")
+
+  // AR and BR share an address so that duplicate recipients can be tested.
+  private val ngoShared = address("ngo-shared")
+
+  override def emailConfig: Config.Email =
+    Config.Email(
+      apiKey            = "apiKey".refined,
+      domain            = "gpp.com".refined,
+      webhookSigningKey = "webhookKey".refined,
+      invitationFrom    = EmailAddress.unsafeFrom("explore@gpp.com"),
+      exploreUrl        = uri"https://explore.gemini.edu/",
+      proposalEmails    = Config.ProposalEmails(
+        demoScience        = address("demo-science"),
+        directorsTime      = address("directors-time"),
+        fastTurnaround     = address("fast-turnaround"),
+        largeProgram       = address("large-program"),
+        poorWeather        = address("poor-weather"),
+        systemVerification = address("system-verification"),
+        subaru             = address("subaru"),
+        keck               = address("keck"),
+        ar                 = ngoShared,
+        br                 = ngoShared,
+        ca                 = address("ca"),
+        cl                 = address("cl"),
+        kr                 = address("kr"),
+        uh                 = address("uh"),
+        us                 = address("us")
+      )
+    )
+
+  private val piAddress: EmailAddress =
+    EmailAddress.unsafeFrom(defaultPiEmail.value)
+
+  private def assertRecipients(pid: Program.Id, expected: List[EmailAddress]): IO[Unit] =
+    getEmailRecipients(pid).map(assertEquals(_, expected.sortBy(_.value.value)))
+
+  private def geminiCall(callType: GeminiCallForProposalsType): IO[CallForProposals.Id] =
+    createGeminiCallForProposalsAs(staff, callType)
+
+  test("✓ fast turnaround notifies the fast turnaround address") {
+    for {
+      cid <- geminiCall(GeminiCallForProposalsType.FastTurnaround)
+      pid <- createProgramWithUsPi(pi)
+      _   <- addProposal(pi, pid, cid.some, "fastTurnaround: {}".some)
+      _   <- addCoisAs(pi, pid, List(Partner.US))
+      _   <- submitProposal(pi, pid)
+      _   <- assertRecipients(pid, List(piAddress, address("fast-turnaround")))
+    } yield ()
+  }
+
+  test("✓ director's time notifies the director's time address") {
+    for {
+      cid <- geminiCall(GeminiCallForProposalsType.DirectorsTime)
+      pid <- createProgramWithUsPi(pi)
+      _   <- addProposal(pi, pid, cid.some, "directorsTime: {}".some)
+      _   <- addCoisAs(pi, pid, List(Partner.US))
+      _   <- submitProposal(pi, pid)
+      _   <- assertRecipients(pid, List(piAddress, address("directors-time")))
+    } yield ()
+  }
+
+  test("✓ regular semester notifies each partner in the splits") {
+    for {
+      cid <- geminiCall(GeminiCallForProposalsType.RegularSemester)
+      pid <- createProgramWithNonPartnerPi(pi)
+      _   <- addProposal(pi, pid, cid.some)
+      _   <- addPartnerSplits(pi, pid, partnerSplits = List((Partner.US, 70), (Partner.CA, 30)))
+      _   <- addCoisAs(pi, pid, List(Partner.US, Partner.CA))
+      _   <- submitProposal(pi, pid)
+      _   <- assertRecipients(pid, List(piAddress, address("us"), address("ca")))
+    } yield ()
+  }
+
+  test("✓ a partner with a zero percent split is not notified") {
+    for {
+      cid <- geminiCall(GeminiCallForProposalsType.RegularSemester)
+      pid <- createProgramWithNonPartnerPi(pi)
+      _   <- addProposal(pi, pid, cid.some)
+      _   <- addPartnerSplits(pi, pid, partnerSplits = List((Partner.US, 100), (Partner.CA, 0)))
+      _   <- addCoisAs(pi, pid, List(Partner.US, Partner.CA))
+      _   <- submitProposal(pi, pid)
+      _   <- assertRecipients(pid, List(piAddress, address("us")))
+    } yield ()
+  }
+
+  test("✓ partners sharing an address are notified once") {
+    for {
+      cid <- geminiCall(GeminiCallForProposalsType.RegularSemester)
+      pid <- createProgramWithNonPartnerPi(pi)
+      _   <- addProposal(pi, pid, cid.some)
+      _   <- addPartnerSplits(pi, pid, partnerSplits = List((Partner.AR, 50), (Partner.BR, 50)))
+      _   <- addCoisAs(pi, pid, List(Partner.AR, Partner.BR))
+      _   <- submitProposal(pi, pid)
+      _   <- assertRecipients(pid, List(piAddress, ngoShared))
+    } yield ()
+  }
+
+  test("✓ an exchange partner request notifies the exchange partner") {
+    for {
+      cid <- geminiCall(GeminiCallForProposalsType.RegularSemester)
+      pid <- createProgramWithNonPartnerPi(pi)
+      _   <- addProposal(pi, pid, cid.some, "classical: { exchangePartner: KECK }".some)
+      _   <- addCoisAs(pi, pid)
+      _   <- submitProposal(pi, pid)
+      _   <- assertRecipients(pid, List(piAddress, address("keck")))
+    } yield ()
+  }
+
+  test("✓ a Subaru proposal notifies no one") {
+    for {
+      cid <- createSubaruCallForProposalsAs(staff)
+      // A US PI, since a Subaru call has no deadline for a non-partner.
+      pid <- createProgramWithUsPi(pi)
+      _   <- createSubaruProposal(pid, cid)
+      _   <- submitProposal(pi, pid)
+      _   <- assertRecipients(pid, List(piAddress))
+    } yield ()
+  }
+
+  test("✓ no emails are sent unless the proposal is submitted") {
+    for {
+      cid <- geminiCall(GeminiCallForProposalsType.RegularSemester)
+      pid <- createProgramWithNonPartnerPi(pi)
+      _   <- addProposal(pi, pid, cid.some)
+      _   <- addPartnerSplits(pi, pid, partnerSplits = List((Partner.US, 100)))
+      _   <- addCoisAs(pi, pid, List(Partner.US))
+      _   <- assertRecipients(pid, Nil)
+      _   <- submitProposal(pi, pid)
+      _   <- unsubmitProposal(pi, pid)
+      _   <- assertRecipients(pid, List(piAddress, address("us")))
+    } yield ()
+  }
+
+  // An external (Subaru) proposal apportions its time across Gemini partners, so it
+  // carries its splits directly.  There is no `addProposal` variant for one.
+  private def createSubaruProposal(
+    pid: Program.Id,
+    cid: CallForProposals.Id
+  ): IO[Unit] =
+    query(
+      user  = pi,
+      query = s"""
+        mutation {
+          createProposal(
+            input: {
+              programId: "$pid"
+              SET: {
+                category: GALACTIC_OTHER
+                callId: "$cid"
+                subaru: { partnerSplits: [{ partner: US, percent: 100 }] }
+              }
+            }
+          ) {
+            proposal { category }
+          }
+        }
+      """
+    ).void
+
+}

--- a/modules/service/src/test/scala/lucuma/odb/service/ProposalServiceSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/service/ProposalServiceSuite.scala
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service
+
+import cats.syntax.option.*
+import lucuma.core.enums.ChargeClass
+import lucuma.core.model.sequence.CategorizedTime
+import lucuma.core.model.sequence.CategorizedTimeRange
+import lucuma.core.util.CalculatedValue
+import lucuma.core.util.CalculationState
+import lucuma.core.util.TimeSpan
+import munit.FunSuite
+
+class ProposalServiceSuite extends FunSuite {
+
+  private def hours(h: Double): TimeSpan =
+    TimeSpan.unsafeFromMicroseconds((h * 3_600_000_000L).toLong)
+
+  private def time(h: Double): CategorizedTime =
+    CategorizedTime(ChargeClass.Program -> hours(h))
+
+  private def range(
+    min:   Double,
+    max:   Double,
+    state: CalculationState = CalculationState.Ready
+  ): Option[CalculatedValue[CategorizedTimeRange]] =
+    CalculatedValue(state, CategorizedTimeRange.from(time(min), time(max))).some
+
+  test("no estimate at all"):
+    assertEquals(ProposalService.timeRequestedText(none), "Not available")
+
+  test("a zero estimate"):
+    assertEquals(ProposalService.timeRequestedText(range(0.0, 0.0)), "Not available")
+
+  test("equal minimum and maximum"):
+    assertEquals(ProposalService.timeRequestedText(range(12.5, 12.5)), "12.50 hours")
+
+  test("differing minimum and maximum"):
+    assertEquals(ProposalService.timeRequestedText(range(10.0, 12.5)), "10.00 - 12.50 hours")
+
+  test("rounds to two decimal places"):
+    assertEquals(ProposalService.timeRequestedText(range(1.0 / 3.0, 1.0 / 3.0)), "0.33 hours")
+
+  test("a stale estimate is reported like any other"):
+    CalculationState.values.foreach: s =>
+      assertEquals(ProposalService.timeRequestedText(range(12.5, 12.5, s)), "12.50 hours")
+
+  test("html escaping"):
+    assertEquals(ProposalService.escapeHtml("Ann & Bob"), "Ann &amp; Bob")
+    assertEquals(ProposalService.escapeHtml("<script>x</script>"), "&lt;script&gt;x&lt;/script&gt;")
+    assertEquals(ProposalService.escapeHtml("nothing to do"), "nothing to do")
+
+}

--- a/populate-db-from-heroku.sh
+++ b/populate-db-from-heroku.sh
@@ -137,6 +137,7 @@ export MAILGUN_API_KEY="dummy"
 export MAILGUN_DOMAIN="dummy.mailgun.org"
 export MAILGUN_WEBHOOK_SIGNING_KEY="dummy"
 export INVITATION_SENDER_EMAIL="noreply@example.com"
+export PROPOSAL_EMAIL_DEFAULT="noreply@example.com"
 export EXPLORE_URL="http://localhost:3000"
 export ODB_DOMAIN="localhost"
 


### PR DESCRIPTION
See https://app.shortcut.com/lucuma/story/7549/email-notification-of-proposal-submission for details.

The deletion of columns from ProposalView is unrelated, but I figured we didn't really need yet another PR for something so small... These columns were removed from t_proposal some time ago, but ProposalView was not updated at that time.