### PR TITLE
Fix three proposal time-request bugs

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/ProposalPropertiesInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/ProposalPropertiesInput.scala
@@ -5,6 +5,7 @@ package lucuma.odb.graphql.input
 
 import cats.syntax.all.*
 import grackle.syntax.*
+import lucuma.core.enums.ExchangePartner
 import lucuma.core.enums.Observatory
 import lucuma.core.enums.Partner
 import lucuma.core.enums.ScienceSubtype
@@ -69,6 +70,11 @@ object ProposalPropertiesInput {
         .orElse(keck.map(_.partnerSplits))
         .orElse(subaru.map(_.partnerSplits))
         .getOrElse(Nullable.Absent)
+
+    // The edited exchange partner.  Only a Gemini queue or classical proposal can
+    // have one; the external variants always leave it null.
+    def exchangePartner: Nullable[ExchangePartner] =
+      gemini.map(_.exchangePartner).getOrElse(Nullable.Absent)
 
     // True when the edit specifies a proposal-type variant.
     def hasType: Boolean =

--- a/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
@@ -1068,9 +1068,10 @@ object ProposalService {
             (SELECT cfp.c_gemini_non_partner_deadline
              WHERE pi.c_partner_link = 'has_non_partner'),
             -- An exchange-partner request is not tied to any Gemini partner, so
-            -- it uses the call's default submission deadline.
-            (SELECT cfp.c_deadline_default
-             WHERE prop.c_exchange_partner IS NOT NULL)
+            -- it uses that community's deadline for the call: its override if it
+            -- has one, and otherwise the call's default.  Null when the call does
+            -- not offer the community at all.
+            cfp_ep.c_deadline
           ) AS c_deadline,
           cfp.c_title,
           cfp.c_cfp_id,
@@ -1093,6 +1094,9 @@ object ProposalService {
         LEFT JOIN v_gemini_cfp_partner cfp_pi
           ON cfp.c_cfp_id = cfp_pi.c_cfp_id
           AND cfp_pi.c_partner = pi.c_gemini_partner
+        LEFT JOIN v_gemini_cfp_exchange_partner cfp_ep
+          ON cfp.c_cfp_id = cfp_ep.c_cfp_id
+          AND cfp_ep.c_exchange_partner = prop.c_exchange_partner
         WHERE
           prog.c_program_id = $program_id
       """.apply(pid) |+|

--- a/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
@@ -143,6 +143,9 @@ object ProposalService {
     def bothTimeRequests(pid: Program.Id): OdbError =
       s"Proposal $pid may not have both an exchange partner and partner splits.".invalidArg
 
+    def unofferedExchangePartner(pid: Program.Id, xp: ExchangePartner): OdbError =
+      s"Program $pid requests time on behalf of ${xp.tag.toUpperCase}, but the Call for Proposals does not offer that exchange partner.".invalidArg
+
     def missingPartners(pid: Program.Id, partners: Set[Partner] = Set.empty): OdbError =
       partners.toList.map(_.abbreviation).sorted match
         case Nil     =>
@@ -256,6 +259,9 @@ object ProposalService {
         cfp:               Option[CfpProperties],
         considerForBand3:  Option[ConsiderForBand3],
         exchangePartner:   Option[ExchangePartner],
+        // Whether the call offers the exchange partner named above.  False when
+        // there is no exchange partner to begin with.
+        exchangeOffered:   Boolean,
         observatory:       Option[Observatory]
       ) {
         // Every stored proposal has an observatory; default to Gemini defensively.
@@ -331,6 +337,9 @@ object ProposalService {
             // both-set time request here with a clear message rather than
             // silently treating it as an exchange request below.
             bothTimeRequests(pid).asFailure.whenA(exchangePartner.isDefined && splitsSum =!= 0),
+            // Time may only be requested on behalf of a community the call invites.
+            exchangePartner.filterNot(_ => exchangeOffered).fold(Result.unit): xp =>
+              unofferedExchangePartner(pid, xp).asFailure,
             scienceSubtype.fold(().success) { s =>
               // An exchange-partner time request carries no Gemini partner
               // splits, so the sum-to-100 rule does not apply to it.
@@ -572,7 +581,7 @@ object ProposalService {
           _instrument.map(_.toList)
 
         val codec: Decoder[ProposalContext] =
-          (proposal_status *: bool *: varchar_nonempty.opt *: text.opt *: text_nonempty.opt *: text.opt *: proposal_reference.opt *: semester.opt *: science_subtype.opt *: int8 *: parts *: parts *: text_list *: instrumentList *: int4_nonneg *: core_timestamp *: core_timestamp.opt *: text_nonempty.opt *: CallForProposalsService.Statements.cfp_properties.opt *: consider_for_band_3.opt *: exchange_partner.opt *: observatory.opt).to[ProposalContext]
+          (proposal_status *: bool *: varchar_nonempty.opt *: text.opt *: text_nonempty.opt *: text.opt *: proposal_reference.opt *: semester.opt *: science_subtype.opt *: int8 *: parts *: parts *: text_list *: instrumentList *: int4_nonneg *: core_timestamp *: core_timestamp.opt *: text_nonempty.opt *: CallForProposalsService.Statements.cfp_properties.opt *: consider_for_band_3.opt *: exchange_partner.opt *: bool *: observatory.opt).to[ProposalContext]
 
         def lookup(pid: Program.Id): F[Result[ProposalContext]] =
           val af = Statements.selectProposalContext(user, pid)
@@ -1082,6 +1091,7 @@ object ProposalService {
           cfp.c_gemini_proprietary,
           prop.c_consider_for_band_3,
           prop.c_exchange_partner,
+          cfp_ep.c_cfp_id IS NOT NULL AS c_exchange_offered,
           prop.c_observatory
         FROM t_program prog
         LEFT JOIN t_proposal prop

--- a/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ProposalService.scala
@@ -696,6 +696,15 @@ object ProposalService {
               partnerSplitsService.updateSplits(splits.getOrElse(Map.empty), pid)
           ).sequence.void)
 
+        // The time-request trigger fires immediately and rejects a proposal that has
+        // both an exchange partner and partner splits, so an edit that swaps one for
+        // the other has to give up what it holds before taking on the other.  Only
+        // assigning an exchange partner needs the splits emptied first; going the
+        // other way clears the exchange partner with the proposal update, ahead of
+        // the splits that replace it.
+        def splitsFirst(set: ProposalPropertiesInput.Edit): Boolean =
+          set.exchangePartner.isPresent
+
         (for {
           pid    <- ResultT(programService.resolvePid(input.programId, input.proposalReference, input.programReference))
           before <- ResultT(ProposalContext.lookup(pid))
@@ -705,9 +714,10 @@ object ProposalService {
           _      <- ResultT.fromResult(after.validateSubmission(pid, after.status))
           _      <- ResultT.liftF(deferConstraints)
           set     = handleTypeChange(before)
+          _      <- updateSplits(pid, set).whenA(splitsFirst(set))
           _      <- updateProposal(pid, set)
           _      <- updateProgram(pid, before, after)
-          _      <- updateSplits(pid, set)
+          _      <- updateSplits(pid, set).unlessA(splitsFirst(set))
         } yield pid).value
       }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -2888,8 +2888,9 @@ trait DatabaseOperations { this: OdbSuite =>
               partnerLink: {
                 ${
                   partnerLink match
-                    case PartnerLink.HasGeminiPartner(gp) => s"geminiPartner: ${gp.tag.toScreamingSnakeCase}"
-                    case _                                => s"linkType: ${partnerLink.linkType.tag.toScreamingSnakeCase}"
+                    case PartnerLink.HasGeminiPartner(gp)   => s"geminiPartner: ${gp.tag.toScreamingSnakeCase}"
+                    case PartnerLink.HasExchangePartner(xp) => s"exchangePartner: ${xp.tag.toScreamingSnakeCase}"
+                    case _                                  => s"linkType: ${partnerLink.linkType.tag.toScreamingSnakeCase}"
                 }
               }
               $preferred

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatus.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatus.scala
@@ -12,11 +12,13 @@ import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Json
 import io.circe.literal.*
 import lucuma.core.enums.CalibrationRole
+import lucuma.core.enums.ExchangePartner
 import lucuma.core.enums.GeminiCallForProposalsType
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.Partner
 import lucuma.core.enums.ProgramType
 import lucuma.core.enums.ProposalStatus
+import lucuma.core.model.CallForProposals
 import lucuma.core.model.PartnerLink
 import lucuma.core.model.Program
 import lucuma.core.model.Semester
@@ -86,17 +88,39 @@ class setProposalStatus extends OdbSuite
     }
   }
 
+  // A Gemini call that offers Keck as an exchange partner, optionally with a
+  // deadline override for it.
+  private def createCallWithKeckExchangeAs(
+    semester:         Semester,
+    activeStart:      LocalDate,
+    activeEnd:        LocalDate,
+    deadlineOverride: Option[Timestamp] = none
+  ): IO[CallForProposals.Id] =
+    createGeminiCallForProposalsAs(
+      staff,
+      GeminiCallForProposalsType.RegularSemester,
+      semester    = semester,
+      activeStart = activeStart,
+      activeEnd   = activeEnd,
+      otherGemini = s"""
+        exchangePartners: [
+          {
+            exchangePartner: KECK
+            ${deadlineOverride.fold("")(ts => s"submissionDeadlineOverride: \"${ts.isoFormat}\"")}
+          }
+        ]
+      """.some
+    )
+
   test("✓ exchange partner submission") {
     // A Keck/Subaru PI requesting Gemini time: the proposal carries an exchange
     // partner instead of partner splits, and uses the call's default submission
     // deadline rather than any Gemini partner deadline.  Uses its own semester
     // so the assigned proposal reference doesn't perturb other tests' counts.
-    createGeminiCallForProposalsAs(
-      staff,
-      GeminiCallForProposalsType.RegularSemester,
-      semester    = Semester.unsafeFromString("2026A"),
-      activeStart = LocalDate.parse("2026-02-01"),
-      activeEnd   = LocalDate.parse("2026-07-31")
+    createCallWithKeckExchangeAs(
+      Semester.unsafeFromString("2026A"),
+      LocalDate.parse("2026-02-01"),
+      LocalDate.parse("2026-07-31")
     ).flatMap { cid =>
       createProgramWithNonPartnerPi(pi).flatMap { pid =>
         addProposal(pi, pid, cid.some, "classical: { exchangePartner: KECK }".some) *>
@@ -143,6 +167,75 @@ class setProposalStatus extends OdbSuite
                 }
               }
             """.asRight
+        )
+      }
+    }
+  }
+
+  test("⨯ exchange partner submission past the community's deadline override") {
+    // The call is open (its default deadline is Timestamp.Max) but closed for the
+    // Keck community, so the request is past its deadline.  The PI belongs to the
+    // exchange community, so neither the Gemini partner nor the non-partner
+    // deadline applies.
+    createCallWithKeckExchangeAs(
+      Semester.unsafeFromString("2026B"),
+      LocalDate.parse("2026-08-01"),
+      LocalDate.parse("2027-01-31"),
+      deadlineOverride = yesterday.some
+    ).flatMap { cid =>
+      createProgramWithPiAffiliation(
+        pi,
+        PartnerLink.HasExchangePartner(ExchangePartner.Keck)
+      ).flatMap { pid =>
+        addProposal(pi, pid, cid.some, "classical: { exchangePartner: KECK }".some) *>
+        addCoisAs(pi, pid) *>
+        expect(
+          user = pi,
+          query = s"""
+            mutation {
+              setProposalStatus(
+                input: {
+                  programId: "$pid"
+                  status: SUBMITTED
+                }
+              ) { program { id } }
+            }
+          """,
+          expected = List(error.pastDeadline(pid).message).asLeft
+        )
+      }
+    }
+  }
+
+  test("⨯ exchange partner the call does not offer has no deadline") {
+    // The call offers no exchange partners at all, so a Keck request has no
+    // deadline to meet and cannot be submitted.
+    createGeminiCallForProposalsAs(
+      staff,
+      GeminiCallForProposalsType.RegularSemester,
+      semester    = Semester.unsafeFromString("2027A"),
+      activeStart = LocalDate.parse("2027-02-01"),
+      activeEnd   = LocalDate.parse("2027-07-31")
+    ).flatMap { cid =>
+      createProgramWithPiAffiliation(
+        pi,
+        PartnerLink.HasExchangePartner(ExchangePartner.Keck)
+      ).flatMap { pid =>
+        addProposal(pi, pid, cid.some, "classical: { exchangePartner: KECK }".some) *>
+        addCoisAs(pi, pid) *>
+        expect(
+          user = pi,
+          query = s"""
+            mutation {
+              setProposalStatus(
+                input: {
+                  programId: "$pid"
+                  status: SUBMITTED
+                }
+              ) { program { id } }
+            }
+          """,
+          expected = List(error.missingDeadline(pid).message).asLeft
         )
       }
     }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatus.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatus.scala
@@ -207,9 +207,9 @@ class setProposalStatus extends OdbSuite
     }
   }
 
-  test("⨯ exchange partner the call does not offer has no deadline") {
-    // The call offers no exchange partners at all, so a Keck request has no
-    // deadline to meet and cannot be submitted.
+  test("⨯ exchange partner the call does not offer") {
+    // The call offers no exchange partners at all, so it cannot be asked for time
+    // on behalf of the Keck community.
     createGeminiCallForProposalsAs(
       staff,
       GeminiCallForProposalsType.RegularSemester,
@@ -235,7 +235,8 @@ class setProposalStatus extends OdbSuite
               ) { program { id } }
             }
           """,
-          expected = List(error.missingDeadline(pid).message).asLeft
+          expected =
+            List(error.unofferedExchangePartner(pid, ExchangePartner.Keck).message).asLeft
         )
       }
     }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatusEmails.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/setProposalStatusEmails.scala
@@ -132,7 +132,13 @@ class setProposalStatusEmails extends OdbSuite {
 
   test("✓ an exchange partner request notifies the exchange partner") {
     for {
-      cid <- geminiCall(GeminiCallForProposalsType.RegularSemester)
+      // The call has to invite the Keck community before it can be asked for time
+      // on its behalf.
+      cid <- createGeminiCallForProposalsAs(
+               staff,
+               GeminiCallForProposalsType.RegularSemester,
+               otherGemini = "exchangePartners: [{ exchangePartner: KECK }]".some
+             )
       pid <- createProgramWithNonPartnerPi(pi)
       _   <- addProposal(pi, pid, cid.some, "classical: { exchangePartner: KECK }".some)
       _   <- addCoisAs(pi, pid)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProposal.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateProposal.scala
@@ -249,7 +249,7 @@ class updateProposal extends OdbSuite with DatabaseOperations {
         """
       ) *>
       // ...then setting an exchange partner (leaving the splits) violates the
-      // deferred constraint trigger at commit.
+      // time-request trigger.
       expect(
         user = pi,
         query = s"""
@@ -261,6 +261,114 @@ class updateProposal extends OdbSuite with DatabaseOperations {
           }
         """,
         expected = List("A proposal may not have both an exchange partner and partner splits.").asLeft
+      )
+    }
+  }
+
+  test("✓ swap partner splits for an exchange partner in one edit") {
+    createProgramAs(pi).flatMap { pid =>
+      addProposal(pi, pid) *>
+      // First give it partner splits...
+      query(
+        user = pi,
+        query = s"""
+          mutation {
+            updateProposal(input: {
+              programId: "$pid"
+              SET: { gemini: { queue: { partnerSplits: [ { partner: US, percent: 100 } ] } } }
+            }) { proposal { gemini { scienceSubtype } } }
+          }
+        """
+      ) *>
+      // ...then hand the whole request over to an exchange partner.  The splits
+      // are emptied before the proposal takes on the exchange partner, so the
+      // two never coexist.
+      expect(
+        user = pi,
+        query = s"""
+          mutation {
+            updateProposal(input: {
+              programId: "$pid"
+              SET: { gemini: { queue: { exchangePartner: KECK, partnerSplits: null } } }
+            }) {
+              proposal {
+                gemini {
+                  ... on Queue { exchangePartner partnerSplits { partner percent } }
+                }
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "updateProposal": {
+              "proposal": {
+                "gemini": {
+                  "exchangePartner": "KECK",
+                  "partnerSplits": []
+                }
+              }
+            }
+          }
+        """.asRight
+      )
+    }
+  }
+
+  test("✓ swap an exchange partner for partner splits in one edit") {
+    createProgramAs(pi).flatMap { pid =>
+      addProposal(pi, pid) *>
+      // First hand the request to an exchange partner...
+      query(
+        user = pi,
+        query = s"""
+          mutation {
+            updateProposal(input: {
+              programId: "$pid"
+              SET: { gemini: { queue: { exchangePartner: KECK } } }
+            }) { proposal { gemini { scienceSubtype } } }
+          }
+        """
+      ) *>
+      // ...then take it back and apportion it across Gemini partners.  The
+      // exchange partner is cleared before the splits are inserted.
+      expect(
+        user = pi,
+        query = s"""
+          mutation {
+            updateProposal(input: {
+              programId: "$pid"
+              SET: {
+                gemini: {
+                  queue: {
+                    exchangePartner: null
+                    partnerSplits: [ { partner: US, percent: 100 } ]
+                  }
+                }
+              }
+            }) {
+              proposal {
+                gemini {
+                  ... on Queue { exchangePartner partnerSplits { partner percent } }
+                }
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "updateProposal": {
+              "proposal": {
+                "gemini": {
+                  "exchangePartner": null,
+                  "partnerSplits": [
+                    { "partner": "US", "percent": 100 }
+                  ]
+                }
+              }
+            }
+          }
+        """.asRight
       )
     }
   }


### PR DESCRIPTION
Three independent bugs in how a proposal's time request — Gemini partner splits, or an assignment to a Keck/Subaru exchange partner community — is written and validated. Each commit stands alone; see the commit messages for detail.

Swapping splits for an exchange partner in one edit was rejected. check_proposal_time_request fires immediately and forbids a proposal from holding both, but updateProposal always wrote t_proposal before t_partner_split, so a valid edit setting exchangePartner alongside partnerSplits: null tripped it. Write order is now direction-dependent. The contract is unchanged: setting an exchange partner while leaving the splits in place is still an error.

Exchange requests ignored the per-community submission deadline. ProposalContext resolved the deadline to the call's default, ignoring the override introduced with t_gemini_cfp_exchange_partner in V1201 — which the API has been advertising all along as CallForProposalsExchangePartner.submissionDeadline. A call could show a Keck PI one deadline and enforce another. Now resolved from v_gemini_cfp_exchange_partner; identical for calls without an override.

A request naming a community the call doesn't invite was accepted. It silently borrowed the call's default deadline. Now rejected at submission with a message that says so, mirroring missingPartners for Gemini partners.

Testing

Five new tests, plus 227 existing across the proposal, CfP and program-user suites. Two pre-existing exchange-partner tests were asserting on a setup the ODB should never have accepted — a Regular Semester call with no exchangePartners declared, then a Keck request against it — and only passed because of the fallbacks removed here; their calls now invite the community they request.
