### PR TITLE
Load ODB schema with Schema stitcher loader

### DIFF
--- a/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaStitcherMacros.scala
+++ b/modules/binding/src/main/scala/lucuma/odb/graphql/schema/SchemaStitcherMacros.scala
@@ -19,6 +19,15 @@ private object SchemaStitcherMacros:
   inline def fromResources(name: String) =
     ${ SchemaStitcherMacros.fromResourcesImpl('name) }
 
+  private val chunkSize = 16384
+
+  /** Splits `s` into constants small enough for the constant pool and rejoins them at runtime. */
+  private def stringExpr(s: String)(using Quotes): Expr[String] =
+    if s.length <= chunkSize then Expr(s)
+    else
+      val chunks = Expr.ofSeq(s.grouped(chunkSize).toSeq.map(Expr(_)))
+      '{ $chunks.mkString }
+
   /**
    * Macro to do some compile time checking for the schema. It will:
    *   - Check that the resource exists
@@ -55,7 +64,7 @@ private object SchemaStitcherMacros:
       schemaSource
     ).build match
       case Result.Success(schema) =>
-        val strSchema = Expr(schema.toString)
+        val strSchema = stringExpr(schema.toString)
         '{ SchemaStitcher.pure($strSchema) }
 
       case Result.Warning(problems, schema) =>
@@ -64,7 +73,7 @@ private object SchemaStitcherMacros:
             s"Loaded schema '${location}' with problems:${lineSeparator}${problems.map(_.toString).mkString_(lineSeparator).indent(4)}",
             x
           )
-        val strSchema = Expr(schema.toString)
+        val strSchema = stringExpr(schema.toString)
         '{ SchemaStitcher.pure($strSchema) }
 
       case Result.Failure(problems) =>

--- a/modules/obscalc/src/main/scala/lucuma/odb/obscalc/Main.scala
+++ b/modules/obscalc/src/main/scala/lucuma/odb/obscalc/Main.scala
@@ -267,6 +267,7 @@ object CalcMain extends MainParams:
       _          <- Resource.eval(pool.use: s =>
                       Services.asSuperUser(UserService.fromSession(s).canonicalizeUser(user))
                     )
+      schema     <- Resource.eval(OdbMapping.loadSchema[F])
       mapping     = (s: Session[F]) =>
                       OdbMapping.forObscalc(
                         Resource.pure(s),
@@ -280,7 +281,8 @@ object CalcMain extends MainParams:
                         http,
                         horizonsClient,
                         GoaClient.noop[F],
-                        c.email
+                        c.email,
+                        schema
                       )
       o          <- runObscalcDaemon(
                       c.database.maxObscalcConnections,

--- a/modules/service/src/main/scala/lucuma/odb/Main.scala
+++ b/modules/service/src/main/scala/lucuma/odb/Main.scala
@@ -258,8 +258,9 @@ object FMain extends MainParams {
       middleware        <- ServerMiddleware(corsOverHttps, domain, ssoClient, userSvc)
       enums             <- Resource.eval(pool.use(Enums.load))
       ptc               <- Resource.eval(pool.use(TimeEstimateCalculatorImplementation.fromSession(_, enums)))
-      introspecService   = GraphQLService(IntrospectionMapping(OdbMapping.introspectionSchema))
-      graphQLRoutes     <- GraphQLRoutes(gaiaClient, itcClient, commitHash, goaUsers, ssoClient, pool, SkunkMonitor.noopMonitor[F], GraphQLServiceTTL, userSvc, ptc, httpClient, horizonsClient, goaClient, emailConfig, introspecService)
+      schema            <- Resource.eval(OdbMapping.loadSchema[F])
+      introspecService   = GraphQLService(IntrospectionMapping(schema))
+      graphQLRoutes     <- GraphQLRoutes(gaiaClient, itcClient, commitHash, goaUsers, ssoClient, pool, SkunkMonitor.noopMonitor[F], GraphQLServiceTTL, userSvc, ptc, httpClient, horizonsClient, goaClient, emailConfig, introspecService, schema)
       s3ClientOps       <- s3OpsResource
       s3Presigner       <- s3PresignerResource
       s3FileService      = S3FileService.fromS3ConfigAndClient(awsConfig, s3ClientOps, s3Presigner)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/GraphQLRoutes.scala
@@ -12,6 +12,7 @@ import cats.kernel.Order
 import fs2.Stream
 import grackle.Operation
 import grackle.Result
+import grackle.Schema
 import grackle.skunk.SkunkMonitor
 import io.circe.Json
 import lucuma.catalog.clients.GaiaClient
@@ -75,7 +76,8 @@ object GraphQLRoutes {
     horizonsClient:       HorizonsClient[F],
     goaClient:            GoaClient[F],
     emailConfig:          Config.Email,
-    introspectionService: GraphQLService[F]
+    introspectionService: GraphQLService[F],
+    schema:               Schema
   ): Resource[F, WebSocketBuilder2[F] => HttpRoutes[F]] =
     OdbMapping.Topics(pool).flatMap { topics =>
 
@@ -117,7 +119,7 @@ object GraphQLRoutes {
                         _    <- OptionT.liftF(Services.asSuperUser(userSvc.canonicalizeUser(user).retryOnInvalidCursorName))
 
                         _    <- OptionT.liftF(info(user, s"New service instance."))
-                        map   = OdbMapping(pool, monitor, user, topics, gaiaClient, itcClient, commitHash, goaUsers, ptc, httpClient, horizonsClient, goaClient, emailConfig)
+                        map   = OdbMapping(pool, monitor, user, topics, gaiaClient, itcClient, commitHash, goaUsers, ptc, httpClient, horizonsClient, goaClient, emailConfig, schema)
                         svc   = new GraphQLService(map, props.toList*) {
                                   override def query(
                                     request:       Operation,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -5,6 +5,7 @@ package lucuma.odb.graphql
 
 import _root_.skunk.AppliedFragment
 import _root_.skunk.Session
+import cats.ApplicativeThrow
 import cats.Monoid
 import cats.Parallel
 import cats.effect.*
@@ -25,6 +26,7 @@ import lucuma.horizons.HorizonsClient
 import lucuma.itc.client.ItcClient
 import lucuma.odb.Config
 import lucuma.odb.graphql.mapping.*
+import lucuma.odb.graphql.schema.SchemaStitcher
 import lucuma.odb.graphql.topic.ConfigurationRequestTopic
 import lucuma.odb.graphql.topic.DatasetTopic
 import lucuma.odb.graphql.topic.ExecutionEventAddedTopic
@@ -40,7 +42,6 @@ import lucuma.odb.service.S3FileService
 import lucuma.odb.service.Services
 import lucuma.odb.util.Codecs.DomainCodec
 import org.http4s.client.Client
-import org.tpolecat.sourcepos.SourcePos
 import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.otel4s.Attribute
@@ -50,7 +51,6 @@ import java.nio.file.Files
 import java.nio.file.Path as NIOPath
 import scala.concurrent.duration.*
 import scala.io.AnsiColor
-import scala.io.Source
 
 object OdbMapping {
 
@@ -89,14 +89,6 @@ object OdbMapping {
       .map(_.millis)
       .getOrElse(5.seconds)
 
-  // Loads a GraphQL file from the classpath, relative to this Class.
-  def unsafeLoadSchema(fileName: String): Schema = {
-    val stream = getClass.getResourceAsStream(fileName)
-    val src  = Source.fromInputStream(stream, "UTF-8")
-    try Schema(src.getLines().mkString("\n")).toEither.fold(x => sys.error(s"Invalid schema: $fileName: ${x.toList.mkString(", ")}"), identity)
-    finally src.close()
-  }
-
   private implicit def monoidPartialFunction[A, B]: Monoid[PartialFunction[A, B]] =
     Monoid.instance(PartialFunction.empty, _ orElse _)
 
@@ -114,8 +106,8 @@ object OdbMapping {
     horizonsClient0: HorizonsClient[F],
     goaClient0:      GoaClient[F],
     emailConfig0:    Config.Email,
+    schema0:         Schema,
     allowSub:        Boolean = true,        // Are submappings (recursive calls) allowed?
-    schema0:         Option[Schema] = None, // If we happen to have a schema we can pass it and avoid more parsing
     shouldValidate:  Boolean = true,        // should we validatate the TypeMappings?
   ): Mapping[F] =
         new SkunkMapping[F](database, monitor0)
@@ -333,8 +325,7 @@ object OdbMapping {
               .copy(terseError = false)
 
           // Our schema
-          val schema: Schema =
-            schema0.getOrElse(unsafeLoadSchema("OdbSchema.graphql"))
+          val schema: Schema = schema0
 
           // Our services and resources needed by various mappings.
           override val commitHash = commitHash0
@@ -366,8 +357,8 @@ object OdbMapping {
                     horizonsClient0,
                     goaClient0,
                     emailConfig0,
+                    schema,
                     false,                  // don't allow further sub-mappings; only one level of recursion is allowed
-                    Some(schema),           // don't re-parse the schema
                     shouldValidate = false  // already validated
                   ),
                 emailConfig0,
@@ -797,13 +788,6 @@ object OdbMapping {
         }
 
   /**
-    * The full ODB schema. This is the schema exposed for introspection (see
-    * `IntrospectionMapping`).
-    */
-  def introspectionSchema: Schema =
-    unsafeLoadSchema("OdbSchema.graphql")
-
-  /**
    * A reduced mapping for use with the Obscalc service.  Obscalc computes the
    * observation workflow, which makes a GraphQL call which in turn requires
    * a `Services` instance that has a mapping.  This mapping ignores
@@ -822,7 +806,7 @@ object OdbMapping {
     horizonsClient: HorizonsClient[F],
     goaClient:      GoaClient[F],
     emailConfig:    Config.Email,
-    schema:         Option[Schema] = None // If we happen to have a schema we can pass it and avoid more parsing
+    schema:         Schema
   ): Mapping[F] =
 
     apply(
@@ -839,9 +823,12 @@ object OdbMapping {
       horizonsClient,
       goaClient,
       emailConfig,
-      allowSub = false,
       schema,
+      allowSub = false,
       shouldValidate = false, // seems to cause overflow from time to time
     )
 
+
+  def loadSchema[F[_]: ApplicativeThrow: Logger]: F[Schema] =
+    SchemaStitcher.load("lucuma/odb/graphql/OdbSchema.graphql")
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -464,7 +464,8 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
       enm <- db.evalMap(Enums.load)
       ptc <- db.evalMap(TimeEstimateCalculatorImplementation.fromSession(_, enm))
       goa <- Resource.eval(goaClient)
-      map  = OdbMapping(db, mon, usr, top, gaiaClient, itc, CommitHash.Zero, goaUsers, ptc, httpClient, horizonsClient, goa, emailConfig)
+      schema <- Resource.eval(OdbMapping.loadSchema[IO])
+      map  = OdbMapping(db, mon, usr, top, gaiaClient, itc, CommitHash.Zero, goaUsers, ptc, httpClient, horizonsClient, goa, emailConfig, schema)
     } yield map
 
   protected def trace: Resource[IO, Trace[IO]] =
@@ -844,9 +845,10 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
         db   <- FMain.databasePoolResource[IO](databaseConfig)
         enm  <- db.evalMap(Enums.load)
         ptc  <- db.evalMap(TimeEstimateCalculatorImplementation.fromSession(_, enm))
-      yield (db, ptc)
+        schema <- Resource.eval(OdbMapping.loadSchema[IO])
+      yield (db, ptc, schema)
 
-    res.use: (db, ptc) =>
+    res.use: (db, ptc, schema) =>
       val mapping = (s: Session[IO]) => OdbMapping.forObscalc(
         Resource.pure(s),
         SkunkMonitor.noopMonitor[IO],
@@ -859,7 +861,8 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
         httpClient,
         horizonsClient,
         GoaClient.noop[IO],
-        emailConfig
+        emailConfig,
+        schema
       )
       db.use: s =>
         given services: Services[IO] = Services.forUser(u, mapping.some, emailConfig, CommitHash.Zero, ptc, httpClient, itcClient, gaiaClient, S3FileService.noop[IO], horizonsClient, TelluricTargetsClient.noop[IO], GoaClient.noop[IO])(s)


### PR DESCRIPTION
Verifies the schema at compile-time, moves some unsafe code out of OdbMapping, and adds safe handling and logging for loading on startup