### PR TITLE
Provide mechanism to opt out of telluric

### DIFF
--- a/modules/service/docs/observation-workflow-states.md
+++ b/modules/service/docs/observation-workflow-states.md
@@ -1,0 +1,138 @@
+# Observation workflow states and transitions
+
+Source of truth: `ObservationWorkflowService.workflowStateAndTransitions`
+(`modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala`).
+
+Black edges are the ones reachable through the `setObservationWorkflowState`
+mutation — they are exactly the contents of `allowedTransitions`. Every other
+colour is a re-derivation that happens on its own, distinguished by who triggers
+it: blue for the PI editing the observation, green for a staff approval, red for
+a staff denial.
+
+![Observation workflow states](observation-workflow.svg)
+
+The four panels are, top to bottom: science observations in a proposal, science
+observations in a program, program-level calibrations, and per-observation
+calibrations. Each is described below.
+
+## Main lifecycle
+
+`Inactive` returns to `executionState.getOrElse(validationStatus)` — so if
+execution has already begun it comes back as `Ongoing`/`Completed`, otherwise to
+whatever the validation state recomputes to, which need not be the state it left.
+
+### Defined and Unapproved
+
+`Unapproved` is one state standing for four validation codes
+(`validateConfigurations`): no request exists, all requests denied, or some
+request still pending. There is no separate reviewed/unreviewed state — approval
+lives entirely in `ConfigurationRequestStatus` — so each direction between
+`Defined` and `Unapproved` has both a PI route and a staff route:
+
+| Edge | Trigger |
+|---|---|
+| `Defined -> Unapproved` (blue) | PI changes the configuration to one no approved request covers |
+| `Defined -> Unapproved` (red) | staff withdraws the approval that was holding it `Defined` |
+| `Unapproved -> Defined` (blue) | PI changes the configuration to one an approved request already covers |
+| `Unapproved -> Defined` (green) | staff approves the pending request |
+
+`Defined` requires at least one request with status `Approved`. Note that denying
+a request that was merely *pending* changes the validation code but not the
+state — the observation stays `Unapproved` — so the red edge specifically means
+revoking an approval, not the everyday act of rejecting a request.
+
+## Calibrations
+
+Two rules apply to **every** calibration role, whatever its kind:
+
+- A calibration never runs the validation pipeline. `validationStatus` is forced
+  to `Defined` as soon as `calibrationRole` is set, so a calibration is never
+  `Undefined` or `Unapproved`.
+- Calibration programs have `ProgramType.hasProposal == false`, so the
+  `Defined -> Ready` gate passes without an accepted proposal.
+
+Beyond that the five roles split into two groups:
+
+| Role | Group | Lifecycle |
+|---|---|---|
+| `Photometric`, `SpectroPhotometric`, `Twilight` | program-level | the generic lifecycle above, entered at `Defined` |
+| `Telluric`, `DaytimePinhole` | per-observation | inherits its science observation's user state; see below |
+
+### Program-level calibrations
+
+`Photometric`, `SpectroPhotometric`, and `Twilight` fall through to the generic
+`else` branch of `allowedTransitions`, so they run the full lifecycle — they are
+simply never gated on validation or on proposal acceptance. `Defined` is both the
+entry point and the floor: because `validationStatus` is pinned to `Defined`, the
+two edges that return "to the validation state" (`Ready -> validationStatus` and
+`Inactive -> validationStatus`) always land back on `Defined`.
+
+Compared with the main lifecycle, only the left-hand side changes: `Undefined`
+and `Unapproved` are unreachable, and `Defined -> Ready` carries no
+proposal-acceptance condition. Everything from `Ready` rightwards is identical,
+including the staff-and-visitor-mode restriction on `Ready <-> Ongoing`.
+
+### Per-observation calibrations
+
+Tellurics and daytime pinholes are auto-created alongside their science
+observation and normally have **no** transitions of their own — they inherit the
+science observation's user state. SC-8458 carves out one exception, for tellurics
+only (see `../../../docs/adr/0008-telluric-decline-override.md`).
+
+A telluric that is `Inactive` only because its science observation is inactive
+offers no transitions — there is no override to clear. Both calibration carve-outs
+apply only while `state <= Ready`; once execution begins the generic rules resume.
+
+## Transition conditions
+
+| Transition | Requires |
+|---|---|
+| `Defined -> Ready` | not an exchange observation, not a target of opportunity, and (proposal accepted or program has no proposal — `hasProposal` is true only for `Science`, `Keck`, `Subaru`) |
+| `Ready -> Ongoing`, `Ongoing -> Ready` | visitor observing mode **and** staff access or above |
+| `Completed -> Ongoing` | execution state was explicitly declared complete, not naturally complete |
+| `Telluric -> Inactive` | calibration role is `Telluric` and `state <= Ready` |
+| `Telluric Inactive -> inherited` | the telluric's own `c_workflow_user_state` is `Inactive` |
+
+Exchange observations (Keck/Subaru) run off-Gemini and have no
+`Ready`/`Ongoing`/`Completed` lifecycle at all; `Inactive` is their only
+transition out of `Defined`.
+
+## DB Columns
+
+The state is not stored as a single column. It is computed each time, from three
+independent sources, in this precedence order:
+
+| Kind | Members | Where it comes from |
+|---|---|---|
+| `ExecutionState` | `Ongoing`, `Completed` | `c_declared_execution_state`, else the generator's execution state |
+| `UserState` | `Inactive`, `Ready` | `c_workflow_user_state` |
+| `ValidationState` | `Undefined`, `Unapproved`, `Defined` | validation codes computed from the observation |
+
+Execution wins over user state, which wins over validation — except that a
+validation error suppresses a stored `Ready` (but never a stored `Inactive`).
+
+## Regenerating the diagram
+
+There is nothing to regenerate: `observation-workflow.svg` is hand-authored and
+is its own source. It is deliberately not produced from mermaid or any other
+text format — the readability depends on hand-placed nodes (`Inactive` stacked
+above each state, `Unapproved` dropped below the row, the legend parked in the
+gap), and auto-layout engines will not reproduce that.
+
+To change it, edit the SVG directly. The header comment lists the shared column
+positions and the per-panel `y` bands; keeping equivalent states on the same
+column is what makes the four panels comparable at a glance.
+
+To preview a change on macOS:
+
+```bash
+qlmanage -t -s 1520 -o /tmp docs/observation-workflow.svg   # writes /tmp/observation-workflow.svg.png
+```
+
+`qlmanage` crops to a square rather than fitting, so on a wide diagram it will
+cut off the right-hand side. To see the whole thing, temporarily pad the
+`viewBox`/`height` to a square (`0 0 1520 1520`) in a scratch copy, or just open
+the file in a browser, which honours the real aspect ratio.
+
+When adding a panel, extend the root `viewBox` and `height` to match; everything
+else is absolute coordinates and will stay where it is.

--- a/modules/service/docs/observation-workflow.svg
+++ b/modules/service/docs/observation-workflow.svg
@@ -1,0 +1,262 @@
+<!--
+  Observation workflow states and transitions.
+
+  This file is HAND-AUTHORED, not generated. There is no build step and no source
+  format other than this file — edit the coordinates directly. See
+  "Regenerating the diagram" in observation-workflow-states.md.
+
+  Layout grid: the four panels share one set of column positions so equivalent
+  states line up vertically across panels.
+
+    Undefined 250   Unapproved 430   Defined 610   Ready 900   Ongoing 1130   Completed 1350
+
+  Panel bands (y):  Phase 1  16-206     Phase 2  230-660
+                    Calibrations (program-level)  690-920
+                    Calibrations (per-observation)  945-1200
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1520 1220" width="1520" height="1220" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="ab-e" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#111111"/>
+    </marker>
+    <marker id="ab-s" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#111111"/>
+    </marker>
+    <marker id="au-e" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1f8fe0"/>
+    </marker>
+    <marker id="au-s" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#1f8fe0"/>
+    </marker>
+    <marker id="ag-e" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#2e9b3f"/>
+    </marker>
+    <marker id="ag-s" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#2e9b3f"/>
+    </marker>
+    <marker id="ar-e" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#e03b2f"/>
+    </marker>
+  </defs>
+
+  <style>
+    .box    { fill:#ffffff; stroke:#111111; stroke-width:2;   rx:5; }
+    .inact  { fill:#d9d9d9; stroke:#555555; stroke-width:1.5; rx:5; }
+    .locked { fill:#f0f0f0; stroke:#9e9e9e; stroke-width:1.5; stroke-dasharray:4 3; rx:5; }
+    .st     { font-size:13px; fill:#111111; text-anchor:middle; font-weight:600; }
+    .si     { font-size:12px; fill:#111111; text-anchor:middle; }
+    .sub    { font-size:10px; fill:#555555; text-anchor:middle; }
+    .el     { font-size:11px; fill:#333333; text-anchor:middle; }
+    .els    { font-size:11px; fill:#333333; text-anchor:start; }
+    .ele    { font-size:11px; fill:#333333; text-anchor:end; }
+    .note   { font-size:10px; fill:#666666; font-style:italic; text-anchor:middle; }
+    .phase  { font-size:13px; fill:#333333; font-weight:700; }
+    .grp    { font-size:12px; fill:#555555; font-weight:700; }
+    .leg    { font-size:11px; fill:#111111; font-weight:700; text-anchor:start; }
+    .foot   { font-size:11px; fill:#666666; font-style:italic; text-anchor:start; }
+    .black  { stroke:#111111; stroke-width:2; fill:none; }
+    .blue   { stroke:#1f8fe0; stroke-width:2; fill:none; }
+    .green  { stroke:#2e9b3f; stroke-width:2; fill:none; }
+    .red    { stroke:#e03b2f; stroke-width:2; fill:none; }
+    .cont   { fill:none; stroke:#555555; stroke-width:1.5; stroke-dasharray:7 5; }
+    .grpbox { fill:none; stroke:#bbbbbb; stroke-width:1.2; }
+  </style>
+
+  <rect x="0" y="0" width="1520" height="1220" fill="#ffffff"/>
+
+  <!-- ===================== Phase 1 ===================== -->
+  <rect class="cont" x="20" y="16" width="760" height="190" rx="14"/>
+  <text class="phase" x="40" y="42">Phase 1 (proposal)</text>
+
+  <circle cx="70" cy="140" r="9" fill="#ffffff" stroke="#111111" stroke-width="2"/>
+  <line class="blue" x1="82" y1="140" x2="242" y2="140" marker-end="url(#au-e)"/>
+  <text class="el" x="162" y="120">PI creates a new</text>
+  <text class="el" x="162" y="133">observation in a proposal</text>
+
+  <rect class="inact" x="256" y="54" width="100" height="30"/>
+  <text class="si" x="306" y="74">Inactive</text>
+  <line class="black" x1="306" y1="88" x2="306" y2="118" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <rect class="box" x="250" y="122" width="112" height="36"/>
+  <text class="st" x="306" y="145">Undefined</text>
+
+  <line class="blue" x1="366" y1="140" x2="638" y2="140" marker-end="url(#au-e)"/>
+  <text class="el" x="502" y="120">PI selects a valid</text>
+  <text class="el" x="502" y="133">configuration</text>
+
+  <rect class="inact" x="650" y="54" width="100" height="30"/>
+  <text class="si" x="700" y="74">Inactive</text>
+  <line class="black" x1="700" y1="88" x2="700" y2="118" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <rect class="box" x="644" y="122" width="112" height="36"/>
+  <text class="st" x="700" y="145">Defined</text>
+
+  <line class="blue" x1="700" y1="158" x2="700" y2="338" marker-end="url(#au-e)"/>
+  <text class="els" x="710" y="252">PI is awarded time</text>
+
+  <!-- ===================== Phase 2 ===================== -->
+  <rect class="cont" x="20" y="230" width="1480" height="430" rx="14"/>
+  <text class="phase" x="40" y="256">Phase 2 (program)</text>
+
+  <circle cx="70" cy="360" r="9" fill="#ffffff" stroke="#111111" stroke-width="2"/>
+  <line class="blue" x1="82" y1="360" x2="242" y2="360" marker-end="url(#au-e)"/>
+  <text class="el" x="162" y="340">PI creates a new observation</text>
+  <text class="el" x="162" y="353">in an approved program</text>
+
+  <rect class="inact" x="256" y="274" width="100" height="30"/>
+  <text class="si" x="306" y="294">Inactive</text>
+  <line class="black" x1="306" y1="308" x2="306" y2="338" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <rect class="box" x="250" y="342" width="112" height="36"/>
+  <text class="st" x="306" y="365">Undefined</text>
+
+  <line class="blue" x1="366" y1="360" x2="606" y2="360" marker-end="url(#au-e)" marker-start="url(#au-s)"/>
+  <text class="el" x="486" y="340">configuration becomes</text>
+  <text class="el" x="486" y="353">valid / invalid</text>
+
+  <rect class="inact" x="570" y="274" width="100" height="30"/>
+  <text class="si" x="620" y="294">Inactive</text>
+  <line class="black" x1="620" y1="308" x2="620" y2="338" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <rect class="box" x="610" y="342" width="112" height="36"/>
+  <text class="st" x="666" y="365">Defined</text>
+
+  <path class="blue" d="M306,382 L306,518 L426,518" marker-end="url(#au-e)" marker-start="url(#au-s)"/>
+  <text class="ele" x="296" y="442">valid, but</text>
+  <text class="ele" x="296" y="455">needs approval</text>
+
+  <rect class="box" x="430" y="500" width="112" height="36"/>
+  <text class="st" x="486" y="523">Unapproved</text>
+  <line class="black" x1="486" y1="540" x2="486" y2="576" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <rect class="inact" x="436" y="580" width="100" height="30"/>
+  <text class="si" x="486" y="600">Inactive</text>
+
+  <!-- Defined <-> Unapproved: two routes each way, PI-driven and staff-driven -->
+  <path class="blue" d="M616,382 L616,412 L470,412 L470,496" marker-end="url(#au-e)"/>
+  <text class="el" x="543" y="406">unapproved change</text>
+
+  <path class="red" d="M646,382 L646,446 L505,446 L505,496" marker-end="url(#ar-e)"/>
+  <text class="el" x="575" y="440">approval withdrawn</text>
+
+  <path class="blue" d="M546,512 L676,512 L676,382" marker-end="url(#au-e)"/>
+  <text class="el" x="628" y="528">approved config selected</text>
+
+  <path class="green" d="M546,530 L704,530 L704,382" marker-end="url(#ag-e)"/>
+  <text class="el" x="625" y="546">request approved</text>
+
+  <line class="black" x1="726" y1="360" x2="896" y2="360" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <text class="el" x="811" y="340">PI verifies the sequence</text>
+  <text class="el" x="811" y="353">/ reopens it</text>
+  <text class="note" x="811" y="378">Ready needs an accepted proposal</text>
+
+  <rect class="inact" x="906" y="274" width="100" height="30"/>
+  <text class="si" x="956" y="294">Inactive</text>
+  <line class="black" x1="956" y1="308" x2="956" y2="338" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <rect class="box" x="900" y="342" width="112" height="36"/>
+  <text class="st" x="956" y="365">Ready</text>
+
+  <line class="blue" x1="1014" y1="348" x2="1126" y2="348" marker-end="url(#au-e)"/>
+  <text class="note" x="1070" y="336">observation started</text>
+  <line class="black" x1="1014" y1="374" x2="1126" y2="374" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <text class="note" x="1070" y="392">staff, visitor modes</text>
+
+  <rect class="box" x="1130" y="342" width="112" height="36"/>
+  <text class="st" x="1186" y="365">Ongoing</text>
+
+  <line class="blue" x1="1246" y1="348" x2="1346" y2="348" marker-end="url(#au-e)"/>
+  <text class="note" x="1296" y="336">sequence complete</text>
+  <line class="black" x1="1246" y1="374" x2="1346" y2="374" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <text class="note" x="1296" y="392">declare complete / reopen</text>
+
+  <rect class="box" x="1350" y="342" width="112" height="36"/>
+  <text class="st" x="1406" y="365">Completed</text>
+
+  <!-- Legend -->
+  <line class="black" x1="1130" y1="470" x2="1248" y2="470" marker-end="url(#ab-e)"/>
+  <text class="leg" x="1260" y="474">PI / staff action</text>
+  <line class="blue" x1="1130" y1="505" x2="1248" y2="505" marker-end="url(#au-e)"/>
+  <text class="leg" x="1260" y="509">Automatic transition</text>
+  <line class="green" x1="1130" y1="540" x2="1248" y2="540" marker-end="url(#ag-e)"/>
+  <text class="leg" x="1260" y="544">Staff approval</text>
+  <line class="red" x1="1130" y1="575" x2="1248" y2="575" marker-end="url(#ar-e)"/>
+  <text class="leg" x="1260" y="579">Staff rejection</text>
+
+  <text class="foot" x="40" y="634">Ongoing and Completed cannot be deactivated — Inactive is reachable only from Undefined, Unapproved, Defined and Ready.</text>
+
+  <!-- ============ Calibrations: program-level ============ -->
+  <rect class="cont" x="20" y="690" width="1480" height="230" rx="14"/>
+  <text class="phase" x="40" y="716">Program-level calibrations (Photometric, SpectroPhotometric, Twilight)</text>
+
+  <circle cx="380" cy="830" r="9" fill="#ffffff" stroke="#111111" stroke-width="2"/>
+  <line class="blue" x1="392" y1="830" x2="606" y2="830" marker-end="url(#au-e)"/>
+  <text class="el" x="499" y="810">calibration created —</text>
+  <text class="el" x="499" y="823">validation is skipped</text>
+
+  <rect class="inact" x="616" y="747" width="100" height="30"/>
+  <text class="si" x="666" y="767">Inactive</text>
+  <line class="black" x1="666" y1="781" x2="666" y2="808" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <rect class="box" x="610" y="812" width="112" height="36"/>
+  <text class="st" x="666" y="835">Defined</text>
+
+  <line class="black" x1="726" y1="830" x2="896" y2="830" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <text class="el" x="811" y="807">verified / reopened</text>
+  <text class="note" x="811" y="848">no proposal gate</text>
+
+  <rect class="inact" x="906" y="747" width="100" height="30"/>
+  <text class="si" x="956" y="767">Inactive</text>
+  <line class="black" x1="956" y1="781" x2="956" y2="808" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <rect class="box" x="900" y="812" width="112" height="36"/>
+  <text class="st" x="956" y="835">Ready</text>
+
+  <line class="blue" x1="1014" y1="818" x2="1126" y2="818" marker-end="url(#au-e)"/>
+  <text class="note" x="1070" y="806">observation started</text>
+  <line class="black" x1="1014" y1="844" x2="1126" y2="844" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <text class="note" x="1070" y="862">staff, visitor modes</text>
+
+  <rect class="box" x="1130" y="812" width="112" height="36"/>
+  <text class="st" x="1186" y="835">Ongoing</text>
+
+  <line class="blue" x1="1246" y1="818" x2="1346" y2="818" marker-end="url(#au-e)"/>
+  <text class="note" x="1296" y="806">sequence complete</text>
+  <line class="black" x1="1246" y1="844" x2="1346" y2="844" marker-end="url(#ab-e)" marker-start="url(#ab-s)"/>
+  <text class="note" x="1296" y="862">declare complete / reopen</text>
+
+  <rect class="box" x="1350" y="812" width="112" height="36"/>
+  <text class="st" x="1406" y="835">Completed</text>
+
+  <text class="foot" x="40" y="898">Undefined and Unapproved are unreachable: validationStatus is pinned to Defined, which is both the entry point and the floor.</text>
+
+  <!-- ============ Calibrations: per-observation ============ -->
+  <rect class="cont" x="20" y="945" width="1480" height="255" rx="14"/>
+  <text class="phase" x="40" y="971">Per-observation calibrations — inherit their science observation's user state</text>
+
+  <rect class="grpbox" x="40" y="990" width="900" height="192" rx="8"/>
+  <text class="grp" x="58" y="1012">Telluric</text>
+
+  <rect class="box" x="90" y="1040" width="220" height="44"/>
+  <text class="st" x="200" y="1058">Defined / Ready</text>
+  <text class="sub" x="200" y="1074">inherited from science obs</text>
+
+  <line class="black" x1="314" y1="1052" x2="516" y2="1052" marker-end="url(#ab-e)"/>
+  <text class="el" x="415" y="1040">PI declines</text>
+  <line class="black" x1="516" y1="1074" x2="314" y2="1074" marker-end="url(#ab-e)"/>
+  <text class="el" x="415" y="1092">PI reinstates — override cleared</text>
+
+  <rect class="box" x="520" y="1040" width="220" height="44"/>
+  <text class="st" x="630" y="1058">Inactive</text>
+  <text class="sub" x="630" y="1074">its own override is set</text>
+
+  <rect class="locked" x="90" y="1120" width="220" height="40"/>
+  <text class="si" x="200" y="1136">Inactive</text>
+  <text class="sub" x="200" y="1150">inherited only — no transitions</text>
+  <line class="blue" x1="200" y1="1120" x2="200" y2="1088" marker-end="url(#au-e)"/>
+  <text class="els" x="216" y="1110">science obs reactivated</text>
+
+  <text class="foot" x="770" y="1136">Declining is offered only</text>
+  <text class="foot" x="770" y="1152">while state ≤ Ready.</text>
+
+  <rect class="grpbox" x="970" y="990" width="490" height="192" rx="8"/>
+  <text class="grp" x="988" y="1012">DaytimePinhole</text>
+
+  <rect class="locked" x="1010" y="1040" width="410" height="44"/>
+  <text class="si" x="1215" y="1058">Defined / Ready / Inactive</text>
+  <text class="sub" x="1215" y="1074">inherited — no transitions of its own</text>
+  <text class="foot" x="1010" y="1130">allowedTransitions is always empty</text>
+  <text class="foot" x="1010" y="1146">while state ≤ Ready.</text>
+</svg>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AccessControl.scala
@@ -15,6 +15,7 @@ import grackle.Query.*
 import grackle.Result
 import grackle.ResultT
 import grackle.Type
+import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.enums.SequenceType
@@ -738,16 +739,16 @@ trait AccessControl[F[_]] extends Predicates[F] {
       .value
 
 
-  def selectForUpdate(input: SetObservationWorkflowStateInput)(using Services[F], NoTransaction[F]): F[Result[CheckedWithId[(Option[ObservingModeType], ObservationWorkflow, ObservationWorkflowState), Observation.Id]]] =
+  def selectForUpdate(input: SetObservationWorkflowStateInput)(using Services[F], NoTransaction[F]): F[Result[CheckedWithId[(Option[ObservingModeType], Option[CalibrationRole], ObservationWorkflow, ObservationWorkflowState), Observation.Id]]] =
     verifyWritable(input.observationId) >>
     Services.asSuperUser:
-      observationWorkflowService.getWorkflowsAndModes(List(input.observationId))
+      observationWorkflowService.getWorkflowsModesAndRoles(List(input.observationId))
         .map: res =>
           res.map(_(input.observationId)).flatMap:
-            case (w, om) =>
+            case (w, om, calibrationRole) =>
               if w.state === input.state || w.validTransitions.contains(input.state)
               then
-                Result(AccessControl.unchecked((om, w, input.state), input.observationId, observation_id))
+                Result(AccessControl.unchecked((om, calibrationRole, w, input.state), input.observationId, observation_id))
               else Result.failure(OdbError.InvalidWorkflowTransition(w.state, input.state).asProblem)
 
   def selectForUpdate[D](

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -69,9 +69,9 @@ import Services.Syntax.*
 
 sealed trait ObservationWorkflowService[F[_]] {
 
-  def getWorkflowsAndModes(
+  def getWorkflowsModesAndRoles(
     oids: List[Observation.Id]
-  )(using NoTransaction[F], SuperUserAccess): F[Result[Map[Observation.Id, (ObservationWorkflow, Option[ObservingModeType])]]]
+  )(using NoTransaction[F], SuperUserAccess): F[Result[Map[Observation.Id, (ObservationWorkflow, Option[ObservingModeType], Option[CalibrationRole])]]]
 
   def getWorkflows(
     oids: List[Observation.Id]
@@ -99,7 +99,7 @@ sealed trait ObservationWorkflowService[F[_]] {
   )(using Transaction[F]): F[Result[ObservationWorkflow]]
 
   def setWorkflowState(
-    input: AccessControl.CheckedWithId[(Option[ObservingModeType], ObservationWorkflow, ObservationWorkflowState), Observation.Id]
+    input: AccessControl.CheckedWithId[(Option[ObservingModeType], Option[CalibrationRole], ObservationWorkflow, ObservationWorkflowState), Observation.Id]
   )(using NoTransaction[F]): F[Result[ObservationWorkflow]]
 
   def filterState(
@@ -121,26 +121,26 @@ sealed trait ObservationWorkflowService[F[_]] {
 
 /* Validation Info Record */
 case class ObservationValidationInfo(
-  pid:                Program.Id,
-  tpe:                ProgramType,
-  oid:                Observation.Id,
-  observingMode:      Option[ObservingModeType],
-  coordinates:        Option[Coordinates],  // explicit base, or coordinates at CFP midpoint, if any
-  explicitBase:       Option[Coordinates],
-  role:               Option[CalibrationRole],
-  userState:          Option[ObservationWorkflowService.UserState],
+  pid:                    Program.Id,
+  tpe:                    ProgramType,
+  oid:                    Observation.Id,
+  observingMode:          Option[ObservingModeType],
+  coordinates:            Option[Coordinates],  // explicit base, or coordinates at CFP midpoint, if any
+  explicitBase:           Option[Coordinates],
+  calibrationRole:        Option[CalibrationRole],
+  userState:              Option[ObservationWorkflowService.UserState],
   declaredExecutionState: Option[DeclaredExecutionState],
-  proposalStatus:     ProposalStatus,
-  cfpid:              Option[CallForProposals.Id],
-  scienceBand:        Option[ScienceBand],
-  asterism:           List[Target],
-  associatedUserState:Option[ObservationWorkflowService.UserState], // state of science obs if this is a per-observation calibration (telluric or daytime pinhole)
-  generatorParams:    Option[Either[GeneratorParamsService.Error, GeneratorParams]] = None,
-  cfpInfo:            Option[CfpInfo] = None,
-  programAllocations: Option[NonEmptyList[ScienceBand]] = None,
-  otherConfigErrors:  List[String] = Nil,
-  keckInstrument:     Option[KeckInstrument] = None,   // set for exchange_keck observations
-  subaruInstrument:   Option[SubaruInstrument] = None  // set for exchange_subaru observations
+  proposalStatus:         ProposalStatus,
+  cfpid:                  Option[CallForProposals.Id],
+  scienceBand:            Option[ScienceBand],
+  asterism:               List[Target],
+  associatedUserState:    Option[ObservationWorkflowService.UserState], // state of science obs if this is a per-observation calibration (telluric or daytime pinhole)
+  generatorParams:        Option[Either[GeneratorParamsService.Error, GeneratorParams]] = None,
+  cfpInfo:                Option[CfpInfo] = None,
+  programAllocations:     Option[NonEmptyList[ScienceBand]] = None,
+  otherConfigErrors:      List[String] = Nil,
+  keckInstrument:         Option[KeckInstrument] = None,   // set for exchange_keck observations
+  subaruInstrument:       Option[SubaruInstrument] = None  // set for exchange_subaru observations
 ) {
 
   def isDeclaredComplete: Boolean =
@@ -152,7 +152,10 @@ case class ObservationValidationInfo(
   def effectiveUserState: Option[UserState] =
     // Per-observation calibrations (tellurics, daytime pinhole flats) inherit
     // their science observation's user state.
-    if role.exists(ObsExtract.PerObservationCalibrationRoles.contains) then associatedUserState
+    // A telluric could be declined however, thus it can carrie its own Inactive state,
+    // which overrides that inheritance.
+    if calibrationRole.contains(CalibrationRole.Telluric) && userState.contains(ObservationWorkflowState.Inactive) then Some(ObservationWorkflowState.Inactive)
+    else if calibrationRole.exists(ObsExtract.PerObservationCalibrationRoles.contains) then associatedUserState
     else userState
 
   /* Has the proposal been accepted? */
@@ -474,7 +477,7 @@ object ObservationWorkflowService {
             case ObservationValidationCode.ConfigurationRequestPending => 7
 
         val validationStatus: ValidationState =
-          if info.role.isDefined then Defined // Calibrations are immediately Defined
+          if info.calibrationRole.isDefined then Defined // Calibrations are immediately Defined
           else codes.minOption.fold(Defined):
             case ObservationValidationCode.CallForProposalsError            |
                   ObservationValidationCode.ConfigurationError               |
@@ -504,7 +507,16 @@ object ObservationWorkflowService {
           info.isVisitor && user.role.access >= Access.Staff
 
         val allowedTransitions: List[ObservationWorkflowState] =
-          if (info.role.exists(ObsExtract.PerObservationCalibrationRoles.contains) && state <= Ready) then Nil
+          if info.calibrationRole.contains(CalibrationRole.Telluric) && state <= Ready then
+            // A telluric may be declined (set to Inactive)
+            state match
+              case Inactive =>
+                if info.userState.contains(Inactive)
+                then List(info.associatedUserState.getOrElse(validationStatus))
+                else Nil
+              case _ =>
+                List(Inactive)
+          else if (info.calibrationRole.exists(ObsExtract.PerObservationCalibrationRoles.contains) && state <= Ready) then Nil
           else state match
             case Inactive   => List(executionState.getOrElse(validationStatus))
             case Undefined  => List(Inactive)
@@ -527,7 +539,7 @@ object ObservationWorkflowService {
 
         type Validator = ObservationValidationInfo => ObservationValidationMap
 
-        val (cals, other)         = infos.partition(_._2.role.isDefined)
+        val (cals, other)         = infos.partition(_._2.calibrationRole.isDefined)
         val (nonScience, science) = other.partition(!_._2.tpe.hasProposal)
 
         // Here are our simple validators
@@ -535,9 +547,9 @@ object ObservationWorkflowService {
         val generatorValidator: Validator = info =>
           if info.isVisitor || info.isExchange then ObservationValidationMap.empty
           else info.generatorParams.foldMap:
-            case Left(error)                                                                   => ObservationValidationMap.singleton(error.toObsValidation)
-            case Right(GeneratorParams(ItcInputDerivation.Incomplete(m), _, _, _, _, _, _, _)) => ObservationValidationMap.singleton(m.toObsValidation)
-            case Right(ps)                                                                     => ObservationValidationMap.empty
+            case Left(error)                                                         => ObservationValidationMap.singleton(error.toObsValidation)
+            case Right(GeneratorParams(itcInput = ItcInputDerivation.Incomplete(m))) => ObservationValidationMap.singleton(m.toObsValidation)
+            case Right(ps)                                                           => ObservationValidationMap.empty
 
         val cfpInstrumentValidator: Validator = info =>
           info.cfpInfo.foldMap: cfp =>
@@ -676,14 +688,14 @@ object ObservationWorkflowService {
       override def getWorkflows(
         oids: List[Observation.Id]
       )(using NoTransaction[F], SuperUserAccess): F[Result[Map[Observation.Id, ObservationWorkflow]]] =
-        ResultT(getWorkflowsAndModes(oids))
+        ResultT(getWorkflowsModesAndRoles(oids))
           .map: m =>
             m.view.mapValues(p => p._1).toMap
           .value
 
-      override def getWorkflowsAndModes(
+      override def getWorkflowsModesAndRoles(
         oids: List[Observation.Id]
-      )(using NoTransaction[F], SuperUserAccess): F[Result[Map[Observation.Id, (ObservationWorkflow, Option[ObservingModeType])]]] =
+      )(using NoTransaction[F], SuperUserAccess): F[Result[Map[Observation.Id, (ObservationWorkflow, Option[ObservingModeType], Option[CalibrationRole])]]] =
 
         // Data obtained from the database, requiring a transaction.
         val select: F[Result[(
@@ -708,7 +720,7 @@ object ObservationWorkflowService {
           withModes =
             workflows.map:
               case (oid, wf) =>
-                oid -> (wf, infos.get(oid).flatMap(_.observingMode))
+                oid -> (wf, infos.get(oid).flatMap(_.observingMode), infos.get(oid).flatMap(_.calibrationRole))
         yield withModes).value
 
       override def getWorkflow(
@@ -752,10 +764,10 @@ object ObservationWorkflowService {
           case _ => false
 
       override def setWorkflowState(
-        input: AccessControl.CheckedWithId[(Option[ObservingModeType], ObservationWorkflow, ObservationWorkflowState), Observation.Id]
+        input: AccessControl.CheckedWithId[(Option[ObservingModeType], Option[CalibrationRole], ObservationWorkflow, ObservationWorkflowState), Observation.Id]
       )(using NoTransaction[F]): F[Result[ObservationWorkflow]] =
         input.foldWithId(OdbError.InvalidArgument().asFailureF):
-          case ((mode, w, state), oid) =>
+          case ((mode, calibrationRole, w, state), oid) =>
             (
               if w.state === state then ResultT.success(w)
               else ResultT:
@@ -796,6 +808,12 @@ object ObservationWorkflowService {
                     // Same for everyone
                     case (Ongoing, Completed) =>
                       updateDeclaredState(oid, Some(Completed))
+                        .as(Result(w.copy(state = state)))
+
+                    // Reinstating a declined telluric clears its override so it
+                    // resumes inheriting its science observation's state.
+                    case (Inactive, Ready) if calibrationRole.contains(CalibrationRole.Telluric) =>
+                      updateUserState(oid, None)
                         .as(Result(w.copy(state = state)))
 
                     // Same for everyone; note that this needs to be the last case

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/perScienceObservationCalibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/perScienceObservationCalibrations.scala
@@ -65,6 +65,8 @@ import lucuma.odb.service.Services
 import lucuma.odb.service.TelluricTargetsServiceSuiteSupport
 import lucuma.odb.smartgcal.data.Gnirs
 import lucuma.refined.*
+import skunk.syntax.all.*
+import lucuma.odb.util.Codecs.{observation_id, user_state}
 
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -2401,3 +2403,84 @@ class perScienceObservationCalibrations
       assert(!pinExists,   "daytime pinhole should be deleted")
       assert(!telExists,   "telluric should be deleted")
     }
+
+  // --- Telluric decline / reinstate ---
+
+  // Reads c_workflow_user_state directly
+  private def obsUserStateTag(oid: Observation.Id): IO[Option[String]] =
+    session.use(
+      _.option(sql"""
+        SELECT c_workflow_user_state::text
+        FROM t_observation
+        WHERE c_observation_id = ${observation_id}
+      """.query(skunk.codec.all.text.opt))(oid)
+    ).map(_.flatten)
+
+  private def attemptSetObservationWorkflowState(
+    user: User, oid: Observation.Id, state: ObservationWorkflowState
+  ): IO[Either[Throwable, ObservationWorkflowState]] =
+    setObservationWorkflowState(user, oid, state).attempt
+
+  // Bypasses workflow validation to place an observation in a given user state;
+  // used to put a science observation in `Ready` so its telluric inherits it.
+  private def forceObsUserState(oid: Observation.Id, us: Option[lucuma.odb.service.ObservationWorkflowService.UserState]): IO[Unit] =
+    session.use(_.execute(sql"""
+      UPDATE t_observation
+      SET c_workflow_user_state = ${user_state.opt}
+      WHERE c_observation_id = ${observation_id}
+    """.command)(us, oid)).void
+
+  test("A telluric can be declined and reinstated while its science obs is Defined"):
+    for
+      pid      <- createProgramAs(pi)
+      tid      <- createTargetWithProfileAs(pi, pid)
+      oid      <- createFlamingos2LongSlitObservationAs(pi, pid, List(tid))
+      _        <- runObscalcUpdate(pid, oid)
+      _        <- recalculateCalibrations(pid, when, oid)
+      telluric <- selectTelluricObservationFor(oid).map(_.get)
+      before   <- obsUserStateTag(telluric)
+      s1       <- setObservationWorkflowState(pi, telluric, ObservationWorkflowState.Inactive)
+      u1       <- obsUserStateTag(telluric)
+      sci      <- obsUserStateTag(oid)
+      s2       <- setObservationWorkflowState(pi, telluric, ObservationWorkflowState.Defined)
+      u2       <- obsUserStateTag(telluric)
+    yield
+      assertEquals(before, None)
+      assertEquals(s1, ObservationWorkflowState.Inactive)
+      assertEquals(u1, Some("inactive"))
+      assertEquals(sci, None)             // declining the telluric leaves its science obs untouched
+      assertEquals(s2, ObservationWorkflowState.Defined)
+      assertEquals(u2, None)              // reinstate clears the override
+
+  test("Reinstating a declined telluric to Ready clears the override rather than pinning it"):
+    for
+      pid      <- createProgramAs(pi)
+      tid      <- createTargetWithProfileAs(pi, pid)
+      oid      <- createFlamingos2LongSlitObservationAs(pi, pid, List(tid))
+      _        <- runObscalcUpdate(pid, oid)
+      _        <- recalculateCalibrations(pid, when, oid)
+      telluric <- selectTelluricObservationFor(oid).map(_.get)
+      // Put the science obs in Ready so the telluric inherits it.
+      _        <- forceObsUserState(oid, Some(ObservationWorkflowState.Ready))
+      s1       <- setObservationWorkflowState(pi, telluric, ObservationWorkflowState.Inactive)
+      u1       <- obsUserStateTag(telluric)
+      s2       <- setObservationWorkflowState(pi, telluric, ObservationWorkflowState.Ready)
+      u2       <- obsUserStateTag(telluric)
+    yield
+      assertEquals(s1, ObservationWorkflowState.Inactive)
+      assertEquals(u1, Some("inactive"))
+      assertEquals(s2, ObservationWorkflowState.Ready)
+      assertEquals(u2, None)
+
+  test("Only tellurics can be declined, not daytime pinholes"):
+    for
+      pid    <- createProgramAs(pi)
+      tid    <- createTargetWithProfileAs(pi, pid)
+      _      <- seedGnirsXdSmartGcal
+      oid    <- createGnirsXdObservationAs(pi, pid, tid)
+      _      <- runObscalcUpdate(pid, oid)
+      _      <- recalculateCalibrations(pid, when, oid)
+      pinOid <- selectDaytimePinholeObservationFor(oid).map(_.get)
+      result <- attemptSetObservationWorkflowState(pi, pinOid, ObservationWorkflowState.Inactive)
+    yield
+      assert(result.isLeft, "a daytime pinhole must not be declinable")

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/perScienceObservationCalibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/perScienceObservationCalibrations.scala
@@ -64,9 +64,10 @@ import lucuma.odb.json.wavelength.decoder.given
 import lucuma.odb.service.Services
 import lucuma.odb.service.TelluricTargetsServiceSuiteSupport
 import lucuma.odb.smartgcal.data.Gnirs
+import lucuma.odb.util.Codecs.observation_id
+import lucuma.odb.util.Codecs.user_state
 import lucuma.refined.*
 import skunk.syntax.all.*
-import lucuma.odb.util.Codecs.{observation_id, user_state}
 
 import java.time.LocalDateTime
 import java.time.ZoneOffset

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow_tellurics.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow_tellurics.scala
@@ -108,8 +108,15 @@ class observation_workflow_tellurics
         ps.execute(req).void
 
   // A per-observation calibration (telluric or daytime pinhole) inherits its
-  // science observation's workflow state and has no valid transitions.
+  // science observation's workflow state. A daytime pinhole has no transitions
+  // of its own; a telluric may additionally be declined.
   private def workflowFollowsScience(role: CalibrationRole): IO[Unit] =
+
+    // Offered while the calibration is inherited and not itself declined.
+    val declinable: List[ObservationWorkflowState] =
+      if role === CalibrationRole.Telluric then List(ObservationWorkflowState.Inactive)
+      else Nil
+
     val setup: IO[(Program.Id, Observation.Id, Observation.Id)] =
       for
         cfp <- createGeminiCallForProposalsAs(staff)
@@ -164,7 +171,7 @@ class observation_workflow_tellurics
             CalculationState.Ready,
             ObservationWorkflow(
               ObservationWorkflowState.Defined,
-              Nil,
+              declinable,
               Nil
             )
           )
@@ -181,13 +188,15 @@ class observation_workflow_tellurics
             CalculationState.Ready,
             ObservationWorkflow(
               ObservationWorkflowState.Ready,
-              Nil,
+              declinable,
               Nil
             )
           )
         ).asRight
       ) >>
-      // Set science to Inactive and Telluric should follow
+      // Set science to Inactive and Telluric should follow. Note that even a
+      // telluric offers nothing here: it is Inactive purely by inheritance, so
+      // there is no override of its own to clear.
       setObservationWorkflowState(pi, sci, ObservationWorkflowState.Inactive) >>
       runObscalcUpdateAs(serviceUser, pid, cal) >>
       expect(
@@ -215,7 +224,7 @@ class observation_workflow_tellurics
             CalculationState.Ready,
             ObservationWorkflow(
               ObservationWorkflowState.Defined,
-              Nil,
+              declinable,
               Nil
             )
           )


### PR DESCRIPTION
Update the workflow to allow telluric calibrations to transition to Inactive independent of the science obs

I also generated some documentation about the workflow states and a diagram about the allowed transitions

<img width="644" height="464" alt="image" src="https://github.com/user-attachments/assets/972b0c0d-c176-4463-b9d7-78f779e56705" />
