### PR TITLE
Use ObservationReferenceLabel for RequestTooTriggerInput

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -15222,7 +15222,7 @@ input RequestTooTriggerInput {
   observationId: ObservationId
 
   "A reference to the observation to request a trigger for.  Provide this or `observationId`."
-  observationReference: ObservationReference
+  observationReference: ObservationReferenceLabel
 }
 
 type RequestTooTriggerResult {


### PR DESCRIPTION
input object can only use scalars or other input objects, not types like the ObservationReference
