### PR TITLE
Add a mask name entry for mask attachments

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7767,6 +7767,13 @@ type Attachment {
   id: AttachmentId!
   attachmentType: AttachmentType!
   fileName: NonEmptyString!
+
+  """
+  The identifier of the physical mask plate this attachment describes, derived
+  from the attachment itself and not settable.  Null when the attachment is not
+  a MOS_MASK, always present when it is.
+  """
+  maskName: NonEmptyString
   description: NonEmptyString
   checked: Boolean!
   fileSize: Long!
@@ -19810,6 +19817,11 @@ input WhereAttachment {
   Matches the attachment file name.
   """
   fileName: WhereString
+
+  """
+  Matches the mask name, which is null for attachments that are not MOS masks.
+  """
+  maskName: WhereOptionString
 
   """
   Matches the description.

--- a/modules/service/src/main/resources/db/migration/V1247__attachment_mask_name.sql
+++ b/modules/service/src/main/resources/db/migration/V1247__attachment_mask_name.sql
@@ -1,0 +1,27 @@
+-- A MOS mask attachment carries a Mask Name: the observatory's identifier for the
+-- physical machined plate (for example 'GN2025AQ001-01'), which is what appears on the
+-- mask cutting queue and used by observe to select the mask.
+--
+-- The name is derived on by stripping the '.fits' extension from the file name but eventually
+-- also from a keyword inside the FITS file itself.
+
+-- We'll likely add a name format for mask names.
+CREATE DOMAIN d_mask_name AS text CHECK (length(VALUE) > 0);
+
+ALTER TABLE t_attachment
+  ADD COLUMN c_mask_name d_mask_name NULL;
+
+-- Backfill existing MOS masks before the invariant is enforced.
+UPDATE t_attachment
+  SET c_mask_name = COALESCE(NULLIF(regexp_replace(c_file_name, '\.fits$', '', 'i'), ''), c_file_name)
+  WHERE c_attachment_type = 'mos_mask';
+
+-- The name is present exactly for MOS masks, so null means "not a MOS mask"
+ALTER TABLE t_attachment
+  ADD CONSTRAINT t_attachment_mask_name_check
+    CHECK ((c_attachment_type = 'mos_mask') = (c_mask_name IS NOT NULL));
+
+-- each mask in a program has a unique mask name
+CREATE UNIQUE INDEX unique_mask_name_index
+  ON t_attachment (c_program_id, c_mask_name)
+  WHERE c_attachment_type = 'mos_mask';

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereAttachment.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereAttachment.scala
@@ -22,6 +22,7 @@ object WhereAttachment {
   def binding(path: Path): Matcher[Predicate] = {
     val WhereOrderAttachmentId = WhereOrder.binding[Attachment.Id](path / "id", AttachmentIdBinding)
     val WhereFileNameBinding   = WhereString.binding(path / "fileName")
+    val WhereMaskNameBinding   = WhereOptionString.binding(path / "maskName")
     val WhereDescriptionBinding   = WhereOptionString.binding(path / "description")
     val WhereAttachmentTypeBinding = WhereEq.binding(path / "attachmentType", enumeratedBinding[AttachmentType])
     val WhereProgramBinding = WhereProgram.binding(path / "program")
@@ -34,13 +35,14 @@ object WhereAttachment {
             WhereAttachmentBinding.Option("NOT", rNOT),
             WhereOrderAttachmentId.Option("id", rId),
             WhereFileNameBinding.Option("fileName", rFileName),
+            WhereMaskNameBinding.Option("maskName", rMaskName),
             WhereDescriptionBinding.Option("description", rDescription),
             WhereAttachmentTypeBinding.Option("attachmentType", rAttachmentType),
             BooleanBinding.Option("checked", rChecked),
             WhereProgramBinding.Option("program", rProgram)
           ) =>
-        (rAND, rOR, rNOT, rId, rFileName, rDescription, rAttachmentType, rChecked, rProgram).parMapN {
-          (AND, OR, NOT, id, name, desc, atType, checked, program) =>
+        (rAND, rOR, rNOT, rId, rFileName, rMaskName, rDescription, rAttachmentType, rChecked, rProgram).parMapN {
+          (AND, OR, NOT, id, name, maskName, desc, atType, checked, program) =>
             and(
               List(
                 AND.map(and),
@@ -48,6 +50,7 @@ object WhereAttachment {
                 NOT.map(Not(_)),
                 id,
                 name,
+                maskName,
                 desc,
                 atType,
                 checked.map(b => Eql(path / "checked", Const(b))),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AttachmentMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/AttachmentMapping.scala
@@ -21,6 +21,7 @@ trait AttachmentMapping[F[_]]
       SqlField("program_id", AttachmentTable.ProgramId, hidden = true),
       SqlField("attachmentType", AttachmentTable.AttachmentType),
       SqlField("fileName", AttachmentTable.FileName),
+      SqlField("maskName", AttachmentTable.MaskName),
       SqlField("description", AttachmentTable.Description),
       SqlField("checked", AttachmentTable.Checked),
       SqlField("fileSize", AttachmentTable.FileSize),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/AttachmentTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/AttachmentTable.scala
@@ -16,6 +16,7 @@ trait AttachmentTable[F[_]] extends BaseMapping[F] {
     val Id             = col("c_attachment_id", attachment_id)
     val AttachmentType = col("c_attachment_type", attachment_type)
     val FileName       = col("c_file_name", text_nonempty)
+    val MaskName       = col("c_mask_name", text_nonempty.opt)
     val Description    = col("c_description", text_nonempty.opt)
     val Checked        = col("c_checked", bool)
     val FileSize       = col("c_file_size", int8)

--- a/modules/service/src/main/scala/lucuma/odb/service/AttachmentFileService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AttachmentFileService.scala
@@ -69,6 +69,9 @@ object AttachmentFileService {
   val DuplicateFileNameMsg                         = "Duplicate file name"
   def duplicateTypeMsg(at: AttachmentType): String =
     s"Duplicate attachment type: Only one ${at.shortName} is allowed per program"
+  val DuplicateMaskNameMsg                         = "Duplicate mask name"
+  def duplicateMaskNameMsg(maskName: NonEmptyString): String =
+    s"$DuplicateMaskNameMsg: ${maskName.value}"
 
   sealed trait AttachmentException extends Exception {
     def asLeftT[F[_]: Applicative, A]: EitherT[F, AttachmentException, A] =
@@ -103,6 +106,11 @@ object AttachmentFileService {
       // does not contain the dot.
       def extName: Option[NonEmptyString] =
         NonEmptyString.from(Path(fileName.value.value).extName.drop(1).toLowerCase).toOption
+
+      // the whole name when there is no extension to strip.
+      def baseName: NonEmptyString =
+        val name = fileName.value.value
+        NonEmptyString.from(name.stripSuffix(Path(name).extName)).getOrElse(fileName.value)
   }
 
   extension [F[_], A](fe: F[Either[AttachmentException, A]])
@@ -142,6 +150,16 @@ object AttachmentFileService {
     }
   }
 
+  /**
+   * The mask name will be derived now from the file, removing the extension.
+   * In the future we should parse the fits file and read the name directly.
+   */
+  def deriveMaskName(
+    attachmentType: AttachmentType,
+    fileName:       FileName
+  ): Option[NonEmptyString] =
+    Option.when(attachmentType === AttachmentType.MosMask)(fileName.baseName)
+
   def checkForEmptyFile(fileSize: Long): Either[AttachmentException, Unit] =
     if (fileSize <= 0) InvalidRequest("File cannot be empty").asLeft
     else ().asRight
@@ -176,6 +194,7 @@ object AttachmentFileService {
       programId:      Program.Id,
       attachmentType: AttachmentType,
       fileName:       FileName,
+      maskName:       Option[NonEmptyString],
       description:    Option[NonEmptyString],
       fileSize:       Long,
       remotePath:     NonEmptyString
@@ -185,12 +204,15 @@ object AttachmentFileService {
           .unique(Statements.InsertAttachment)(programId,
                                                attachmentType,
                                                fileName.value,
+                                               maskName,
                                                description,
                                                fileSize,
                                                remotePath
           )
           .map(_.asRight)
           .recover {
+            case SqlState.UniqueViolation(e) if e.detail.exists(_.contains("c_mask_name"))       =>
+              InvalidRequest(DuplicateMaskNameMsg).asLeft
             case SqlState.UniqueViolation(e) if e.detail.exists(_.contains("c_file_name"))       =>
               InvalidRequest(DuplicateFileNameMsg).asLeft
             case SqlState.UniqueViolation(e) if e.detail.exists(_.contains("c_attachment_type")) =>
@@ -202,6 +224,7 @@ object AttachmentFileService {
       programId:    Program.Id,
       attachmentId: Attachment.Id,
       fileName:     FileName,
+      maskName:     Option[NonEmptyString],
       description:  Option[NonEmptyString],
       fileSize:     Long,
       remotePath:   NonEmptyString
@@ -209,6 +232,7 @@ object AttachmentFileService {
       T.span("updateAttachment").surround {
         session
           .unique(Statements.UpdateAttachment)(fileName.value,
+                                               maskName,
                                                description,
                                                fileSize,
                                                remotePath,
@@ -220,6 +244,8 @@ object AttachmentFileService {
             else FileNotFound.asLeft
           )
           .recover {
+            case SqlState.UniqueViolation(e) if e.detail.exists(_.contains("c_mask_name")) =>
+              InvalidRequest(DuplicateMaskNameMsg).asLeft
             case SqlState.UniqueViolation(e) if e.detail.exists(_.contains("c_file_name")) =>
               InvalidRequest(DuplicateFileNameMsg).asLeft
           }
@@ -270,6 +296,23 @@ object AttachmentFileService {
         )
     }
 
+    def checkForDuplicateMaskName(
+      programId: Program.Id,
+      maskName:  Option[NonEmptyString],
+      oaid:      Option[Attachment.Id]
+    ): F[Either[AttachmentException, Unit]] =
+      maskName.fold(().asRight.pure) { mn =>
+        val af   = Statements.checkForDuplicateMaskName(programId, mn, oaid)
+        val stmt = af.fragment.query(bool)
+
+        session
+          .prepareR(stmt)
+          .use(pg =>
+            pg.option(af.argument)
+              .map(_.fold(().asRight)(_ => InvalidRequest(duplicateMaskNameMsg(mn)).asLeft))
+          )
+      }
+
     def getAttachmentTypeById(
       attachmentId: Attachment.Id
     ): F[Either[AttachmentException, AttachmentType]] =
@@ -286,9 +329,9 @@ object AttachmentFileService {
     def validateFileExtensionById(
       attachmentId: Attachment.Id,
       fileName:     FileName
-    ): F[Either[AttachmentException, Unit]] =
+    ): F[Either[AttachmentException, AttachmentType]] =
       getAttachmentTypeById(attachmentId)
-        .map(_.flatMap(at => checkExtension(fileName, at.fileExtensions)))
+        .map(_.flatMap(at => checkExtension(fileName, at.fileExtensions).as(at)))
 
     // This can only be an issue on insert
     def checkForDuplicateType(
@@ -332,15 +375,16 @@ object AttachmentFileService {
           (
             for {
               fn     <- FileName.fromString(fileName).liftF
-              _      <- services.transactionallyEitherT {
+              mn      = deriveMaskName(attachmentType, fn)
+              _      <- services.transactionallyEitherT:
                           checkAccess(user, programId, AccessRequired.Write, Forbidden) >>
                             validateFileExtensionByType(attachmentType, fn).liftF >>
                             checkForDuplicateType(programId, attachmentType).asEitherT >>
-                            checkForDuplicateName(programId, fn, none).asEitherT
-                        }
+                            checkForDuplicateName(programId, fn, none).asEitherT >>
+                            checkForDuplicateMaskName(programId, mn, none).asEitherT
               uuid   <- UUIDGen[F].randomUUID.right
               path    = Services.asSuperUser(filePath(programId, uuid, fn.value))
-            } yield (fn, path)
+            } yield (fn, mn, path)
           ).value
           .flatTap {
             // Up to this point, we haven't read the data yet.
@@ -350,14 +394,16 @@ object AttachmentFileService {
             // https://github.com/http4s/http4s/pull/7602
             case Left(_)  => data.compile.drain
             case _ => ().pure
-          }.asEitherT
-          .flatMap((fn, path) =>
+          }
+          .asEitherT
+          .flatMap((fn, mn, path) =>
             for {
               size   <- Services.asSuperUser(s3FileSvc.upload(path, data)).right
               _      <- checkForEmptyFile(size).liftF
               result <- insertAttachmentInDB(programId,
                                              attachmentType,
                                              fn,
+                                             mn,
                                              description,
                                              size,
                                              path
@@ -375,30 +421,34 @@ object AttachmentFileService {
       )(using NoTransaction[F]): F[Either[AttachmentException, Unit]] =
         (
           for {
-            fn      <- FileName.fromString(fileName).liftF
-            (pid, oldPath) <- services.transactionallyEitherT {
+            fn                 <- FileName.fromString(fileName).liftF
+            (pid, mn, oldPath) <- services.transactionallyEitherT {
                 for {
                   (pid, oldPath) <- getAttachmentInfoAndCheckAccess(user, attachmentId, AccessRequired.Write)
-                  _              <- validateFileExtensionById(attachmentId, fn).asEitherT
+                  at             <- validateFileExtensionById(attachmentId, fn).asEitherT
+                  mn              = deriveMaskName(at, fn)
                   _              <- checkForDuplicateName(pid, fn, attachmentId.some).asEitherT
-                } yield (pid, oldPath)
+                  _              <- checkForDuplicateMaskName(pid, mn, attachmentId.some).asEitherT
+                } yield (pid, mn, oldPath)
               }
-            uuid           <- UUIDGen[F].randomUUID.right
-            newPath         = Services.asSuperUser(filePath(pid, uuid, fn.value))
-          } yield (fn, pid, oldPath, newPath)
+            uuid               <- UUIDGen[F].randomUUID.right
+            newPath            = Services.asSuperUser(filePath(pid, uuid, fn.value))
+          } yield (fn, mn, pid, oldPath, newPath)
         ).value
         .flatTap {
           // See comment in similar location in insertAttachment.
           case Left(_)  => data.compile.drain
           case _ => ().pure
-        }.asEitherT
-        .flatMap((fn, pid, oldPath, newPath) =>
+        }
+        .asEitherT
+        .flatMap((fn, mn, pid, oldPath, newPath) =>
           for {
             size    <- Services.asSuperUser(s3FileSvc.upload(newPath, data)).right
             _       <- checkForEmptyFile(size).liftF
             _       <- updateAttachmentInDB(pid,
                                             attachmentId,
                                             fn,
+                                            mn,
                                             description,
                                             size,
                                             newPath
@@ -441,7 +491,7 @@ object AttachmentFileService {
   object Statements {
 
     val InsertAttachment: Query[
-      (Program.Id, AttachmentType, NonEmptyString, Option[NonEmptyString], Long, NonEmptyString),
+      (Program.Id, AttachmentType, NonEmptyString, Option[NonEmptyString], Option[NonEmptyString], Long, NonEmptyString),
       Attachment.Id
     ] =
       sql"""
@@ -449,6 +499,7 @@ object AttachmentFileService {
           c_program_id,
           c_attachment_type,
           c_file_name,
+          c_mask_name,
           c_description,
           c_file_size,
           c_remote_path
@@ -458,18 +509,20 @@ object AttachmentFileService {
           $attachment_type,
           $text_nonempty,
           ${text_nonempty.opt},
+          ${text_nonempty.opt},
           $int8,
           $text_nonempty
         RETURNING c_attachment_id
       """.query(attachment_id)
 
     val UpdateAttachment: Query[
-      (NonEmptyString, Option[NonEmptyString], Long, NonEmptyString, Program.Id, Attachment.Id),
+      (NonEmptyString, Option[NonEmptyString], Option[NonEmptyString], Long, NonEmptyString, Program.Id, Attachment.Id),
       Boolean
     ] =
       sql"""
         UPDATE t_attachment
         SET c_file_name   = $text_nonempty,
+            c_mask_name   = ${text_nonempty.opt},
             c_description = ${text_nonempty.opt},
             c_checked     = false,
             c_file_size   = $int8,
@@ -495,6 +548,22 @@ object AttachmentFileService {
         FROM t_attachment
         WHERE c_program_id = $program_id AND c_file_name = $text_nonempty
       """.apply(programId, fileName) |+|
+        attachmentId.foldMap(aid => sql"""
+            AND c_attachment_id != $attachment_id
+          """.apply(aid))
+
+    def checkForDuplicateMaskName(
+      programId:    Program.Id,
+      maskName:     NonEmptyString,
+      attachmentId: Option[Attachment.Id]
+    ): AppliedFragment =
+      sql"""
+        SELECT true
+        FROM t_attachment
+        WHERE c_program_id      = $program_id
+          AND c_mask_name       = $text_nonempty
+          AND c_attachment_type = 'mos_mask'
+      """.apply(programId, maskName) |+|
         attachmentId.foldMap(aid => sql"""
             AND c_attachment_id != $attachment_id
           """.apply(aid))

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentsSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/AttachmentsSuite.scala
@@ -22,7 +22,7 @@ import org.typelevel.log4cats.Logger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 abstract class AttachmentsSuite extends OdbSuiteWithS3 {
-  
+
   // this logger is turned off to silence some errors (see logback.xml)
   override implicit val log: Logger[IO] =
     Slf4jLogger.getLoggerFromName("lucuma-odb-test-attachments")
@@ -49,7 +49,7 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
           aid <- resp.getBody.map(s => Attachment.Id.parse(s).get)
         } yield aid
       }
-    
+
     def toNonEmptyString: IO[NonEmptyString] =
       response.use { resp =>
         for {
@@ -70,7 +70,8 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
     attachmentType: String,
     description:    Option[String],
     content:        String,
-    checked:        Boolean = false
+    checked:        Boolean = false,
+    maskName:       Option[String] = None
   ) {
     val upperType: String = attachmentType.toUpperCase
   }
@@ -97,7 +98,7 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
 
         client.run(request)
       }
-  
+
   def updateAttachment(
     user:         User,
     attachmentId: Attachment.Id,
@@ -188,6 +189,7 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
             "id"             -> tid.asJson,
             "attachmentType" -> ta.attachmentType.toUpperCase.asJson,
             "fileName"       -> ta.fileName.asJson,
+            "maskName"       -> ta.maskName.asJson,
             "description"    -> ta.description.asJson,
             "checked"        -> ta.checked.asJson,
             "fileSize"       -> ta.content.length.asJson
@@ -201,6 +203,7 @@ abstract class AttachmentsSuite extends OdbSuiteWithS3 {
        |  id
        |  attachmentType
        |  fileName
+       |  maskName
        |  description
        |  checked
        |  fileSize

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachments.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachments.scala
@@ -91,9 +91,10 @@ class attachments extends AttachmentsSuite {
   }
 
   // TODO: science, team and custom_sed file tests
-  val mosMask1A         = TestAttachment("file1.fits", "mos_mask", "A description".some, "Hopeful")
-  val mosMask1B         = TestAttachment("file1.fits", "mos_mask", None, "New contents")
-  val mosMask2          = TestAttachment("file2.fits", "mos_mask", "Masked".some, "Zorro")
+  val mosMask1A         = TestAttachment("file1.fits", "mos_mask", "A description".some, "Hopeful", maskName = "file1".some)
+  val mosMask1B         = TestAttachment("file1.fits", "mos_mask", None, "New contents", maskName = "file1".some)
+  val mosMask1Upper     = TestAttachment("file1.FITS", "mos_mask", "Shouty".some, "Also hopeful", maskName = "file1".some)
+  val mosMask2          = TestAttachment("file2.fits", "mos_mask", "Masked".some, "Zorro", maskName = "file2".some)
   val finderPNG         = TestAttachment("different.png", "finder", "Unmatching file name".some, "Something different")
   val finderJPG         = TestAttachment("finder.jpg", "finder", "jpg file".some, "A finder JPG file")
   val preImaging        = TestAttachment("pi.fits", "pre_imaging", none, "A pre imaging file")
@@ -845,4 +846,83 @@ class attachments extends AttachmentsSuite {
                )
     } yield ()
   }
+
+  test("mask name ignores the case of the extension"):
+    for {
+      pid <- createProgramAs(pi)
+      aid <- insertAttachment(pi, pid, mosMask1Upper).toAttachmentId
+      _   <- assertAttachmentsGql(pi, pid, (aid, mosMask1Upper))
+    } yield ()
+
+  test("insert with duplicate mask name is a BadRequest"):
+    for {
+      pid <- createProgramAs(pi)
+      aid <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
+      _   <- insertAttachment(pi, pid, mosMask1Upper)
+               .withExpectation(Status.BadRequest, AttachmentFileService.duplicateMaskNameMsg(NonEmptyString.unsafeFrom("file1")))
+      _   <- assertAttachmentsGql(pi, pid, (aid, mosMask1A))
+    } yield ()
+
+  test("the same mask name in a different program is accepted"):
+    for {
+      pid1 <- createProgramAs(pi)
+      pid2 <- createProgramAs(pi)
+      aid1 <- insertAttachment(pi, pid1, mosMask1A).toAttachmentId
+      aid2 <- insertAttachment(pi, pid2, mosMask1A).toAttachmentId
+      _    <- assertAttachmentsGql(pi, pid1, (aid1, mosMask1A))
+      _    <- assertAttachmentsGql(pi, pid2, (aid2, mosMask1A))
+    } yield ()
+
+  test("update with duplicate mask name is a BadRequest"):
+    for {
+      pid  <- createProgramAs(pi)
+      aid1 <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
+      aid2 <- insertAttachment(pi, pid, mosMask2).toAttachmentId
+      _    <- updateAttachment(pi, aid2, mosMask1Upper)
+                .withExpectation(Status.BadRequest, AttachmentFileService.duplicateMaskNameMsg(NonEmptyString.unsafeFrom("file1")))
+      _    <- assertAttachmentsGql(pi, pid, (aid1, mosMask1A), (aid2, mosMask2))
+      _    <- getAttachment(pi, aid2).expectBody(mosMask2.content)
+    } yield ()
+
+  test("update attachments metadata: by mask name"):
+    for {
+      pid   <- createProgramAs(pi)
+      _     <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
+      aid2  <- insertAttachment(pi, pid, mosMask2).toAttachmentId
+      _     <- insertAttachment(pi, pid, finderPNG).toAttachmentId
+      newTa2 = mosMask2.copy(description = "Found".some)
+      _     <- updateAttachmentsGql(pi,
+                                    WHERE = s"""{ maskName: { EQ: "file2" }, program: { id: { EQ: "$pid" } } }""",
+                                    SET = """{ description: "Found" }""",
+                                    (aid2, newTa2)
+               )
+    } yield ()
+
+  test("update attachments metadata: by null mask name"):
+    for {
+      pid   <- createProgramAs(pi)
+      _     <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
+      aid2  <- insertAttachment(pi, pid, finderPNG).toAttachmentId
+      aid3  <- insertAttachment(pi, pid, preImaging).toAttachmentId
+      newTa2 = finderPNG.copy(description = "Not a mask".some)
+      newTa3 = preImaging.copy(description = "Not a mask".some)
+      _     <- updateAttachmentsGql(pi,
+                                    WHERE = s"""{ maskName: { IS_NULL: true }, program: { id: { EQ: "$pid" } } }""",
+                                    SET = """{ description: "Not a mask" }""",
+                                    (aid2, newTa2),
+                                    (aid3, newTa3)
+               )
+    } yield ()
+
+  test("updateAttachments cannot set the mask name"):
+    for {
+      pid <- createProgramAs(pi)
+      aid <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
+      _   <- updateAttachmentsGql(pi,
+                                  WHERE = s"""{ id: { EQ: "$aid" }}""",
+                                  SET = """{ maskName: "whatever" }""",
+                                  List("Unknown field(s) 'maskName' for input object value of type AttachmentPropertiesInput in field 'updateAttachments' of type 'Mutation'").asLeft
+             )
+    } yield ()
+
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/obsAttachmentsAssignments.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/obsAttachmentsAssignments.scala
@@ -128,7 +128,7 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
           }
         }
       """,
-      expected = 
+      expected =
         error.fold(
           Json.obj(
             "updateObservations" -> Json.obj(
@@ -167,10 +167,10 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
           }
         }
       """,
-      expected = 
+      expected =
           Json.obj(
             "updateObservations" -> Json.obj(
-              "observations" -> 
+              "observations" ->
                 oids.map(_ => input.expect).asJson
             )
           ).asRight
@@ -209,7 +209,7 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       expected = List(error).asLeft
     )
 
-  val mosMask = TestAttachment("file1.fits", "mos_mask", "A description".some, "Hopeful")
+  val mosMask = TestAttachment("file1.fits", "mos_mask", "A description".some, "Hopeful", maskName = "file1".some)
   val finder  = TestAttachment("file2.jpg", "finder", "jpg file".some, "A finder JPG file")
   val preImaging  = TestAttachment("preImaging.fits", "pre_imaging", none, "A pre imaging file")
   val science = TestAttachment("science.pdf", "science", none, "science file")

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
@@ -2680,13 +2680,13 @@ class cloneObservation extends OdbSuite with ObservingModeSetupOperations {
 
   // The mask attachment is a two-column (id + type) composite-FK reference.
   private def insertMosMaskAttachment(pid: Program.Id, fileName: String): IO[Attachment.Id] =
-    val q: Query[(Program.Id, String), Attachment.Id] =
+    val q: Query[(Program.Id, String, String), Attachment.Id] =
       sql"""
-        INSERT INTO t_attachment (c_program_id, c_attachment_type, c_file_name, c_file_size, c_remote_path)
-        VALUES ($program_id, 'mos_mask', $text, 42, 'unused')
+        INSERT INTO t_attachment (c_program_id, c_attachment_type, c_file_name, c_file_size, c_remote_path, c_mask_name)
+        VALUES ($program_id, 'mos_mask', $text, 42, 'unused', $text)
         RETURNING c_attachment_id
       """.query(attachment_id)
-    withSession(_.unique(q)(pid, fileName))
+    withSession(_.unique(q)(pid, fileName, fileName.stripSuffix(".fits")))
 
   private def readMaskColumns(
     table: String,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GmosMos.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GmosMos.scala
@@ -31,19 +31,20 @@ class createObservation_GmosMos extends OdbSuite:
   // Insert the attachment directly rather than through the file service and S3,
   // so the setup depends only on the database.
   protected def insertMosMaskAttachment(pid: Program.Id, fileName: String): IO[Attachment.Id] =
-    val q: Query[(Program.Id, String), Attachment.Id] =
+    val q: Query[(Program.Id, String, String), Attachment.Id] =
       sql"""
         INSERT INTO t_attachment (
           c_program_id,
           c_attachment_type,
           c_file_name,
           c_file_size,
-          c_remote_path
+          c_remote_path,
+          c_mask_name
         )
-        VALUES ($program_id, 'mos_mask', $text, 42, 'unused')
+        VALUES ($program_id, 'mos_mask', $text, 42, 'unused', $text)
         RETURNING c_attachment_id
       """.query(attachment_id)
-    withSession(_.unique(q)(pid, fileName))
+    withSession(_.unique(q)(pid, fileName, fileName.stripSuffix(".fits")))
 
   private def scienceRequirements: String =
     """

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/customMask.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/customMask.scala
@@ -29,19 +29,20 @@ trait CustomMaskOps extends ReplaceSequenceOps:
   // Insert a mos_mask attachment directly rather than going through the file
   // service and S3, so the setup depends only on the database.
   protected def insertMosMaskAttachment(pid: Program.Id, fileName: String): IO[Attachment.Id] =
-    val q: Query[(Program.Id, String), Attachment.Id] =
+    val q: Query[(Program.Id, String, String), Attachment.Id] =
       sql"""
         INSERT INTO t_attachment (
           c_program_id,
           c_attachment_type,
           c_file_name,
           c_file_size,
-          c_remote_path
+          c_remote_path,
+          c_mask_name
         )
-        VALUES ($program_id, 'mos_mask', $text, 42, 'unused')
+        VALUES ($program_id, 'mos_mask', $text, 42, 'unused', $text)
         RETURNING c_attachment_id
       """.query(attachment_id)
-    withSession(_.unique(q)(pid, fileName))
+    withSession(_.unique(q)(pid, fileName, fileName.stripSuffix(".fits")))
 
   protected def gmosStep(customMask: String): String =
     s"""

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations_GmosMos.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations_GmosMos.scala
@@ -31,19 +31,21 @@ class updateObservations_GmosMos extends OdbSuite:
   lazy val validUsers: List[User] = List(pi)
 
   private def insertAttachment(pid: Program.Id, tpe: String, fileName: String): IO[Attachment.Id] =
-    val q: Query[(Program.Id, String, String), Attachment.Id] =
+    val q: Query[(Program.Id, String, String, Option[String]), Attachment.Id] =
       sql"""
         INSERT INTO t_attachment (
           c_program_id,
           c_attachment_type,
           c_file_name,
           c_file_size,
-          c_remote_path
+          c_remote_path,
+          c_mask_name
         )
-        VALUES ($program_id, $text::e_attachment_type, $text, 42, 'unused')
+        VALUES ($program_id, $text::e_attachment_type, $text, 42, 'unused', ${text.opt})
         RETURNING c_attachment_id
       """.query(attachment_id)
-    withSession(_.unique(q)(pid, tpe, fileName))
+    val maskName = Option.when(tpe === "mos_mask")(fileName.stripSuffix(".fits"))
+    withSession(_.unique(q)(pid, tpe, fileName, maskName))
 
   // The mask attachment is stored as two columns (id + type) pinned together
   // by a composite foreign key, and the type column is not exposed via GraphQL,


### PR DESCRIPTION
Observe needs a mask name to tell the instrument with a specific format.

In OCS this is solved because staff adds the mask but in gpp anybody can upload a mask. This PR adds a field for the mask name that, for the moment, is derived from the file name, but should in the future be read directly from the mask file. 

The field is read only