### PR TITLE
Shortcut 9812: Support multiple GNIRS central wavelengths

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -11332,11 +11332,48 @@ type GnirsSpectroscopyAcquisition {
 }
 
 """
+A GNIRS spectroscopy science configuration: a central wavelength together with
+the exposure time mode and coadds that apply at that wavelength.
+"""
+type GnirsSpectroscopyWavelength {
+
+  centralWavelength: Wavelength!
+
+  """
+  Exposure time mode for this central wavelength.
+  If not specified, it is taken from the observation's requirements.
+  """
+  exposureTimeMode: ExposureTimeMode!
+
+  coadds: PosInt!
+
+}
+
+"""
+Defines a GNIRS spectroscopy central wavelength to use along with its exposure
+time mode and coadds.
+"""
+input GnirsSpectroscopyWavelengthInput {
+
+  centralWavelength: WavelengthInput!
+
+  """
+  Exposure time mode for this central wavelength.
+  If not specified, it is taken from the observation's requirements.
+  """
+  exposureTimeMode: ExposureTimeModeInput
+
+  """
+  Coadds for this central wavelength.  Defaults to 1 when not specified.
+  """
+  coadds: PosInt
+
+}
+
+"""
 GNIRS Spectroscopy mode (long slit or IFU, distinguished by the FPU).
 """
 type GnirsSpectroscopy {
-
-  exposureTimeMode: ExposureTimeMode!
 
   grating: GnirsGrating!
   explicitGrating: GnirsGrating
@@ -11346,8 +11383,18 @@ type GnirsSpectroscopy {
   explicitPrism: GnirsPrism
   initialPrism: GnirsPrism!
 
-  centralWavelength: Wavelength!
-  initialCentralWavelength: Wavelength!
+  """
+  The central wavelengths at which spectra are taken, in increasing wavelength
+  order.  Each one is a separate configuration with its own exposure time mode,
+  coadds, ITC calculation and calibrations.
+  """
+  centralWavelengths: [GnirsSpectroscopyWavelength!]!
+
+  """
+  The central wavelengths as they were configured when the observing mode was
+  created.
+  """
+  initialCentralWavelengths: [GnirsSpectroscopyWavelength!]!
 
   camera: GnirsCamera!
   initialCamera: GnirsCamera!
@@ -11366,8 +11413,6 @@ type GnirsSpectroscopy {
 
   filter: GnirsFilter!
   initialFilter: GnirsFilter!
-
-  coadds: PosInt!
 
   decker: GnirsDecker!
   explicitDecker: GnirsDecker
@@ -11482,9 +11527,12 @@ Edit or create GNIRS Spectroscopy configuration (long slit or IFU).
 """
 input GnirsSpectroscopyInput {
 
-  exposureTimeMode: ExposureTimeModeInput
-
-  coadds: PosInt
+  """
+  The central wavelengths at which spectra are taken.  Required on create, and
+  must contain at least one entry with no duplicated wavelength.  When given on
+  edit, it replaces the existing list wholesale.
+  """
+  centralWavelengths: [GnirsSpectroscopyWavelengthInput!]
 
   filter: GnirsFilter
 
@@ -11499,8 +11547,6 @@ input GnirsSpectroscopyInput {
   grating: GnirsGrating
 
   prism: GnirsPrism
-
-  centralWavelength: WavelengthInput
 
   explicitDecker: GnirsDecker
 
@@ -14509,6 +14555,15 @@ type ItcGnirsImagingResultSet {
 }
 
 """
+Combines a GNIRS spectroscopy central wavelength with an `ItcResultSet`. In
+other words, ITC results for all targets but a single central wavelength.
+"""
+type ItcGnirsSpectroscopyResultSet {
+  centralWavelength: Wavelength!
+  results:           ItcResultSet!
+}
+
+"""
 ITC results for a particular observation, including relevant instrument
 configurations and targets.  There are specific instances for each `ItcType`.
 """
@@ -14561,6 +14616,16 @@ GNIRS imaging ITC results.  Here each filter is paired with its result set.
 type ItcGnirsImaging implements Itc {
   itcType: ItcType!
   gnirsImagingScience: [ItcGnirsImagingResultSet!]!
+}
+
+"""
+GNIRS spectroscopy ITC results.  Each central wavelength is a separate
+configuration and is paired with its own result set.
+"""
+type ItcGnirsSpectroscopy implements Itc {
+  itcType: ItcType!
+  acquisition: ItcResultSet!
+  gnirsSpectroscopyScience: [ItcGnirsSpectroscopyResultSet!]!
 }
 
 """

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -11335,7 +11335,7 @@ type GnirsSpectroscopyAcquisition {
 A GNIRS spectroscopy science configuration: a central wavelength together with
 the exposure time mode and coadds that apply at that wavelength.
 """
-type GnirsSpectroscopyWavelength {
+type GnirsCentralWavelengthConfig {
 
   centralWavelength: Wavelength!
 
@@ -11353,7 +11353,7 @@ type GnirsSpectroscopyWavelength {
 Defines a GNIRS spectroscopy central wavelength to use along with its exposure
 time mode and coadds.
 """
-input GnirsSpectroscopyWavelengthInput {
+input GnirsCentralWavelengthConfigInput {
 
   centralWavelength: WavelengthInput!
 
@@ -11388,13 +11388,13 @@ type GnirsSpectroscopy {
   order.  Each one is a separate configuration with its own exposure time mode,
   coadds, ITC calculation and calibrations.
   """
-  centralWavelengths: [GnirsSpectroscopyWavelength!]!
+  centralWavelengths: [GnirsCentralWavelengthConfig!]!
 
   """
   The central wavelengths as they were configured when the observing mode was
   created.
   """
-  initialCentralWavelengths: [GnirsSpectroscopyWavelength!]!
+  initialCentralWavelengths: [GnirsCentralWavelengthConfig!]!
 
   camera: GnirsCamera!
   initialCamera: GnirsCamera!
@@ -11532,7 +11532,7 @@ input GnirsSpectroscopyInput {
   must contain at least one entry with no duplicated wavelength.  When given on
   edit, it replaces the existing list wholesale.
   """
-  centralWavelengths: [GnirsSpectroscopyWavelengthInput!]
+  centralWavelengths: [GnirsCentralWavelengthConfigInput!]
 
   filter: GnirsFilter
 

--- a/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
@@ -16,6 +16,7 @@ import lucuma.core.enums.GmosNorthFilter
 import lucuma.core.enums.GmosSouthFilter
 import lucuma.core.enums.GnirsAcquisitionType
 import lucuma.core.enums.GnirsFilter
+import lucuma.core.math.Wavelength
 import lucuma.core.model.Target
 import lucuma.core.util.Enumerated
 import lucuma.core.util.TimeSpan
@@ -95,6 +96,19 @@ sealed trait ItcScience:
 
 object ItcScience:
 
+  /**
+   * Total exposure count across every keyed configuration (filter or central
+   * wavelength).  Saturates rather than overflowing: the value only feeds the
+   * sequence-size guard, which any saturated total will trip anyway.
+   */
+  private def sumExposureCounts[A](
+    science: NonEmptyMap[A, Zipper[ItcResult]]
+  ): PosInt =
+    PosInt.unsafeFrom:
+      science.foldLeft(0): (cnt, z) =>
+        val n = z.focus.value.exposureCount.value
+        if cnt > Int.MaxValue - n then Int.MaxValue else cnt + n
+
   // ITC result type discriminator.
   enum Type(val tag: String) derives Enumerated:
     case Flamingos2Imaging   extends Type("flamingos_2_imaging")
@@ -102,6 +116,7 @@ object ItcScience:
     case GmosNorthImaging    extends Type("gmos_north_imaging")
     case GmosSouthImaging    extends Type("gmos_south_imaging")
     case GnirsImaging        extends Type("gnirs_imaging")
+    case GnirsSpectroscopy   extends Type("gnirs_spectroscopy")
     case Spectroscopy        extends Type("spectroscopy")
 
   case class Flamingos2Imaging(
@@ -112,10 +127,7 @@ object ItcScience:
       Type.Flamingos2Imaging
 
     override def scienceExposureCount: PosInt =
-      PosInt.unsafeFrom:
-        science.foldLeft(0) { (cnt, z) =>
-          cnt + z.focus.value.exposureCount.value
-        }
+      sumExposureCounts(science)
 
   val flamingos2Imaging: Prism[ItcScience, Flamingos2Imaging] =
     GenPrism[ItcScience, Flamingos2Imaging]
@@ -149,10 +161,7 @@ object ItcScience:
       Type.GmosNorthImaging
 
     override def scienceExposureCount: PosInt =
-      PosInt.unsafeFrom:
-        science.foldLeft(0) { (cnt, z) =>
-          cnt + z.focus.value.exposureCount.value
-        }
+      sumExposureCounts(science)
 
   object GmosNorthImaging:
     given Eq[GmosNorthImaging] =
@@ -172,10 +181,7 @@ object ItcScience:
       Type.GmosSouthImaging
 
     override def scienceExposureCount: PosInt =
-      PosInt.unsafeFrom:
-        science.foldLeft(0) { (cnt, z) =>
-          cnt + z.focus.value.exposureCount.value
-        }
+      sumExposureCounts(science)
 
   object GmosSouthImaging:
     given Eq[GmosSouthImaging] =
@@ -195,10 +201,7 @@ object ItcScience:
       Type.GnirsImaging
 
     override def scienceExposureCount: PosInt =
-      PosInt.unsafeFrom:
-        science.foldLeft(0) { (cnt, z) =>
-          cnt + z.focus.value.exposureCount.value
-        }
+      sumExposureCounts(science)
 
   object GnirsImaging:
     given Eq[GnirsImaging] =
@@ -206,6 +209,27 @@ object ItcScience:
 
   val gnirsImaging: Prism[ItcScience, GnirsImaging] =
     GenPrism[ItcScience, GnirsImaging]
+
+  /**
+   * GNIRS spectroscopy results.  There are results per central wavelength, each
+   * a separate configuration with its own exposure time mode and coadds.
+   */
+  case class GnirsSpectroscopy(
+    science: NonEmptyMap[Wavelength, Zipper[ItcResult]]
+  ) extends ItcScience:
+
+    override def dataType: Type =
+      Type.GnirsSpectroscopy
+
+    override def scienceExposureCount: PosInt =
+      sumExposureCounts(science)
+
+  object GnirsSpectroscopy:
+    given Eq[GnirsSpectroscopy] =
+      Eq.by(_.science)
+
+  val gnirsSpectroscopy: Prism[ItcScience, GnirsSpectroscopy] =
+    GenPrism[ItcScience, GnirsSpectroscopy]
 
   /**
    * Spectroscopy science results, shared by every spectroscopy mode (whether or
@@ -240,6 +264,7 @@ object ItcScience:
       case (a: GmosNorthImaging,  b: GmosNorthImaging)  => a === b
       case (a: GmosSouthImaging,  b: GmosSouthImaging)  => a === b
       case (a: GnirsImaging,      b: GnirsImaging)      => a === b
+      case (a: GnirsSpectroscopy, b: GnirsSpectroscopy) => a === b
       case (a: Spectroscopy,      b: Spectroscopy)      => a === b
       case _                                            => false
 

--- a/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
@@ -94,8 +94,9 @@ trait ItcCodec:
       // Emitted only when set (only GNIRS pins an acquisition type).
       ).deepMerge(a.gnirsAcqType.fold(Json.obj())(t => Json.obj("gnirsAcqType" -> t.asJson)))
 
-  private def imagingScienceNemDecoder[A: Decoder: Order](
-    fieldName: String
+  private def keyedScienceNemDecoder[A: Decoder: Order](
+    fieldName: String,
+    keyName:   String = "filter"
   ): Decoder[NonEmptyMap[A, Zipper[ItcResult]]] =
     Decoder.instance: c =>
       c.downField(fieldName)
@@ -106,9 +107,9 @@ trait ItcCodec:
          val res = nel.traverse: json =>
            val c = json.hcursor
            for
-             filter  <- c.downField("filter").as[A]
+             key     <- c.downField(keyName).as[A]
              results <- c.downField("results").as[Zipper[ItcResult]]
-           yield filter -> results
+           yield key -> results
          res.map(_.toNem)
 
   given Decoder[ItcScience.GhostIfu] =
@@ -119,29 +120,33 @@ trait ItcCodec:
       yield ItcScience.GhostIfu(red, blue)
 
   given Decoder[ItcScience.Flamingos2Imaging] =
-    imagingScienceNemDecoder[Flamingos2Filter]("flamingos2ImagingScience").map(ItcScience.Flamingos2Imaging.apply)
+    keyedScienceNemDecoder[Flamingos2Filter]("flamingos2ImagingScience").map(ItcScience.Flamingos2Imaging.apply)
 
   given Decoder[ItcScience.GmosNorthImaging] =
-    imagingScienceNemDecoder[GmosNorthFilter]("gmosNorthImagingScience").map(ItcScience.GmosNorthImaging.apply)
+    keyedScienceNemDecoder[GmosNorthFilter]("gmosNorthImagingScience").map(ItcScience.GmosNorthImaging.apply)
 
   given Decoder[ItcScience.GmosSouthImaging] =
-    imagingScienceNemDecoder[GmosSouthFilter]("gmosSouthImagingScience").map(ItcScience.GmosSouthImaging.apply)
+    keyedScienceNemDecoder[GmosSouthFilter]("gmosSouthImagingScience").map(ItcScience.GmosSouthImaging.apply)
 
   given Decoder[ItcScience.GnirsImaging] =
-    imagingScienceNemDecoder[GnirsFilter]("gnirsImagingScience").map(ItcScience.GnirsImaging.apply)
+    keyedScienceNemDecoder[GnirsFilter]("gnirsImagingScience").map(ItcScience.GnirsImaging.apply)
+
+  given (using Decoder[Wavelength]): Decoder[ItcScience.GnirsSpectroscopy] =
+    keyedScienceNemDecoder[Wavelength]("gnirsSpectroscopyScience", "centralWavelength")
+      .map(ItcScience.GnirsSpectroscopy.apply)
 
   given Decoder[ItcScience.Spectroscopy] =
     Decoder.instance:
       _.downField("spectroscopyScience").as[Zipper[ItcResult]].map(ItcScience.Spectroscopy.apply)
 
-  private def imagingScienceNemEncoder[A: Encoder](
-    using Encoder[TimeSpan], Encoder[Wavelength]
-  ): Encoder[NonEmptyMap[A, Zipper[ItcResult]]] =
+  private def keyedScienceNemEncoder[A: Encoder](
+    keyName: String = "filter"
+  )(using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[NonEmptyMap[A, Zipper[ItcResult]]] =
     Encoder.instance: a =>
       Json.fromValues:
-        a.toNel.toList.map: (filter, results) =>
+        a.toNel.toList.map: (key, results) =>
           Json.obj(
-            "filter"  -> filter.asJson,
+            keyName   -> key.asJson,
             "results" -> results.asJson
           )
 
@@ -157,28 +162,35 @@ trait ItcCodec:
     Encoder.instance: a =>
       Json.obj(
         "itcType"                  -> ItcScience.Type.Flamingos2Imaging.asJson,
-        "flamingos2ImagingScience" -> a.science.asJson(using imagingScienceNemEncoder[Flamingos2Filter])
+        "flamingos2ImagingScience" -> a.science.asJson(using keyedScienceNemEncoder[Flamingos2Filter]())
       )
 
   given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[ItcScience.GmosNorthImaging] =
     Encoder.instance: a =>
       Json.obj(
         "itcType"                 -> ItcScience.Type.GmosNorthImaging.asJson,
-        "gmosNorthImagingScience" -> a.science.asJson(using imagingScienceNemEncoder[GmosNorthFilter])
+        "gmosNorthImagingScience" -> a.science.asJson(using keyedScienceNemEncoder[GmosNorthFilter]())
       )
 
   given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[ItcScience.GmosSouthImaging] =
     Encoder.instance: a =>
       Json.obj(
         "itcType"                 -> ItcScience.Type.GmosSouthImaging.asJson,
-        "gmosSouthImagingScience" -> a.science.asJson(using imagingScienceNemEncoder[GmosSouthFilter])
+        "gmosSouthImagingScience" -> a.science.asJson(using keyedScienceNemEncoder[GmosSouthFilter]())
       )
 
   given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[ItcScience.GnirsImaging] =
     Encoder.instance: a =>
       Json.obj(
         "itcType"             -> ItcScience.Type.GnirsImaging.asJson,
-        "gnirsImagingScience" -> a.science.asJson(using imagingScienceNemEncoder[GnirsFilter])
+        "gnirsImagingScience" -> a.science.asJson(using keyedScienceNemEncoder[GnirsFilter]())
+      )
+
+  given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[ItcScience.GnirsSpectroscopy] =
+    Encoder.instance: a =>
+      Json.obj(
+        "itcType"                  -> ItcScience.Type.GnirsSpectroscopy.asJson,
+        "gnirsSpectroscopyScience" -> a.science.asJson(using keyedScienceNemEncoder[Wavelength]("centralWavelength"))
       )
 
   given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[ItcScience.Spectroscopy] =
@@ -198,6 +210,7 @@ trait ItcCodec:
          case ItcScience.Type.GmosNorthImaging    => Decoder[ItcScience.GmosNorthImaging].apply(c)
          case ItcScience.Type.GmosSouthImaging    => Decoder[ItcScience.GmosSouthImaging].apply(c)
          case ItcScience.Type.GnirsImaging        => Decoder[ItcScience.GnirsImaging].apply(c)
+         case ItcScience.Type.GnirsSpectroscopy   => Decoder[ItcScience.GnirsSpectroscopy].apply(c)
          case ItcScience.Type.Spectroscopy        => Decoder[ItcScience.Spectroscopy].apply(c)
 
   given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[ItcScience] =
@@ -207,6 +220,7 @@ trait ItcCodec:
       case a @ ItcScience.GmosNorthImaging(_)    => Encoder[ItcScience.GmosNorthImaging].apply(a)
       case a @ ItcScience.GmosSouthImaging(_)    => Encoder[ItcScience.GmosSouthImaging].apply(a)
       case a @ ItcScience.GnirsImaging(_)        => Encoder[ItcScience.GnirsImaging].apply(a)
+      case a @ ItcScience.GnirsSpectroscopy(_)   => Encoder[ItcScience.GnirsSpectroscopy].apply(a)
       case a @ ItcScience.Spectroscopy(_)        => Encoder[ItcScience.Spectroscopy].apply(a)
 
   // The GraphQL `Itc` union predates the acquisition/science split, so its output
@@ -224,6 +238,15 @@ trait ItcCodec:
     Encoder.instance: itc =>
       val science = itc.science.asJson
       itc.science match
+        // GNIRS spectroscopy always has an acquisition sequence, and its science
+        // results are keyed by central wavelength, so there is no IGRINS-style
+        // fallback type here.
+        case _: ItcScience.GnirsSpectroscopy =>
+          itc.acquisition match
+            case ItcAcquisition.Available(times, _) =>
+              science.deepMerge(Json.obj("acquisition" -> times.asJson))
+            case _                                  =>
+              science
         case _: ItcScience.Spectroscopy =>
           itc.acquisition match
             case ItcAcquisition.Available(times, _) =>

--- a/modules/schema/src/test/scala/lucuma/odb/data/arb/ArbItc.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/data/arb/ArbItc.scala
@@ -135,6 +135,18 @@ trait ArbItc:
     Cogen[List[(GnirsFilter, Zipper[ItcResult])]].contramap: a =>
       a.science.toNel.toList
 
+  given Arbitrary[ItcScience.GnirsSpectroscopy] =
+    Arbitrary:
+      for
+        w0 <- arbitrary[Wavelength]
+        ws <- Gen.listOf(arbitrary[Wavelength]).map(ws => (w0 :: ws).distinct)
+        zs <- Gen.listOfN(ws.size, arbitrary[Zipper[ItcResult]])
+      yield ItcScience.GnirsSpectroscopy(NonEmptyList.fromListUnsafe(ws.zip(zs)).toNem)
+
+  given Cogen[ItcScience.GnirsSpectroscopy] =
+    Cogen[List[(Wavelength, Zipper[ItcResult])]].contramap: a =>
+      a.science.toNel.toList
+
   given Arbitrary[ItcScience.Spectroscopy] =
     Arbitrary:
       arbitrary[Zipper[ItcResult]].map(ItcScience.Spectroscopy.apply)
@@ -150,19 +162,21 @@ trait ArbItc:
         arbitrary[ItcScience.GmosNorthImaging],
         arbitrary[ItcScience.GmosSouthImaging],
         arbitrary[ItcScience.GnirsImaging],
+        arbitrary[ItcScience.GnirsSpectroscopy],
         arbitrary[ItcScience.Spectroscopy]
       )
 
   given Cogen[ItcScience] =
     Cogen[
-      Either[ItcScience.Spectroscopy, Either[ItcScience.GmosNorthImaging, Either[ItcScience.GmosSouthImaging, Either[ItcScience.GnirsImaging, Either[ItcScience.GhostIfu, ItcScience.Flamingos2Imaging]]]]]
+      Either[ItcScience.Spectroscopy, Either[ItcScience.GnirsSpectroscopy, Either[ItcScience.GmosNorthImaging, Either[ItcScience.GmosSouthImaging, Either[ItcScience.GnirsImaging, Either[ItcScience.GhostIfu, ItcScience.Flamingos2Imaging]]]]]]
     ].contramap:
       case a: ItcScience.Spectroscopy      => Left(a)
-      case a: ItcScience.GmosNorthImaging  => Right(Left(a))
-      case a: ItcScience.GmosSouthImaging  => Right(Right(Left(a)))
-      case a: ItcScience.GnirsImaging      => Right(Right(Right(Left(a))))
-      case a: ItcScience.GhostIfu          => Right(Right(Right(Right(Left(a)))))
-      case a: ItcScience.Flamingos2Imaging => Right(Right(Right(Right(Right(a)))))
+      case a: ItcScience.GnirsSpectroscopy => Right(Left(a))
+      case a: ItcScience.GmosNorthImaging  => Right(Right(Left(a)))
+      case a: ItcScience.GmosSouthImaging  => Right(Right(Right(Left(a))))
+      case a: ItcScience.GnirsImaging      => Right(Right(Right(Right(Left(a)))))
+      case a: ItcScience.GhostIfu          => Right(Right(Right(Right(Right(Left(a))))))
+      case a: ItcScience.Flamingos2Imaging => Right(Right(Right(Right(Right(Right(a))))))
 
   given Arbitrary[ItcAcquisition.Available] =
     Arbitrary:

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
@@ -10,7 +10,6 @@ import cats.Order.given
 import cats.data.NonEmptyList
 import cats.derived.*
 import cats.syntax.eq.*
-import cats.syntax.option.*
 import lucuma.core.model.Target
 import lucuma.core.util.Timestamp
 import lucuma.itc.client.ImagingInput
@@ -22,6 +21,7 @@ import lucuma.odb.sequence.syntax.all.*
 import lucuma.odb.sequence.util.HashBytes
 import lucuma.odb.sequence.util.HashBytes.given
 import monocle.Prism
+import monocle.macros.GenPrism
 
 import scala.collection.mutable.ArrayBuilder
 
@@ -177,10 +177,7 @@ object ItcInput:
         bld.result()
 
   val gnirsSpectroscopy: Prism[ItcInput, ItcInput.GnirsSpectroscopy] =
-    Prism[ItcInput, ItcInput.GnirsSpectroscopy] {
-      case s: ItcInput.GnirsSpectroscopy => s.some
-      case _                             => none
-    }(identity)
+    GenPrism[ItcInput, ItcInput.GnirsSpectroscopy]
 
   /**
     * ItcInput for spectroscopy, for instruments where GPP does not manage
@@ -205,16 +202,10 @@ object ItcInput:
         )
 
   val spectroscopy: Prism[ItcInput, ItcInput.Spectroscopy] =
-    Prism[ItcInput, ItcInput.Spectroscopy] {
-      case s: ItcInput.Spectroscopy => s.some
-      case _                        => none
-    }(identity)
+    GenPrism[ItcInput, ItcInput.Spectroscopy]
 
   val scienceOnlySpectroscopy: Prism[ItcInput, ItcInput.ScienceOnlySpectroscopy] =
-    Prism[ItcInput, ItcInput.ScienceOnlySpectroscopy] {
-      case s: ItcInput.ScienceOnlySpectroscopy => s.some
-      case _                                   => none
-    }(identity)
+    GenPrism[ItcInput, ItcInput.ScienceOnlySpectroscopy]
 
   given Eq[ItcInput] =
     Eq.instance:

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/data/ItcInput.scala
@@ -136,6 +136,53 @@ object ItcInput:
         )
 
   /**
+   * GNIRS spectroscopy takes spectra at one or more central wavelengths, each a
+   * separate configuration with its own exposure time mode and coadds, and so
+   * its own ITC calculation.  The acquisition is still a single pass.
+   *
+   * This is the spectroscopy analogue of [[Imaging]]'s per-filter fan out; the
+   * other spectroscopy modes have exactly one science configuration and use
+   * [[Spectroscopy]].
+   */
+  case class GnirsSpectroscopy(
+    acquisition:           ImagingParameters,
+    science:               NonEmptyList[SpectroscopyParameters],
+    targets:               NonEmptyList[TargetDefinition],
+    blindOffset:           Option[TargetDefinition],
+    signalToNoiseTargetId: Option[Target.Id],
+    gnirsAcqAutoClassify:  Boolean = false
+  ) extends ItcInput derives Eq:
+
+    def acquisitionTargets: NonEmptyList[TargetDefinition] =
+      blindOffset.fold(targets)(NonEmptyList.one)
+
+    def acquisitionInput: ImagingInput =
+      ImagingInput(acquisition, acquisitionTargets.map(_.input))
+
+    def scienceInput: NonEmptyList[SpectroscopyInput] =
+      science.map(SpectroscopyInput(_, targets.map(_.input)))
+
+  object GnirsSpectroscopy:
+    given HashBytes[GnirsSpectroscopy] with
+      def hashBytes(a: GnirsSpectroscopy): Array[Byte] =
+        val bld = ArrayBuilder.make[Byte]
+        bld.addAll(a.acquisition.hashBytes)
+        // Every science configuration must contribute: two observations that
+        // differ only in an extra central wavelength must not share a cache key.
+        a.science.toList.foreach: params =>
+          bld.addAll(params.hashBytes)
+        bld.addAll(hashTargets(a.blindOffset.fold(a.targets)(_ :: a.targets)))
+        bld.addAll(a.signalToNoiseTargetId.hashBytes)
+        bld.addAll(a.gnirsAcqAutoClassify.hashBytes)
+        bld.result()
+
+  val gnirsSpectroscopy: Prism[ItcInput, ItcInput.GnirsSpectroscopy] =
+    Prism[ItcInput, ItcInput.GnirsSpectroscopy] {
+      case s: ItcInput.GnirsSpectroscopy => s.some
+      case _                             => none
+    }(identity)
+
+  /**
     * ItcInput for spectroscopy, for instruments where GPP does not manage
     * acquisition (IGRINS2, GHOST).
     */
@@ -173,12 +220,14 @@ object ItcInput:
     Eq.instance:
       case (n0: Imaging,                 n1: Imaging)                 => n0 === n1
       case (n0: Spectroscopy,            n1: Spectroscopy)            => n0 === n1
+      case (n0: GnirsSpectroscopy,       n1: GnirsSpectroscopy)       => n0 === n1
       case (n0: ScienceOnlySpectroscopy, n1: ScienceOnlySpectroscopy) => n0 === n1
       case _                                                          => false
 
   given HashBytes[ItcInput] with
     def hashBytes(a: ItcInput): Array[Byte] =
       a match
-        case in @ Imaging(_, _, _, _, _)            => in.hashBytes
-        case in @ Spectroscopy(_, _, _, _, _, _)    => in.hashBytes
-        case in @ ScienceOnlySpectroscopy(_, _, _)  => in.hashBytes
+        case in @ Imaging(_, _, _, _, _)              => in.hashBytes
+        case in @ Spectroscopy(_, _, _, _, _, _)      => in.hashBytes
+        case in @ GnirsSpectroscopy(_, _, _, _, _, _) => in.hashBytes
+        case in @ ScienceOnlySpectroscopy(_, _, _)    => in.hashBytes

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Acquisition.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Acquisition.scala
@@ -247,14 +247,14 @@ object Acquisition:
         for
           _ <- State.modify[GnirsDynamicConfig]: dyn =>
                  dyn.copy(
-                   coadds            = config.coadds,
+                   coadds            = config.primaryWavelength.coadds,
                    filter            = config.filter,
                    decker            = config.decker,
                    fpu               = config.fpu,
                    acquisitionMirror = GnirsAcquisitionMirrorMode.Out(
                                          config.prism,
                                          config.grating,
-                                         GnirsGratingWavelength(config.centralWavelength)
+                                         GnirsGratingWavelength(config.primaryCentralWavelength)
                                        ),
                    camera            = config.camera,
                    focus             = config.focus
@@ -376,7 +376,7 @@ object Acquisition:
                      )
         mode       = config.acquisition.resolvedMode(t, defaultFaintSkyOffset(config.fpu), pinnedAcqType)
         selFilter <- config.acquisition
-                       .selectedFilter(mode, GnirsFilter.fromAcquisitionWavelength(config.centralWavelength))
+                       .selectedFilter(mode, GnirsFilter.fromAcquisitionWavelength(config.primaryCentralWavelength))
                        .leftMap(sequenceError)
       yield (t, mode, selFilter)
 

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/CentralWavelengthConfig.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/CentralWavelengthConfig.scala
@@ -18,16 +18,16 @@ import lucuma.odb.sequence.util.HashBytes
  * a separate ITC calculation and a separate block of science steps with its own
  * flats and arcs.
  */
-case class ScienceWavelength(
+case class CentralWavelengthConfig(
   centralWavelength: Wavelength,
   exposureTimeMode:  ExposureTimeMode,
   coadds:            PosInt
 ) derives Eq
 
-object ScienceWavelength:
+object CentralWavelengthConfig:
 
-  given HashBytes[ScienceWavelength] with
-    def hashBytes(a: ScienceWavelength): Array[Byte] =
+  given HashBytes[CentralWavelengthConfig] with
+    def hashBytes(a: CentralWavelengthConfig): Array[Byte] =
       Array.concat(
         a.centralWavelength.hashBytes,
         a.exposureTimeMode.hashBytes,

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Config.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Config.scala
@@ -30,7 +30,7 @@ case class Config(
   fpu:                     GnirsFpu.Spectroscopy,
   prism:                   GnirsPrism,
   grating:                 GnirsGrating,
-  wavelengths:             NonEmptyList[ScienceWavelength],
+  wavelengths:             NonEmptyList[CentralWavelengthConfig],
   camera:                  GnirsCamera,
   focus:                   GnirsFocus,
   explicitReadMode:        Option[GnirsReadMode],
@@ -47,7 +47,7 @@ case class Config(
    * HR-IFU alignment flat.  Wavelengths are stored in increasing order, so this
    * is the shortest.
    */
-  def primaryWavelength: ScienceWavelength =
+  def primaryWavelength: CentralWavelengthConfig =
     wavelengths.head
 
   def primaryCentralWavelength: Wavelength =

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Config.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Config.scala
@@ -6,8 +6,6 @@ package lucuma.odb.sequence.gnirs.spectroscopy
 import cats.Eq
 import cats.data.NonEmptyList
 import cats.derived.*
-import eu.timepit.refined.cats.*
-import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsDecker
 import lucuma.core.enums.GnirsFilter
@@ -16,7 +14,6 @@ import lucuma.core.enums.GnirsPrism
 import lucuma.core.enums.GnirsReadMode
 import lucuma.core.enums.GnirsWellDepth
 import lucuma.core.math.Wavelength
-import lucuma.core.model.ExposureTimeMode
 import lucuma.core.model.TelluricType
 import lucuma.core.model.sequence.TelescopeConfig
 import lucuma.core.model.sequence.gnirs.GnirsFocus
@@ -33,17 +30,28 @@ case class Config(
   fpu:                     GnirsFpu.Spectroscopy,
   prism:                   GnirsPrism,
   grating:                 GnirsGrating,
-  centralWavelength:       Wavelength,
+  wavelengths:             NonEmptyList[ScienceWavelength],
   camera:                  GnirsCamera,
   focus:                   GnirsFocus,
   explicitReadMode:        Option[GnirsReadMode],
   wellDepth:               GnirsWellDepth,
-  exposureTimeMode:        ExposureTimeMode,
-  coadds:                  PosInt,
   telescopeConfigs:        NonEmptyList[TelescopeConfig],
   acquisition:             AcquisitionConfig,
   telluricType:            TelluricType
 ) derives Eq:
+
+  /**
+   * The configuration the sequence starts with.  Used where a single
+   * representative setting is required: the acquisition filter (both when
+   * generating the acquisition sequence and when sizing it via the ITC) and the
+   * HR-IFU alignment flat.  Wavelengths are stored in increasing order, so this
+   * is the shortest.
+   */
+  def primaryWavelength: ScienceWavelength =
+    wavelengths.head
+
+  def primaryCentralWavelength: Wavelength =
+    primaryWavelength.centralWavelength
 
   def hashBytes: Array[Byte] =
     val bao = new ByteArrayOutputStream(512)
@@ -61,7 +69,11 @@ case class Config(
         out.writeChars(i.tag)
     out.writeChars(prism.tag)
     out.writeChars(grating.tag)
-    out.write(centralWavelength.hashBytes)
+    // Length-prefixed: the element count is user-controlled, so without it two
+    // different wavelength lists could hash to the same bytes.
+    out.writeInt(wavelengths.length)
+    wavelengths.toList.foreach: w =>
+      out.write(w.hashBytes)
     out.writeChars(camera.tag)
     focus match
       case GnirsFocus.Best          => out.writeByte(0)
@@ -70,8 +82,6 @@ case class Config(
         out.writeInt(qty.value.value.value)
     out.writeChars(explicitReadMode.fold("")(_.tag))
     out.writeChars(wellDepth.tag)
-    out.write(exposureTimeMode.hashBytes)
-    out.write(coadds.value.hashBytes)
 
     telescopeConfigs.toList.foreach: tc =>
       out.write(tc.hashBytes)

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
@@ -83,7 +83,7 @@ object Science:
 
   /** `cals` holds the flat, the arc or both; empty for telluric sequences. */
   case class StepDefinition(
-    wavelength:   ScienceWavelength,
+    wavelength:   CentralWavelengthConfig,
     scienceSteps: NonEmptyList[ProtoStep[GnirsDynamicConfig]],
     cals:         Option[NonEmptyList[ProtoStep[GnirsDynamicConfig]]]
   ):
@@ -102,7 +102,7 @@ object Science:
 
     // PreDef is a StepDefinition before SmartGcal expansion.
     case class PreDef(
-      wavelength:   ScienceWavelength,
+      wavelength:   CentralWavelengthConfig,
       scienceSteps: NonEmptyList[ProtoStep[GnirsDynamicConfig]],
       // Unexpanded SmartGcal (flat, arc), absent for telluric sequences.
       cals:         Option[(ProtoStep[GnirsDynamicConfig], ProtoStep[GnirsDynamicConfig])]
@@ -127,7 +127,7 @@ object Science:
 
       def apply(
         config:  Config,
-        sw:      ScienceWavelength,
+        sw:      CentralWavelengthConfig,
         time:    IntegrationTime,
         calRole: Option[CalibrationRole]
       ): PreDef =
@@ -177,7 +177,7 @@ object Science:
 
     def compute[F[_]: Monad](
       config:   Config,
-      sw:       ScienceWavelength,
+      sw:       CentralWavelengthConfig,
       time:     IntegrationTime,
       static:   GnirsStaticConfig,
       expander: SmartGcalExpander[F, GnirsStaticConfig, GnirsDynamicConfig],
@@ -191,7 +191,7 @@ object Science:
      */
     def computeAll[F[_]: Monad](
       config:   Config,
-      times:    NonEmptyList[(ScienceWavelength, IntegrationTime)],
+      times:    NonEmptyList[(CentralWavelengthConfig, IntegrationTime)],
       static:   GnirsStaticConfig,
       expander: SmartGcalExpander[F, GnirsStaticConfig, GnirsDynamicConfig],
       calRole:  Option[CalibrationRole]
@@ -315,7 +315,7 @@ object Science:
   private def definitionError(oid: Observation.Id, msg: String): OdbError =
     OdbError.SequenceUnavailable(oid, s"Could not generate a sequence for $oid: $msg".some)
 
-  private def nm(sw: ScienceWavelength): String =
+  private def nm(sw: CentralWavelengthConfig): String =
     f"${sw.centralWavelength.toNanometers.value.value.toDouble}%.0f nm"
 
   /**
@@ -324,17 +324,17 @@ object Science:
    * unchanged), suffixed with the wavelength when it has several, so the
    * observer can tell the segments apart.
    */
-  private def atomTitle(base: NonEmptyString, sw: ScienceWavelength, multi: Boolean): NonEmptyString =
+  private def atomTitle(base: NonEmptyString, sw: CentralWavelengthConfig, multi: Boolean): NonEmptyString =
     if multi then NonEmptyString.unsafeFrom(s"${base.value} (${nm(sw)})") else base
 
   // "GNIRS Spectroscopy" rather than "Long Slit": this generator serves the IFU too.
   private def zeroExposureTime(oid: Observation.Id): OdbError =
     definitionError(oid, "GNIRS Spectroscopy requires a positive exposure time.")
 
-  private def missingItcResult(oid: Observation.Id, sw: ScienceWavelength): OdbError =
+  private def missingItcResult(oid: Observation.Id, sw: CentralWavelengthConfig): OdbError =
     definitionError(oid, s"No ITC result for central wavelength ${nm(sw)}.")
 
-  private def exposureTimeTooLong(oid: Observation.Id, sw: ScienceWavelength, estimate: TimeSpan): OdbError =
+  private def exposureTimeTooLong(oid: Observation.Id, sw: CentralWavelengthConfig, estimate: TimeSpan): OdbError =
     definitionError(oid, s"Estimated science cycle time (${estimate.toMinutes} minutes) at ${nm(sw)} for $oid must be less than ${MaxSciencePeriod.toMinutes} minutes.")
 
   /**
@@ -357,7 +357,7 @@ object Science:
     // the grating angle, so a single flat is only valid for one setting: take one
     // per distinct central wavelength.  These are DayCal and so cost no program
     // time.
-    def flat(sw: ScienceWavelength): ProtoStep[GnirsDynamicConfig] =
+    def flat(sw: CentralWavelengthConfig): ProtoStep[GnirsDynamicConfig] =
       SeqState.eval:
         for
           _ <- State.modify[GnirsDynamicConfig]: dyn =>
@@ -378,7 +378,7 @@ object Science:
           f <- SeqState.flatStep(TelescopeConfig(Offset.Zero, StepGuideState.Disabled), ObserveClass.DayCal)
         yield f
 
-    val distinctWavelengths: NonEmptyList[ScienceWavelength] =
+    val distinctWavelengths: NonEmptyList[CentralWavelengthConfig] =
       NonEmptyList.fromListUnsafe(config.wavelengths.toList.distinctBy(_.centralWavelength))
 
     val multi: Boolean = distinctWavelengths.length > 1
@@ -427,7 +427,7 @@ object Science:
     // Pair each configured wavelength with its ITC result, in configuration
     // order.  A wavelength with no result is a programming error upstream, not
     // something to silently drop.
-    val pairs: EitherT[F, OdbError, NonEmptyList[(ScienceWavelength, IntegrationTime)]] =
+    val pairs: EitherT[F, OdbError, NonEmptyList[(CentralWavelengthConfig, IntegrationTime)]] =
       EitherT.fromEither:
         times.flatMap: m =>
           config.wavelengths.traverse: sw =>

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Science.scala
@@ -8,6 +8,8 @@ package spectroscopy
 import cats.Monad
 import cats.data.EitherT
 import cats.data.NonEmptyList
+import cats.data.NonEmptyMap
+import cats.data.NonEmptyVector
 import cats.data.State
 import cats.syntax.either.*
 import cats.syntax.option.*
@@ -25,6 +27,7 @@ import lucuma.core.enums.ObserveClass
 import lucuma.core.enums.SequenceType
 import lucuma.core.enums.StepGuideState
 import lucuma.core.math.Offset
+import lucuma.core.math.Wavelength
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.TelescopeConfig
@@ -80,6 +83,7 @@ object Science:
 
   /** `cals` holds the flat, the arc or both; empty for telluric sequences. */
   case class StepDefinition(
+    wavelength:   ScienceWavelength,
     scienceSteps: NonEmptyList[ProtoStep[GnirsDynamicConfig]],
     cals:         Option[NonEmptyList[ProtoStep[GnirsDynamicConfig]]]
   ):
@@ -98,6 +102,7 @@ object Science:
 
     // PreDef is a StepDefinition before SmartGcal expansion.
     case class PreDef(
+      wavelength:   ScienceWavelength,
       scienceSteps: NonEmptyList[ProtoStep[GnirsDynamicConfig]],
       // Unexpanded SmartGcal (flat, arc), absent for telluric sequences.
       cals:         Option[(ProtoStep[GnirsDynamicConfig], ProtoStep[GnirsDynamicConfig])]
@@ -113,15 +118,16 @@ object Science:
         def adjustReadMode(s: ProtoStep[GnirsDynamicConfig]): ProtoStep[GnirsDynamicConfig] =
           s.copy(value = s.value.copy(readMode = GnirsReadMode.forExposureTime(s.value.exposure)))
 
-        cals.fold(EitherT.pure(StepDefinition(scienceSteps, none))): (flat, arc) =>
+        cals.fold(EitherT.pure(StepDefinition(wavelength, scienceSteps, none))): (flat, arc) =>
           // 111/LXD, for instance, has arcs but no slit flat.
           EitherT(expander.expandFlatAndOrArc(static, flat, arc))
-            .map(cs => StepDefinition(scienceSteps, cs.map(adjustReadMode).some))
+            .map(cs => StepDefinition(wavelength, scienceSteps, cs.map(adjustReadMode).some))
 
     object PreDef:
 
       def apply(
         config:  Config,
+        sw:      ScienceWavelength,
         time:    IntegrationTime,
         calRole: Option[CalibrationRole]
       ): PreDef =
@@ -133,7 +139,7 @@ object Science:
         val acqMirror        = GnirsAcquisitionMirrorMode.Out(
           config.prism,
           config.grating,
-          GnirsGratingWavelength(config.centralWavelength)
+          GnirsGratingWavelength(sw.centralWavelength)
         )
 
         val sciClass = calRole.sciClass
@@ -150,7 +156,7 @@ object Science:
             _  <- State.modify[GnirsDynamicConfig]: dyn =>
                     dyn.copy(
                       exposure          = time.exposureTime,
-                      coadds            = config.coadds,
+                      coadds            = sw.coadds,
                       filter            = config.filter,
                       decker            = config.decker,
                       fpu               = config.fpu,
@@ -164,62 +170,117 @@ object Science:
             f  <- SeqState.flatStep(ct, ObserveClass.NightCal)
             r  <- SeqState.arcStep(ct, ObserveClass.NightCal)
           yield PreDef(
+            sw,
             ss,
             Option.when(includeCals)((f, r))
           )
 
     def compute[F[_]: Monad](
       config:   Config,
+      sw:       ScienceWavelength,
       time:     IntegrationTime,
       static:   GnirsStaticConfig,
       expander: SmartGcalExpander[F, GnirsStaticConfig, GnirsDynamicConfig],
       calRole:  Option[CalibrationRole]
     ): EitherT[F, String, StepDefinition] =
-      PreDef(config, time, calRole).expand(static, expander)
+      PreDef(config, sw, time, calRole).expand(static, expander)
+
+    /**
+     * One step definition per central wavelength.  Each gets its own SmartGcal
+     * expansion, since the flat and arc lookups are keyed on the wavelength.
+     */
+    def computeAll[F[_]: Monad](
+      config:   Config,
+      times:    NonEmptyList[(ScienceWavelength, IntegrationTime)],
+      static:   GnirsStaticConfig,
+      expander: SmartGcalExpander[F, GnirsStaticConfig, GnirsDynamicConfig],
+      calRole:  Option[CalibrationRole]
+    ): EitherT[F, String, NonEmptyList[StepDefinition]] =
+      times.traverse((sw, t) => compute(config, sw, t, static, expander, calRole))
 
   end StepDefinition
 
-  case class Generator(
+  /**
+   * One central wavelength's contribution to the science sequence: its steps
+   * (science plus, unless this is a telluric, its own flat and/or arc), the
+   * estimated duration of a single science cycle at that wavelength, and the
+   * number of cycles needed to reach the requested signal-to-noise there.
+   */
+  case class WavelengthBlock(
     steps:         StepDefinition,
     cycleEstimate: TimeSpan,
-    builder:       AtomBuilder[GnirsDynamicConfig],
     goalCycles:    NonNegInt
+  )
+
+  /**
+   * Generates the science sequence across every central wavelength.
+   *
+   * Each wavelength is a separate configuration whose flats and arcs are looked
+   * up by wavelength, so its exposures run as a contiguous segment followed by
+   * its own calibrations.  The segments are then round-robined -- λ1, λ2, ... λN,
+   * λ1, ... -- until every wavelength has met its goal, following the GMOS
+   * wavelength-dither generator.  Running each wavelength to completion instead
+   * would push the later ones into fresh visits (paying a full acquisition each
+   * time) and would leave an interrupted program with nothing at all for the
+   * wavelengths it never reached.
+   */
+  case class Generator(
+    blocks:  NonEmptyVector[WavelengthBlock],
+    builder: AtomBuilder[GnirsDynamicConfig]
   ) extends SequenceGenerator[GnirsDynamicConfig]:
 
-    // Computes the atoms remaining in a 3 hour science block, limited to
-    // `maxCycles` at most.  A "Nighttime Calibrations" atom (flat + arc) is
-    // inserted at the end of the block and, when the block is long enough,
-    // around its midpoint, aligned to a science cycle boundary.  Telluric
-    // sequences (`steps.cals.isEmpty`) omit the calibration atoms entirely.
-    private def atomsInBlock(maxCycles: NonNegInt): (Int, List[ProtoAtom[ProtoStep[GnirsDynamicConfig]]]) =
+    private val multi: Boolean = blocks.length > 1
+
+    /**
+     * Nominal on-sky time given to one wavelength before moving to the next.
+     * The visit-length budget is shared out, so N wavelengths still break for a
+     * telluric at the same cadence a single one would.  For N = 1 this is
+     * exactly `MaxVisitLength`.
+     */
+    private val segmentBudget: TimeSpan =
+      MaxVisitLength /| NonZeroInt.unsafeFrom(blocks.length)
+
+    // Computes the atoms in one wavelength's segment, limited to `maxCycles`.
+    // A "Nighttime Calibrations" atom (flat + arc) closes the segment and, when
+    // the segment is long enough, appears around its midpoint aligned to a cycle
+    // boundary.  Telluric sequences (`cals.isEmpty`) omit them entirely.
+    private def atomsInSegment(
+      b:         WavelengthBlock,
+      maxCycles: NonNegInt
+    ): (Int, List[ProtoAtom[ProtoStep[GnirsDynamicConfig]]]) =
 
       def cyclesIn(timeSpan: TimeSpan): Int =
-        (timeSpan.toMicroseconds / cycleEstimate.toMicroseconds).toInt
+        (timeSpan.toMicroseconds / b.cycleEstimate.toMicroseconds).toInt
 
-      val cycles: Int = cyclesIn(MaxVisitLength) min maxCycles.value
+      // `1 max` guarantees forward progress: once the visit budget is split N
+      // ways a single cycle can be longer than one segment.  The cycle is still
+      // bounded by MaxSciencePeriod, checked at instantiation.
+      val cycles: Int = (1 max cyclesIn(segmentBudget)) min maxCycles.value
 
-      val scienceTime: TimeSpan = cycleEstimate *| cycles
+      val scienceTime: TimeSpan = b.cycleEstimate *| cycles
 
-      val scienceAtom: ProtoAtom[ProtoStep[GnirsDynamicConfig]] = ProtoAtom(ScienceCycleTitle.some, steps.scienceSteps)
+      val scienceAtom: ProtoAtom[ProtoStep[GnirsDynamicConfig]] =
+        ProtoAtom(atomTitle(ScienceCycleTitle, b.steps.wavelength, multi).some, b.steps.scienceSteps)
 
-      steps.cals.fold(cycles -> List.fill(cycles)(scienceAtom)): cals =>
-        val gcalAtom: ProtoAtom[ProtoStep[GnirsDynamicConfig]] = ProtoAtom(NighttimeCalTitle.some, cals)
+      b.steps.cals.fold(cycles -> List.fill(cycles)(scienceAtom)): cals =>
+        val gcalAtom: ProtoAtom[ProtoStep[GnirsDynamicConfig]] =
+          ProtoAtom(atomTitle(NighttimeCalTitle, b.steps.wavelength, multi).some, cals)
 
         cycles ->
           Option
             .when(scienceTime >= MaxSciencePeriod)(scienceTime /| Two)
             .fold(
-              // The science time is not long enough to warrant a mid-science cal in this block.
+              // The science time is not long enough to warrant a mid-science cal in this segment.
               List.fill(cycles)(scienceAtom) ++ Option.when(cycles > 0)(gcalAtom).toList
             ): timeUntilMidScienceCals =>
 
               val fullPreCalCycles: Int        = cyclesIn(timeUntilMidScienceCals)
-              val leftOverPreCalTime: TimeSpan = timeUntilMidScienceCals -| (cycleEstimate *| fullPreCalCycles)
+              val leftOverPreCalTime: TimeSpan = timeUntilMidScienceCals -| (b.cycleEstimate *| fullPreCalCycles)
 
               // If the nominal cal time falls in the middle of a science cycle, make it so
               // the break to do calibrations falls closest to a cycle boundary.
               val extraPreCalCycle: Int =
-                if leftOverPreCalTime >= (cycleEstimate /| Two) then 1 min cycles else 0
+                if leftOverPreCalTime >= (b.cycleEstimate /| Two) then 1 min cycles else 0
 
               val preCalCycles:  Int = fullPreCalCycles + extraPreCalCycle
               val postCalCycles: Int = cycles - preCalCycles
@@ -230,30 +291,51 @@ object Science:
 
     override def generate: Stream[Pure, Atom[GnirsDynamicConfig]] =
 
-      // Add future blocks until we've completed all the cycles.
-      val atoms: List[ProtoAtom[ProtoStep[GnirsDynamicConfig]]] =
+      val n = blocks.length
+
+      // Round-robin the wavelengths, skipping any that have met their goal, until
+      // all have.  Atom ids come from the atom's index within a single builder,
+      // so every segment must feed the same `buildStream` -- separate builders
+      // would emit duplicate ids.
+      val atoms: Stream[Pure, ProtoAtom[ProtoStep[GnirsDynamicConfig]]] =
         Stream
-          .unfold(0): c =>
-            Option.when(goalCycles.value - c > 0):
-              val (cycles, atoms) = atomsInBlock(NonNegInt.unsafeFrom(goalCycles.value - c))
+          .unfold((blocks.map(_.goalCycles.value).toVector, 0)): (remaining, pos) =>
+            Option.when(remaining.exists(_ > 0)):
+              val i = LazyList.from(0).map(k => (pos + k) % n).find(remaining(_) > 0).get
+              val (used, as) = atomsInSegment(blocks.getUnsafe(i), NonNegInt.unsafeFrom(remaining(i)))
 
               // Sanity check....
-              assert(cycles > 0, "No progress made generating future GNIRS Long Slit sequence!")
+              assert(used > 0, "No progress made generating future GNIRS Spectroscopy sequence!")
 
-              (atoms, c + cycles)
+              (as, (remaining.updated(i, remaining(i) - used), (i + 1) % n))
           .flatMap(Stream.emits)
-          .toList
 
-      builder.buildStream(Stream.emits(atoms))
+      builder.buildStream(atoms)
 
   private def definitionError(oid: Observation.Id, msg: String): OdbError =
     OdbError.SequenceUnavailable(oid, s"Could not generate a sequence for $oid: $msg".some)
 
-  private def zeroExposureTime(oid: Observation.Id): OdbError =
-    definitionError(oid, "GNIRS Long Slit requires a positive exposure time.")
+  private def nm(sw: ScienceWavelength): String =
+    f"${sw.centralWavelength.toNanometers.value.value.toDouble}%.0f nm"
 
-  private def exposureTimeTooLong(oid: Observation.Id, estimate: TimeSpan): OdbError =
-    definitionError(oid, s"Estimated science cycle time (${estimate.toMinutes} minutes) for $oid must be less than ${MaxSciencePeriod.toMinutes} minutes.")
+  /**
+   * Atom title for a block of steps taken at one central wavelength: bare when
+   * the observation has a single wavelength (so existing sequences are
+   * unchanged), suffixed with the wavelength when it has several, so the
+   * observer can tell the segments apart.
+   */
+  private def atomTitle(base: NonEmptyString, sw: ScienceWavelength, multi: Boolean): NonEmptyString =
+    if multi then NonEmptyString.unsafeFrom(s"${base.value} (${nm(sw)})") else base
+
+  // "GNIRS Spectroscopy" rather than "Long Slit": this generator serves the IFU too.
+  private def zeroExposureTime(oid: Observation.Id): OdbError =
+    definitionError(oid, "GNIRS Spectroscopy requires a positive exposure time.")
+
+  private def missingItcResult(oid: Observation.Id, sw: ScienceWavelength): OdbError =
+    definitionError(oid, s"No ITC result for central wavelength ${nm(sw)}.")
+
+  private def exposureTimeTooLong(oid: Observation.Id, sw: ScienceWavelength, estimate: TimeSpan): OdbError =
+    definitionError(oid, s"Estimated science cycle time (${estimate.toMinutes} minutes) at ${nm(sw)} for $oid must be less than ${MaxSciencePeriod.toMinutes} minutes.")
 
   /**
    * Generates the sequence for a daytime pinhole flat calibration: a single
@@ -271,19 +353,23 @@ object Science:
     config:        Config
   ): F[Either[OdbError, SequenceGenerator[GnirsDynamicConfig]]] =
 
-    val flat: ProtoStep[GnirsDynamicConfig] =
+    // A pinhole flat traces the cross-dispersed order positions, which move with
+    // the grating angle, so a single flat is only valid for one setting: take one
+    // per distinct central wavelength.  These are DayCal and so cost no program
+    // time.
+    def flat(sw: ScienceWavelength): ProtoStep[GnirsDynamicConfig] =
       SeqState.eval:
         for
           _ <- State.modify[GnirsDynamicConfig]: dyn =>
                  dyn.copy(
-                   coadds            = config.coadds,
+                   coadds            = sw.coadds,
                    filter            = config.filter,
                    decker            = config.decker,
                    fpu               = GnirsFpu.Other(pinholeFpu(config.camera)),
                    acquisitionMirror = GnirsAcquisitionMirrorMode.Out(
                                          config.prism,
                                          config.grating,
-                                         GnirsGratingWavelength(config.centralWavelength)
+                                         GnirsGratingWavelength(sw.centralWavelength)
                                        ),
                    camera            = config.camera,
                    focus             = config.focus,
@@ -292,15 +378,23 @@ object Science:
           f <- SeqState.flatStep(TelescopeConfig(Offset.Zero, StepGuideState.Disabled), ObserveClass.DayCal)
         yield f
 
-    EitherT(expander.expandStep(static, flat))
+    val distinctWavelengths: NonEmptyList[ScienceWavelength] =
+      NonEmptyList.fromListUnsafe(config.wavelengths.toList.distinctBy(_.centralWavelength))
+
+    val multi: Boolean = distinctWavelengths.length > 1
+
+    distinctWavelengths
+      .traverse: sw =>
+        EitherT(expander.expandStep(static, flat(sw)))
+          .map: steps =>
+            ProtoAtom(atomTitle(DaytimePinholeTitle, sw, multi).some, steps)
       .bimap(
         m => definitionError(observationId, m),
-        steps =>
-          val atom    = ProtoAtom(DaytimePinholeTitle.some, steps)
+        atoms =>
           val builder = AtomBuilder.instantiate(estimator, static, namespace, SequenceType.Science)
           new SequenceGenerator[GnirsDynamicConfig]:
             def generate: Stream[Pure, Atom[GnirsDynamicConfig]] =
-              builder.buildStream(Stream.emit(atom))
+              builder.buildStream(Stream.emits(atoms.toList))
       ).value
 
   def instantiate[F[_]: Monad](
@@ -310,14 +404,14 @@ object Science:
     namespace:     UUID,
     expander:      SmartGcalExpander[F, GnirsStaticConfig, GnirsDynamicConfig],
     config:        Config,
-    time:          Either[OdbError, IntegrationTime],
+    times:         Either[OdbError, NonEmptyMap[Wavelength, IntegrationTime]],
     calRole:       Option[CalibrationRole]
   ): F[Either[OdbError, SequenceGenerator[GnirsDynamicConfig]]] =
     calRole match
       case Some(CalibrationRole.DaytimePinhole) =>
         daytimePinhole(observationId, estimator, static, namespace, expander, config)
       case _ =>
-        instantiateScience(observationId, estimator, static, namespace, expander, config, time, calRole)
+        instantiateScience(observationId, estimator, static, namespace, expander, config, times, calRole)
 
   private def instantiateScience[F[_]: Monad](
     observationId: Observation.Id,
@@ -326,29 +420,40 @@ object Science:
     namespace:     UUID,
     expander:      SmartGcalExpander[F, GnirsStaticConfig, GnirsDynamicConfig],
     config:        Config,
-    time:          Either[OdbError, IntegrationTime],
+    times:         Either[OdbError, NonEmptyMap[Wavelength, IntegrationTime]],
     calRole:       Option[CalibrationRole]
   ): F[Either[OdbError, SequenceGenerator[GnirsDynamicConfig]]] =
 
-    val posTime: EitherT[F, OdbError, IntegrationTime] =
+    // Pair each configured wavelength with its ITC result, in configuration
+    // order.  A wavelength with no result is a programming error upstream, not
+    // something to silently drop.
+    val pairs: EitherT[F, OdbError, NonEmptyList[(ScienceWavelength, IntegrationTime)]] =
       EitherT.fromEither:
-        time.filterOrElse(_.exposureTime.toNonNegMicroseconds.value > 0, zeroExposureTime(observationId))
+        times.flatMap: m =>
+          config.wavelengths.traverse: sw =>
+            m(sw.centralWavelength)
+              .toRight(missingItcResult(observationId, sw))
+              .flatMap: t =>
+                Either.cond(t.exposureTime.toNonNegMicroseconds.value > 0, (sw, t), zeroExposureTime(observationId))
 
+    // A science cycle must fit inside the calibration validity period at every
+    // wavelength; the error names the offending one.
     def cycleEstimate(steps: StepDefinition): EitherT[F, OdbError, TimeSpan] =
       val estimate = StepTimeEstimateCalculator.runEmpty(estimator.estimateTotalNel(static, steps.scienceSteps))
       EitherT.fromEither:
-        Either.cond(estimate < MaxSciencePeriod, estimate, exposureTimeTooLong(observationId, estimate))
+        Either.cond(estimate < MaxSciencePeriod, estimate, exposureTimeTooLong(observationId, steps.wavelength, estimate))
 
     val gen = for
-      t <- posTime
-      s <- StepDefinition.compute(config, t, static, expander, calRole).leftMap(m => definitionError(observationId, m))
-      e <- cycleEstimate(s)
-      c <- EitherT.fromEither(s.cycleCount(t).leftMap(m => definitionError(observationId, m)))
+      ts <- pairs
+      ds <- StepDefinition.computeAll(config, ts, static, expander, calRole).leftMap(m => definitionError(observationId, m))
+      bs <- ds.zip(ts).traverse: (d, wt) =>
+              for
+                e <- cycleEstimate(d)
+                c <- EitherT.fromEither(d.cycleCount(wt._2).leftMap(m => definitionError(observationId, m)))
+              yield WavelengthBlock(d, e, c)
     yield Generator(
-      s,
-      e,
-      AtomBuilder.instantiate(estimator, static, namespace, SequenceType.Science),
-      c
+      bs.toNev,
+      AtomBuilder.instantiate(estimator, static, namespace, SequenceType.Science)
     ): SequenceGenerator[GnirsDynamicConfig]
 
     gen.value

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/ScienceWavelength.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/ScienceWavelength.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence.gnirs.spectroscopy
+
+import cats.Eq
+import cats.derived.*
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.math.Wavelength
+import lucuma.core.model.ExposureTimeMode
+import lucuma.odb.sequence.syntax.all.*
+import lucuma.odb.sequence.util.HashBytes
+
+/**
+ * One GNIRS spectroscopy science configuration: a central wavelength together
+ * with the exposure time mode and coadds that apply at that wavelength.  Each is
+ * a separate ITC calculation and a separate block of science steps with its own
+ * flats and arcs.
+ */
+case class ScienceWavelength(
+  centralWavelength: Wavelength,
+  exposureTimeMode:  ExposureTimeMode,
+  coadds:            PosInt
+) derives Eq
+
+object ScienceWavelength:
+
+  given HashBytes[ScienceWavelength] with
+    def hashBytes(a: ScienceWavelength): Array[Byte] =
+      Array.concat(
+        a.centralWavelength.hashBytes,
+        a.exposureTimeMode.hashBytes,
+        a.coadds.value.hashBytes
+      )

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Spectroscopy.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/spectroscopy/Spectroscopy.scala
@@ -6,11 +6,13 @@ package gnirs.spectroscopy
 
 import cats.Monad
 import cats.data.EitherT
+import cats.data.NonEmptyMap
 import cats.syntax.applicative.*
 import cats.syntax.either.*
 import fs2.Pure
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.GnirsAcquisitionType
+import lucuma.core.math.Wavelength
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.gnirs.GnirsDynamicConfig
 import lucuma.core.model.sequence.gnirs.GnirsStaticConfig
@@ -34,7 +36,7 @@ object Spectroscopy:
     config:         Config,
     acquisitionItc: Either[OdbError, IntegrationTime],
     gnirsAcqType:   Option[GnirsAcquisitionType],
-    scienceItc:     Either[OdbError, IntegrationTime],
+    scienceItc:     Either[OdbError, NonEmptyMap[Wavelength, IntegrationTime]],
     calRole:        Option[CalibrationRole]
   ): F[Either[OdbError, StreamingExecutionConfig[Pure, GnirsStaticConfig, GnirsDynamicConfig]]] =
     val static = staticFrom(config)

--- a/modules/sequence/src/test/scala/lucuma/odb/sequence/data/ItcInputSuite.scala
+++ b/modules/sequence/src/test/scala/lucuma/odb/sequence/data/ItcInputSuite.scala
@@ -8,6 +8,7 @@ import cats.syntax.eq.*
 import cats.syntax.functor.*
 import lucuma.itc.client.TargetInput
 import lucuma.odb.sequence.data.arb.ArbItcInput.given
+import lucuma.odb.sequence.util.HashBytes
 import munit.ScalaCheckSuite
 import org.scalacheck.Prop.*
 
@@ -26,4 +27,19 @@ class ItcInputSuite extends ScalaCheckSuite:
       // Science should use regular targets only
       assert(sci.asterism.length === itcInput.targets.size)
       assert(sci.asterism.head === itcInput.targets.head._2)
+    }
+
+  property("GNIRS spectroscopy hashes every central wavelength"):
+    forAll { (itcInput: ItcInput.GnirsSpectroscopy) =>
+      // Dropping a central wavelength must change the cache key: two observations
+      // differing only in an extra wavelength must not collide in t_itc_result.
+      val trimmed = itcInput.science.toList match
+        case _ :: (t @ _ :: _) => Some(itcInput.copy(science = cats.data.NonEmptyList.fromListUnsafe(t)))
+        case _                 => None
+
+      trimmed.foreach: t =>
+        assert(
+          !java.util.Arrays.equals(HashBytes[ItcInput].hashBytes(itcInput), HashBytes[ItcInput].hashBytes(t)),
+          "Removing a central wavelength did not change the hash"
+        )
     }

--- a/modules/sequence/src/test/scala/lucuma/odb/sequence/data/arb/ArbItcInput.scala
+++ b/modules/sequence/src/test/scala/lucuma/odb/sequence/data/arb/ArbItcInput.scala
@@ -63,6 +63,24 @@ trait ArbItcInput:
         sn
       )
 
+  given Arbitrary[ItcInput.GnirsSpectroscopy] =
+    Arbitrary:
+      for
+        acq <- arbitrary[ImagingParameters]
+        wc  <- Gen.choose(1, 4)
+        sci <- Gen.listOfN(wc, arbitrary[SpectroscopyParameters])
+        ct  <- Gen.choose(1, 10)
+        ts  <- List.range(1L, ct + 1L).traverse(genTargetDefinition)
+        bo  <- Gen.option(genTargetDefinition(ct + 1L))
+        sn  <- Gen.option(Gen.oneOf(ts.map(_.targetId)))
+      yield ItcInput.GnirsSpectroscopy(
+        acq,
+        NonEmptyList.fromListUnsafe(sci),
+        NonEmptyList.fromListUnsafe(ts),
+        bo,
+        sn
+      )
+
   given Arbitrary[ItcInput.ScienceOnlySpectroscopy] =
     Arbitrary:
       for
@@ -81,6 +99,7 @@ trait ArbItcInput:
       Gen.oneOf(
         arbitrary[ItcInput.Imaging],
         arbitrary[ItcInput.Spectroscopy],
+        arbitrary[ItcInput.GnirsSpectroscopy],
         arbitrary[ItcInput.ScienceOnlySpectroscopy]
       )
 

--- a/modules/service/src/main/resources/db/migration/V1248__gnirs_central_wavelength_config.sql
+++ b/modules/service/src/main/resources/db/migration/V1248__gnirs_central_wavelength_config.sql
@@ -5,7 +5,7 @@
 -- t_gnirs_spectroscopy moves to a child table with one row per wavelength,
 -- modeled after t_gnirs_imaging_filter.
 
-CREATE TABLE t_gnirs_spectroscopy_wavelength (
+CREATE TABLE t_gnirs_central_wavelength_config (
   c_observation_id        d_observation_id             NOT NULL,
   c_central_wavelength    d_wavelength_pm              NOT NULL,
   c_version               e_observing_mode_row_version NOT NULL DEFAULT 'current',
@@ -14,7 +14,7 @@ CREATE TABLE t_gnirs_spectroscopy_wavelength (
   c_role                  e_exposure_time_mode_role    NOT NULL DEFAULT 'science' CHECK (c_role = 'science'),
 
   PRIMARY KEY (c_observation_id, c_central_wavelength, c_version),
-  CONSTRAINT t_gnirs_spectroscopy_wavelength_unique_exposure_time_mode_id
+  CONSTRAINT t_gnirs_central_wavelength_config_unique_exposure_time_mode_id
     UNIQUE (c_exposure_time_mode_id),
   FOREIGN KEY (c_observation_id)
     REFERENCES t_gnirs_spectroscopy(c_observation_id) ON DELETE CASCADE,
@@ -23,13 +23,13 @@ CREATE TABLE t_gnirs_spectroscopy_wavelength (
     ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
 );
 
-COMMENT ON TABLE t_gnirs_spectroscopy_wavelength IS
+COMMENT ON TABLE t_gnirs_central_wavelength_config IS
   'GNIRS spectroscopy central wavelengths, each with its own exposure time mode and coadds';
 
 -- Backfill.  Existing observations have exactly one science ETM, which becomes the
 -- 'current' row's ETM.  The 'initial' row needs its own ETM (the unique constraint
 -- above allows an ETM to back only one wavelength row), so clone it.
-INSERT INTO t_gnirs_spectroscopy_wavelength (
+INSERT INTO t_gnirs_central_wavelength_config (
   c_observation_id,
   c_central_wavelength,
   c_version,
@@ -71,7 +71,7 @@ WITH cloned AS (
    AND m.c_role = 'science'::e_exposure_time_mode_role
   RETURNING c_exposure_time_mode_id, c_observation_id
 )
-INSERT INTO t_gnirs_spectroscopy_wavelength (
+INSERT INTO t_gnirs_central_wavelength_config (
   c_observation_id,
   c_central_wavelength,
   c_version,

--- a/modules/service/src/main/resources/db/migration/V1248__gnirs_spectroscopy_wavelengths.sql
+++ b/modules/service/src/main/resources/db/migration/V1248__gnirs_spectroscopy_wavelengths.sql
@@ -1,0 +1,272 @@
+-- GNIRS spectroscopy observations may take spectra at several central wavelengths.
+-- Each central wavelength is a separate configuration with its own exposure time
+-- mode, coadds, ITC calculation and smart calibrations, so the single
+-- (c_central_wavelength, c_initial_central_wavelength, c_coadds) triple on
+-- t_gnirs_spectroscopy moves to a child table with one row per wavelength,
+-- modeled after t_gnirs_imaging_filter.
+
+CREATE TABLE t_gnirs_spectroscopy_wavelength (
+  c_observation_id        d_observation_id             NOT NULL,
+  c_central_wavelength    d_wavelength_pm              NOT NULL,
+  c_version               e_observing_mode_row_version NOT NULL DEFAULT 'current',
+  c_coadds                int4                         NOT NULL DEFAULT 1 CHECK (c_coadds > 0),
+  c_exposure_time_mode_id integer                      NOT NULL,
+  c_role                  e_exposure_time_mode_role    NOT NULL DEFAULT 'science' CHECK (c_role = 'science'),
+
+  PRIMARY KEY (c_observation_id, c_central_wavelength, c_version),
+  CONSTRAINT t_gnirs_spectroscopy_wavelength_unique_exposure_time_mode_id
+    UNIQUE (c_exposure_time_mode_id),
+  FOREIGN KEY (c_observation_id)
+    REFERENCES t_gnirs_spectroscopy(c_observation_id) ON DELETE CASCADE,
+  FOREIGN KEY (c_exposure_time_mode_id, c_role)
+    REFERENCES t_exposure_time_mode(c_exposure_time_mode_id, c_role)
+    ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+);
+
+COMMENT ON TABLE t_gnirs_spectroscopy_wavelength IS
+  'GNIRS spectroscopy central wavelengths, each with its own exposure time mode and coadds';
+
+-- Backfill.  Existing observations have exactly one science ETM, which becomes the
+-- 'current' row's ETM.  The 'initial' row needs its own ETM (the unique constraint
+-- above allows an ETM to back only one wavelength row), so clone it.
+INSERT INTO t_gnirs_spectroscopy_wavelength (
+  c_observation_id,
+  c_central_wavelength,
+  c_version,
+  c_coadds,
+  c_exposure_time_mode_id
+)
+SELECT
+  ls.c_observation_id,
+  COALESCE(ls.c_central_wavelength, ls.c_initial_central_wavelength),
+  'current'::e_observing_mode_row_version,
+  ls.c_coadds,
+  m.c_exposure_time_mode_id
+FROM t_gnirs_spectroscopy ls
+JOIN t_exposure_time_mode m
+  ON m.c_observation_id = ls.c_observation_id
+ AND m.c_role = 'science'::e_exposure_time_mode_role;
+
+WITH cloned AS (
+  INSERT INTO t_exposure_time_mode (
+    c_observation_id,
+    c_role,
+    c_exposure_time_mode,
+    c_signal_to_noise,
+    c_signal_to_noise_at,
+    c_exposure_time,
+    c_exposure_count
+  )
+  SELECT
+    m.c_observation_id,
+    m.c_role,
+    m.c_exposure_time_mode,
+    m.c_signal_to_noise,
+    m.c_signal_to_noise_at,
+    m.c_exposure_time,
+    m.c_exposure_count
+  FROM t_gnirs_spectroscopy ls
+  JOIN t_exposure_time_mode m
+    ON m.c_observation_id = ls.c_observation_id
+   AND m.c_role = 'science'::e_exposure_time_mode_role
+  RETURNING c_exposure_time_mode_id, c_observation_id
+)
+INSERT INTO t_gnirs_spectroscopy_wavelength (
+  c_observation_id,
+  c_central_wavelength,
+  c_version,
+  c_coadds,
+  c_exposure_time_mode_id
+)
+SELECT
+  ls.c_observation_id,
+  ls.c_initial_central_wavelength,
+  'initial'::e_observing_mode_row_version,
+  ls.c_coadds,
+  cloned.c_exposure_time_mode_id
+FROM t_gnirs_spectroscopy ls
+JOIN cloned ON cloned.c_observation_id = ls.c_observation_id;
+
+-- The wavelength and coadds now live in the child table.
+DROP VIEW v_gnirs_spectroscopy;
+
+ALTER TABLE t_gnirs_spectroscopy
+  DROP COLUMN c_central_wavelength,
+  DROP COLUMN c_initial_central_wavelength,
+  DROP COLUMN c_coadds;
+
+CREATE VIEW v_gnirs_spectroscopy AS
+  SELECT
+    ls.*,
+    COALESCE(ls.c_grating, ls.c_initial_grating) AS c_grating_effective,
+    COALESCE(ls.c_prism,   ls.c_initial_prism)   AS c_prism_effective,
+    -- ATTENTION: This logic is duplicated from lucuma-core GnirsDecker. Modify in sync.
+    d.c_decker_default,
+    COALESCE(ls.c_decker, d.c_decker_default) AS c_decker_effective,
+    -- ATTENTION: This logic is duplicated from lucuma-core GnirsWellDepth. Modify in sync.
+    d.c_well_depth_default,
+    COALESCE(ls.c_well_depth, d.c_well_depth_default) AS c_well_depth_effective,
+    d.c_slit_offset_mode_default,
+    d.c_telescope_configs_default,
+    COALESCE(ls.c_slit_offset_mode, d.c_slit_offset_mode_default) AS c_slit_offset_mode_effective,
+    COALESCE(ls.c_telescope_configs, d.c_telescope_configs_default) AS c_telescope_configs_effective
+  FROM t_gnirs_spectroscopy ls
+  CROSS JOIN LATERAL (
+    SELECT
+      -- IFU has no slit offset mode.
+      (CASE WHEN ls.c_observing_mode_type = 'gnirs_ifu' THEN NULL ELSE 'nod_along_slit' END)::varchar
+        AS c_slit_offset_mode_default,
+      (CASE
+        WHEN ls.c_fpu_ifu = 'LowResolution'  THEN 'LowResolutionIfu'
+        WHEN ls.c_fpu_ifu = 'HighResolution' THEN 'HighResolutionIfu'
+        WHEN COALESCE(ls.c_prism, ls.c_initial_prism) = 'Mirror' THEN
+          CASE WHEN ls.c_camera IN ('ShortRed', 'ShortBlue') THEN 'ShortCamLongSlit'
+               ELSE 'LongCamLongSlit'
+          END
+        ELSE -- Sxd or Lxd
+          CASE WHEN ls.c_camera IN ('ShortRed', 'ShortBlue') THEN 'ShortCamCrossDispersed'
+               ELSE 'LongCamCrossDispersed'
+          END
+      END)::e_gnirs_decker AS c_decker_default,
+      (CASE
+        WHEN ls.c_camera IN ('ShortBlue', 'LongBlue') THEN 'Shallow'
+        WHEN ls.c_camera IN ('ShortRed',  'LongRed')  THEN 'Deep'
+      END)::e_gnirs_well_depth AS c_well_depth_default,
+      -- IFU telescope configs have no derived default (seeded at creation); only long slit.
+      CASE
+        WHEN ls.c_observing_mode_type = 'gnirs_ifu' THEN NULL
+        WHEN COALESCE(ls.c_prism, ls.c_initial_prism) IN ('Sxd', 'Lxd') THEN
+          '[{"q":{"microarcseconds":-1000000},"guiding":"ENABLED"},{"q":{"microarcseconds":2000000},"guiding":"ENABLED"},{"q":{"microarcseconds":2000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-1000000},"guiding":"ENABLED"}]'
+        WHEN ls.c_camera IN ('ShortBlue', 'ShortRed') THEN
+          '[{"q":{"microarcseconds":2000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-4000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-4000000},"guiding":"ENABLED"},{"q":{"microarcseconds":2000000},"guiding":"ENABLED"}]'
+        WHEN ls.c_filter IN ('Order2', 'Order1', 'PAH') THEN
+          '[{"q":{"microarcseconds":-3000000},"guiding":"ENABLED"},{"q":{"microarcseconds":3000000},"guiding":"ENABLED"},{"q":{"microarcseconds":3000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-3000000},"guiding":"ENABLED"}]'
+        ELSE
+          '[{"q":{"microarcseconds":-1000000},"guiding":"ENABLED"},{"q":{"microarcseconds":5000000},"guiding":"ENABLED"},{"q":{"microarcseconds":5000000},"guiding":"ENABLED"},{"q":{"microarcseconds":-1000000},"guiding":"ENABLED"}]'
+      END AS c_telescope_configs_default
+  ) d;
+
+-- Update check_etm_consistent.  GNIRS spectroscopy now has per-wavelength science
+-- ETMs, in both the 'initial' and 'current' versions, so the science count is no
+-- longer fixed -- exactly as for the imaging modes.  The acquisition ETM is still
+-- required, and still exactly one.
+CREATE OR REPLACE FUNCTION check_etm_consistent()
+RETURNS TRIGGER AS $$
+DECLARE
+  obs_id   d_observation_id;
+  obs_mode e_observing_mode_type;
+  acq_count INTEGER;
+  sci_count INTEGER;
+BEGIN
+
+  obs_id := COALESCE(NEW.c_observation_id, OLD.c_observation_id);
+
+  SELECT c_observing_mode_type INTO obs_mode
+    FROM t_observation
+   WHERE c_observation_id = obs_id;
+
+  SELECT
+    COUNT(*) FILTER (WHERE c_role = 'acquisition'),
+    COUNT(*) FILTER (WHERE c_role = 'science')
+  INTO acq_count, sci_count
+  FROM t_exposure_time_mode
+  WHERE c_observation_id = obs_id;
+
+  IF obs_mode IS NULL THEN
+
+    IF acq_count <> 0 OR sci_count <> 0 THEN
+      RAISE EXCEPTION 'Observation % with mode % should not have acquisition nor science exposure time modes', obs_id, obs_mode;
+    END IF;
+
+  ELSE
+
+    CASE
+      WHEN obs_mode IN ('flamingos_2_long_slit', 'gmos_north_long_slit', 'gmos_south_long_slit') THEN
+        IF acq_count <> 1 THEN
+          RAISE EXCEPTION 'Observation % with mode % must have an acquisition exposure time mode', obs_id, obs_mode;
+        END IF;
+
+        IF sci_count <> 1 THEN
+          RAISE EXCEPTION 'Observation % with mode % must have exactly one science exposure time mode', obs_id, obs_mode;
+        END IF;
+
+      -- GNIRS spectroscopy keeps its single acquisition ETM, but science ETMs are
+      -- now per central wavelength, in both the 'initial' and 'current' row
+      -- versions, so their count is not fixed.
+      WHEN obs_mode IN ('gnirs_long_slit', 'gnirs_ifu') THEN
+        IF acq_count <> 1 THEN
+          RAISE EXCEPTION 'Observation % with mode % must have an acquisition exposure time mode', obs_id, obs_mode;
+        END IF;
+
+        IF sci_count < 1 THEN
+          RAISE EXCEPTION 'Observation % with mode % must have at least one science exposure time mode', obs_id, obs_mode;
+        END IF;
+
+      WHEN obs_mode IN ('gmos_north_mos', 'gmos_south_mos') THEN
+        IF acq_count <> 1 THEN
+          RAISE EXCEPTION 'Observation % with mode % must have an acquisition exposure time mode', obs_id, obs_mode;
+        END IF;
+
+        IF sci_count <> 1 THEN
+          RAISE EXCEPTION 'Observation % with mode % must have exactly one science exposure time mode', obs_id, obs_mode;
+        END IF;
+
+        -- The acquisition mode must be Time & Count: there is no acquisition ITC
+        -- pass to solve a signal-to-noise one.
+        IF NOT EXISTS (
+          SELECT 1
+            FROM t_exposure_time_mode e
+           WHERE e.c_observation_id = obs_id
+             AND e.c_role = 'acquisition'
+             AND e.c_exposure_time_mode = 'time_and_count'
+        ) THEN
+          RAISE EXCEPTION 'Observation % with mode % must have a Time & Count acquisition exposure time mode', obs_id, obs_mode;
+        END IF;
+
+      WHEN obs_mode = 'ghost_ifu' THEN
+        IF sci_count <> 2 THEN
+          RAISE EXCEPTION 'Observation % with mode % must have two science exposure time modes (red and blue camera)', obs_id, obs_mode;
+        END IF;
+
+      WHEN obs_mode = 'igrins_2_long_slit' THEN
+        IF sci_count <> 1 THEN
+          RAISE EXCEPTION 'Observation % with mode % must have exactly one science exposure time mode', obs_id, obs_mode;
+        END IF;
+
+      WHEN obs_mode = 'gnirs_imaging' THEN
+        IF acq_count <> 1 THEN
+          RAISE EXCEPTION 'Observation % with mode % must have an acquisition exposure time mode', obs_id, obs_mode;
+        END IF;
+
+      WHEN obs_mode IN ('gmos_north_imaging', 'gmos_south_imaging', 'flamingos_2_imaging') THEN
+        NULL;
+
+      -- no checks for visitor modes
+      WHEN obs_mode IN (
+        'alopeke_speckle',
+        'alopeke_wide_field',
+        'visitor_north',
+        'visitor_south',
+        'zorro_speckle',
+        'zorro_wide_field',
+        'maroon_x'
+      ) THEN
+        NULL;
+
+      WHEN obs_mode IN ('exchange_keck', 'exchange_subaru') THEN
+        IF acq_count <> 0 OR sci_count <> 0 THEN
+          RAISE EXCEPTION 'Observation % with mode % should not have acquisition nor science exposure time modes', obs_id, obs_mode;
+        END IF;
+
+      ELSE
+        RAISE EXCEPTION 'Unknown observing mode % for observation %', obs_mode, obs_id;
+    END CASE;
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- The stored ITC science results for GNIRS spectroscopy change shape (one result
+-- set per central wavelength), so cached, unfrozen results can no longer be decoded.
+DELETE FROM t_itc_result WHERE NOT c_is_frozen;

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -249,7 +249,7 @@ trait BaseMapping[F[_]]
   lazy val GnirsImagingFilterType                  = schema.ref("GnirsImagingFilter")
   lazy val GnirsImagingAcquisitionType             = schema.ref("GnirsImagingAcquisition")
   lazy val GnirsSpectroscopyType                   = schema.ref("GnirsSpectroscopy")
-  lazy val GnirsSpectroscopyWavelengthType         = schema.ref("GnirsSpectroscopyWavelength")
+  lazy val GnirsCentralWavelengthConfigType         = schema.ref("GnirsCentralWavelengthConfig")
   lazy val GnirsSlitType                           = schema.ref("GnirsSlit")
   lazy val GnirsIfuType                            = schema.ref("GnirsIfu")
   lazy val GnirsPrismType                          = schema.ref("GnirsPrism")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/BaseMapping.scala
@@ -249,6 +249,7 @@ trait BaseMapping[F[_]]
   lazy val GnirsImagingFilterType                  = schema.ref("GnirsImagingFilter")
   lazy val GnirsImagingAcquisitionType             = schema.ref("GnirsImagingAcquisition")
   lazy val GnirsSpectroscopyType                   = schema.ref("GnirsSpectroscopy")
+  lazy val GnirsSpectroscopyWavelengthType         = schema.ref("GnirsSpectroscopyWavelength")
   lazy val GnirsSlitType                           = schema.ref("GnirsSlit")
   lazy val GnirsIfuType                            = schema.ref("GnirsIfu")
   lazy val GnirsPrismType                          = schema.ref("GnirsPrism")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -480,7 +480,7 @@ object OdbMapping {
                 Igrins2StaticMapping,
                 GnirsSpectroscopyAcquisitionMapping,
                 GnirsSpectroscopyMapping,
-                GnirsSpectroscopyWavelengthMapping,
+                GnirsCentralWavelengthConfigMapping,
                 GnirsSlitMapping,
                 GnirsIfuMapping,
                 GnirsDynamicMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/OdbMapping.scala
@@ -480,6 +480,7 @@ object OdbMapping {
                 Igrins2StaticMapping,
                 GnirsSpectroscopyAcquisitionMapping,
                 GnirsSpectroscopyMapping,
+                GnirsSpectroscopyWavelengthMapping,
                 GnirsSlitMapping,
                 GnirsIfuMapping,
                 GnirsDynamicMapping,

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsCentralWavelengthConfigInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsCentralWavelengthConfigInput.scala
@@ -15,15 +15,15 @@ import lucuma.odb.graphql.binding.*
  * exposure time mode and coadds that apply there.  A missing exposure time mode
  * falls back to the observation's requirements; missing coadds default to 1.
  */
-case class GnirsSpectroscopyWavelengthInput(
+case class GnirsCentralWavelengthConfigInput(
   centralWavelength: Wavelength,
   exposureTimeMode:  Option[ExposureTimeMode],
   coadds:            Option[PosInt]
 )
 
-object GnirsSpectroscopyWavelengthInput:
+object GnirsCentralWavelengthConfigInput:
 
-  val Binding: Matcher[GnirsSpectroscopyWavelengthInput] =
+  val Binding: Matcher[GnirsCentralWavelengthConfigInput] =
     ObjectFieldsBinding.rmap:
       case List(
         WavelengthInput.Binding("centralWavelength", rCentralWavelength),
@@ -31,7 +31,7 @@ object GnirsSpectroscopyWavelengthInput:
         PosIntBinding.Option("coadds", rCoadds)
       ) =>
         (rCentralWavelength, rEtm, rCoadds).parMapN: (w, etm, coadds) =>
-          GnirsSpectroscopyWavelengthInput(w, etm, GnirsSpectroscopyWavelengthInput.coaddsForEtm(etm, coadds))
+          GnirsCentralWavelengthConfigInput(w, etm, GnirsCentralWavelengthConfigInput.coaddsForEtm(etm, coadds))
 
   /**
    * Signal-to-noise exposure time mode does not support coadds.  When the ETM is

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsSpectroscopyInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsSpectroscopyInput.scala
@@ -31,13 +31,13 @@ object GnirsSpectroscopyInput:
 
   /**
    * Validates a central wavelength list: at least one entry, no duplicated
-   * wavelength (each one backs a distinct row in t_gnirs_spectroscopy_wavelength),
+   * wavelength (each one backs a distinct row in t_gnirs_central_wavelength_config),
    * returned sorted by increasing wavelength, which is the order the sequence
    * executes them in.
    */
   private def resolveWavelengths(
-    ws: List[GnirsSpectroscopyWavelengthInput]
-  ): Result[NonEmptyList[GnirsSpectroscopyWavelengthInput]] =
+    ws: List[GnirsCentralWavelengthConfigInput]
+  ): Result[NonEmptyList[GnirsCentralWavelengthConfigInput]] =
     val duplicates = ws.groupBy(_.centralWavelength).filter(_._2.sizeIs > 1).keys.toList
     if duplicates.nonEmpty then
       Matcher.validationFailure:
@@ -116,7 +116,7 @@ object GnirsSpectroscopyInput:
   val AcquisitionInput = GnirsAcquisitionInput
 
   case class Create(
-    centralWavelengths: NonEmptyList[GnirsSpectroscopyWavelengthInput],
+    centralWavelengths: NonEmptyList[GnirsCentralWavelengthConfigInput],
     filter:           GnirsFilter,
     fpu:              GnirsFpu.Spectroscopy,
     camera:           GnirsCamera,
@@ -142,7 +142,7 @@ object GnirsSpectroscopyInput:
     val Binding: Matcher[Create] =
       ObjectFieldsBinding.rmap:
         case List(
-          GnirsSpectroscopyWavelengthInput.Binding.List.Option("centralWavelengths", rCentralWavelengths),
+          GnirsCentralWavelengthConfigInput.Binding.List.Option("centralWavelengths", rCentralWavelengths),
           GnirsFilterBinding("filter", rFilter),
           GnirsSlitInput.Binding.Option("slit", rSlit),
           GnirsIfuInput.Binding.Option("ifu", rIfu),
@@ -174,7 +174,7 @@ object GnirsSpectroscopyInput:
                        telluricType.getOrElse(TelluricType.Hot))
 
   case class Edit(
-    centralWavelengths:        Option[NonEmptyList[GnirsSpectroscopyWavelengthInput]],
+    centralWavelengths:        Option[NonEmptyList[GnirsCentralWavelengthConfigInput]],
     filter:                    Option[GnirsFilter],
     fpu:                       Option[GnirsFpu.Spectroscopy],
     camera:                    Option[GnirsCamera],
@@ -222,7 +222,7 @@ object GnirsSpectroscopyInput:
     val Binding: Matcher[Edit] =
       ObjectFieldsBinding.rmap:
         case List(
-          GnirsSpectroscopyWavelengthInput.Binding.List.Option("centralWavelengths", rCentralWavelengths),
+          GnirsCentralWavelengthConfigInput.Binding.List.Option("centralWavelengths", rCentralWavelengths),
           GnirsFilterBinding.Option("filter", rFilter),
           GnirsSlitInput.Binding.Option("slit", rSlit),
           GnirsIfuInput.Binding.Option("ifu", rIfu),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsSpectroscopyInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsSpectroscopyInput.scala
@@ -4,10 +4,10 @@
 package lucuma.odb.graphql
 package input
 
+import cats.Order.given
 import cats.data.NonEmptyList
 import cats.syntax.parallel.*
 import cats.syntax.traverse.*
-import eu.timepit.refined.types.numeric.PosInt
 import grackle.Result
 import lucuma.core.enums.GnirsCamera
 import lucuma.core.enums.GnirsDecker
@@ -19,9 +19,7 @@ import lucuma.core.enums.GnirsPrism
 import lucuma.core.enums.GnirsReadMode
 import lucuma.core.enums.GnirsWellDepth
 import lucuma.core.enums.ObservingModeType
-import lucuma.core.math.Wavelength
 import lucuma.core.model.Access
-import lucuma.core.model.ExposureTimeMode
 import lucuma.core.model.SlitTelescopeConfigs
 import lucuma.core.model.TelluricType
 import lucuma.core.model.sequence.TelescopeConfig
@@ -31,15 +29,24 @@ import lucuma.odb.graphql.binding.*
 
 object GnirsSpectroscopyInput:
 
-  // Signal-to-noise exposure time mode does not support coadds. When the ETM is set to
-  // signal-to-noise, force coadds to 1 so a previously-set value doesn't linger.
-  private def coaddsForEtm(
-    etm:    Option[ExposureTimeMode],
-    coadds: Option[PosInt]
-  ): Option[PosInt] =
-    etm match
-      case Some(ExposureTimeMode.SignalToNoiseMode(_, _)) => PosInt.from(1).toOption
-      case _                                           => coadds
+  /**
+   * Validates a central wavelength list: at least one entry, no duplicated
+   * wavelength (each one backs a distinct row in t_gnirs_spectroscopy_wavelength),
+   * returned sorted by increasing wavelength, which is the order the sequence
+   * executes them in.
+   */
+  private def resolveWavelengths(
+    ws: List[GnirsSpectroscopyWavelengthInput]
+  ): Result[NonEmptyList[GnirsSpectroscopyWavelengthInput]] =
+    val duplicates = ws.groupBy(_.centralWavelength).filter(_._2.sizeIs > 1).keys.toList
+    if duplicates.nonEmpty then
+      Matcher.validationFailure:
+        s"Duplicate central wavelengths are not allowed: ${duplicates.sorted.map(_.toNanometers.value.value).mkString(", ")} nm."
+    else
+      Result.fromOption(
+        NonEmptyList.fromList(ws.sortBy(_.centralWavelength)),
+        Matcher.validationProblem("At least one central wavelength must be specified for GNIRS spectroscopy observations.")
+      )
 
   // The observing mode type follows the FPU: the long slit and the IFU are persisted
   // in the same table but carry distinct ObservingModeType values.
@@ -109,14 +116,12 @@ object GnirsSpectroscopyInput:
   val AcquisitionInput = GnirsAcquisitionInput
 
   case class Create(
-    exposureTimeMode: Option[ExposureTimeMode],
-    coadds:           Option[PosInt],
+    centralWavelengths: NonEmptyList[GnirsSpectroscopyWavelengthInput],
     filter:           GnirsFilter,
     fpu:              GnirsFpu.Spectroscopy,
     camera:           GnirsCamera,
     grating:          GnirsGrating,
     prism:            GnirsPrism,
-    centralWavelength:            Wavelength,
     explicitDecker:               Option[GnirsDecker]              = None,
     explicitGrating:              Option[GnirsGrating]             = None,
     explicitPrism:                Option[GnirsPrism]               = None,
@@ -137,15 +142,13 @@ object GnirsSpectroscopyInput:
     val Binding: Matcher[Create] =
       ObjectFieldsBinding.rmap:
         case List(
-          ExposureTimeModeInput.Binding.Option("exposureTimeMode", rEtm),
-          PosIntBinding.Option("coadds", rCoadds),
+          GnirsSpectroscopyWavelengthInput.Binding.List.Option("centralWavelengths", rCentralWavelengths),
           GnirsFilterBinding("filter", rFilter),
           GnirsSlitInput.Binding.Option("slit", rSlit),
           GnirsIfuInput.Binding.Option("ifu", rIfu),
           GnirsCameraBinding("camera", rCamera),
           GnirsGratingBinding("grating", rGrating),
           GnirsPrismBinding("prism", rPrism),
-          WavelengthInput.Binding("centralWavelength", rCentralWavelength),
           GnirsDeckerBinding.Option("explicitDecker", rDecker),
           GnirsGratingBinding.Option("explicitGrating", rExplGrating),
           GnirsPrismBinding.Option("explicitPrism", rExplPrism),
@@ -155,27 +158,28 @@ object GnirsSpectroscopyInput:
           AcquisitionInput.Binding.Option("acquisition", rAcq),
           TelluricTypeBinding.Option("telluricType", rTelluricType)
         ) =>
-          (rEtm, rCoadds, rFilter, rSlit, rIfu, rCamera, rGrating, rPrism,
-           rCentralWavelength, rDecker, rExplGrating, rExplPrism,
+          (rCentralWavelengths, rFilter, rSlit, rIfu, rCamera, rGrating, rPrism,
+           rDecker, rExplGrating, rExplPrism,
            rFocus, rReadMode, rWellDepth, rAcq, rTelluricType).parTupled.flatMap:
-            (etm, coadds, filter, slit, ifu, camera, grating, prism,
-             centralWavelength, decker, explGrating, explPrism,
+            (centralWavelengths, filter, slit, ifu, camera, grating, prism,
+             decker, explGrating, explPrism,
              focus, readMode, wellDepth, acq, telluricType) =>
-              resolveCreate(slit, ifu).map: (fpu, explTelescopeSlit, telescopeIfu) =>
-                Create(etm, coaddsForEtm(etm, coadds), filter, fpu, camera, grating, prism,
-                       centralWavelength, decker, explGrating, explPrism,
+              (resolveWavelengths(centralWavelengths.getOrElse(Nil)),
+               resolveCreate(slit, ifu)
+              ).parMapN: (ws, resolved) =>
+                val (fpu, explTelescopeSlit, telescopeIfu) = resolved
+                Create(ws, filter, fpu, camera, grating, prism,
+                       decker, explGrating, explPrism,
                        focus, readMode, wellDepth, explTelescopeSlit, telescopeIfu, acq,
                        telluricType.getOrElse(TelluricType.Hot))
 
   case class Edit(
-    exposureTimeMode:          Option[ExposureTimeMode],
-    coadds:                    Option[PosInt],
+    centralWavelengths:        Option[NonEmptyList[GnirsSpectroscopyWavelengthInput]],
     filter:                    Option[GnirsFilter],
     fpu:                       Option[GnirsFpu.Spectroscopy],
     camera:                    Option[GnirsCamera],
     grating:                   Nullable[GnirsGrating],
     prism:                     Nullable[GnirsPrism],
-    centralWavelength:         Option[Wavelength],
     explicitDecker:            Nullable[GnirsDecker],
     explicitGrating:           Nullable[GnirsGrating],
     explicitPrism:             Nullable[GnirsPrism],
@@ -206,9 +210,9 @@ object GnirsSpectroscopyInput:
         c  <- required(camera, "camera")
         g  <- required(grating.toOption, "grating")
         p  <- required(prism.toOption, "prism")
-        w  <- required(centralWavelength, "centralWavelength")
-      yield Create(exposureTimeMode, coadds, f, u, c, g, p,
-                   w, explicitDecker.toOption,
+        ws <- required(centralWavelengths, "centralWavelengths")
+      yield Create(ws, f, u, c, g, p,
+                   explicitDecker.toOption,
                    explicitGrating.toOption, explicitPrism.toOption,
                    explicitFocusMotorSteps.toOption, explicitReadMode.toOption, explicitWellDepth.toOption,
                    explicitTelescopeConfigsSlit.toOption, telescopeConfigsIfu, acquisition,
@@ -218,15 +222,13 @@ object GnirsSpectroscopyInput:
     val Binding: Matcher[Edit] =
       ObjectFieldsBinding.rmap:
         case List(
-          ExposureTimeModeInput.Binding.Option("exposureTimeMode", rEtm),
-          PosIntBinding.Option("coadds", rCoadds),
+          GnirsSpectroscopyWavelengthInput.Binding.List.Option("centralWavelengths", rCentralWavelengths),
           GnirsFilterBinding.Option("filter", rFilter),
           GnirsSlitInput.Binding.Option("slit", rSlit),
           GnirsIfuInput.Binding.Option("ifu", rIfu),
           GnirsCameraBinding.Option("camera", rCamera),
           GnirsGratingBinding.Nullable("grating", rGrating),
           GnirsPrismBinding.Nullable("prism", rPrism),
-          WavelengthInput.Binding.Option("centralWavelength", rCentralWavelength),
           GnirsDeckerBinding.Nullable("explicitDecker", rDecker),
           GnirsGratingBinding.Nullable("explicitGrating", rExplGrating),
           GnirsPrismBinding.Nullable("explicitPrism", rExplPrism),
@@ -236,13 +238,16 @@ object GnirsSpectroscopyInput:
           AcquisitionInput.Binding.Option("acquisition", rAcq),
           TelluricTypeBinding.Option("telluricType", rTelluricType)
         ) =>
-          (rEtm, rCoadds, rFilter, rSlit, rIfu, rCamera, rGrating, rPrism,
-           rCentralWavelength, rDecker, rExplGrating, rExplPrism,
+          (rCentralWavelengths, rFilter, rSlit, rIfu, rCamera, rGrating, rPrism,
+           rDecker, rExplGrating, rExplPrism,
            rFocus, rReadMode, rWellDepth, rAcq, rTelluricType).parTupled.flatMap:
-            (etm, coadds, filter, slit, ifu, camera, grating, prism,
-             centralWavelength, decker, explGrating, explPrism,
+            (centralWavelengths, filter, slit, ifu, camera, grating, prism,
+             decker, explGrating, explPrism,
              focus, readMode, wellDepth, acq, telluricType) =>
-              resolveEdit(slit, ifu).map: (fpu, explTelescopeSlit, telescopeIfu) =>
-                Edit(etm, coaddsForEtm(etm, coadds), filter, fpu, camera, grating, prism,
-                     centralWavelength, decker, explGrating, explPrism,
+              (centralWavelengths.traverse(resolveWavelengths),
+               resolveEdit(slit, ifu)
+              ).parMapN: (ws, resolved) =>
+                val (fpu, explTelescopeSlit, telescopeIfu) = resolved
+                Edit(ws, filter, fpu, camera, grating, prism,
+                     decker, explGrating, explPrism,
                      focus, readMode, wellDepth, explTelescopeSlit, telescopeIfu, acq, telluricType)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsSpectroscopyWavelengthInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsSpectroscopyWavelengthInput.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql.input
+
+import cats.syntax.parallel.*
+import eu.timepit.refined.types.numeric.PosInt
+import grackle.Result
+import lucuma.core.math.Wavelength
+import lucuma.core.model.ExposureTimeMode
+import lucuma.odb.graphql.binding.*
+
+/**
+ * One GNIRS spectroscopy science configuration: a central wavelength with the
+ * exposure time mode and coadds that apply there.  A missing exposure time mode
+ * falls back to the observation's requirements; missing coadds default to 1.
+ */
+case class GnirsSpectroscopyWavelengthInput(
+  centralWavelength: Wavelength,
+  exposureTimeMode:  Option[ExposureTimeMode],
+  coadds:            Option[PosInt]
+)
+
+object GnirsSpectroscopyWavelengthInput:
+
+  val Binding: Matcher[GnirsSpectroscopyWavelengthInput] =
+    ObjectFieldsBinding.rmap:
+      case List(
+        WavelengthInput.Binding("centralWavelength", rCentralWavelength),
+        ExposureTimeModeInput.Binding.Option("exposureTimeMode", rEtm),
+        PosIntBinding.Option("coadds", rCoadds)
+      ) =>
+        (rCentralWavelength, rEtm, rCoadds).parMapN: (w, etm, coadds) =>
+          GnirsSpectroscopyWavelengthInput(w, etm, GnirsSpectroscopyWavelengthInput.coaddsForEtm(etm, coadds))
+
+  /**
+   * Signal-to-noise exposure time mode does not support coadds.  When the ETM is
+   * set to signal-to-noise, force coadds to 1 so a previously-set value doesn't
+   * linger.
+   */
+  private def coaddsForEtm(
+    etm:    Option[ExposureTimeMode],
+    coadds: Option[PosInt]
+  ): Option[PosInt] =
+    etm match
+      case Some(ExposureTimeMode.SignalToNoiseMode(_, _)) => PosInt.from(1).toOption
+      case _                                              => coadds

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExposureTimeModeMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExposureTimeModeMapping.scala
@@ -75,7 +75,7 @@ trait ExposureTimeModeMapping[F[_]] extends ExposureTimeModeView[F]:
       etmMappings(GmosSouthMosType,                 ExposureTimeModeView),
 
       // GNIRS
-      etmMappings(GnirsSpectroscopyType,            ExposureTimeModeView),
+      etmMappings(GnirsSpectroscopyWavelengthType,  ExposureTimeModeView),
       etmMappings(GnirsSpectroscopyAcquisitionType, ExposureTimeModeView),
 
       // IGRINS2

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExposureTimeModeMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/ExposureTimeModeMapping.scala
@@ -75,7 +75,7 @@ trait ExposureTimeModeMapping[F[_]] extends ExposureTimeModeView[F]:
       etmMappings(GmosSouthMosType,                 ExposureTimeModeView),
 
       // GNIRS
-      etmMappings(GnirsSpectroscopyWavelengthType,  ExposureTimeModeView),
+      etmMappings(GnirsCentralWavelengthConfigType,  ExposureTimeModeView),
       etmMappings(GnirsSpectroscopyAcquisitionType, ExposureTimeModeView),
 
       // IGRINS2

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GnirsSpectroscopyMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GnirsSpectroscopyMapping.scala
@@ -66,16 +66,16 @@ trait GnirsSpectroscopyMapping[F[_]]
    * there.  Keyed on (observation, wavelength, version) to match the table's
    * primary key.
    */
-  lazy val GnirsSpectroscopyWavelengthMapping: ObjectMapping =
-    ObjectMapping(GnirsSpectroscopyWavelengthType)(
-      SqlField("observationId",     GnirsSpectroscopyWavelengthTable.ObservationId, key = true, hidden = true),
+  lazy val GnirsCentralWavelengthConfigMapping: ObjectMapping =
+    ObjectMapping(GnirsCentralWavelengthConfigType)(
+      SqlField("observationId",     GnirsCentralWavelengthConfigTable.ObservationId, key = true, hidden = true),
       // `centralWavelength` is an object in the schema (see WavelengthMapping), so the
       // key is a hidden field on the same column.  It doubles as the sort key.
-      SqlField("centralWavelengthKey", GnirsSpectroscopyWavelengthTable.CentralWavelength, key = true, hidden = true),
-      SqlField("version",           GnirsSpectroscopyWavelengthTable.Version, key = true, hidden = true),
+      SqlField("centralWavelengthKey", GnirsCentralWavelengthConfigTable.CentralWavelength, key = true, hidden = true),
+      SqlField("version",           GnirsCentralWavelengthConfigTable.Version, key = true, hidden = true),
       SqlObject("centralWavelength"),
-      SqlField("coadds",            GnirsSpectroscopyWavelengthTable.Coadds),
-      SqlObject("exposureTimeMode", Join(GnirsSpectroscopyWavelengthTable.ExposureTimeModeId, ExposureTimeModeView.Id))
+      SqlField("coadds",            GnirsCentralWavelengthConfigTable.Coadds),
+      SqlObject("exposureTimeMode", Join(GnirsCentralWavelengthConfigTable.ExposureTimeModeId, ExposureTimeModeView.Id))
     )
 
   lazy val GnirsSpectroscopyMapping: ObjectMapping =
@@ -95,8 +95,8 @@ trait GnirsSpectroscopyMapping[F[_]]
 
       // Central wavelengths: one child row each, in the "current" and "initial"
       // row versions respectively (see the elaborator below).
-      SqlObject("centralWavelengths",        Join(GnirsSpectroscopyView.ObservationId, GnirsSpectroscopyWavelengthTable.ObservationId)),
-      SqlObject("initialCentralWavelengths", Join(GnirsSpectroscopyView.ObservationId, GnirsSpectroscopyWavelengthTable.ObservationId)),
+      SqlObject("centralWavelengths",        Join(GnirsSpectroscopyView.ObservationId, GnirsCentralWavelengthConfigTable.ObservationId)),
+      SqlObject("initialCentralWavelengths", Join(GnirsSpectroscopyView.ObservationId, GnirsCentralWavelengthConfigTable.ObservationId)),
 
       // Camera + Filter
       SqlField("camera",        GnirsSpectroscopyView.Camera),
@@ -184,7 +184,7 @@ trait GnirsSpectroscopyMapping[F[_]]
   private def wavelengthElaborator(v: ObservingModeRowVersion): Elab[Unit] =
     Elab.transformChild: child =>
       OrderBy(
-        OrderSelections(List(OrderSelection[Wavelength](GnirsSpectroscopyWavelengthType / "centralWavelengthKey"))),
+        OrderSelections(List(OrderSelection[Wavelength](GnirsCentralWavelengthConfigType / "centralWavelengthKey"))),
         Filter(Predicates.gnirsSpectroscopyWavelength.version.eql(v), child)
       )
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GnirsSpectroscopyMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GnirsSpectroscopyMapping.scala
@@ -6,6 +6,9 @@ package mapping
 
 import grackle.Query.Binding
 import grackle.Query.Filter
+import grackle.Query.OrderBy
+import grackle.Query.OrderSelection
+import grackle.Query.OrderSelections
 import grackle.Query.Unique
 import grackle.QueryCompiler.Elab
 import grackle.TypeRef
@@ -14,7 +17,9 @@ import io.circe.Json
 import io.circe.syntax.*
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
+import lucuma.core.math.Wavelength
 import lucuma.odb.data.ExposureTimeModeRole
+import lucuma.odb.data.ObservingModeRowVersion
 import lucuma.odb.graphql.predicate.Predicates
 import lucuma.odb.graphql.table.*
 import lucuma.odb.json.offset.query.given
@@ -56,12 +61,27 @@ trait GnirsSpectroscopyMapping[F[_]]
       SqlObject("exposureTimeMode", Join(GnirsSpectroscopyView.ObservationId, ExposureTimeModeView.ObservationId)),
     )
 
+  /**
+   * One central wavelength with the exposure time mode and coadds that apply
+   * there.  Keyed on (observation, wavelength, version) to match the table's
+   * primary key.
+   */
+  lazy val GnirsSpectroscopyWavelengthMapping: ObjectMapping =
+    ObjectMapping(GnirsSpectroscopyWavelengthType)(
+      SqlField("observationId",     GnirsSpectroscopyWavelengthTable.ObservationId, key = true, hidden = true),
+      // `centralWavelength` is an object in the schema (see WavelengthMapping), so the
+      // key is a hidden field on the same column.  It doubles as the sort key.
+      SqlField("centralWavelengthKey", GnirsSpectroscopyWavelengthTable.CentralWavelength, key = true, hidden = true),
+      SqlField("version",           GnirsSpectroscopyWavelengthTable.Version, key = true, hidden = true),
+      SqlObject("centralWavelength"),
+      SqlField("coadds",            GnirsSpectroscopyWavelengthTable.Coadds),
+      SqlObject("exposureTimeMode", Join(GnirsSpectroscopyWavelengthTable.ExposureTimeModeId, ExposureTimeModeView.Id))
+    )
+
   lazy val GnirsSpectroscopyMapping: ObjectMapping =
     ObjectMapping(GnirsSpectroscopyType)(
 
       SqlField("observationId", GnirsSpectroscopyView.ObservationId, key = true, hidden = true),
-
-      SqlObject("exposureTimeMode", Join(GnirsSpectroscopyView.ObservationId, ExposureTimeModeView.ObservationId)),
 
       // Grating: effective = COALESCE(explicit, initial)
       SqlField("grating",        GnirsSpectroscopyView.GratingEffective),
@@ -73,11 +93,12 @@ trait GnirsSpectroscopyMapping[F[_]]
       SqlField("explicitPrism",  GnirsSpectroscopyView.Prism),
       SqlField("initialPrism",   GnirsSpectroscopyView.InitialPrism),
 
-      // Central wavelength: required stored value + initial snapshot
-      SqlObject("centralWavelength"),
-      SqlObject("initialCentralWavelength"),
+      // Central wavelengths: one child row each, in the "current" and "initial"
+      // row versions respectively (see the elaborator below).
+      SqlObject("centralWavelengths",        Join(GnirsSpectroscopyView.ObservationId, GnirsSpectroscopyWavelengthTable.ObservationId)),
+      SqlObject("initialCentralWavelengths", Join(GnirsSpectroscopyView.ObservationId, GnirsSpectroscopyWavelengthTable.ObservationId)),
 
-      // Camera + Filter + Wavelength
+      // Camera + Filter
       SqlField("camera",        GnirsSpectroscopyView.Camera),
       SqlField("initialCamera", GnirsSpectroscopyView.InitialCamera),
       // FPU + telescope configs are grouped, by variant, into the slit / ifu
@@ -87,7 +108,6 @@ trait GnirsSpectroscopyMapping[F[_]]
       SqlObject("ifu"),
       SqlField("filter",        GnirsSpectroscopyView.Filter),
       SqlField("initialFilter", GnirsSpectroscopyView.InitialFilter),
-      SqlField("coadds",        GnirsSpectroscopyView.Coadds),
 
       // Decker: effective (DB-computed COALESCE), default, explicit
       SqlField("decker",         GnirsSpectroscopyView.DeckerEffective),
@@ -159,15 +179,21 @@ trait GnirsSpectroscopyMapping[F[_]]
       ),
     )
 
+  // Order the central wavelengths by increasing wavelength -- the order the
+  // sequence executes them in -- and limit to one row version.
+  private def wavelengthElaborator(v: ObservingModeRowVersion): Elab[Unit] =
+    Elab.transformChild: child =>
+      OrderBy(
+        OrderSelections(List(OrderSelection[Wavelength](GnirsSpectroscopyWavelengthType / "centralWavelengthKey"))),
+        Filter(Predicates.gnirsSpectroscopyWavelength.version.eql(v), child)
+      )
+
   lazy val GnirsSpectroscopyElaborator: PartialFunction[(TypeRef, String, List[Binding]), Elab[Unit]] =
-    case (GnirsSpectroscopyType, "exposureTimeMode", Nil) =>
-      Elab.transformChild: child =>
-        Unique(
-          Filter(
-            Predicates.exposureTimeMode.role.eql(ExposureTimeModeRole.Science),
-            child
-          )
-        )
+    case (GnirsSpectroscopyType, "centralWavelengths", Nil) =>
+      wavelengthElaborator(ObservingModeRowVersion.Current)
+
+    case (GnirsSpectroscopyType, "initialCentralWavelengths", Nil) =>
+      wavelengthElaborator(ObservingModeRowVersion.Initial)
 
     case (GnirsSpectroscopyAcquisitionType, "exposureTimeMode", Nil) =>
       Elab.transformChild: child =>

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/WavelengthMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/WavelengthMapping.scala
@@ -89,11 +89,11 @@ trait WavelengthMapping[F[_]]
       wavelengthMappingAtPath(TimeAndCountExposureTimeModeType / "at", ExposureTimeModeView.TimeAndCount.At, ExposureTimeModeView.TimeAndCount.SyntheticId),
       wavelengthMappingAtPath(VisitorType / "centralWavelength", VisitorTable.CentralWavelength, VisitorTable.ObservationId),
       wavelengthMappingAtPath(
-        GnirsSpectroscopyWavelengthType / "centralWavelength",
-        GnirsSpectroscopyWavelengthTable.CentralWavelength,
+        GnirsCentralWavelengthConfigType / "centralWavelength",
+        GnirsCentralWavelengthConfigTable.CentralWavelength,
         // The child table's primary key: one wavelength object per row.
-        GnirsSpectroscopyWavelengthTable.ObservationId,
-        GnirsSpectroscopyWavelengthTable.CentralWavelength,
-        GnirsSpectroscopyWavelengthTable.Version
+        GnirsCentralWavelengthConfigTable.ObservationId,
+        GnirsCentralWavelengthConfigTable.CentralWavelength,
+        GnirsCentralWavelengthConfigTable.Version
       ),
     )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/WavelengthMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/WavelengthMapping.scala
@@ -88,6 +88,12 @@ trait WavelengthMapping[F[_]]
       wavelengthMappingAtPath(StepRecordType / "gmosSouth" / "gratingConfig" / "wavelength", GmosSouthDynamicTable.Grating.Wavelength, GmosSouthDynamicTable.Id),
       wavelengthMappingAtPath(TimeAndCountExposureTimeModeType / "at", ExposureTimeModeView.TimeAndCount.At, ExposureTimeModeView.TimeAndCount.SyntheticId),
       wavelengthMappingAtPath(VisitorType / "centralWavelength", VisitorTable.CentralWavelength, VisitorTable.ObservationId),
-      wavelengthMappingAtPath(GnirsSpectroscopyType / "centralWavelength",        GnirsSpectroscopyView.CentralWavelengthEffective, GnirsSpectroscopyView.ObservationId),
-      wavelengthMappingAtPath(GnirsSpectroscopyType / "initialCentralWavelength", GnirsSpectroscopyView.InitialCentralWavelength,   GnirsSpectroscopyView.ObservationId),
+      wavelengthMappingAtPath(
+        GnirsSpectroscopyWavelengthType / "centralWavelength",
+        GnirsSpectroscopyWavelengthTable.CentralWavelength,
+        // The child table's primary key: one wavelength object per row.
+        GnirsSpectroscopyWavelengthTable.ObservationId,
+        GnirsSpectroscopyWavelengthTable.CentralWavelength,
+        GnirsSpectroscopyWavelengthTable.Version
+      ),
     )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
@@ -41,6 +41,7 @@ trait Predicates[F[_]] extends BaseMapping[F]:
     val gmosNorthStep                   = StepPredicates(Path.from(GmosNorthStepType))
     val gmosSouthImagingFilter          = GmosImagingFilterPredicates(Path.from(GmosSouthImagingFilterType))
     val gnirsImagingFilter              = GmosImagingFilterPredicates(Path.from(GnirsImagingFilterType))
+    val gnirsSpectroscopyWavelength     = GmosImagingFilterPredicates(Path.from(GnirsSpectroscopyWavelengthType))
     val gmosSouthStep                   = StepPredicates(Path.from(GmosSouthStepType))
     val group                           = GroupPredicates(Path.from(GroupType))
     val groupEdit                       = GroupEditPredicates(Path.from(GroupEditType))

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/Predicates.scala
@@ -41,7 +41,7 @@ trait Predicates[F[_]] extends BaseMapping[F]:
     val gmosNorthStep                   = StepPredicates(Path.from(GmosNorthStepType))
     val gmosSouthImagingFilter          = GmosImagingFilterPredicates(Path.from(GmosSouthImagingFilterType))
     val gnirsImagingFilter              = GmosImagingFilterPredicates(Path.from(GnirsImagingFilterType))
-    val gnirsSpectroscopyWavelength     = GmosImagingFilterPredicates(Path.from(GnirsSpectroscopyWavelengthType))
+    val gnirsSpectroscopyWavelength     = GmosImagingFilterPredicates(Path.from(GnirsCentralWavelengthConfigType))
     val gmosSouthStep                   = StepPredicates(Path.from(GmosSouthStepType))
     val group                           = GroupPredicates(Path.from(GroupType))
     val groupEdit                       = GroupEditPredicates(Path.from(GroupEditType))

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/GnirsSpectroscopyView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/GnirsSpectroscopyView.scala
@@ -87,7 +87,7 @@ trait GnirsSpectroscopyView[F[_]] extends BaseMapping[F]:
    * The central wavelengths, one row per wavelength per row version.  Each row
    * owns its own exposure time mode row in t_exposure_time_mode.
    */
-  object GnirsSpectroscopyWavelengthTable extends TableDef("t_gnirs_spectroscopy_wavelength"):
+  object GnirsCentralWavelengthConfigTable extends TableDef("t_gnirs_central_wavelength_config"):
     val ObservationId: ColumnRef     = col("c_observation_id", observation_id)
     val CentralWavelength: ColumnRef = col("c_central_wavelength", wavelength_pm)
     val Version: ColumnRef           = col("c_version", observing_mode_row_version)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/GnirsSpectroscopyView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/GnirsSpectroscopyView.scala
@@ -17,13 +17,10 @@ trait GnirsSpectroscopyView[F[_]] extends BaseMapping[F]:
 
     val Grating: ColumnRef           = col("c_grating", gnirs_grating.opt)
     val Prism: ColumnRef             = col("c_prism", gnirs_prism.opt)
-    // Central wavelength override (nullable); effective falls back to the initial value.
-    val CentralWavelength: ColumnRef = col("c_central_wavelength", wavelength_pm.opt)
 
     // Initial acquisition mirror (always set, always Out)
     val InitialGrating: ColumnRef           = col("c_initial_grating", gnirs_grating)
     val InitialPrism: ColumnRef             = col("c_initial_prism", gnirs_prism)
-    val InitialCentralWavelength: ColumnRef = col("c_initial_central_wavelength", wavelength_pm)
 
     // Camera
     val Camera: ColumnRef           = col("c_camera", gnirs_camera)
@@ -48,9 +45,6 @@ trait GnirsSpectroscopyView[F[_]] extends BaseMapping[F]:
     // Filter
     val Filter: ColumnRef           = col("c_filter", gnirs_filter)
     val InitialFilter: ColumnRef    = col("c_initial_filter", gnirs_filter)
-
-    // Coadds
-    val Coadds: ColumnRef           = col("c_coadds", int4_pos)
 
     // Explicit overrides (nullable)
     val ExplicitDecker: ColumnRef   = col("c_decker", gnirs_decker.opt)
@@ -82,10 +76,20 @@ trait GnirsSpectroscopyView[F[_]] extends BaseMapping[F]:
     val DefaultWellDepth: ColumnRef        = col("c_well_depth_default", gnirs_well_depth)
     val WellDepthEffective: ColumnRef      = col("c_well_depth_effective", gnirs_well_depth)
 
-    // Effective grating/prism/central wavelength: COALESCE(explicit, initial)
+    // Effective grating/prism: COALESCE(explicit, initial)
     val GratingEffective: ColumnRef           = col("c_grating_effective", gnirs_grating)
     val PrismEffective: ColumnRef             = col("c_prism_effective", gnirs_prism)
-    val CentralWavelengthEffective: ColumnRef = col("c_central_wavelength_effective", wavelength_pm)
 
     // Telluric type (stored as jsonb)
     val TelluricType: ColumnRef     = col("c_telluric_type", jsonb)
+
+  /**
+   * The central wavelengths, one row per wavelength per row version.  Each row
+   * owns its own exposure time mode row in t_exposure_time_mode.
+   */
+  object GnirsSpectroscopyWavelengthTable extends TableDef("t_gnirs_spectroscopy_wavelength"):
+    val ObservationId: ColumnRef     = col("c_observation_id", observation_id)
+    val CentralWavelength: ColumnRef = col("c_central_wavelength", wavelength_pm)
+    val Version: ColumnRef           = col("c_version", observing_mode_row_version)
+    val Coadds: ColumnRef            = col("c_coadds", int4_pos)
+    val ExposureTimeModeId: ColumnRef = col("c_exposure_time_mode_id", exposure_time_mode_id)

--- a/modules/service/src/main/scala/lucuma/odb/logic/GeneratorContext.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/GeneratorContext.scala
@@ -46,7 +46,7 @@ case class GeneratorContext(
       md5.update(z.focus.value.exposureTime.hashBytes)
       md5.update(z.focus.value.exposureCount.hashBytes)
 
-    def addImagingResultSet[A: HashBytes](kv: (A, Zipper[ItcResult])): Unit =
+    def addKeyedResultSet[A: HashBytes](kv: (A, Zipper[ItcResult])): Unit =
       md5.update(kv._1.hashBytes)
       addResultSet(kv._2)
 
@@ -54,16 +54,18 @@ case class GeneratorContext(
     itcRes.foreach: itc =>
       itc.science match
         case ItcScience.Flamingos2Imaging(m) =>
-          m.toNel.toList.foreach(addImagingResultSet)
+          m.toNel.toList.foreach(addKeyedResultSet)
         case ItcScience.GhostIfu(r, b)       =>
           addResultSet(r)
           addResultSet(b)
         case ItcScience.GmosNorthImaging(m)  =>
-          m.toNel.toList.foreach(addImagingResultSet)
+          m.toNel.toList.foreach(addKeyedResultSet)
         case ItcScience.GmosSouthImaging(m)  =>
-          m.toNel.toList.foreach(addImagingResultSet)
+          m.toNel.toList.foreach(addKeyedResultSet)
         case ItcScience.GnirsImaging(m)      =>
-          m.toNel.toList.foreach(addImagingResultSet)
+          m.toNel.toList.foreach(addKeyedResultSet)
+        case ItcScience.GnirsSpectroscopy(m) =>
+          m.toNel.toList.foreach(addKeyedResultSet)
         case ItcScience.Spectroscopy(sci)    =>
           addResultSet(sci)
 

--- a/modules/service/src/main/scala/lucuma/odb/logic/GeneratorStreaming.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/GeneratorStreaming.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.logic
 
 import cats.data.EitherT
+import cats.data.NonEmptyMap
 import cats.effect.Async
 import cats.syntax.applicative.*
 import cats.syntax.either.*
@@ -14,6 +15,7 @@ import fs2.Pure
 import fs2.Stream
 import lucuma.core.enums.GnirsAcquisitionType
 import lucuma.core.enums.SequenceType
+import lucuma.core.math.Wavelength
 import lucuma.core.model.Observation
 import lucuma.core.model.sequence.Atom
 import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig as Flamingos2Dynamic
@@ -184,6 +186,17 @@ object GeneratorStreaming:
       ItcScience.spectroscopy.getOption(i.science)
         .toRight(OdbError.InvalidObservation(oid, s"Expecting a spectroscopy ITC result for this observation".some))
         .map(_.science.focus.value)
+
+  // Science integration times for a GNIRS spectroscopy observation, one per
+  // central wavelength.
+  def gnirsSpectroscopyScienceTimes(
+    oid: Observation.Id,
+    itc: Either[OdbError, Itc]
+  ): Either[OdbError, NonEmptyMap[Wavelength, IntegrationTime]] =
+    itc.flatMap: i =>
+      ItcScience.gnirsSpectroscopy.getOption(i.science)
+        .toRight(OdbError.InvalidObservation(oid, s"Expecting a GNIRS spectroscopy ITC result for this observation".some))
+        .map(_.science.map(_.focus.value))
 
   // Acquisition integration time for a mode that has an acquisition sequence.  A
   // Failed acquisition (a cached deterministic ITC failure) or a NotApplicable
@@ -377,7 +390,7 @@ object GeneratorStreaming:
           cfg <- extractMode(ObservingMode.GnirsSpectroscopyName, context)(_.asGnirsSpectroscopy)
           acq  = acquisitionTime(context.oid, context.itcRes)
           typ  = gnirsAcqType(context.itcRes)
-          sci  = spectroscopyScienceTime(context.oid, context.itcRes)
+          sci  = gnirsSpectroscopyScienceTimes(context.oid, context.itcRes)
           rol  = context.params.calibrationRole
           gen <- EitherT(Spectroscopy.instantiate(context.oid, calculator.gnirsStep, context.namespace, exp.gnirs, cfg, acq, typ, sci, rol))
           res <- collapseIfNecessary(context, gen)

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -295,6 +295,41 @@ object GeneratorParamsService {
 
           GeneratorParams(ItcInputDerivation.fromEither(itcInput), obsParams.scienceBand, obsMode, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount, obsParams.executionRequirement.isSplittable)
 
+        /**
+         * GNIRS spectroscopy takes spectra at one or more central wavelengths,
+         * each its own ITC calculation, so it gets a list of science modes where
+         * the other spectroscopy modes have exactly one.
+         */
+        def gnirsSpectroscopyGeneratorParams(
+          obsMode:              ObservingMode,
+          acqMode:              InstrumentMode,
+          sciModes:             NonEmptyList[InstrumentMode],
+          gnirsAcqAutoClassify: Boolean
+        ): GeneratorParams =
+
+          val consInput   = obsParams.constraints.toInput
+          val acquisition = ImagingParameters(consInput, acqMode)
+          val science     = sciModes.map(SpectroscopyParameters(consInput, _))
+
+          val itcInput    = (
+             obsParams.targets.traverse(itcTargetParams),
+             // the db guarantees at most one BO
+             obsParams.blindOffset.traverse(itcTargetParams)
+            ).mapN { case (regularTargetInputs, blindOffsetTargetInput) =>
+              ItcInput.GnirsSpectroscopy(
+                acquisition,
+                science,
+                regularTargetInputs,
+                blindOffsetTargetInput,
+                obsParams.signalToNoiseTargetId,
+                gnirsAcqAutoClassify
+              )
+            }
+            .leftMap(MissingParamSet.fromParams)
+            .toEither
+
+          GeneratorParams(ItcInputDerivation.fromEither(itcInput), obsParams.scienceBand, obsMode, obsParams.calibrationRole, obsParams.declaredState, obsParams.executionState, obsParams.stepCount, obsParams.executionRequirement.isSplittable)
+
         observingMode(obsParams.targets, config, obsParams.calibrationRole).flatMap:
 
           // Exchange Modes (no ITC, like visitors)
@@ -553,28 +588,34 @@ object GeneratorParamsService {
             for
               // Acquisition (imaging) filter for the ITC: the explicit acquisition
               // filter if set, otherwise the default for the spectroscopy wavelength.
+              // This must use the same wavelength as Acquisition.scala's filter
+              // selection, or the acquisition would be sized for a different filter
+              // than the sequence actually uses.
               acqFilter <- gn.acquisition.explicitFilter
-                             .fold(GnirsFilter.fromAcquisitionWavelength(gn.centralWavelength))(_.asRight[String])
+                             .fold(GnirsFilter.fromAcquisitionWavelength(gn.primaryCentralWavelength))(_.asRight[String])
                              .leftMap(msg => Error.MisconfiguredObservation(obsParams.observationId, msg))
             yield
-              val sciReadMode = gn.exposureTimeMode match
-                                  case ExposureTimeMode.SignalToNoiseMode(_, _) =>
-                                    GnirsReadMode.Bright // In practice this will be ignored by the ITC, which derives the read mode itself in S/N mode
-                                  case ExposureTimeMode.TimeAndCountMode(time = time) =>
-                                    gn.explicitReadMode.getOrElse(GnirsReadMode.forExposureTime(time))
+              // One science mode per central wavelength: each is a separate
+              // configuration and so a separate ITC calculation.
+              val sciModes = gn.wavelengths.map: w =>
+                val sciReadMode = w.exposureTimeMode match
+                                    case ExposureTimeMode.SignalToNoiseMode(_, _) =>
+                                      GnirsReadMode.Bright // In practice this will be ignored by the ITC, which derives the read mode itself in S/N mode
+                                    case ExposureTimeMode.TimeAndCountMode(time = time) =>
+                                      gn.explicitReadMode.getOrElse(GnirsReadMode.forExposureTime(time))
 
-              val sciMode = InstrumentMode.GnirsSpectroscopy(
-                exposureTimeMode  = gn.exposureTimeMode,
-                centralWavelength = gn.centralWavelength,
-                filter            = gn.filter,
-                fpu               = gn.fpu,
-                prism             = gn.prism,
-                grating           = gn.grating,
-                camera            = gn.camera,
-                readMode          = sciReadMode,
-                wellDepth         = gn.wellDepth,
-                coadds            = gn.coadds
-              )
+                InstrumentMode.GnirsSpectroscopy(
+                  exposureTimeMode  = w.exposureTimeMode,
+                  centralWavelength = w.centralWavelength,
+                  filter            = gn.filter,
+                  fpu               = gn.fpu,
+                  prism             = gn.prism,
+                  grating           = gn.grating,
+                  camera            = gn.camera,
+                  readMode          = sciReadMode,
+                  wellDepth         = gn.wellDepth,
+                  coadds            = w.coadds
+                )
 
               // Two-pass acquisition ITC whenever the acquisition mode and filter are
               // both auto: only then does the resolved filter depend on the ITC-derived
@@ -585,7 +626,7 @@ object GeneratorParamsService {
                 gn.acquisition.explicitAcqMode.isEmpty &&
                 gn.acquisition.explicitFilter.isEmpty
 
-              spectroscopyGeneratorParams(
+              gnirsSpectroscopyGeneratorParams(
                 obsMode = gn,
                 acqMode = InstrumentMode.GnirsImaging(
                   exposureTimeMode = gn.acquisition.exposureTimeMode,
@@ -595,7 +636,7 @@ object GeneratorParamsService {
                   wellDepth        = gn.wellDepth,
                   coadds           = gn.acquisition.coadds
                 ),
-                sciMode = sciMode,
+                sciModes = sciModes,
                 gnirsAcqAutoClassify = acqAutoClassify
               )
 

--- a/modules/service/src/main/scala/lucuma/odb/service/GnirsSpectroscopyService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GnirsSpectroscopyService.scala
@@ -39,12 +39,12 @@ import lucuma.odb.data.ObservingModeRowVersion
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.format.telescopeConfigs.*
+import lucuma.odb.graphql.input.GnirsCentralWavelengthConfigInput
 import lucuma.odb.graphql.input.GnirsSpectroscopyInput
-import lucuma.odb.graphql.input.GnirsSpectroscopyWavelengthInput
 import lucuma.odb.sequence.gnirs.AcquisitionConfig
 import lucuma.odb.sequence.gnirs.spectroscopy.Acquisition
+import lucuma.odb.sequence.gnirs.spectroscopy.CentralWavelengthConfig
 import lucuma.odb.sequence.gnirs.spectroscopy.Config
-import lucuma.odb.sequence.gnirs.spectroscopy.ScienceWavelength
 import lucuma.odb.util.Codecs.*
 import lucuma.odb.util.GnirsCodecs.*
 import skunk.*
@@ -84,7 +84,7 @@ object GnirsSpectroscopyService:
 
   private val DefaultCoadds: PosInt = PosInt.unsafeFrom(1)
 
-  val WavelengthTableName: String = "t_gnirs_spectroscopy_wavelength"
+  val CentralWavelengthConfigTableName: String = "t_gnirs_central_wavelength_config"
 
   def instantiate[F[_]: {Concurrent as F, Services}]: GnirsSpectroscopyService[F] =
 
@@ -95,7 +95,7 @@ object GnirsSpectroscopyService:
        * yields carries only that row's wavelength; `select` groups the rows per
        * observation and replaces `wavelengths` with the full list.
        */
-      val gnirsLS: Decoder[(ScienceWavelength, Config)] = (
+      val gnirsLS: Decoder[(CentralWavelengthConfig, Config)] = (
         // The row's central wavelength, its science ETM (joined via the row's FK)
         // and its coadds.
         wavelength_pm                    *: // c_central_wavelength
@@ -169,7 +169,7 @@ object GnirsSpectroscopyService:
                         val acq = AcquisitionConfig(explicitAcqMode, acqFilterExp, acqEtm, acqCoaddsP)
                         val focus = focusMotorSteps.fold(GnirsFocus.Best): n =>
                           GnirsFocus.Custom(GnirsFocusMotorStepsValue.unsafeFrom(n).withUnit[GnirsFocusMotorStep])
-                        val sw = ScienceWavelength(centralWav, sciEtm, coaddsP)
+                        val sw = CentralWavelengthConfig(centralWav, sciEtm, coaddsP)
                         (sw,
                          Config(
                           filter,
@@ -212,7 +212,7 @@ object GnirsSpectroscopyService:
        * child rows can be written from the resolved result.
        */
       private def resolveKey(
-        w: GnirsSpectroscopyWavelengthInput
+        w: GnirsCentralWavelengthConfigInput
       ): (Wavelength, Option[ExposureTimeMode]) =
         (w.centralWavelength, w.exposureTimeMode)
 
@@ -222,7 +222,7 @@ object GnirsSpectroscopyService:
         m.view.mapValues(_._2).toMap
 
       private def insertWavelengths(
-        input:   NonEmptyList[GnirsSpectroscopyWavelengthInput],
+        input:   NonEmptyList[GnirsCentralWavelengthConfigInput],
         etms:    Map[Observation.Id, NonEmptyList[(Wavelength, ExposureTimeModeId)]],
         version: ObservingModeRowVersion
       ): F[Unit] =
@@ -276,7 +276,7 @@ object GnirsSpectroscopyService:
       )(using Transaction[F]): ResultT[F, Unit] =
         SET.centralWavelengths.fold(ResultT.unit): ws =>
           for
-            _   <- ResultT.liftF(session.exec(ImagingStatements.deleteCurrentScienceFiltersAndEtms(WavelengthTableName, oids)))
+            _   <- ResultT.liftF(session.exec(ImagingStatements.deleteCurrentScienceFiltersAndEtms(CentralWavelengthConfigTableName, oids)))
             r   <- ResultT(exposureTimeModeService.resolve("GNIRS Spectroscopy", none, ws.map(resolveKey), none, which))
             cur <- ResultT.liftF(exposureTimeModeService.insertResolvedScienceOnly(stripAcquisition(r)))
             _   <- ResultT.liftF(insertWavelengths(ws, cur, ObservingModeRowVersion.Current))
@@ -371,7 +371,7 @@ object GnirsSpectroscopyService:
           acq.c_exposure_count,
           ls.c_telluric_type
         FROM v_gnirs_spectroscopy ls
-        JOIN t_gnirs_spectroscopy_wavelength w
+        JOIN t_gnirs_central_wavelength_config w
            ON w.c_observation_id = ls.c_observation_id
           AND w.c_version = 'current'
         JOIN t_exposure_time_mode sci
@@ -695,7 +695,7 @@ object GnirsSpectroscopyService:
     ): AppliedFragment =
       val insertInto: AppliedFragment =
         void"""
-          INSERT INTO t_gnirs_spectroscopy_wavelength (
+          INSERT INTO t_gnirs_central_wavelength_config (
             c_observation_id,
             c_central_wavelength,
             c_version,
@@ -732,7 +732,7 @@ object GnirsSpectroscopyService:
               ARRAY[${exposure_time_mode_id.list(etms.length)}]
             ) AS map(old_exposure_time_mode_id, new_exposure_time_mode_id)
         )
-        INSERT INTO t_gnirs_spectroscopy_wavelength (
+        INSERT INTO t_gnirs_central_wavelength_config (
           c_observation_id,
           c_central_wavelength,
           c_version,
@@ -747,7 +747,7 @@ object GnirsSpectroscopyService:
           w.c_coadds,
           e.new_exposure_time_mode_id,
           w.c_role
-        FROM t_gnirs_spectroscopy_wavelength w
+        FROM t_gnirs_central_wavelength_config w
         JOIN etm_map e ON e.old_exposure_time_mode_id = w.c_exposure_time_mode_id
         WHERE w.c_observation_id = $observation_id
       """.apply(etms.map(_._1), etms.map(_._2), newId, originalId)

--- a/modules/service/src/main/scala/lucuma/odb/service/GnirsSpectroscopyService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GnirsSpectroscopyService.scala
@@ -33,14 +33,18 @@ import lucuma.core.model.sequence.gnirs.GnirsFocusMotorStep
 import lucuma.core.model.sequence.gnirs.GnirsFocusMotorStepsValue
 import lucuma.core.model.sequence.gnirs.GnirsFpu
 import lucuma.core.model.sequence.gnirs.defaultIfuTelescopeConfigs
+import lucuma.odb.data.ExposureTimeModeId
 import lucuma.odb.data.ExposureTimeModeRole
+import lucuma.odb.data.ObservingModeRowVersion
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.format.telescopeConfigs.*
 import lucuma.odb.graphql.input.GnirsSpectroscopyInput
+import lucuma.odb.graphql.input.GnirsSpectroscopyWavelengthInput
 import lucuma.odb.sequence.gnirs.AcquisitionConfig
 import lucuma.odb.sequence.gnirs.spectroscopy.Acquisition
 import lucuma.odb.sequence.gnirs.spectroscopy.Config
+import lucuma.odb.sequence.gnirs.spectroscopy.ScienceWavelength
 import lucuma.odb.util.Codecs.*
 import lucuma.odb.util.GnirsCodecs.*
 import skunk.*
@@ -67,32 +71,45 @@ trait GnirsSpectroscopyService[F[_]]:
     which: List[Observation.Id]
   )(using Transaction[F]): F[Result[Unit]]
 
-  def clone(originalId: Observation.Id, newId: Observation.Id)(using Transaction[F]): F[Unit]
+  def clone(
+    originalId: Observation.Id,
+    newId:      Observation.Id,
+    etms:       List[(ExposureTimeModeId, ExposureTimeModeId)]
+  )(using Transaction[F]): F[Unit]
 
   /** Reset `oid`'s configuration to telluric defaults (config-dependent slit offsets). */
   def resetTelluricConfig(oid: Observation.Id)(using Transaction[F]): F[Unit]
 
 object GnirsSpectroscopyService:
 
+  private val DefaultCoadds: PosInt = PosInt.unsafeFrom(1)
+
+  val WavelengthTableName: String = "t_gnirs_spectroscopy_wavelength"
+
   def instantiate[F[_]: {Concurrent as F, Services}]: GnirsSpectroscopyService[F] =
 
     new GnirsSpectroscopyService[F]:
 
-      val gnirsLS: Decoder[Config] = (
-        // Science ETM (joined from t_exposure_time_mode via FK)
+      /**
+       * Decodes one (observation, central wavelength) row.  The `Config` it
+       * yields carries only that row's wavelength; `select` groups the rows per
+       * observation and replaces `wavelengths` with the full list.
+       */
+      val gnirsLS: Decoder[(ScienceWavelength, Config)] = (
+        // The row's central wavelength, its science ETM (joined via the row's FK)
+        // and its coadds.
+        wavelength_pm                    *: // c_central_wavelength
         exposure_time_mode               *:
-        // Effective grating/prism/wavelength for the acquisition configuration
+        int4                             *: // c_coadds
+        // Effective grating/prism for the acquisition configuration
         gnirs_grating                    *: // c_grating_effective
         gnirs_prism                      *: // c_prism_effective
-        wavelength_pm                    *: // c_central_wavelength_effective
         // Camera
         gnirs_camera                     *:
         // FPU (exactly one of slit / ifu)
         gnirs_fpu_spectroscopy           *:
         // Filter
         gnirs_filter                     *:
-        // Coadds
-        int4                             *:
         // Decker effective (DB-computed COALESCE)
         gnirs_decker                     *: // c_decker_effective
         // Read mode explicit override (None => compute from exposure time)
@@ -113,8 +130,9 @@ object GnirsSpectroscopyService:
         exposure_time_mode               *: // acquisition ETM
         telluric_type                       // c_telluric_type
       ).emap:
-        case (sciEtm *: gratingEff *: prismEff *: centralWavEff *:
-              camera *: fpu *: filter *: coadds *:
+        case (centralWav *: sciEtm *: coadds *:
+              gratingEff *: prismEff *:
+              camera *: fpu *: filter *:
               deckerEff *:
               readModeExp *:
               wellDepthEff *:
@@ -151,23 +169,24 @@ object GnirsSpectroscopyService:
                         val acq = AcquisitionConfig(explicitAcqMode, acqFilterExp, acqEtm, acqCoaddsP)
                         val focus = focusMotorSteps.fold(GnirsFocus.Best): n =>
                           GnirsFocus.Custom(GnirsFocusMotorStepsValue.unsafeFrom(n).withUnit[GnirsFocusMotorStep])
-                        Config(
+                        val sw = ScienceWavelength(centralWav, sciEtm, coaddsP)
+                        (sw,
+                         Config(
                           filter,
                           deckerEff,
                           fpu,
                           prismEff,
                           gratingEff,
-                          centralWavEff,
+                          NonEmptyList.one(sw),
                           camera,
                           focus,
                           readModeExp,
                           wellDepthEff,
-                          sciEtm,
-                          coaddsP,
                           resolvedTC,
                           acq,
                           telluricType
                           )
+                        )
               }
 
       override def select(
@@ -178,45 +197,97 @@ object GnirsSpectroscopyService:
           .fold(Map.empty.pure[F]): oids =>
             val af = Statements.selectGnirsSpectroscopy(oids)
             session.prepareR(af.fragment.query(observation_id *: gnirsLS)).use: pq =>
-              pq.stream(af.argument, chunkSize = 1024).compile.toList.map(_.toMap)
+              pq.stream(af.argument, chunkSize = 1024).compile.toList.map: rows =>
+                // One row per central wavelength, ordered by increasing wavelength.
+                // `groupBy` preserves that order within each group.
+                rows
+                  .groupBy(_._1)
+                  .flatMap: (oid, group) =>
+                    NonEmptyList.fromList(group.map(_._2)).map: ws =>
+                      oid -> group.head._3.copy(wavelengths = ws)
+                  .toMap
 
-      private def insertExposureTimeModes(
-        input: GnirsSpectroscopyInput.Create,
-        req:   Option[ExposureTimeMode],
-        which: List[Observation.Id]
-      )(using Transaction[F]): F[Result[Unit]] =
-        val acqEtm: Option[ExposureTimeMode] = input.acquisition.flatMap(_.exposureTimeMode)
-        exposureTimeModeService
-          .insertOneWithDefaults("GNIRS Spectroscopy", acqEtm, input.exposureTimeMode, req, which)
-          .map(_.void)
+      /**
+       * The ETM resolution key is the central wavelength; coadds ride along so the
+       * child rows can be written from the resolved result.
+       */
+      private def resolveKey(
+        w: GnirsSpectroscopyWavelengthInput
+      ): (Wavelength, Option[ExposureTimeMode]) =
+        (w.centralWavelength, w.exposureTimeMode)
+
+      private def stripAcquisition[E](
+        m: Map[Observation.Id, (E, NonEmptyList[(Wavelength, E)])]
+      ): Map[Observation.Id, NonEmptyList[(Wavelength, E)]] =
+        m.view.mapValues(_._2).toMap
+
+      private def insertWavelengths(
+        input:   NonEmptyList[GnirsSpectroscopyWavelengthInput],
+        etms:    Map[Observation.Id, NonEmptyList[(Wavelength, ExposureTimeModeId)]],
+        version: ObservingModeRowVersion
+      ): F[Unit] =
+        val coaddsFor: Map[Wavelength, PosInt] =
+          input.toList.map(w => w.centralWavelength -> w.coadds.getOrElse(DefaultCoadds)).toMap
+        NonEmptyList
+          .fromList:
+            etms.toList.flatMap: (oid, ws) =>
+              ws.toList.map: (wav, eid) =>
+                (oid, wav, coaddsFor.getOrElse(wav, DefaultCoadds), eid)
+          .traverse_ : rs =>
+            session.exec(Statements.insertWavelengths(rs, version))
 
       override def insert(
         input:  GnirsSpectroscopyInput.Create,
         req:    Option[ExposureTimeMode],
         which:  List[Observation.Id]
       )(using Transaction[F]): F[Result[Unit]] =
+        val acqEtm: Option[ExposureTimeMode] = input.acquisition.flatMap(_.exposureTimeMode)
         (for
-          _ <- ResultT(insertExposureTimeModes(input, req, which))
-          _ <- ResultT.liftF:
-            which.traverse: oid =>
-              session.exec(Statements.insertGnirsSpectroscopy(oid, input))
-            .void
+          _   <- ResultT.liftF:
+                   which.traverse: oid =>
+                     session.exec(Statements.insertGnirsSpectroscopy(oid, input))
+                   .void
+
+          // Resolve the ETMs for acquisition and each central wavelength.  An explicit
+          // acquisition ETM wins; otherwise it is derived from the first science ETM.
+          r   <- ResultT(exposureTimeModeService.resolve("GNIRS Spectroscopy", acqEtm, input.centralWavelengths.map(resolveKey), req, which))
+
+          ids <- ResultT.liftF(exposureTimeModeService.insertResolvedAcquisitionAndScience(r))
+          _   <- ResultT.liftF(insertWavelengths(input.centralWavelengths, stripAcquisition(ids), ObservingModeRowVersion.Initial))
+
+          // The 'current' rows need their own ETM rows (each wavelength row backs
+          // exactly one ETM), so resolve the science side a second time.
+          cur <- ResultT.liftF(exposureTimeModeService.insertResolvedScienceOnly(stripAcquisition(r)))
+          _   <- ResultT.liftF(insertWavelengths(input.centralWavelengths, cur, ObservingModeRowVersion.Current))
         yield ()).value
 
       override def delete(which: List[Observation.Id])(using Transaction[F]): F[Unit] =
         Statements.deleteGnirs(which).fold(F.unit)(session.exec)
 
-      private def updateExposureTimeModes(
+      /**
+       * Replaces the current central wavelength rows and their science ETMs.  The
+       * acquisition ETM is user-editable here, so it is left in place and changed
+       * only when the input asks for it.
+       */
+      private def updateWavelengths(
+        SET:   GnirsSpectroscopyInput.Edit,
+        oids:  NonEmptyList[Observation.Id],
+        which: List[Observation.Id]
+      )(using Transaction[F]): ResultT[F, Unit] =
+        SET.centralWavelengths.fold(ResultT.unit): ws =>
+          for
+            _   <- ResultT.liftF(session.exec(ImagingStatements.deleteCurrentScienceFiltersAndEtms(WavelengthTableName, oids)))
+            r   <- ResultT(exposureTimeModeService.resolve("GNIRS Spectroscopy", none, ws.map(resolveKey), none, which))
+            cur <- ResultT.liftF(exposureTimeModeService.insertResolvedScienceOnly(stripAcquisition(r)))
+            _   <- ResultT.liftF(insertWavelengths(ws, cur, ObservingModeRowVersion.Current))
+          yield ()
+
+      private def updateAcquisitionExposureTimeMode(
         input: GnirsSpectroscopyInput.Edit,
         which: List[Observation.Id]
       )(using Transaction[F]): F[Unit] =
-        def update(etm: Option[ExposureTimeMode], role: ExposureTimeModeRole): F[Unit] =
-          etm.fold(().pure[F]): e =>
-            services.exposureTimeModeService.updateMany(which, role, e)
-        for
-          _ <- update(input.acquisition.flatMap(_.exposureTimeMode), ExposureTimeModeRole.Acquisition)
-          _ <- update(input.exposureTimeMode, ExposureTimeModeRole.Science)
-        yield ()
+        input.acquisition.flatMap(_.exposureTimeMode).fold(().pure[F]): e =>
+          services.exposureTimeModeService.updateMany(which, ExposureTimeModeRole.Acquisition, e)
 
       // A NonNull telescope-config override of a specific kind must match the persisted FPU.
       // The input validates this against an edited FPU; when the FPU is unchanged we check the
@@ -244,14 +315,21 @@ object GnirsSpectroscopyService:
         SET:   GnirsSpectroscopyInput.Edit,
         which: List[Observation.Id]
       )(using Transaction[F]): F[Result[Unit]] =
-        (for
-          _ <- ResultT(validateTelescopeConfigKind(SET, which))
-          _ <- ResultT.liftF(updateExposureTimeModes(SET, which))
-          _ <- ResultT.liftF(Statements.updateGnirsSpectroscopy(SET, which).fold(F.unit)(session.exec))
-        yield ()).value
+        NonEmptyList.fromList(which).fold(Result.unit.pure[F]): oids =>
+          (for
+            _ <- ResultT(validateTelescopeConfigKind(SET, which))
+            _ <- ResultT.liftF(updateAcquisitionExposureTimeMode(SET, which))
+            _ <- updateWavelengths(SET, oids, which)
+            _ <- ResultT.liftF(Statements.updateGnirsSpectroscopy(SET, which).fold(F.unit)(session.exec))
+          yield ()).value
 
-      override def clone(originalId: Observation.Id, newId: Observation.Id)(using Transaction[F]): F[Unit] =
-        session.exec(Statements.cloneGnirs(originalId, newId))
+      override def clone(
+        originalId: Observation.Id,
+        newId:      Observation.Id,
+        etms:       List[(ExposureTimeModeId, ExposureTimeModeId)]
+      )(using Transaction[F]): F[Unit] =
+        session.exec(Statements.cloneGnirs(originalId, newId)) *>
+          session.exec(Statements.cloneWavelengths(originalId, newId, etms)).unlessA(etms.isEmpty)
 
       override def resetTelluricConfig(oid: Observation.Id)(using Transaction[F]): F[Unit] =
         session.exec(Statements.applyGnirsTelluricDefaults(oid))
@@ -262,19 +340,19 @@ object GnirsSpectroscopyService:
       sql"""
         SELECT
           ls.c_observation_id,
+          w.c_central_wavelength,
           sci.c_exposure_time_mode,
           sci.c_signal_to_noise_at,
           sci.c_signal_to_noise,
           sci.c_exposure_time,
           sci.c_exposure_count,
+          w.c_coadds,
           ls.c_grating_effective,
           ls.c_prism_effective,
-          ls.c_central_wavelength_effective,
           ls.c_camera,
           ls.c_fpu_slit,
           ls.c_fpu_ifu,
           ls.c_filter,
-          ls.c_coadds,
           ls.c_decker_effective,
           ls.c_read_mode,
           ls.c_well_depth_effective,
@@ -293,16 +371,18 @@ object GnirsSpectroscopyService:
           acq.c_exposure_count,
           ls.c_telluric_type
         FROM v_gnirs_spectroscopy ls
-        LEFT JOIN t_exposure_time_mode sci
-           ON sci.c_observation_id = ls.c_observation_id
-          AND sci.c_role = 'science'
+        JOIN t_gnirs_spectroscopy_wavelength w
+           ON w.c_observation_id = ls.c_observation_id
+          AND w.c_version = 'current'
+        JOIN t_exposure_time_mode sci
+           ON sci.c_exposure_time_mode_id = w.c_exposure_time_mode_id
         LEFT JOIN t_exposure_time_mode acq
            ON acq.c_observation_id = ls.c_observation_id
           AND acq.c_role = 'acquisition'
       """(Void) |+|
       void"WHERE ls.c_observation_id IN (" |+|
         observationIds.map(sql"$observation_id").intercalate(void",") |+|
-      void")"
+      void") ORDER BY ls.c_observation_id, w.c_central_wavelength"
 
     // None => no explicit acquisition type; resolved from the exposure time at
     // sequence-generation time (mirrors read mode handling).
@@ -320,10 +400,6 @@ object GnirsSpectroscopyService:
       GnirsCamera,
       GnirsFpu.Spectroscopy,
       GnirsFilter,
-      // coadds
-      Int,
-      // central wavelength (required; stored as the initial value, override left NULL)
-      Wavelength,
       // explicit overrides (all nullable)
       Option[GnirsDecker],
       Option[GnirsGrating],   // explicit grating
@@ -357,10 +433,7 @@ object GnirsSpectroscopyService:
           c_initial_fpu_ifu,
           c_filter,
           c_initial_filter,
-          c_coadds,
           c_decker,
-          c_central_wavelength,
-          c_initial_central_wavelength,
           c_grating,
           c_prism,
           c_focus_motor_steps,
@@ -387,10 +460,7 @@ object GnirsSpectroscopyService:
           $gnirs_fpu_spectroscopy,
           $gnirs_filter,
           $gnirs_filter,
-          $int4,
           ${gnirs_decker.opt},
-          NULL,
-          $wavelength_pm,
           ${gnirs_grating.opt},
           ${gnirs_prism.opt},
           ${int4.opt},
@@ -407,14 +477,14 @@ object GnirsSpectroscopyService:
         FROM t_observation
         WHERE c_observation_id = $observation_id
       """.contramap {
-        (oid, obsModeType, initGrating, initPrism, camera, fpu, filter, coadds,
-         centralWav, decker, explGrating, explPrism, focus,
+        (oid, obsModeType, initGrating, initPrism, camera, fpu, filter,
+         decker, explGrating, explPrism, focus,
          readMode, wellDepth, slitMode, offsets,
          acqType, acqCoadds, acqFilter, acqSkyOffP, acqSkyOffQ, telluricType) =>
           // fpu appears twice (current + initial); the spectroscopy codec expands each
           // into the (c_fpu_slit, c_fpu_ifu) column pair.
           (oid, obsModeType, initGrating, initPrism, camera, camera, fpu, fpu,
-           filter, filter, coadds, decker, centralWav,
+           filter, filter, decker,
            explGrating, explPrism, focus, readMode, wellDepth,
            slitMode, offsets,
            acqType, acqCoadds, acqFilter, acqSkyOffP, acqSkyOffQ, telluricType, oid)
@@ -444,8 +514,6 @@ object GnirsSpectroscopyService:
         input.camera,
         input.fpu,
         input.filter,
-        input.coadds.map(_.value).getOrElse(1),
-        input.centralWavelength,
         input.explicitDecker,
         input.explicitGrating,
         input.explicitPrism,
@@ -471,7 +539,6 @@ object GnirsSpectroscopyService:
           void"WHERE " |+| observationIdIn(oids)
 
     private def gnirsUpdates(SET: GnirsSpectroscopyInput.Edit): Option[NonEmptyList[AppliedFragment]] =
-      val upCoadds       = sql"c_coadds             = ${int4_pos.opt}"
       val upFilter       = sql"c_filter             = ${gnirs_filter.opt}"
       // FPU edits set the matching column only. Switching kind (slit<->ifu) would also
       // require changing the observation's mode type, so it is not supported here: a
@@ -482,7 +549,6 @@ object GnirsSpectroscopyService:
           case GnirsFpu.Spectroscopy.Ifu(i)  => sql"c_fpu_ifu  = $gnirs_fpu_ifu".apply(i)
       val upCamera       = sql"c_camera             = ${gnirs_camera.opt}"
       val upDecker       = sql"c_decker             = ${gnirs_decker.opt}"
-      val upCentralWav   = sql"c_central_wavelength = $wavelength_pm"
       val upFocus        = sql"c_focus_motor_steps  = ${int4.opt}"
       val upReadMode     = sql"c_read_mode          = ${gnirs_read_mode.opt}"
       val upWellDepth    = sql"c_well_depth         = ${gnirs_well_depth.opt}"
@@ -537,12 +603,10 @@ object GnirsSpectroscopyService:
           ).flatten ++ typeAndOffset
 
       val ups: List[AppliedFragment] = List(
-        SET.coadds.map(c => upCoadds(Some(c))),
         SET.filter.map(f => upFilter(Some(f))),
         SET.fpu.map(fpuUpdates),
         SET.camera.map(c => upCamera(Some(c))),
         SET.explicitDecker.toOptionOption.map(upDecker),
-        SET.centralWavelength.map(upCentralWav),
         SET.explicitFocusMotorSteps.toOptionOption.map(upFocus),
         SET.explicitReadMode.toOptionOption.map(upReadMode),
         SET.explicitWellDepth.toOptionOption.map(upWellDepth),
@@ -595,12 +659,12 @@ object GnirsSpectroscopyService:
       sql"""
         INSERT INTO t_gnirs_spectroscopy (
           c_observation_id, c_program_id, c_observing_mode_type,
-          c_grating, c_prism, c_central_wavelength, c_initial_central_wavelength,
+          c_grating, c_prism,
           c_initial_grating, c_initial_prism,
           c_camera, c_initial_camera,
           c_fpu_slit, c_fpu_ifu, c_initial_fpu_slit, c_initial_fpu_ifu,
           c_filter, c_initial_filter,
-          c_coadds, c_decker, c_focus_motor_steps, c_read_mode, c_well_depth,
+          c_decker, c_focus_motor_steps, c_read_mode, c_well_depth,
           c_slit_offset_mode, c_telescope_configs,
           c_acq_type, c_acq_coadds, c_acq_filter,
           c_acq_sky_offset_p, c_acq_sky_offset_q,
@@ -610,12 +674,12 @@ object GnirsSpectroscopyService:
           $observation_id,
           (SELECT c_program_id FROM t_observation WHERE c_observation_id = $observation_id),
           c_observing_mode_type,
-          c_grating, c_prism, c_central_wavelength, c_initial_central_wavelength,
+          c_grating, c_prism,
           c_initial_grating, c_initial_prism,
           c_camera, c_initial_camera,
           c_fpu_slit, c_fpu_ifu, c_initial_fpu_slit, c_initial_fpu_ifu,
           c_filter, c_initial_filter,
-          c_coadds, c_decker, c_focus_motor_steps, c_read_mode, c_well_depth,
+          c_decker, c_focus_motor_steps, c_read_mode, c_well_depth,
           c_slit_offset_mode, c_telescope_configs,
           c_acq_type, c_acq_coadds, c_acq_filter,
           c_acq_sky_offset_p, c_acq_sky_offset_q,
@@ -623,3 +687,67 @@ object GnirsSpectroscopyService:
         FROM t_gnirs_spectroscopy
         WHERE c_observation_id = $observation_id
       """.apply(newId, newId, originalId)
+
+    /** Inserts the central wavelength rows for one row version. */
+    def insertWavelengths(
+      rows:    NonEmptyList[(Observation.Id, Wavelength, PosInt, ExposureTimeModeId)],
+      version: ObservingModeRowVersion
+    ): AppliedFragment =
+      val insertInto: AppliedFragment =
+        void"""
+          INSERT INTO t_gnirs_spectroscopy_wavelength (
+            c_observation_id,
+            c_central_wavelength,
+            c_version,
+            c_coadds,
+            c_exposure_time_mode_id
+          ) VALUES
+        """
+
+      val values =
+        rows.map: (oid, wav, coadds, eid) =>
+          sql"($observation_id, $wavelength_pm, $observing_mode_row_version, $int4_pos, $exposure_time_mode_id)"(
+            oid, wav, version, coadds, eid
+          )
+
+      insertInto |+| values.intercalate(void", ")
+
+    /**
+     * Copies the central wavelength rows to a cloned observation, remapping each
+     * to its cloned exposure time mode row.
+     */
+    def cloneWavelengths(
+      originalId: Observation.Id,
+      newId:      Observation.Id,
+      etms:       List[(ExposureTimeModeId, ExposureTimeModeId)]
+    ): AppliedFragment =
+      sql"""
+        WITH etm_map AS (
+          SELECT
+            old_exposure_time_mode_id,
+            new_exposure_time_mode_id
+          FROM
+            unnest(
+              ARRAY[${exposure_time_mode_id.list(etms.length)}],
+              ARRAY[${exposure_time_mode_id.list(etms.length)}]
+            ) AS map(old_exposure_time_mode_id, new_exposure_time_mode_id)
+        )
+        INSERT INTO t_gnirs_spectroscopy_wavelength (
+          c_observation_id,
+          c_central_wavelength,
+          c_version,
+          c_coadds,
+          c_exposure_time_mode_id,
+          c_role
+        )
+        SELECT
+          $observation_id,
+          w.c_central_wavelength,
+          w.c_version,
+          w.c_coadds,
+          e.new_exposure_time_mode_id,
+          w.c_role
+        FROM t_gnirs_spectroscopy_wavelength w
+        JOIN etm_map e ON e.old_exposure_time_mode_id = w.c_exposure_time_mode_id
+        WHERE w.c_observation_id = $observation_id
+      """.apply(etms.map(_._1), etms.map(_._2), newId, originalId)

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -34,6 +34,7 @@ import lucuma.core.enums.GmosSouthFilter
 import lucuma.core.enums.GnirsAcquisitionType
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.math.SignalToNoise
+import lucuma.core.math.Wavelength
 import lucuma.core.model.ExposureTimeMode
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
@@ -532,62 +533,76 @@ object ItcService {
                .flatMap(id => z.findFocus(_.targetId === id))
                .getOrElse(z)
 
-      sealed trait Imaging[A]:
+      /**
+       * A science result set keyed by something that varies per ITC call: the
+       * filter for imaging modes, the central wavelength for GNIRS spectroscopy.
+       */
+      sealed trait Keyed[A]:
         def pf: PartialFunction[InstrumentMode, A]
         def wrap(nem: NonEmptyMap[A, Zipper[ItcResult]]): ItcScience
 
-      object Imaging:
-        case object Flamingos2Imaging extends Imaging[Flamingos2Filter]:
+      object Keyed:
+        case object Flamingos2Imaging extends Keyed[Flamingos2Filter]:
           override def pf: PartialFunction[InstrumentMode, Flamingos2Filter] =
             case InstrumentMode.Flamingos2Imaging(filter = f) => f
 
           override def wrap(nem: NonEmptyMap[Flamingos2Filter, Zipper[ItcResult]]): ItcScience =
             ItcScience.Flamingos2Imaging(nem)
 
-        case object GmosNorthImaging extends Imaging[GmosNorthFilter]:
+        case object GmosNorthImaging extends Keyed[GmosNorthFilter]:
           override def pf: PartialFunction[InstrumentMode, GmosNorthFilter] =
             case InstrumentMode.GmosNorthImaging(filter = f) => f
 
           override def wrap(nem: NonEmptyMap[GmosNorthFilter, Zipper[ItcResult]]): ItcScience =
             ItcScience.GmosNorthImaging(nem)
 
-        case object GmosSouthImaging extends Imaging[GmosSouthFilter]:
+        case object GmosSouthImaging extends Keyed[GmosSouthFilter]:
           override def pf: PartialFunction[InstrumentMode, GmosSouthFilter] =
                case InstrumentMode.GmosSouthImaging(filter = f) => f
 
           override def wrap(nem: NonEmptyMap[GmosSouthFilter, Zipper[ItcResult]]): ItcScience =
             ItcScience.GmosSouthImaging(nem)
 
-        case object GnirsImaging extends Imaging[GnirsFilter]:
+        case object GnirsImaging extends Keyed[GnirsFilter]:
           override def pf: PartialFunction[InstrumentMode, GnirsFilter] =
             case InstrumentMode.GnirsImaging(filter = f) => f
 
           override def wrap(nem: NonEmptyMap[GnirsFilter, Zipper[ItcResult]]): ItcScience =
             ItcScience.GnirsImaging(nem)
 
-      private def callRemoteImagingItc[A: Order](
-        oid:   Observation.Id,
-        input: ItcInput.Imaging,
-        im:    Imaging[A]
-      ): EitherT[F, OdbError, Itc] =
+        case object GnirsSpectroscopy extends Keyed[Wavelength]:
+          override def pf: PartialFunction[InstrumentMode, Wavelength] =
+            case InstrumentMode.GnirsSpectroscopy(centralWavelength = w) => w
 
-        def extractFilters(
+          override def wrap(nem: NonEmptyMap[Wavelength, Zipper[ItcResult]]): ItcScience =
+            ItcScience.GnirsSpectroscopy(nem)
+
+      private def callRemoteKeyedItc[A: Order, I](
+        oid:     Observation.Id,
+        modes:   NonEmptyList[InstrumentMode],
+        inputs:  NonEmptyList[I],
+        targets: NonEmptyList[ItcInput.TargetDefinition],
+        snTarget: Option[Target.Id],
+        im:      Keyed[A],
+        call:    I => F[ClientCalculationResult]
+      ): EitherT[F, OdbError, ItcScience] =
+
+        def extractKeys(
           remaining: List[InstrumentMode],
-          filters:   List[A]
+          keys:      List[A]
         ): Either[OdbError, NonEmptyList[A]] =
           remaining match
             case Nil    =>
               // remaining originally comes from a NonEmptyList
-              NonEmptyList.fromListUnsafe(filters.reverse).asRight
+              NonEmptyList.fromListUnsafe(keys.reverse).asRight
             case h :: t =>
-              if im.pf.isDefinedAt(h) then extractFilters(t, im.pf(h) :: filters)
+              if im.pf.isDefinedAt(h) then extractKeys(t, im.pf(h) :: keys)
               else OdbError.InvalidObservation(oid, s"Mixed instrument mode observations are not supported.".some).asLeft
 
+        // One ITC call per key, in parallel.
         val clientCalculationResults: F[Either[OdbError, NonEmptyList[ClientCalculationResult]]] =
-          input
-            .scienceInput
-            .parTraverse: in =>
-              client.imaging(in, useCache = false)
+          inputs
+            .parTraverse(call)
             .map(_.asRight)
             .handleErrorWith:
               case e: ResponseException[?] =>
@@ -596,10 +611,10 @@ object ItcService {
                 OdbError.RemoteServiceCallError(s"Error calling ITC service: ${t.getMessage}".some).asLeft.pure
 
         for
-          fs <- EitherT.fromEither(extractFilters(input.science.map(_.mode).toList, Nil))
+          fs <- EitherT.fromEither(extractKeys(modes.toList, Nil))
           cs <- EitherT(clientCalculationResults)
-          ts <- EitherT.fromEither(toTargetResults(input.targets, cs, input.signalToNoiseTargetId))
-        yield Itc(ItcAcquisition.NotApplicable, im.wrap(fs.zip(ts).toNem))
+          ts <- EitherT.fromEither(toTargetResults(targets, cs, snTarget))
+        yield im.wrap(fs.zip(ts).toNem)
 
 
       private def callRemoteItc(
@@ -646,20 +661,37 @@ object ItcService {
               )
             )
 
+        // Imaging modes have no acquisition ITC of their own (GNIRS folds one in
+        // below), so their keyed science result is the whole thing.
+        def imagingScience[A: Order](
+          oid: Observation.Id,
+          im:  ItcInput.Imaging,
+          k:   Keyed[A]
+        ): EitherT[F, OdbError, Itc] =
+          callRemoteKeyedItc(
+            oid,
+            im.science.map(_.mode),
+            im.scienceInput,
+            im.targets,
+            im.signalToNoiseTargetId,
+            k,
+            client.imaging(_, useCache = false)
+          ).map(Itc(ItcAcquisition.NotApplicable, _))
+
         def imaging(im: ItcInput.Imaging): EitherT[F, OdbError, Itc] =
           val science: EitherT[F, OdbError, Itc] =
             im.science.head.mode match
               case InstrumentMode.Flamingos2Imaging(_, _, _, _) =>
-                callRemoteImagingItc(oid, im, Imaging.Flamingos2Imaging)
+                imagingScience(oid, im, Keyed.Flamingos2Imaging)
 
               case InstrumentMode.GmosNorthImaging(_, _, _, _) =>
-                callRemoteImagingItc(oid, im, Imaging.GmosNorthImaging)
+                imagingScience(oid, im, Keyed.GmosNorthImaging)
 
               case InstrumentMode.GmosSouthImaging(_, _, _, _) =>
-                callRemoteImagingItc(oid, im, Imaging.GmosSouthImaging)
+                imagingScience(oid, im, Keyed.GmosSouthImaging)
 
               case InstrumentMode.GnirsImaging(_, _, _, _, _, _, _) =>
-                callRemoteImagingItc(oid, im, Imaging.GnirsImaging)
+                imagingScience(oid, im, Keyed.GnirsImaging)
 
               case m                                     =>
                 EitherT.leftT:
@@ -682,6 +714,22 @@ object ItcService {
             acq <- acquisitionResult(oid, sp.acquisitionInput, sp.acquisitionTargets, sp.gnirsAcqAutoClassify)
           yield Itc(acq, ItcScience.Spectroscopy(sci))
 
+        // GNIRS spectroscopy: one science call per central wavelength, plus the
+        // usual single acquisition pass (including the two-pass auto-classify).
+        def gnirsSpectroscopy(sp: ItcInput.GnirsSpectroscopy): EitherT[F, OdbError, Itc] =
+          for
+            sci <- callRemoteKeyedItc[Wavelength, SpectroscopyInput](
+                     oid,
+                     sp.science.map(_.mode),
+                     sp.scienceInput,
+                     sp.targets,
+                     sp.signalToNoiseTargetId,
+                     Keyed.GnirsSpectroscopy,
+                     client.spectroscopy(_, useCache = false)
+                   )
+            acq <- acquisitionResult(oid, sp.acquisitionInput, sp.acquisitionTargets, sp.gnirsAcqAutoClassify)
+          yield Itc(acq, sci)
+
         // Modes with no acquisition sequence: the science call is the whole result.
         def scienceOnlySpectroscopy(sp: ItcInput.ScienceOnlySpectroscopy): EitherT[F, OdbError, Itc] =
           for
@@ -694,6 +742,8 @@ object ItcService {
             imaging(im)
           case sp @ ItcInput.Spectroscopy(_, _, _, _, _, _) =>
             spectroscopy(sp)
+          case sp @ ItcInput.GnirsSpectroscopy(_, _, _, _, _, _) =>
+            gnirsSpectroscopy(sp)
           case sp @ ItcInput.ScienceOnlySpectroscopy(SpectroscopyParameters(_, gh @ InstrumentMode.GhostSpectroscopy(_, _, _, _)), targets, _) =>
             ghost(gh, targets)
           case sp @ ItcInput.ScienceOnlySpectroscopy(SpectroscopyParameters(_, InstrumentMode.Igrins2Spectroscopy(_, _)), _, _) =>
@@ -751,6 +801,12 @@ object ItcService {
           .flatMap: params =>
             params.itcInput match
               case ItcInputDerivation.Ready(sp: ItcInput.Spectroscopy)           =>
+                safeAcquisitionCall(oid, sp.acquisitionInput, sp.acquisitionTargets, sp.gnirsAcqAutoClassify)
+                  .map((z, t) => ItcAcquisition.Available(z, t): ItcAcquisition)
+
+              // GNIRS spectroscopy has a single acquisition pass regardless of how
+              // many central wavelengths the science side has.
+              case ItcInputDerivation.Ready(sp: ItcInput.GnirsSpectroscopy)      =>
                 safeAcquisitionCall(oid, sp.acquisitionInput, sp.acquisitionTargets, sp.gnirsAcqAutoClassify)
                   .map((z, t) => ItcAcquisition.Available(z, t): ItcAcquisition)
 

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservingModeServices.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservingModeServices.scala
@@ -276,7 +276,7 @@ object ObservingModeServices:
             case ObservingModeType.GmosSouthImaging   => gmosImagingService.cloneSouth(origOid, newOid, etms)
             case ObservingModeType.GmosSouthMos       => gmosMosService.cloneSouth(origOid, newOid)
             case ObservingModeType.GnirsImaging       => gnirsImagingService.clone(origOid, newOid, etms)
-            case ObservingModeType.GnirsLongSlit | ObservingModeType.GnirsIfu => gnirsSpectroscopyService.clone(origOid, newOid)
+            case ObservingModeType.GnirsLongSlit | ObservingModeType.GnirsIfu => gnirsSpectroscopyService.clone(origOid, newOid, etms)
             case ObservingModeType.Igrins2LongSlit    => igrins2LongSlitService.clone(origOid, newOid)
             case _: VisitorObservingModeType          => visitorService.clone(origOid, newOid)
 

--- a/modules/service/src/main/scala/lucuma/odb/service/PerScienceObservationCalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/PerScienceObservationCalibrationsService.scala
@@ -367,15 +367,21 @@ object PerScienceObservationCalibrationsService:
               MaxTelluricSN
           ExposureTimeMode.SignalToNoiseMode(snValue, etm.at)
 
+        // Update in place rather than delete-and-insert: GNIRS spectroscopy's
+        // central wavelength rows reference their science ETM with ON DELETE
+        // CASCADE, so deleting the ETM would take the observing mode's
+        // wavelengths with it.  `updateMany` updates the rows that exist and
+        // inserts where none does, so the end state is the same for every other
+        // mode.
         def replaceEtm(
           role:    ExposureTimeModeRole,
           newEtm:  ExposureTimeMode,
           current: Option[ExposureTimeMode]
         ): F[Unit] =
-          (exposureTimeModeService.deleteMany(List(telluricOid), role) *>
-            exposureTimeModeService.insertOne(telluricOid, role, newEtm))
-              .unlessA(current.contains(newEtm))
-              .void
+          exposureTimeModeService
+            .updateMany(List(telluricOid), role, newEtm)
+            .unlessA(current.contains(newEtm))
+            .void
 
         for {
           allEtm     <- exposureTimeModeService

--- a/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/DatabaseOperations.scala
@@ -1401,14 +1401,18 @@ trait DatabaseOperations { this: OdbSuite =>
             camera: SHORT_BLUE
             slit: { fpu: LONG_SLIT_0_30 }
             filter: ORDER3
-            centralWavelength: { nanometers: 2200 }
-            exposureTimeMode: {
-              timeAndCount: {
-                time: { seconds: 30.0 }
-                count: 3
-                at: { nanometers: 2200 }
+            centralWavelengths: [
+              {
+                centralWavelength: { nanometers: 2200 }
+                exposureTimeMode: {
+                  timeAndCount: {
+                    time: { seconds: 30.0 }
+                    count: 3
+                    at: { nanometers: 2200 }
+                  }
+                }
               }
-            }
+            ]
           }
         }"""
       case ObservingModeType.GnirsIfu =>
@@ -1419,14 +1423,18 @@ trait DatabaseOperations { this: OdbSuite =>
             camera: SHORT_BLUE
             ifu: { fpu: LOW_RESOLUTION }
             filter: ORDER3
-            centralWavelength: { nanometers: 2200 }
-            exposureTimeMode: {
-              timeAndCount: {
-                time: { seconds: 30.0 }
-                count: 3
-                at: { nanometers: 2200 }
+            centralWavelengths: [
+              {
+                centralWavelength: { nanometers: 2200 }
+                exposureTimeMode: {
+                  timeAndCount: {
+                    time: { seconds: 30.0 }
+                    count: 3
+                    at: { nanometers: 2200 }
+                  }
+                }
               }
-            }
+            ]
           }
         }"""
       case ObservingModeType.Igrins2LongSlit =>
@@ -1607,14 +1615,18 @@ trait DatabaseOperations { this: OdbSuite =>
             camera: SHORT_BLUE
             slit: { fpu: LONG_SLIT_0_30 }
             filter: ORDER3
-            centralWavelength: { nanometers: 2200 }
-            exposureTimeMode: {
-              timeAndCount: {
-                time: { seconds: 30.0 }
-                count: 3
-                at: { nanometers: 2200 }
+            centralWavelengths: [
+              {
+                centralWavelength: { nanometers: 2200 }
+                exposureTimeMode: {
+                  timeAndCount: {
+                    time: { seconds: 30.0 }
+                    count: 3
+                    at: { nanometers: 2200 }
+                  }
+                }
               }
-            }
+            ]
           }
         }"""
       case ObservingModeType.GnirsIfu =>
@@ -1625,14 +1637,18 @@ trait DatabaseOperations { this: OdbSuite =>
             camera: SHORT_BLUE
             ifu: { fpu: LOW_RESOLUTION }
             filter: ORDER3
-            centralWavelength: { nanometers: 2200 }
-            exposureTimeMode: {
-              timeAndCount: {
-                time: { seconds: 30.0 }
-                count: 3
-                at: { nanometers: 2200 }
+            centralWavelengths: [
+              {
+                centralWavelength: { nanometers: 2200 }
+                exposureTimeMode: {
+                  timeAndCount: {
+                    time: { seconds: 30.0 }
+                    count: 3
+                    at: { nanometers: 2200 }
+                  }
+                }
               }
-            }
+            ]
           }
         }"""
       case v: VisitorObservingModeType =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/perScienceObservationCalibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/perScienceObservationCalibrations.scala
@@ -2281,8 +2281,12 @@ class perScienceObservationCalibrations
                   camera: SHORT_BLUE
                   slit: { fpu: LONG_SLIT_0_30 }
                   filter: ORDER3
-                  centralWavelength: { nanometers: 1650 }
-                  exposureTimeMode: { timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 1650 } } }
+                  centralWavelengths: [
+                    {
+                      centralWavelength: { nanometers: 1650 }
+                      exposureTimeMode: { timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 1650 } } }
+                    }
+                  ]
                 }
               }
               constraintSet: { imageQuality: POINT_EIGHT }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GnirsIfu.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GnirsIfu.scala
@@ -40,14 +40,18 @@ class createObservation_GnirsIfu extends OdbSuite:
                         camera: SHORT_BLUE
                         ifu: { fpu: LOW_RESOLUTION }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
-                        exposureTimeMode: {
-                          timeAndCount: {
-                            time: { seconds: 30.0 }
-                            count: 3
-                            at: { nanometers: 2200 }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                            exposureTimeMode: {
+                              timeAndCount: {
+                                time: { seconds: 30.0 }
+                                count: 3
+                                at: { nanometers: 2200 }
+                              }
+                            }
                           }
-                        }
+                        ]
                       }
                     }
                   }
@@ -119,7 +123,11 @@ class createObservation_GnirsIfu extends OdbSuite:
                         slit: { fpu: LONG_SLIT_0_30 }
                         ifu: { fpu: LOW_RESOLUTION }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                          }
+                        ]
                       }
                     }
                   }
@@ -157,10 +165,14 @@ class createObservation_GnirsIfu extends OdbSuite:
                         camera: SHORT_BLUE
                         ifu: { fpu: LOW_RESOLUTION }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
-                        exposureTimeMode: {
-                          timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2200 } }
-                        }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                            exposureTimeMode: {
+                              timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2200 } }
+                            }
+                          }
+                        ]
                       }
                     }
                   }
@@ -227,7 +239,11 @@ class createObservation_GnirsIfu extends OdbSuite:
                         camera: SHORT_BLUE
                         ifu: { fpu: LOW_RESOLUTION }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                          }
+                        ]
                         slit: { explicitTelescopeConfigs: { toSky: [ { offset: { p: { arcseconds: 1 }, q: { arcseconds: 1 } }, guiding: ENABLED } ] } }
                       }
                     }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GnirsLongSlit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GnirsLongSlit.scala
@@ -43,14 +43,18 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         camera: SHORT_BLUE
                         slit: { fpu: LONG_SLIT_0_30 }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
-                        exposureTimeMode: {
-                          timeAndCount: {
-                            time: { seconds: 30.0 }
-                            count: 3
-                            at: { nanometers: 2200 }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                            exposureTimeMode: {
+                              timeAndCount: {
+                                time: { seconds: 30.0 }
+                                count: 3
+                                at: { nanometers: 2200 }
+                              }
+                            }
                           }
-                        }
+                        ]
                       }
                     }
                   }
@@ -68,12 +72,19 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         initialCamera
                         filter
                         initialFilter
-                        coadds
                         decker
                         defaultDecker
                         explicitDecker
-                        centralWavelength { nanometers }
-                        initialCentralWavelength { nanometers }
+                        centralWavelengths {
+                          centralWavelength { nanometers }
+                          coadds
+                          exposureTimeMode {
+                            timeAndCount { time { seconds } count at { nanometers } }
+                          }
+                        }
+                        initialCentralWavelengths {
+                          centralWavelength { nanometers }
+                        }
                         explicitReadMode
                         wellDepth
                         defaultWellDepth
@@ -87,9 +98,6 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                             alongSlit { q { arcseconds } guiding }
                             toSky { offset { p { arcseconds } q { arcseconds } } guiding }
                           }
-                        }
-                        exposureTimeMode {
-                          timeAndCount { time { seconds } count at { nanometers } }
                         }
                         acquisition {
                           explicitAcquisitionType
@@ -123,12 +131,25 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                       "initialCamera": "SHORT_BLUE",
                       "filter": "ORDER3",
                       "initialFilter": "ORDER3",
-                      "coadds": 1,
                       "decker": "SHORT_CAM_LONG_SLIT",
                       "defaultDecker": "SHORT_CAM_LONG_SLIT",
                       "explicitDecker": null,
-                      "centralWavelength": { "nanometers": 2200.000 },
-                      "initialCentralWavelength": { "nanometers": 2200.000 },
+                      "centralWavelengths": [
+                        {
+                          "centralWavelength": { "nanometers": 2200.000 },
+                          "coadds": 1,
+                            "exposureTimeMode": {
+                            "timeAndCount": {
+                              "time": { "seconds": 30.000000 },
+                              "count": 3,
+                              "at": { "nanometers": 2200.000 }
+                            }
+                            }
+                        }
+                      ],
+                      "initialCentralWavelengths": [
+                        { "centralWavelength": { "nanometers": 2200.000 } }
+                      ],
                       "explicitReadMode": null,
                       "wellDepth": "SHALLOW",
                       "defaultWellDepth": "SHALLOW",
@@ -146,13 +167,6 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                             { "q": { "arcseconds": 2.000000 },  "guiding": "ENABLED" }
                           ],
                           "toSky": null
-                        }
-                      },
-                      "exposureTimeMode": {
-                        "timeAndCount": {
-                          "time": { "seconds": 30.000000 },
-                          "count": 3,
-                          "at": { "nanometers": 2200.000 }
                         }
                       },
                       "acquisition": {
@@ -204,14 +218,18 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         camera: SHORT_BLUE
                         slit: { fpu: LONG_SLIT_0_30 }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
-                        exposureTimeMode: {
-                          timeAndCount: {
-                            time: { seconds: 30.0 }
-                            count: 3
-                            at: { nanometers: 2200 }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                            exposureTimeMode: {
+                              timeAndCount: {
+                                time: { seconds: 30.0 }
+                                count: 3
+                                at: { nanometers: 2200 }
+                              }
+                            }
                           }
-                        }
+                        ]
                         acquisition: {
                           explicitAcquisitionType: FAINT
                           skyOffset: {
@@ -348,19 +366,23 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         camera: LONG_RED
                         slit: { fpu: LONG_SLIT_0_45 }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2100 }
-                        coadds: 2
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2100 }
+                            coadds: 2
+                            exposureTimeMode: {
+                              timeAndCount: {
+                                time: { seconds: 10.0 }
+                                count: 5
+                                at: { nanometers: 2200 }
+                              }
+                            }
+                          }
+                        ]
                         explicitDecker: ACQUISITION
                         explicitReadMode: BRIGHT
                         explicitWellDepth: SHALLOW
                         explicitFocusMotorSteps: 500
-                        exposureTimeMode: {
-                          timeAndCount: {
-                            time: { seconds: 10.0 }
-                            count: 5
-                            at: { nanometers: 2200 }
-                          }
-                        }
                       }
                     }
                   }
@@ -373,12 +395,19 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         camera
                         slit { fpu }
                         filter
-                        coadds
                         decker
                         defaultDecker
                         explicitDecker
-                        centralWavelength { nanometers }
-                        initialCentralWavelength { nanometers }
+                        centralWavelengths {
+                          centralWavelength { nanometers }
+                          coadds
+                          exposureTimeMode {
+                            timeAndCount { time { seconds } count at { nanometers } }
+                          }
+                        }
+                        initialCentralWavelengths {
+                          centralWavelength { nanometers }
+                        }
                         explicitReadMode
                         wellDepth
                         defaultWellDepth
@@ -401,12 +430,25 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                       "camera": "LONG_RED",
                       "slit": { "fpu": "LONG_SLIT_0_45" },
                       "filter": "ORDER3",
-                      "coadds": 2,
                       "decker": "ACQUISITION",
                       "defaultDecker": "LONG_CAM_CROSS_DISPERSED",
                       "explicitDecker": "ACQUISITION",
-                      "centralWavelength": { "nanometers": 2100.000 },
-                      "initialCentralWavelength": { "nanometers": 2100.000 },
+                      "centralWavelengths": [
+                        {
+                          "centralWavelength": { "nanometers": 2100.000 },
+                          "coadds": 2,
+                          "exposureTimeMode": {
+                            "timeAndCount": {
+                              "time": { "seconds": 10.000000 },
+                              "count": 5,
+                              "at": { "nanometers": 2200.000 }
+                            }
+                          }
+                        }
+                      ],
+                      "initialCentralWavelengths": [
+                        { "centralWavelength": { "nanometers": 2100.000 } }
+                      ],
                       "explicitReadMode": "BRIGHT",
                       "wellDepth": "SHALLOW",
                       "defaultWellDepth": "DEEP",
@@ -503,15 +545,19 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                           camera: SHORT_BLUE
                           slit: { fpu: LONG_SLIT_0_30 }
                           filter: ORDER3
-                          centralWavelength: { nanometers: 2200 }
-                          explicitFocusMotorSteps: 500
-                          exposureTimeMode: {
-                            timeAndCount: {
-                              time: { seconds: 30.0 }
-                              count: 3
-                              at: { nanometers: 2200 }
+                          centralWavelengths: [
+                            {
+                              centralWavelength: { nanometers: 2200 }
+                              exposureTimeMode: {
+                                timeAndCount: {
+                                  time: { seconds: 30.0 }
+                                  count: 3
+                                  at: { nanometers: 2200 }
+                                }
+                              }
                             }
-                          }
+                          ]
+                          explicitFocusMotorSteps: 500
                         }
                       }
                     }
@@ -551,15 +597,19 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         camera: SHORT_BLUE
                         slit: { fpu: LONG_SLIT_0_30 }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
-                        explicitFocusMotorSteps: 500
-                        exposureTimeMode: {
-                          timeAndCount: {
-                            time: { seconds: 30.0 }
-                            count: 3
-                            at: { nanometers: 2200 }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                            exposureTimeMode: {
+                              timeAndCount: {
+                                time: { seconds: 30.0 }
+                                count: 3
+                                at: { nanometers: 2200 }
+                              }
+                            }
                           }
-                        }
+                        ]
+                        explicitFocusMotorSteps: 500
                       }
                     }
                   }
@@ -792,14 +842,18 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         camera: SHORT_BLUE
                         slit: { fpu: LONG_SLIT_0_30 }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
-                        exposureTimeMode: {
-                          timeAndCount: {
-                            time: { seconds: 30.0 }
-                            count: 3
-                            at: { nanometers: 2200 }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                            exposureTimeMode: {
+                              timeAndCount: {
+                                time: { seconds: 30.0 }
+                                count: 3
+                                at: { nanometers: 2200 }
+                              }
+                            }
                           }
-                        }
+                        ]
                         acquisition: {
                           explicitFilter: H2
                         }
@@ -862,14 +916,18 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         camera: SHORT_BLUE
                         slit: { fpu: LONG_SLIT_0_30 }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
-                        exposureTimeMode: {
-                          timeAndCount: {
-                            time: { seconds: 30.0 }
-                            count: 3
-                            at: { nanometers: 2200 }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                            exposureTimeMode: {
+                              timeAndCount: {
+                                time: { seconds: 30.0 }
+                                count: 3
+                                at: { nanometers: 2200 }
+                              }
+                            }
                           }
-                        }
+                        ]
                         acquisition: {
                           explicitFilter: K
                         }
@@ -912,7 +970,11 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         camera: SHORT_BLUE
                         slit: { fpu: LONG_SLIT_0_30 }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                          }
+                        ]
                         acquisition: {
                           explicitAcquisitionType: BRIGHT
                           skyOffset: { p: { arcseconds: 1.5 }, q: { arcseconds: -2.5 } }
@@ -956,7 +1018,11 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         camera: SHORT_BLUE
                         slit: { fpu: LONG_SLIT_0_30 }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                          }
+                        ]
                         acquisition: {
                           explicitAcquisitionType: FAINT
                         }
@@ -999,14 +1065,18 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         camera: SHORT_BLUE
                         slit: { fpu: LONG_SLIT_0_30 }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
-                        exposureTimeMode: {
-                          timeAndCount: {
-                            time: { seconds: 30.0 }
-                            count: 3
-                            at: { nanometers: 2200 }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                            exposureTimeMode: {
+                              timeAndCount: {
+                                time: { seconds: 30.0 }
+                                count: 3
+                                at: { nanometers: 2200 }
+                              }
+                            }
                           }
-                        }
+                        ]
                         acquisition: {
                           explicitAcquisitionType: BRIGHT
                         }
@@ -1073,10 +1143,14 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         camera: SHORT_BLUE
                         slit: { fpu: LONG_SLIT_0_30 }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
-                        exposureTimeMode: {
-                          timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2200 } }
-                        }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                            exposureTimeMode: {
+                              timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2200 } }
+                            }
+                          }
+                        ]
                       }
                     }
                   }
@@ -1132,11 +1206,15 @@ class createObservation_GnirsLongSlit extends OdbSuite:
                         camera: SHORT_BLUE
                         slit: { fpu: LONG_SLIT_0_30 }
                         filter: ORDER3
-                        centralWavelength: { nanometers: 2200 }
+                        centralWavelengths: [
+                          {
+                            centralWavelength: { nanometers: 2200 }
+                            exposureTimeMode: {
+                              timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2200 } }
+                            }
+                          }
+                        ]
                         telluricType: { tag: SOLAR }
-                        exposureTimeMode: {
-                          timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2200 } }
-                        }
                       }
                     }
                   }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGnirs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ExecutionTestSupportForGnirs.scala
@@ -213,8 +213,12 @@ trait ExecutionTestSupportForGnirs extends ExecutionTestSupport:
       """
     ).void
 
-  /** Replace the science TimeAndCount ETM on a GNIRS LongSlit observation. */
-  def setScienceTimeAndCount(oid: Observation.Id, seconds: BigDecimal, count: Int, atNm: BigDecimal): IO[Unit] =
+  /**
+   * Replace the science TimeAndCount ETM on a GNIRS LongSlit observation.  The
+   * ETM is per central wavelength, so the wavelength must be given too; it
+   * defaults to the 2200 nm the test observations are created with.
+   */
+  def setScienceTimeAndCount(oid: Observation.Id, seconds: BigDecimal, count: Int, atNm: BigDecimal, centralNm: BigDecimal = BigDecimal(2200)): IO[Unit] =
     query(
       pi,
       s"""
@@ -223,13 +227,18 @@ trait ExecutionTestSupportForGnirs extends ExecutionTestSupport:
             SET: {
               observingMode: {
                 gnirsSpectroscopy: {
-                  exposureTimeMode: {
-                    timeAndCount: {
-                      time:  { seconds: $seconds }
-                      count: $count
-                      at:    { nanometers: $atNm }
+                  centralWavelengths: [
+                    {
+                      centralWavelength: { nanometers: $centralNm }
+                      exposureTimeMode: {
+                        timeAndCount: {
+                          time:  { seconds: $seconds }
+                          count: $count
+                          at:    { nanometers: $atNm }
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -254,7 +263,18 @@ trait ExecutionTestSupportForGnirs extends ExecutionTestSupport:
                   camera: LONG_BLUE
                   explicitGrating: D10
                   slit: { fpu: LONG_SLIT_0_20 }
-                  centralWavelength: { nanometers: 3300 }
+                  centralWavelengths: [
+                    {
+                      centralWavelength: { nanometers: 3300 }
+                      exposureTimeMode: {
+                        timeAndCount: {
+                          time: { seconds: 30.0 }
+                          count: 3
+                          at: { nanometers: 3300 }
+                        }
+                      }
+                    }
+                  ]
                   explicitWellDepth: DEEP
                 }
               }
@@ -284,7 +304,18 @@ trait ExecutionTestSupportForGnirs extends ExecutionTestSupport:
                   explicitGrating: D111
                   explicitPrism: LXD
                   slit: { fpu: LONG_SLIT_0_675 }
-                  centralWavelength: { nanometers: 1600 }
+                  centralWavelengths: [
+                    {
+                      centralWavelength: { nanometers: 1600 }
+                      exposureTimeMode: {
+                        timeAndCount: {
+                          time: { seconds: 30.0 }
+                          count: 3
+                          at: { nanometers: 1600 }
+                        }
+                      }
+                    }
+                  ]
                   explicitWellDepth: SHALLOW
                 }
               }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
@@ -488,3 +488,84 @@ class executionSciGnirsLongSlit extends ExecutionTestSupportForGnirs:
             )
           ).asRight
       )
+
+  test("[gnirs] two central wavelengths -> round-robined segments, each with its own calibrations"):
+    // Each central wavelength is its own configuration, so it runs as a
+    // contiguous segment closed by its own flat + arc, and the segments are
+    // round-robined.  With one cycle needed at each, the whole sequence is
+    // sci(2200), cal(2200), sci(2300), cal(2300).
+    val setup: IO[Observation.Id] =
+      for
+        oid <- gnirsObs
+        _   <- query(
+                 pi,
+                 s"""
+                   mutation {
+                     updateObservations(input: {
+                       SET: {
+                         observingMode: {
+                           gnirsSpectroscopy: {
+                             centralWavelengths: [
+                               {
+                                 centralWavelength: { nanometers: 2200 }
+                                 exposureTimeMode: { timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2200 } } }
+                               }
+                               {
+                                 centralWavelength: { nanometers: 2300 }
+                                 exposureTimeMode: { timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2300 } } }
+                               }
+                             ]
+                           }
+                         }
+                       }
+                       WHERE: { id: { EQ: "$oid" } }
+                     }) {
+                       observations { id }
+                     }
+                   }
+                 """
+               ).void
+      yield oid
+
+    // With more than one wavelength the atom titles carry it, so the observer
+    // can tell the segments apart.
+    def titled(atom: Json, description: String): Json =
+      atom.deepMerge(Json.obj("description" -> description.asJson))
+
+    val snapshot2300: GnirsDynamicSnapshot =
+      DynamicSnapshot.copy(
+        centralWavelengthNm = BigDecimal("2300.000"),
+        mirrorWavelengthNm  = Some(BigDecimal("2300.000"))
+      )
+
+    setup.flatMap: oid =>
+      val sci2200 = titled(
+        gnirsExpectedScienceAtom(DynamicSnapshot, (0, 2, Enabled), (0, -4, Enabled), (0, -4, Enabled), (0, 2, Enabled)),
+        "Science Cycle (2200 nm)"
+      )
+      val cal2200 = titled(calAtom(0, 2), "Nighttime Calibrations (2200 nm)")
+      val sci2300 = titled(
+        gnirsExpectedScienceAtom(snapshot2300, (0, 2, Enabled), (0, -4, Enabled), (0, -4, Enabled), (0, 2, Enabled)),
+        "Science Cycle (2300 nm)"
+      )
+      val cal2300 = titled(
+        gnirsExpectedCalAtom(snapshot2300, 0, 2, 20.secondTimeSpan, 2, 1, 10.secondTimeSpan, 3, 1),
+        "Nighttime Calibrations (2300 nm)"
+      )
+
+      expect(
+        user     = pi,
+        query    = gnirsScienceQuery(oid),
+        expected =
+          Json.obj(
+            "executionConfig" -> Json.obj(
+              "gnirs" -> Json.obj(
+                "science" -> Json.obj(
+                  "nextAtom"       -> sci2200,
+                  "possibleFuture" -> List(cal2200, sci2300, cal2300).asJson,
+                  "hasMore"        -> false.asJson
+                )
+              )
+            )
+          ).asRight
+      )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -732,4 +732,93 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
       )
     yield ()
 
+  test("GNIRS spectroscopy: one ITC result set per central wavelength"):
+
+    def setWavelengths(oid: Observation.Id): IO[Unit] =
+      query(
+        user,
+        s"""
+          mutation {
+            updateObservations(input: {
+              SET: {
+                observingMode: {
+                  gnirsSpectroscopy: {
+                    centralWavelengths: [
+                      {
+                        centralWavelength: { nanometers: 2300 }
+                        exposureTimeMode: { timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2300 } } }
+                      }
+                      {
+                        centralWavelength: { nanometers: 2100 }
+                        exposureTimeMode: { timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2100 } } }
+                      }
+                      {
+                        centralWavelength: { nanometers: 2200 }
+                        exposureTimeMode: { timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2200 } } }
+                      }
+                    ]
+                  }
+                }
+              }
+              WHERE: { id: { EQ: "$oid" } }
+            }) {
+              observations { id }
+            }
+          }
+        """
+      ).void
+
+    def q(oid: Observation.Id): String =
+      s"""
+        query {
+          observation(observationId: "$oid") {
+            itc {
+              ... on ItcGnirsSpectroscopy {
+                gnirsSpectroscopyScience {
+                  centralWavelength { nanometers }
+                  results { selected { exposureCount } }
+                }
+                acquisition { selected { exposureCount } }
+              }
+            }
+          }
+        }
+      """
+
+    // One result set per central wavelength, ordered by increasing wavelength.
+    // The fake ITC echoes the requested Time & Count count (3) for science; the
+    // acquisition pass uses the fake default.
+    val expected: Json =
+      json"""
+        {
+          "observation": {
+            "itc": {
+              "gnirsSpectroscopyScience": [
+                {
+                  "centralWavelength": { "nanometers": 2100.000 },
+                  "results": { "selected": { "exposureCount": 3 } }
+                },
+                {
+                  "centralWavelength": { "nanometers": 2200.000 },
+                  "results": { "selected": { "exposureCount": 3 } }
+                },
+                {
+                  "centralWavelength": { "nanometers": 2300.000 },
+                  "results": { "selected": { "exposureCount": 3 } }
+                }
+              ],
+              "acquisition": { "selected": { "exposureCount": ${FakeItcResult.exposureCount.value} } }
+            }
+          }
+        }
+      """
+
+    for
+      p <- createProgram
+      t <- createTargetWithProfileAs(user, p)
+      o <- createGnirsLongSlitObservationAs(user, p, t)
+      _ <- setWavelengths(o)
+      _ <- expect(user = user, query = q(o), expected = expected.asRight)
+    yield ()
+
 }


### PR DESCRIPTION
NOTE: One bit I'm unsure of is in Acquisition.scala. It is using the first (lowest) wavelength and coadds for something, and I'm not sure if that is correct.

What follows is claude's commit message:
The GNIRS higher-resolution modes cover only part of the spectral band, so observers take spectra at several central wavelengths in one observation. Unlike GMOS wavelength dithers, which all contribute to a single S/N, each central wavelength here is a separate configuration: its own exposure time mode, coadds, ITC calculation and smart calibrations.

GnirsSpectroscopy's single centralWavelength / exposureTimeMode / coadds become a list of (centralWavelength, exposureTimeMode, coadds), stored in a new t_gnirs_spectroscopy_wavelength child table modeled on t_gnirs_imaging_filter.  The ITC fans out one call per wavelength, mirroring the per-filter imaging fan out, and returns results keyed by wavelength through the previously unused GNIRS_SPECTROSCOPY ItcType.  The science sequence runs each wavelength as a contiguous segment closed by its own flats and arcs, round-robining between them as the GMOS wavelength-dither generator does; the visit-length budget is shared out, so a single-wavelength observation generates exactly the sequence it did before.

Two adjustments outside GNIRS were required.  check_etm_consistent no longer fixes the science exposure time mode count for gnirs_long_slit / gnirs_ifu, since those are now per wavelength and per row version, as for the imaging modes.  PerScienceObservationCalibrationsService now updates the telluric exposure time modes in place rather than deleting and reinserting them: the wavelength rows reference their ETM with ON DELETE CASCADE, so replacing it would take the observing mode's wavelengths with it.