### PR TITLE
Include overheads for GNIRS component changes

### DIFF
--- a/modules/service/src/main/resources/db/migration/V1249__gnirs_config_change_overheads.sql
+++ b/modules/service/src/main/resources/db/migration/V1249__gnirs_config_change_overheads.sql
@@ -1,4 +1,4 @@
--- GNIRS central wavelength change overhead.
+-- GNIRS config change overheads.
 --
 -- V1148 noted that GNIRS in OCS declares no mechanism-change overheads (no
 -- CONFIG_CHANGE entries in InstGNIRS.calc), and so seeded no gnirs_<mechanism>
@@ -13,6 +13,19 @@ INSERT INTO t_time_estimate VALUES(
   'gnirs_wavelength',
   'GNIRS Wavelength',
   'GNIRS central wavelength change cost',
+  'Gnirs',
+  '10 seconds'
+);
+
+-- The filter wheel moves whenever consecutive steps use different filters.  That
+-- happens in imaging, whose science sequence steps through the configured
+-- filters, and also in spectroscopy: an acquisition images the field and then
+-- the slit or IFU through different filters, even though the science sequence
+-- itself stays on one.
+INSERT INTO t_time_estimate VALUES(
+  'gnirs_filter',
+  'GNIRS Filter',
+  'GNIRS filter change cost',
   'Gnirs',
   '10 seconds'
 );

--- a/modules/service/src/main/resources/db/migration/V1249__gnirs_wavelength_overhead.sql
+++ b/modules/service/src/main/resources/db/migration/V1249__gnirs_wavelength_overhead.sql
@@ -1,0 +1,18 @@
+-- GNIRS central wavelength change overhead.
+--
+-- V1148 noted that GNIRS in OCS declares no mechanism-change overheads (no
+-- CONFIG_CHANGE entries in InstGNIRS.calc), and so seeded no gnirs_<mechanism>
+-- rows.  That held while a GNIRS spectroscopy observation sat at a single
+-- grating setting for its whole science sequence: the grating turret never
+-- moved once the sequence started, so there was nothing to charge.
+--
+-- Observations may now take spectra at several central wavelengths, running
+-- each as its own segment and returning to earlier ones, so the turret moves
+-- repeatedly for the life of the observation.  That motion is charged here.
+INSERT INTO t_time_estimate VALUES(
+  'gnirs_wavelength',
+  'GNIRS Wavelength',
+  'GNIRS central wavelength change cost',
+  'Gnirs',
+  '10 seconds'
+);

--- a/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
@@ -94,6 +94,7 @@ final class Enums(
     case GnirsLongslitMaxVisit      extends TimeEstimate("gnirs_longslit_max_visit")
     case GnirsLongslitSetup         extends TimeEstimate("gnirs_longslit_setup")
     case GnirsReacquisition         extends TimeEstimate("gnirs_reacquisition")
+    case GnirsWavelength            extends TimeEstimate("gnirs_wavelength")
     case GnirsWrite                 extends TimeEstimate("gnirs_write")
 
     case Igrins2LongslitMaxVisit    extends TimeEstimate("igrins2_longslit_max_visit")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/enums/Enums.scala
@@ -91,6 +91,7 @@ final class Enums(
     case GmosSouthReacquisition     extends TimeEstimate("gmos_south_reacquisition")
     case GmosSouthWrite             extends TimeEstimate("gmos_south_write")
 
+    case GnirsFilter                extends TimeEstimate("gnirs_filter")
     case GnirsLongslitMaxVisit      extends TimeEstimate("gnirs_longslit_max_visit")
     case GnirsLongslitSetup         extends TimeEstimate("gnirs_longslit_setup")
     case GnirsReacquisition         extends TimeEstimate("gnirs_reacquisition")

--- a/modules/service/src/main/scala/lucuma/odb/logic/ConfigChangeEstimator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/ConfigChangeEstimator.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.logic
 
 import cats.Eq
+import cats.syntax.apply.*
 import cats.syntax.eq.*
 import cats.syntax.functorFilter.*
 import lucuma.core.math.Angle
@@ -13,7 +14,9 @@ import lucuma.core.model.sequence.StepConfig
 import lucuma.core.model.sequence.flamingos2.Flamingos2DynamicConfig
 import lucuma.core.model.sequence.ghost.GhostDynamicConfig
 import lucuma.core.model.sequence.gmos.DynamicConfig
+import lucuma.core.model.sequence.gnirs.GnirsAcquisitionMirrorMode
 import lucuma.core.model.sequence.gnirs.GnirsDynamicConfig
+import lucuma.core.model.sequence.gnirs.GnirsGratingWavelength
 import lucuma.core.model.sequence.igrins2.Igrins2DynamicConfig
 import lucuma.odb.graphql.enums.Enums
 import lucuma.odb.sequence.StepTimeEstimateCalculator
@@ -99,12 +102,27 @@ object ConfigChangeEstimator:
           past: StepTimeEstimateCalculator.Last[GnirsDynamicConfig],
           present: ProtoStep[GnirsDynamicConfig]
         ): List[Option[ConfigChangeEstimate]] =
-          // GNIRS in OCS does not declare any mechanism-change overheads (no
-          // CONFIG_CHANGE entries in InstGNIRS.calc, unlike GMOS / Flamingos-2
-          // / NIRI / GSAOI / GPI / NICI).  We match that here.  If a future
-          // requirement adds GNIRS mechanism costs, add them per-mechanism —
-          // the base trait still applies the generic offset + gcal overheads.
-          Nil
+          // GNIRS in OCS declares no mechanism-change overheads (no CONFIG_CHANGE
+          // entries in InstGNIRS.calc, unlike GMOS / Flamingos-2 / NIRI / GSAOI /
+          // GPI / NICI), so the filter, FPU, camera, decker and prism are all
+          // free here.  The exception is the central wavelength: an observation
+          // may take spectra at several, and the grating turret moves each time
+          // the sequence changes between them.
+          //
+          // Only a genuine wavelength change counts: both steps must have the
+          // mirror out, and their grating settings must differ.  Moving the
+          // mirror in and out during acquisition is not a wavelength change, so
+          // it is deliberately not charged here -- which a plain `check` on the
+          // wavelength would do, since it reads as None with the mirror in.
+          def wavelengthOf(d: GnirsDynamicConfig): Option[GnirsGratingWavelength] =
+            GnirsAcquisitionMirrorMode.out.getOption(d.acquisitionMirror).map(_.wavelength)
+
+          val changed: Boolean =
+            (past.step.flatMap(s => wavelengthOf(s.value)), wavelengthOf(present.value))
+              .mapN(_ =!= _)
+              .getOrElse(false)
+
+          List(Option.when(changed)(enums.TimeEstimate.GnirsWavelength.toConfigChange))
 
     private def gcal[D](past: StepTimeEstimateCalculator.Last[D], present: ProtoStep[D]): List[ConfigChangeEstimate] =
       val scienceFold = Option.unless(past.step.exists(_.stepConfig.usesGcalUnit) === present.stepConfig.usesGcalUnit)(

--- a/modules/service/src/main/scala/lucuma/odb/logic/ConfigChangeEstimator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/logic/ConfigChangeEstimator.scala
@@ -122,7 +122,14 @@ object ConfigChangeEstimator:
               .mapN(_ =!= _)
               .getOrElse(false)
 
-          List(Option.when(changed)(enums.TimeEstimate.GnirsWavelength.toConfigChange))
+          // The filter is a plain field, so the usual check applies.  It moves in
+          // imaging, whose science sequence steps through the configured filters,
+          // and in spectroscopy acquisition, which images the field and then the
+          // slit or IFU through different filters.
+          List(
+            Option.when(changed)(enums.TimeEstimate.GnirsWavelength.toConfigChange),
+            check(enums.TimeEstimate.GnirsFilter, past, present)(_.filter)
+          )
 
     private def gcal[D](past: StepTimeEstimateCalculator.Last[D], present: ProtoStep[D]): List[ConfigChangeEstimate] =
       val scienceFold = Option.unless(past.step.exists(_.stepConfig.usesGcalUnit) === present.stepConfig.usesGcalUnit)(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirs.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionAcqGnirs.scala
@@ -568,3 +568,60 @@ class executionAcqGnirs extends ExecutionTestSupportForGnirs:
             s"Could not generate a sequence for $oid: PAH acquisition filter cannot be used with short camera"
           ).asLeft
         )
+
+  test("[gnirs] the acquisition filter change costs the configured overhead"):
+    // A spectroscopy acquisition images the slit and then the field, and the two
+    // do not always use the same filter: the slit image falls back to H (Order4)
+    // for filters that have no short-camera entry of their own, so an H2
+    // acquisition moves the wheel even though the science sequence stays on one
+    // filter.  (With the default Order3 the two coincide and nothing is charged,
+    // which is why this picks H2 explicitly.)
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createGnirsLongSlitObservationAs(pi, p, t)
+        _ <- setAcquisitionTimeAndCount(o, 5.0, 1, 1645)
+        _ <- setAcquisitionFilter(o, "H2")
+      yield o
+
+    setup.flatMap: oid =>
+      query(
+        pi,
+        s"""
+          query {
+            executionConfig(observationId: "$oid") {
+              gnirs {
+                acquisition {
+                  nextAtom { steps { instrumentConfig { filter } estimate { configChange { all { name estimate { seconds } } } } } }
+                }
+              }
+            }
+          }
+        """
+      ).map: json =>
+        val steps =
+          json.hcursor
+            .downField("executionConfig").downField("gnirs").downField("acquisition")
+            .downField("nextAtom").downField("steps")
+            .values.toList.flatten
+
+        val filters: List[String] =
+          steps.flatMap(_.hcursor.downField("instrumentConfig").downField("filter").as[String].toOption)
+
+        val filterChanges: List[BigDecimal] =
+          steps.flatMap: step =>
+            step.hcursor
+              .downField("estimate").downField("configChange").downField("all")
+              .values.toList.flatten
+              .flatMap: c =>
+                (for
+                  n <- c.hcursor.downField("name").as[String].toOption
+                  v <- c.hcursor.downField("estimate").downField("seconds").as[BigDecimal].toOption
+                  if n == "GNIRS Filter"
+                yield v).toList
+
+        // The acquisition really does change filter, and each change is charged.
+        assertEquals(filterChanges.size, filters.zip(filters.tail).count(_ != _))
+        assert(filterChanges.nonEmpty, s"expected a filter change in the acquisition; filters were $filters")
+        assert(filterChanges.forall(_ == BigDecimal("10.000000")), s"unexpected costs: $filterChanges")

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsImaging.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsImaging.scala
@@ -251,3 +251,56 @@ class executionSciGnirsImaging extends ExecutionTestSupportForGnirs:
     setup.flatMap: oid =>
       query(pi, gnirsAcquisitionQuery(oid)).map: json =>
         assert(json.hcursor.downFields("executionConfig", "gnirs", "acquisition").focus.exists(!_.isNull))
+
+  test("[gnirs] an imaging filter change costs the configured overhead"):
+    // Grouped imaging runs all of J then all of Order4, so the wheel moves once,
+    // entering the second filter's block.
+    val mode =
+      s"""
+        gnirsImaging: {
+          camera: SHORT_BLUE
+          variant: { grouped: { skyCount: 0 } }
+          filters: [ { filter: J }, { filter: ORDER4 } ]
+        }
+      """
+
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationWithModeAs(pi, p, List(t), mode)
+      yield o
+
+    setup.flatMap: oid =>
+      query(
+        pi,
+        s"""
+          query {
+            executionConfig(observationId: "$oid") {
+              gnirs {
+                science {
+                  nextAtom { steps { estimate { configChange { all { name estimate { seconds } } } } } }
+                  possibleFuture { steps { estimate { configChange { all { name estimate { seconds } } } } } }
+                }
+              }
+            }
+          }
+        """
+      ).map: json =>
+        val sci = json.hcursor.downField("executionConfig").downField("gnirs").downField("science")
+        val atoms = sci.downField("nextAtom").focus.toList ++
+                    sci.downField("possibleFuture").values.toList.flatten
+        val filterChanges =
+          atoms.flatMap: atom =>
+            atom.hcursor.downField("steps").values.toList.flatten.flatMap: step =>
+              step.hcursor
+                .downField("estimate").downField("configChange").downField("all")
+                .values.toList.flatten
+                .flatMap: c =>
+                  (for
+                    n <- c.hcursor.downField("name").as[String].toOption
+                    v <- c.hcursor.downField("estimate").downField("seconds").as[BigDecimal].toOption
+                    if n == "GNIRS Filter"
+                  yield v).toList
+
+        assertEquals(filterChanges, List(BigDecimal("10.000000")))

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsLongSlit.scala
@@ -569,3 +569,77 @@ class executionSciGnirsLongSlit extends ExecutionTestSupportForGnirs:
             )
           ).asRight
       )
+
+  test("[gnirs] a central wavelength change costs the configured overhead"):
+    // The sequence is sci(2200), cal(2200), sci(2300), cal(2300).  The grating
+    // turret moves exactly once, entering the 2300 nm segment, so that segment's
+    // first step should carry a GNIRS Wavelength config change and no other step
+    // should.
+    val setup: IO[Observation.Id] =
+      for
+        oid <- gnirsObs
+        _   <- query(
+                 pi,
+                 s"""
+                   mutation {
+                     updateObservations(input: {
+                       SET: {
+                         observingMode: {
+                           gnirsSpectroscopy: {
+                             centralWavelengths: [
+                               {
+                                 centralWavelength: { nanometers: 2200 }
+                                 exposureTimeMode: { timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2200 } } }
+                               }
+                               {
+                                 centralWavelength: { nanometers: 2300 }
+                                 exposureTimeMode: { timeAndCount: { time: { seconds: 30.0 } count: 3 at: { nanometers: 2300 } } }
+                               }
+                             ]
+                           }
+                         }
+                       }
+                       WHERE: { id: { EQ: "$oid" } }
+                     }) { observations { id } }
+                   }
+                 """
+               ).void
+      yield oid
+
+    setup.flatMap: oid =>
+      query(
+        pi,
+        s"""
+          query {
+            executionConfig(observationId: "$oid") {
+              gnirs {
+                science {
+                  nextAtom { steps { estimate { configChange { all { name estimate { seconds } } } } } }
+                  possibleFuture { steps { estimate { configChange { all { name estimate { seconds } } } } } }
+                }
+              }
+            }
+          }
+        """
+      ).map: json =>
+        val changes: List[(String, BigDecimal)] =
+          json.hcursor
+            .downField("executionConfig").downField("gnirs").downField("science")
+            .focus
+            .toList
+            .flatMap: sci =>
+              val atoms = sci.hcursor.downField("nextAtom").focus.toList ++
+                          sci.hcursor.downField("possibleFuture").values.toList.flatten
+              atoms.flatMap: atom =>
+                atom.hcursor.downField("steps").values.toList.flatten.flatMap: step =>
+                  step.hcursor
+                    .downField("estimate").downField("configChange").downField("all")
+                    .values.toList.flatten
+                    .flatMap: c =>
+                      (for
+                        n <- c.hcursor.downField("name").as[String].toOption
+                        v <- c.hcursor.downField("estimate").downField("seconds").as[BigDecimal].toOption
+                      yield (n, v)).toList
+
+        val wavelengthChanges = changes.filter(_._1 == "GNIRS Wavelength")
+        assertEquals(wavelengthChanges.map(_._2), List(BigDecimal("10.000000")))


### PR DESCRIPTION
Add 10 second overheads for GNIRS filter changes and wavelength changes. See individual commit messages for more detail. Science will more accurately measure the timing when the instrument is available and we will update the times as needed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>