### PR TITLE
SS-9725 initial support for warnings take2

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -94,9 +94,6 @@ object ObservationWorkflowService {
   type ExecutionState  = Ongoing.type   | Completed.type
   type ValidationState = Undefined.type | Unapproved.type | Defined.type
 
-  @deprecated("remove this forwarder")
-  val Messages = ObservationValidator.Messages
-
   extension (ws: ObservationWorkflowState) def asUserState: Option[UserState] =
     ws match
       case Inactive => Some(Inactive)

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -13,38 +13,24 @@ import lucuma.core.enums.Band
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.ConfigurationRequestStatus
 import lucuma.core.enums.DeclaredExecutionState
-import lucuma.core.enums.DeclaredExecutionState.given
 import lucuma.core.enums.ExchangeObservingModeType
 import lucuma.core.enums.ExecutionState as CoreExecutionState
 import lucuma.core.enums.Instrument
-import lucuma.core.enums.KeckInstrument
 import lucuma.core.enums.ObservationValidationCode
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.Observatory
 import lucuma.core.enums.ObservingModeType
-import lucuma.core.enums.ProgramType
-import lucuma.core.enums.ProposalStatus
 import lucuma.core.enums.ScienceBand
-import lucuma.core.enums.Site
-import lucuma.core.enums.SubaruInstrument
 import lucuma.core.enums.TooActivation
 import lucuma.core.enums.VisitorObservingModeType
-import lucuma.core.math.Coordinates
-import lucuma.core.math.Declination
-import lucuma.core.math.RightAscension
 import lucuma.core.model.Access
-import lucuma.core.model.CallCoordinatesLimits
-import lucuma.core.model.CallForProposals
 import lucuma.core.model.Observation
 import lucuma.core.model.ObservationValidation
 import lucuma.core.model.ObservationWorkflow
 import lucuma.core.model.Program
-import lucuma.core.model.SiteCoordinatesLimits
 import lucuma.core.model.StandardRole.*
 import lucuma.core.model.Target
 import lucuma.core.syntax.string.*
-import lucuma.core.util.DateInterval
-import lucuma.core.util.Timestamp
 import lucuma.odb.data.Itc
 import lucuma.odb.data.ItcAcquisition
 import lucuma.odb.data.ObservationValidationMap
@@ -55,18 +41,14 @@ import lucuma.odb.sequence.data.GeneratorParams
 import lucuma.odb.sequence.data.ItcInputDerivation
 import lucuma.odb.sequence.data.MissingParamSet
 import lucuma.odb.service.GeneratorParamsService.Error as GenParamsError
-import lucuma.odb.service.ObservationWorkflowService.UserState
 import lucuma.odb.service.Services.SuperUserAccess
-import lucuma.odb.syntax.instrument.*
-import lucuma.odb.syntax.observingModeType.*
 import lucuma.odb.util.Codecs.*
 import skunk.*
 import skunk.codec.boolean.*
 import skunk.implicits.*
 
-import java.time.Instant
-
 import Services.Syntax.*
+import workflow.*
 
 sealed trait ObservationWorkflowService[F[_]] {
 
@@ -119,124 +101,6 @@ sealed trait ObservationWorkflowService[F[_]] {
   )(using NoTransaction[F], SuperUserAccess): F[Result[List[Target.Id]]]
 
 }
-
-/* Validation Info Record */
-case class ObservationValidationInfo(
-  pid:                    Program.Id,
-  tpe:                    ProgramType,
-  oid:                    Observation.Id,
-  observingMode:          Option[ObservingModeType],
-  coordinates:            Option[Coordinates],  // explicit base, or coordinates at CFP midpoint, if any
-  explicitBase:           Option[Coordinates],
-  calibrationRole:        Option[CalibrationRole],
-  userState:              Option[ObservationWorkflowService.UserState],
-  declaredExecutionState: Option[DeclaredExecutionState],
-  proposalStatus:         ProposalStatus,
-  tooActivation:          TooActivation,
-  tooCeiling:             Option[TooActivation], // effective proposal ceiling; None when the program has no proposal
-  cfpid:                  Option[CallForProposals.Id],
-  scienceBand:            Option[ScienceBand],
-  asterism:               List[Target],
-  associatedUserState:    Option[ObservationWorkflowService.UserState], // state of science obs if this is a per-observation calibration (telluric or daytime pinhole)
-  generatorParams:        Option[Either[GeneratorParamsService.Error, GeneratorParams]] = None,
-  cfpInfo:                Option[CfpInfo] = None,
-  programAllocations:     Option[NonEmptyList[ScienceBand]] = None,
-  otherConfigErrors:      List[String] = Nil,
-  keckInstrument:         Option[KeckInstrument] = None,   // set for exchange_keck observations
-  subaruInstrument:       Option[SubaruInstrument] = None  // set for exchange_subaru observations
-) {
-
-  def isDeclaredComplete: Boolean =
-    declaredExecutionState === Some(CoreExecutionState.DeclaredComplete)
-
-  def instrument: Option[Instrument] =
-    observingMode.flatMap(_.instrumentOption)
-
-  def effectiveUserState: Option[UserState] =
-    // Per-observation calibrations (tellurics, daytime pinhole flats) inherit
-    // their science observation's user state.
-    // A telluric could be declined however, thus it can carrie its own Inactive state,
-    // which overrides that inheritance.
-    if calibrationRole.contains(CalibrationRole.Telluric) && userState.contains(ObservationWorkflowState.Inactive) then Some(ObservationWorkflowState.Inactive)
-    else if calibrationRole.exists(ObsExtract.PerObservationCalibrationRoles.contains) then associatedUserState
-    else userState
-
-  /* Has the proposal been accepted? */
-  def isAccepted:Boolean =
-    proposalStatus === ProposalStatus.Accepted
-
-  /**
-   * Does this observation demand more Target-of-Opportunity disruption than the
-   * program's proposal allows?  Before acceptance the ceiling is derived as the
-   * maximum over the program's own observations, so this can only be true then
-   * if the PI explicitly chose a ceiling below one of their observations -- also
-   * worth surfacing.  A program with no proposal has no ceiling to enforce.
-   */
-  def exceedsTooCeiling: Boolean =
-    tooCeiling.exists(tooActivation > _)
-
-  def site: Option[Site] =
-    instrument.map(_.site)
-
-  /**
-   * Is this a Target-of-Opportunity observation -- one that waits for an alert
-   * rather than for the queue?  Setting such an observation `Ready` is what
-   * requests its trigger.
-   *
-   * Independent of [[hasTooTarget]]: this is about the observation's declared
-   * urgency, not about whether its target has been found yet.
-   */
-  def isTooObservation: Boolean =
-    tooActivation =!= TooActivation.None
-
-  /**
-   * Does the asterism still hold an opportunity target -- the placeholder that
-   * stands in for a Target of Opportunity until the real one is identified?
-   *
-   * Independent of [[isTooObservation]]: a placeholder is only coherent in an
-   * observation that declares a ToO activation, and only until the alert
-   * arrives, but neither implies the other.
-   */
-  def hasTooTarget: Boolean =
-    asterism.exists:
-      case t: Target.Opportunity => true
-      case _ => false
-
-  def isVisitor: Boolean =
-    observingMode.exists:
-      case _: VisitorObservingModeType => true
-      case _ => false
-
-  def isExchange: Boolean =
-    observingMode.exists(_.isExchange)
-
-  lazy val cfpMidpoint: Option[Timestamp] =
-    for
-      s  <- site
-      c  <- cfpInfo
-      ts <- Timestamp.fromInstant(c.midpoint(s))
-    yield ts
-
-}
-
-case class CfpInfo(
-  cfpid:             CallForProposals.Id,
-  observatory:       Observatory,
-  limits:            CallCoordinatesLimits,
-  active:            DateInterval,
-  instruments:       List[Instrument],        // Gemini instruments allowed by the call
-  keckInstruments:   List[KeckInstrument],    // Keck exchange instruments allowed by the call
-  subaruInstruments: List[SubaruInstrument]   // Subaru exchange instruments allowed by the call
-) {
-
-  def midpoint(at: Site): Instant =
-    at.midpoint(active)
-
-  def addInstrument(insts: Option[Instrument]): CfpInfo =
-    insts.fold(this)(inst => copy(instruments = inst :: instruments))
-
-}
-
 
 object ObservationWorkflowService {
 
@@ -310,152 +174,6 @@ object ObservationWorkflowService {
   /* Construct an instance. */
   def instantiate[F[_]: Async](using Services[F]): ObservationWorkflowService[F] =
     new ObservationWorkflowService[F] {
-
-      private def lookupObsDefinitions(
-        oids: List[Observation.Id]
-      )(using Transaction[F]): F[Map[Observation.Id, ObservationValidationInfo]] = {
-
-        def partialObsInfos(oids: NonEmptyList[Observation.Id]): F[Map[Observation.Id, ObservationValidationInfo]] =
-          val enc = observation_id.nel(oids)
-          session
-            .stream(Statements.ObservationValidationInfosWithoutAsterisms(enc))(oids, 1024)
-            .compile
-            .toList
-            .map: list =>
-              list
-                .fproductLeft(_.oid)
-                .toMap
-
-        def addAsterisms(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
-          Services.asSuperUser:
-            asterismService
-              .getAsterisms(input.keys.toList)
-              .map: results =>
-                input.map: (oid, info) =>
-                  oid -> info.copy(asterism = results.get(oid).foldMap(_.map(_._2)))
-
-        def addGeneratorParams(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
-          generatorParamsService
-            .selectMany(input.keys.toList)
-            .map: results =>
-              input.map: (oid, info) =>
-                oid -> info.copy(generatorParams = results.get(oid))
-
-        def addCfpInfos(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
-          NonEmptyList.fromList(input.values.flatMap(_.cfpid).toList.distinct) match
-            case None => input.pure[F]
-            case Some(nel) =>
-              val enc = cfp_id.nel(nel)
-              session
-                .stream(Statements.CfpInfos(enc))(nel, 1024)
-                .compile
-                .fold(Map.empty[CallForProposals.Id, CfpInfo]):
-                  case (m, (cfp, oinst)) =>
-                    m.updatedWith(cfp.cfpid):
-                      case None    => cfp.addInstrument(oinst).some
-                      case Some(c) => c.addInstrument(oinst).some
-                .map: results =>
-                  input.map: (oid, info) =>
-                    oid -> info.copy(cfpInfo = info.cfpid.flatMap(results.get))
-
-        // Enriches exchange observations with their chosen Keck/Subaru instrument.
-        // Only exchange-mode observations are looked up, so non-exchange programs
-        // pay nothing here.
-        def addExchangeInfos(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
-          val exchangeOids =
-            input.collect:
-              case (oid, info) if info.observingMode.exists(_.isExchange) => oid
-            .toList
-          if exchangeOids.isEmpty then input.pure[F]
-          else
-            exchangeService.select(exchangeOids).map: configs =>
-              input.map: (oid, info) =>
-                configs.get(oid).fold(oid -> info): cfg =>
-                  oid -> info.copy(keckInstrument = cfg.keckInstrument, subaruInstrument = cfg.subaruInstrument)
-
-        def addProgramAllocations(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
-          NonEmptyList.fromList(input.values.map(_.pid).toList.distinct) match
-            case None => input.pure[F]
-            case Some(nel) =>
-              val enc = program_id.nel(nel)
-              session
-                .stream(Statements.ProgramAllocations(enc))(nel, 1024)
-                .compile
-                .toList
-                .map: list =>
-                  list.foldMap: (pid, band) =>
-                    Map(pid -> NonEmptyList.one(band))
-                .map: result =>
-                  input.map: (oid, info) =>
-                    oid -> info.copy(programAllocations = result.get(info.pid))
-
-        def addCoordinates(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
-          input
-            .values
-            .groupBy(_.cfpMidpoint)
-            .collect:
-              case (Some(k), v) => k -> v.toList.map(_.oid)
-            .toList // we now have a list of (Timestamp, List[oid]) batches
-            .foldLeftM(input): // fold over this list with `input` as the starting point, updating when we can find coordinates
-              case (accum, (when, batch)) =>
-                trackingService
-                  .getCoordinatesSnapshotOrRegion(batch, when, false)
-                  .map: batchResults =>
-                    batchResults
-                      .collect:
-                        case (oid, Result.Success(Left(snap))) => oid -> snap.base // we only care about results where coordinates are known
-                        case (oid, Result.Success(Right(_, Some(eb)))) => oid -> eb
-                      .foldLeft(accum):
-                        case (accum2, (oid, coords)) =>
-                          accum2.updatedWith(oid): op =>
-                            op.map(_.copy(coordinates = Some(coords)))
-
-        // Configuration errors that don't fit elsewhere.
-        def addOtherConfigErrors(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
-          import lucuma.odb.sequence.ghost.ifu.Config as GhostIfu
-
-          extension (e: CoreExecutionState)
-            def shouldCheck: Boolean =
-              e match
-                case CoreExecutionState.NotDefined |
-                     CoreExecutionState.NotStarted => true
-                case _                             => false
-
-          // Get a list of GHOST observations that need to be checked.
-          val ghostObsList: List[Observation.Id] =
-            input
-              .toList
-              .mapFilter: (oid, info) =>
-                info
-                  .generatorParams
-                  .flatMap(_.toOption)
-                  .flatMap: params =>
-                    params.observingMode match
-                      case GhostIfu(_, _, _, _, _, _, _, _) if params.executionState.shouldCheck => oid.some
-                      case _                                                                     => none
-
-          // Validate each one to ensure it has an IFU mapping.
-          ghostIfuService
-            .validationErrors(ghostObsList)
-            .map: errors =>
-              errors.toList.foldLeft(input) { case (m, (oid, msg)) =>
-                m.updatedWith(oid): info =>
-                  info.map(in => in.copy(otherConfigErrors = msg :: in.otherConfigErrors))
-              }
-
-        NonEmptyList.fromList(oids) match
-          case None      =>
-            Map.empty.pure
-          case Some(nel) =>
-            partialObsInfos(nel)
-              .flatMap(addAsterisms)
-              .flatMap(addGeneratorParams)
-              .flatMap(addCfpInfos)
-              .flatMap(addExchangeInfos)
-              .flatMap(addProgramAllocations)
-              .flatMap(addCoordinates)
-              .flatMap(addOtherConfigErrors)
-      }
 
       private def lookupCachedItcResults(
         input:      Map[Observation.Id, ObservationValidationInfo],
@@ -783,7 +501,7 @@ object ObservationWorkflowService {
           services.transactionally:
             (
               for
-                infos  <- ResultT.liftF(lookupObsDefinitions(oids))         // Map[Observation.Id, ObsDefinition]
+                infos  <- ResultT.liftF(ObservationValidationInfo.fetch(oids))         // Map[Observation.Id, ObsDefinition]
                 itcRes <- ResultT.liftF(lookupCachedItcResults(infos))      // Map[Observation.Id, ItcService.AsterismResults]
                 errs   <- validateObsDefinition(infos, itcRes.get)          // Map[Observation.Id, ObservationValidationMap]
               yield (infos, errs, itcRes)
@@ -815,7 +533,7 @@ object ObservationWorkflowService {
         exec0: Option[CoreExecutionState]
       )(using Transaction[F]): F[Result[ObservationWorkflow]] =
         (for
-          infos <- ResultT.liftF(lookupObsDefinitions(List(oid)))
+          infos <- ResultT.liftF(ObservationValidationInfo.fetch(List(oid)))
           errs  <- validateObsDefinition(infos, _ => itc)
           exec = exec0.filter:
             case a: DeclaredExecutionState => true // always ok
@@ -967,99 +685,6 @@ object ObservationWorkflowService {
   }
 
   object Statements {
-
-    def ObservationValidationInfosWithoutAsterisms[A <: NonEmptyList[Observation.Id]](enc: Encoder[A]): Query[A, ObservationValidationInfo] =
-      sql"""
-        SELECT
-          o.c_program_id,
-          p.c_program_type,
-          o.c_observation_id,
-          o.c_observing_mode_type,
-          o.c_explicit_ra,
-          o.c_explicit_dec,
-          o.c_calibration_role,
-          o.c_workflow_user_state,
-          o.c_declared_state,
-          p.c_proposal_status,
-          o.c_too_activation,
-          x.c_too_activation_effective,
-          x.c_cfp_id,
-          o.c_science_band,
-          s.c_workflow_user_state
-        FROM t_observation o
-        JOIN t_program p on p.c_program_id = o.c_program_id
-        -- v_proposal rather than t_proposal: it adds the effective ToO ceiling
-        -- (explicit, else derived from the program's observations).
-        LEFT JOIN v_proposal x
-          ON o.c_program_id = x.c_program_id
-        LEFT JOIN t_observation s
-          ON  o.c_calibration_role = ANY(ARRAY['telluric','daytime_pinhole']::e_calibration_role[])
-          AND s.c_calibration_role IS NULL
-          AND o.c_group_id = s.c_group_id
-        WHERE o.c_observation_id IN ($enc)
-      """
-      .query(program_id *: program_type *: observation_id *: observing_mode_type.opt *: right_ascension.opt *: declination.opt *: calibration_role.opt *: user_state.opt *: declared_execution_state.opt *: proposal_status *: too_activation *: too_activation.opt *: cfp_id.opt *: science_band.opt *: user_state.opt)
-      .map:
-        case (pid, tpe, oid, mode, ra, dec, cal, state, ds, ps, too, ceil, cfp, sci, state2) =>
-          ObservationValidationInfo(pid, tpe, oid, mode, None, (ra, dec).mapN(Coordinates.apply), cal, state, ds, ps, too, ceil, cfp, sci, Nil, state2)
-
-    def ProgramAllocations[A <: NonEmptyList[Program.Id]](enc: Encoder[A]): Query[A, (Program.Id, ScienceBand)] =
-      sql"""
-        SELECT DISTINCT
-          c_program_id,
-          c_science_band
-        FROM
-          t_allocation
-        WHERE
-          c_program_id IN ($enc)
-      """.query(program_id *: science_band)
-
-    def CfpInfos[A <: NonEmptyList[CallForProposals.Id]](enc: Encoder[A]): Query[A, (CfpInfo, Option[Instrument])] =
-      sql"""
-        SELECT
-          c.c_cfp_id,
-          c.c_observatory,
-          c.c_north_ra_start,
-          c.c_north_ra_end,
-          c.c_north_dec_start,
-          c.c_north_dec_end,
-          c.c_south_ra_start,
-          c.c_south_ra_end,
-          c.c_south_dec_start,
-          c.c_south_dec_end,
-          c.c_active_start,
-          c.c_active_end,
-          c.c_keck_instruments,
-          c.c_subaru_instruments,
-          i.c_instrument
-        FROM t_cfp c
-        LEFT JOIN t_gemini_cfp_instrument i
-        ON c.c_cfp_id = i.c_cfp_id
-        WHERE c.c_cfp_id in ($enc)
-      """.query(
-          cfp_id                 *:
-          observatory            *:
-          right_ascension        *: // north limits
-          right_ascension        *: // north limits
-          declination            *: // north limits
-          declination            *: // north liits
-          right_ascension.opt    *: // south limits
-          right_ascension.opt    *: // south limits
-          declination.opt        *: // south limits
-          declination.opt        *: // south limits
-          date_interval          *: // active period
-          _keck_instrument.opt   *:
-          _subaru_instrument.opt *:
-          instrument.opt
-        ).map:
-          // The south coordinate limits are null for exchange (keck/subaru) calls,
-          // which use only the northern limits.  Exchange observations have no site
-          // and so never exercise the coordinate-limit validation; we fall back to
-          // the north limits to keep CallCoordinatesLimits total.
-          case (id, obs, n_ra_s, n_ra_e, n_dec_s, n_dec_e, s_ra_s, s_ra_e, s_dec_s, s_dec_e, active, keck, subaru, oinst) =>
-            val north = SiteCoordinatesLimits(n_ra_s, n_ra_e, n_dec_s, n_dec_e)
-            val south = (s_ra_s, s_ra_e, s_dec_s, s_dec_e).mapN(SiteCoordinatesLimits.apply).getOrElse(north)
-            (CfpInfo(id, obs, CallCoordinatesLimits(north, south), active, Nil, keck.orEmpty, subaru.orEmpty), oinst)
 
     val UpdateUserState: Command[(Option[UserState], Observation.Id)] =
       sql"""

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationWorkflowService.scala
@@ -3,44 +3,28 @@
 
 package lucuma.odb.service
 
-import cats.data.NonEmptyChain
-import cats.data.NonEmptyList
 import cats.effect.Async
 import cats.implicits.*
 import grackle.Result
 import grackle.ResultT
-import lucuma.core.enums.Band
 import lucuma.core.enums.CalibrationRole
-import lucuma.core.enums.ConfigurationRequestStatus
 import lucuma.core.enums.DeclaredExecutionState
-import lucuma.core.enums.ExchangeObservingModeType
 import lucuma.core.enums.ExecutionState as CoreExecutionState
-import lucuma.core.enums.Instrument
 import lucuma.core.enums.ObservationValidationCode
 import lucuma.core.enums.ObservationWorkflowState
-import lucuma.core.enums.Observatory
 import lucuma.core.enums.ObservingModeType
-import lucuma.core.enums.ScienceBand
-import lucuma.core.enums.TooActivation
 import lucuma.core.enums.VisitorObservingModeType
 import lucuma.core.model.Access
 import lucuma.core.model.Observation
-import lucuma.core.model.ObservationValidation
 import lucuma.core.model.ObservationWorkflow
 import lucuma.core.model.Program
 import lucuma.core.model.StandardRole.*
 import lucuma.core.model.Target
-import lucuma.core.syntax.string.*
 import lucuma.odb.data.Itc
-import lucuma.odb.data.ItcAcquisition
 import lucuma.odb.data.ObservationValidationMap
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.graphql.mapping.AccessControl
-import lucuma.odb.sequence.data.GeneratorParams
-import lucuma.odb.sequence.data.ItcInputDerivation
-import lucuma.odb.sequence.data.MissingParamSet
-import lucuma.odb.service.GeneratorParamsService.Error as GenParamsError
 import lucuma.odb.service.Services.SuperUserAccess
 import lucuma.odb.util.Codecs.*
 import skunk.*
@@ -110,35 +94,8 @@ object ObservationWorkflowService {
   type ExecutionState  = Ongoing.type   | Completed.type
   type ValidationState = Undefined.type | Unapproved.type | Defined.type
 
-  /* Validation Messages */
-  object Messages {
-
-    val CoordinatesOutOfRange = "Base coordinates out of Call for Proposals limits."
-
-    def invalidInstrument(instr: Instrument): String =
-      s"Instrument $instr not part of Call for Proposals."
-
-    def invalidScienceBand(b: ScienceBand): String =
-      s"Science Band ${b.tag.toScreamingSnakeCase} has no time allocation."
-
-    def tooActivationExceedsCeiling(obs: TooActivation, ceiling: TooActivation): String =
-      s"Target of Opportunity activation ${obs.tag.toScreamingSnakeCase} exceeds the maximum " +
-      s"${ceiling.tag.toScreamingSnakeCase} allowed by the proposal."
-
-    val OpportunityTargetRequiresActivation =
-      "An observation with a Target of Opportunity placeholder must set a ToO activation other than NONE."
-
-    val OpportunityTargetNotResolved =
-      "Replace the Target of Opportunity placeholder with the actual target coordinates."
-
-    def exchangeObservatoryMismatch(modeObs: Observatory, cfpObs: Observatory): String =
-      s"Exchange observation requires a $modeObs Call for Proposals, but the proposal's observatory is $cfpObs."
-
-    def invalidExchangeInstrument(instr: String): String =
-      s"Instrument $instr is not part of the Call for Proposals."
-
-    val MissingVMagnitude = "Please add a V magnitude."
-  }
+  @deprecated("remove this forwarder")
+  val Messages = ObservationValidator.Messages
 
   extension (ws: ObservationWorkflowState) def asUserState: Option[UserState] =
     ws match
@@ -162,15 +119,6 @@ object ObservationWorkflowService {
       case ((ls, rs), (a, Left(b)))  => (ls + (a -> b), rs)
       case ((ls, rs), (a, Right(c))) => (ls, rs + (a -> c))
 
-  extension (mp: MissingParamSet)
-    def toObsValidation: ObservationValidation =
-      ObservationValidation.configuration(s"Missing ${mp.params.map(_.name).toList.intercalate(", ")}")
-
-  extension (ge: GeneratorParamsService.Error)
-    private def toObsValidation: ObservationValidation = ge match
-      case GenParamsError.MissingData(p) => p.toObsValidation
-      case _                             => ObservationValidation.configuration(ge.format)
-
   /* Construct an instance. */
   def instantiate[F[_]: Async](using Services[F]): ObservationWorkflowService[F] =
     new ObservationWorkflowService[F] {
@@ -187,21 +135,6 @@ object ObservationWorkflowService {
                 case (id, Some(Right(params))) => id -> params
               .toMap
 
-
-      @annotation.nowarn("msg=unused implicit parameter")
-      private def validateConfigurations(infos: NonEmptyList[ObservationValidationInfo])(using Transaction[F]): ResultT[F, Map[Observation.Id, ObservationValidationMap]] =
-        ResultT(configurationService.selectRequests(infos.toList.map(i => (i.pid, i.oid)))).map: rs =>
-          rs.view
-            .map:
-              case ((_, oid), lst) =>
-                oid -> {
-                  val m = ObservationValidationMap.empty
-                  if lst.isEmpty then m.add(ObservationValidation.configurationRequestNotRequested)
-                  else if lst.exists(_.status === ConfigurationRequestStatus.Approved) then m
-                  else if lst.forall(_.status === ConfigurationRequestStatus.Denied) then m.add(ObservationValidation.configurationRequestDenied)
-                  else m.add(ObservationValidation.configurationRequestPending)
-                }
-            .toMap
 
       private def executionStates(
         infos: Map[Observation.Id, ObservationValidationInfo]
@@ -294,178 +227,6 @@ object ObservationWorkflowService {
 
         (state, allowedTransitions)
 
-      private def validateObsDefinition(
-        infos:  Map[Observation.Id, ObservationValidationInfo],
-        itcFor: Observation.Id => Option[Itc]
-      )(using Transaction[F]): ResultT[F, Map[Observation.Id, ObservationValidationMap]] = {
-
-        type Validator = ObservationValidationInfo => ObservationValidationMap
-
-        val (cals, other)         = infos.partition(_._2.calibrationRole.isDefined)
-        val (nonScience, science) = other.partition(!_._2.tpe.hasProposal)
-
-        // Here are our simple validators
-
-        val generatorValidator: Validator = info =>
-          if info.isVisitor || info.isExchange then ObservationValidationMap.empty
-          else info.generatorParams.foldMap:
-            case Left(error)                                                         => ObservationValidationMap.singleton(error.toObsValidation)
-            case Right(GeneratorParams(itcInput = ItcInputDerivation.Incomplete(m))) => ObservationValidationMap.singleton(m.toObsValidation)
-            case Right(ps)                                                           => ObservationValidationMap.empty
-
-        val cfpInstrumentValidator: Validator = info =>
-          info.cfpInfo.foldMap: cfp =>
-            if cfp.instruments.isEmpty then ObservationValidationMap.empty // weird but original logic does this
-            else info.instrument.foldMap: inst =>
-              if cfp.instruments.contains(inst) then ObservationValidationMap.empty
-              else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.invalidInstrument(inst)))
-
-        // Exchange observations must match the proposal's observatory, and (when
-        // the call restricts instruments) use one of its allowed exchange instruments.
-        val exchangeValidator: Validator = info =>
-          info.observingMode match
-            case Some(e: ExchangeObservingModeType) =>
-              info.cfpInfo.foldMap: cfp =>
-                if cfp.observatory =!= e.observatory then
-                  ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.exchangeObservatoryMismatch(e.observatory, cfp.observatory)))
-                else e match
-                  case ExchangeObservingModeType.ExchangeKeck =>
-                    if cfp.keckInstruments.isEmpty then ObservationValidationMap.empty
-                    else info.keckInstrument.foldMap: inst =>
-                      if cfp.keckInstruments.contains(inst) then ObservationValidationMap.empty
-                      else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.invalidExchangeInstrument(inst.tag)))
-                  case ExchangeObservingModeType.ExchangeSubaru =>
-                    if cfp.subaruInstruments.isEmpty then ObservationValidationMap.empty
-                    else info.subaruInstrument.foldMap: inst =>
-                      if cfp.subaruInstruments.contains(inst) then ObservationValidationMap.empty
-                      else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.invalidExchangeInstrument(inst.tag)))
-            case _ => ObservationValidationMap.empty
-
-        val cfpRaDecValidator: Validator = info =>
-          info.cfpInfo.foldMap: cfp =>
-            info.site.foldMap: site =>
-              info.coordinates.foldMap: coords =>
-                val ok = cfp.limits.siteLimits(site).inLimits(coords)
-                if ok then ObservationValidationMap.empty
-                else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.CoordinatesOutOfRange))
-
-        val bandValidator: Validator = info =>
-          (info.scienceBand, info.programAllocations).tupled.foldMap: (b, bs) =>
-            if bs.toList.contains(b) then ObservationValidationMap.empty
-            else ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.invalidScienceBand(b)))
-
-        // The Target-of-Opportunity ceiling.  This is an authorization failure
-        // rather than a misconfiguration, so it maps to Unapproved -- the
-        // observation cannot advance to Ready until the activation is lowered or
-        // the proposal's ceiling is raised.
-        val tooActivationValidator: Validator = info =>
-          if !info.exceedsTooCeiling then ObservationValidationMap.empty
-          else
-            ObservationValidationMap.singleton:
-              ObservationValidation.tooActivationUnapproved:
-                Messages.tooActivationExceedsCeiling(info.tooActivation, info.tooCeiling.get)
-
-        // An opportunity target is a placeholder standing in for a target that
-        // has not been found yet, so it makes sense only in an observation that
-        // declares itself a Target of Opportunity, and only until the alert
-        // arrives.  Either way the observation is internally inconsistent rather
-        // than merely unapproved, so this is a ConfigurationError -- Undefined,
-        // which also suppresses a stored Ready.
-        //
-        // The second case is a backstop.  A placeholder already blocks the
-        // Defined -> Ready transition, so a trigger cannot be requested for one,
-        // but the asterism can still be edited afterwards (Ready is in
-        // preExecutionSet) and a Ready ToO with no coordinates is worse than a
-        // loud error.
-        val opportunityTargetValidator: Validator = info =>
-          if !info.hasTooTarget then ObservationValidationMap.empty
-          else if !info.isTooObservation then
-            ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.OpportunityTargetRequiresActivation))
-          else if info.effectiveUserState.contains(Ready) then
-            ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.OpportunityTargetNotResolved))
-          else ObservationValidationMap.empty
-
-        val itcValidator: Validator = info =>
-          if itcFor(info.oid).isDefined || info.isVisitor || info.isExchange then ObservationValidationMap.empty
-          else ObservationValidationMap.singleton(ObservationValidation.itc("ITC results are not present."))
-
-        // An acquisition-capable mode whose acquisition ITC could not be produced
-        // (a cached deterministic failure) carries an ItcError.  Pre-execution this
-        // maps to Undefined and blocks Ready; during execution the frozen snapshot
-        // is present and execution-state dominance keeps the observation Ongoing,
-        // so it is a non-blocking standing error there.
-        val acquisitionValidator: Validator = info =>
-          if info.isVisitor then ObservationValidationMap.empty
-          else itcFor(info.oid).foldMap:
-            _.acquisition match
-              case ItcAcquisition.Failed(msg) => ObservationValidationMap.singleton(ObservationValidation.itc(msg))
-              case _                          => ObservationValidationMap.empty
-
-        // V magnitudes are used by Observe to set the GHOST slit viewing
-        // camera exposure time, so every target in a GHOST observation needs one.
-        val ghostVMagnitudeValidator: Validator = info =>
-          if info.observingMode.contains(ObservingModeType.GhostIfu) && info.asterism.exists(!_.sourceProfile.hasBand(Band.V)) then
-            ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.MissingVMagnitude))
-          else ObservationValidationMap.empty
-
-        val otherConfigErrors: Validator = info =>
-          NonEmptyChain.fromSeq(info.otherConfigErrors) match
-            case None       => ObservationValidationMap.empty
-            case Some(errs) => ObservationValidationMap.singleton(ObservationValidation(ObservationValidationCode.ConfigurationError, errs))
-
-        // Here are our composed validators
-
-        val calibrationValidator, engValidator: Validator = _ =>
-          ObservationValidationMap.empty
-
-        val scienceValidator1: Validator =
-          generatorValidator         |+|
-          cfpInstrumentValidator     |+|
-          exchangeValidator          |+|
-          cfpRaDecValidator          |+|
-          bandValidator              |+|
-          ghostVMagnitudeValidator   |+|
-          tooActivationValidator     |+|
-          opportunityTargetValidator |+|
-          otherConfigErrors
-
-        val scienceValidator2: Validator =
-          itcValidator |+| acquisitionValidator
-
-        // And our validation results
-
-        val engResults: Map[Observation.Id, ObservationValidationMap] =
-          nonScience.view.mapValues(engValidator).toMap
-
-        val calibrationResults: Map[Observation.Id, ObservationValidationMap] =
-          cals.view.mapValues(calibrationValidator).toMap
-
-        val scienceResults1: Map[Observation.Id, ObservationValidationMap] =
-          science.view.mapValues(scienceValidator1).toMap
-
-        val scienceResults2: Map[Observation.Id, ObservationValidationMap] =
-          science
-            .view
-            .filterKeys(k => scienceResults1.get(k).forall(_.isEmpty)) // ensure there are no warnigs in stage 1
-            .mapValues(scienceValidator2)
-            .toMap
-
-        val prelimV: Map[Observation.Id, ObservationValidationMap] =
-          calibrationResults |+| engResults |+| scienceResults1 |+| scienceResults2
-
-        val toCheck: List[ObservationValidationInfo] =
-          science.values.toList.filter: info =>
-            info.isAccepted && !info.isExchange && prelimV.get(info.oid).forall(_.isEmpty)
-
-        val configValidations: ResultT[F, Map[Observation.Id, ObservationValidationMap]] =
-          NonEmptyList
-            .fromList(toCheck)
-            .fold(ResultT.pure(Map.empty[Observation.Id, ObservationValidationMap]))(validateConfigurations)
-
-        configValidations.map(prelimV |+| _)
-
-      }
-
       private def computeWorkflows(
         infos: Map[Observation.Id, ObservationValidationInfo],
         errs:  Map[Observation.Id, ObservationValidationMap],
@@ -503,7 +264,7 @@ object ObservationWorkflowService {
               for
                 infos  <- ResultT.liftF(ObservationValidationInfo.fetch(oids))         // Map[Observation.Id, ObsDefinition]
                 itcRes <- ResultT.liftF(lookupCachedItcResults(infos))      // Map[Observation.Id, ItcService.AsterismResults]
-                errs   <- validateObsDefinition(infos, itcRes.get)          // Map[Observation.Id, ObservationValidationMap]
+                errs   <- ObservationValidator.validate(infos, itcRes.get)          // Map[Observation.Id, ObservationValidationMap]
               yield (infos, errs, itcRes)
             ).value
 
@@ -534,7 +295,7 @@ object ObservationWorkflowService {
       )(using Transaction[F]): F[Result[ObservationWorkflow]] =
         (for
           infos <- ResultT.liftF(ObservationValidationInfo.fetch(List(oid)))
-          errs  <- validateObsDefinition(infos, _ => itc)
+          errs  <- ObservationValidator.validate(infos, _ => itc)
           exec = exec0.filter:
             case a: DeclaredExecutionState => true // always ok
             case _ => !infos.get(oid).exists(i => i.isVisitor || i.isExchange) // otherwise discard the state if it's a visitor or exchange

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidationInfo.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidationInfo.scala
@@ -1,0 +1,411 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service
+package workflow
+
+import cats.data.NonEmptyList
+import cats.implicits.*
+import lucuma.core.enums.CalibrationRole
+import lucuma.core.enums.DeclaredExecutionState
+import lucuma.core.enums.DeclaredExecutionState.given
+import lucuma.core.enums.ExecutionState as CoreExecutionState
+import lucuma.core.enums.Instrument
+import lucuma.core.enums.KeckInstrument
+import lucuma.core.enums.ObservationWorkflowState
+import lucuma.core.enums.ObservingModeType
+import lucuma.core.enums.ProgramType
+import lucuma.core.enums.ProposalStatus
+import lucuma.core.enums.ScienceBand
+import lucuma.core.enums.Site
+import lucuma.core.enums.SubaruInstrument
+import lucuma.core.enums.TooActivation
+import lucuma.core.enums.VisitorObservingModeType
+import lucuma.core.math.Coordinates
+import lucuma.core.model.CallForProposals
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.StandardRole.*
+import lucuma.core.model.Target
+import lucuma.core.util.Timestamp
+import lucuma.odb.sequence.data.GeneratorParams
+import lucuma.odb.service.ObservationWorkflowService.UserState
+import lucuma.odb.syntax.instrument.*
+import lucuma.odb.syntax.observingModeType.*
+import skunk.Transaction
+import lucuma.core.model.SiteCoordinatesLimits
+import lucuma.core.model.CallCoordinatesLimits
+import lucuma.odb.util.Codecs.*
+import Services.Syntax.*
+import cats.*
+import cats.effect.Concurrent
+import grackle.Result
+import skunk.{ Encoder, Query }
+import skunk.syntax.all.*
+import lucuma.core.enums.Observatory
+import lucuma.core.util.DateInterval
+import java.time.Instant
+
+/* Validation Info Record */
+case class ObservationValidationInfo(
+  pid:                    Program.Id,
+  tpe:                    ProgramType,
+  oid:                    Observation.Id,
+  observingMode:          Option[ObservingModeType],
+  coordinates:            Option[Coordinates],  // explicit base, or coordinates at CFP midpoint, if any
+  explicitBase:           Option[Coordinates],
+  calibrationRole:        Option[CalibrationRole],
+  userState:              Option[ObservationWorkflowService.UserState],
+  declaredExecutionState: Option[DeclaredExecutionState],
+  proposalStatus:         ProposalStatus,
+  tooActivation:          TooActivation,
+  tooCeiling:             Option[TooActivation], // effective proposal ceiling; None when the program has no proposal
+  cfpid:                  Option[CallForProposals.Id],
+  scienceBand:            Option[ScienceBand],
+  asterism:               List[Target],
+  associatedUserState:    Option[ObservationWorkflowService.UserState], // state of science obs if this is a per-observation calibration (telluric or daytime pinhole)
+  generatorParams:        Option[Either[GeneratorParamsService.Error, GeneratorParams]] = None,
+  cfpInfo:                Option[CfpInfo] = None,
+  programAllocations:     Option[NonEmptyList[ScienceBand]] = None,
+  otherConfigErrors:      List[String] = Nil,
+  keckInstrument:         Option[KeckInstrument] = None,   // set for exchange_keck observations
+  subaruInstrument:       Option[SubaruInstrument] = None  // set for exchange_subaru observations
+) {
+
+  def isDeclaredComplete: Boolean =
+    declaredExecutionState === Some(CoreExecutionState.DeclaredComplete)
+
+  def instrument: Option[Instrument] =
+    observingMode.flatMap(_.instrumentOption)
+
+  def effectiveUserState: Option[UserState] =
+    // Per-observation calibrations (tellurics, daytime pinhole flats) inherit
+    // their science observation's user state.
+    // A telluric could be declined however, thus it can carrie its own Inactive state,
+    // which overrides that inheritance.
+    if calibrationRole.contains(CalibrationRole.Telluric) && userState.contains(ObservationWorkflowState.Inactive) then Some(ObservationWorkflowState.Inactive)
+    else if calibrationRole.exists(ObsExtract.PerObservationCalibrationRoles.contains) then associatedUserState
+    else userState
+
+  /* Has the proposal been accepted? */
+  def isAccepted:Boolean =
+    proposalStatus === ProposalStatus.Accepted
+
+  /**
+   * Does this observation demand more Target-of-Opportunity disruption than the
+   * program's proposal allows?  Before acceptance the ceiling is derived as the
+   * maximum over the program's own observations, so this can only be true then
+   * if the PI explicitly chose a ceiling below one of their observations -- also
+   * worth surfacing.  A program with no proposal has no ceiling to enforce.
+   */
+  def exceedsTooCeiling: Boolean =
+    tooCeiling.exists(tooActivation > _)
+
+  def site: Option[Site] =
+    instrument.map(_.site)
+
+  /**
+   * Is this a Target-of-Opportunity observation -- one that waits for an alert
+   * rather than for the queue?  Setting such an observation `Ready` is what
+   * requests its trigger.
+   *
+   * Independent of [[hasTooTarget]]: this is about the observation's declared
+   * urgency, not about whether its target has been found yet.
+   */
+  def isTooObservation: Boolean =
+    tooActivation =!= TooActivation.None
+
+  /**
+   * Does the asterism still hold an opportunity target -- the placeholder that
+   * stands in for a Target of Opportunity until the real one is identified?
+   *
+   * Independent of [[isTooObservation]]: a placeholder is only coherent in an
+   * observation that declares a ToO activation, and only until the alert
+   * arrives, but neither implies the other.
+   */
+  def hasTooTarget: Boolean =
+    asterism.exists:
+      case t: Target.Opportunity => true
+      case _ => false
+
+  def isVisitor: Boolean =
+    observingMode.exists:
+      case _: VisitorObservingModeType => true
+      case _ => false
+
+  def isExchange: Boolean =
+    observingMode.exists(_.isExchange)
+
+  lazy val cfpMidpoint: Option[Timestamp] =
+    for
+      s  <- site
+      c  <- cfpInfo
+      ts <- Timestamp.fromInstant(c.midpoint(s))
+    yield ts
+
+}
+
+case class CfpInfo(
+  cfpid:             CallForProposals.Id,
+  observatory:       Observatory,
+  limits:            CallCoordinatesLimits,
+  active:            DateInterval,
+  instruments:       List[Instrument],        // Gemini instruments allowed by the call
+  keckInstruments:   List[KeckInstrument],    // Keck exchange instruments allowed by the call
+  subaruInstruments: List[SubaruInstrument]   // Subaru exchange instruments allowed by the call
+) {
+
+  def midpoint(at: Site): Instant =
+    at.midpoint(active)
+
+  def addInstrument(insts: Option[Instrument]): CfpInfo =
+    insts.fold(this)(inst => copy(instruments = inst :: instruments))
+
+}
+
+object ObservationValidationInfo {
+
+  def fetch[F[_]: Concurrent](
+    oids: List[Observation.Id]
+  )(using Transaction[F], Services[F]): F[Map[Observation.Id, ObservationValidationInfo]] = {
+
+    def partialObsInfos(oids: NonEmptyList[Observation.Id]): F[Map[Observation.Id, ObservationValidationInfo]] =
+      val enc = observation_id.nel(oids)
+      session
+        .stream(Statements.ObservationValidationInfosWithoutAsterisms(enc))(oids, 1024)
+        .compile
+        .toList
+        .map: list =>
+          list
+            .fproductLeft(_.oid)
+            .toMap
+
+    def addAsterisms(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
+      Services.asSuperUser:
+        asterismService
+          .getAsterisms(input.keys.toList)
+          .map: results =>
+            input.map: (oid, info) =>
+              oid -> info.copy(asterism = results.get(oid).foldMap(_.map(_._2)))
+
+    def addGeneratorParams(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
+      generatorParamsService
+        .selectMany(input.keys.toList)
+        .map: results =>
+          input.map: (oid, info) =>
+            oid -> info.copy(generatorParams = results.get(oid))
+
+    def addCfpInfos(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
+      NonEmptyList.fromList(input.values.flatMap(_.cfpid).toList.distinct) match
+        case None => input.pure[F]
+        case Some(nel) =>
+          val enc = cfp_id.nel(nel)
+          session
+            .stream(Statements.CfpInfos(enc))(nel, 1024)
+            .compile
+            .fold(Map.empty[CallForProposals.Id, CfpInfo]):
+              case (m, (cfp, oinst)) =>
+                m.updatedWith(cfp.cfpid):
+                  case None    => cfp.addInstrument(oinst).some
+                  case Some(c) => c.addInstrument(oinst).some
+            .map: results =>
+              input.map: (oid, info) =>
+                oid -> info.copy(cfpInfo = info.cfpid.flatMap(results.get))
+
+    // Enriches exchange observations with their chosen Keck/Subaru instrument.
+    // Only exchange-mode observations are looked up, so non-exchange programs
+    // pay nothing here.
+    def addExchangeInfos(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
+      val exchangeOids =
+        input.collect:
+          case (oid, info) if info.observingMode.exists(_.isExchange) => oid
+        .toList
+      if exchangeOids.isEmpty then input.pure[F]
+      else
+        exchangeService.select(exchangeOids).map: configs =>
+          input.map: (oid, info) =>
+            configs.get(oid).fold(oid -> info): cfg =>
+              oid -> info.copy(keckInstrument = cfg.keckInstrument, subaruInstrument = cfg.subaruInstrument)
+
+    def addProgramAllocations(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
+      NonEmptyList.fromList(input.values.map(_.pid).toList.distinct) match
+        case None => input.pure[F]
+        case Some(nel) =>
+          val enc = program_id.nel(nel)
+          session
+            .stream(Statements.ProgramAllocations(enc))(nel, 1024)
+            .compile
+            .toList
+            .map: list =>
+              list.foldMap: (pid, band) =>
+                Map(pid -> NonEmptyList.one(band))
+            .map: result =>
+              input.map: (oid, info) =>
+                oid -> info.copy(programAllocations = result.get(info.pid))
+
+    def addCoordinates(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
+      input
+        .values
+        .groupBy(_.cfpMidpoint)
+        .collect:
+          case (Some(k), v) => k -> v.toList.map(_.oid)
+        .toList // we now have a list of (Timestamp, List[oid]) batches
+        .foldLeftM(input): // fold over this list with `input` as the starting point, updating when we can find coordinates
+          case (accum, (when, batch)) =>
+            trackingService
+              .getCoordinatesSnapshotOrRegion(batch, when, false)
+              .map: batchResults =>
+                batchResults
+                  .collect:
+                    case (oid, Result.Success(Left(snap))) => oid -> snap.base // we only care about results where coordinates are known
+                    case (oid, Result.Success(Right(_, Some(eb)))) => oid -> eb
+                  .foldLeft(accum):
+                    case (accum2, (oid, coords)) =>
+                      accum2.updatedWith(oid): op =>
+                        op.map(_.copy(coordinates = Some(coords)))
+
+    // Configuration errors that don't fit elsewhere.
+    def addOtherConfigErrors(input: Map[Observation.Id, ObservationValidationInfo]): F[Map[Observation.Id, ObservationValidationInfo]] =
+      import lucuma.odb.sequence.ghost.ifu.Config as GhostIfu
+
+      extension (e: CoreExecutionState)
+        def shouldCheck: Boolean =
+          e match
+            case CoreExecutionState.NotDefined |
+                  CoreExecutionState.NotStarted => true
+            case _                             => false
+
+      // Get a list of GHOST observations that need to be checked.
+      val ghostObsList: List[Observation.Id] =
+        input
+          .toList
+          .mapFilter: (oid, info) =>
+            info
+              .generatorParams
+              .flatMap(_.toOption)
+              .flatMap: params =>
+                params.observingMode match
+                  case GhostIfu(_, _, _, _, _, _, _, _) if params.executionState.shouldCheck => oid.some
+                  case _                                                                     => none
+
+      // Validate each one to ensure it has an IFU mapping.
+      ghostIfuService
+        .validationErrors(ghostObsList)
+        .map: errors =>
+          errors.toList.foldLeft(input) { case (m, (oid, msg)) =>
+            m.updatedWith(oid): info =>
+              info.map(in => in.copy(otherConfigErrors = msg :: in.otherConfigErrors))
+          }
+
+    NonEmptyList.fromList(oids) match
+      case None      =>
+        Map.empty.pure
+      case Some(nel) =>
+        partialObsInfos(nel)
+          .flatMap(addAsterisms)
+          .flatMap(addGeneratorParams)
+          .flatMap(addCfpInfos)
+          .flatMap(addExchangeInfos)
+          .flatMap(addProgramAllocations)
+          .flatMap(addCoordinates)
+          .flatMap(addOtherConfigErrors)
+  }
+
+  object Statements {
+
+    def ObservationValidationInfosWithoutAsterisms[A <: NonEmptyList[Observation.Id]](enc: Encoder[A]): Query[A, ObservationValidationInfo] =
+      sql"""
+        SELECT
+          o.c_program_id,
+          p.c_program_type,
+          o.c_observation_id,
+          o.c_observing_mode_type,
+          o.c_explicit_ra,
+          o.c_explicit_dec,
+          o.c_calibration_role,
+          o.c_workflow_user_state,
+          o.c_declared_state,
+          p.c_proposal_status,
+          o.c_too_activation,
+          x.c_too_activation_effective,
+          x.c_cfp_id,
+          o.c_science_band,
+          s.c_workflow_user_state
+        FROM t_observation o
+        JOIN t_program p on p.c_program_id = o.c_program_id
+        -- v_proposal rather than t_proposal: it adds the effective ToO ceiling
+        -- (explicit, else derived from the program's observations).
+        LEFT JOIN v_proposal x
+          ON o.c_program_id = x.c_program_id
+        LEFT JOIN t_observation s
+          ON  o.c_calibration_role = ANY(ARRAY['telluric','daytime_pinhole']::e_calibration_role[])
+          AND s.c_calibration_role IS NULL
+          AND o.c_group_id = s.c_group_id
+        WHERE o.c_observation_id IN ($enc)
+      """
+      .query(program_id *: program_type *: observation_id *: observing_mode_type.opt *: right_ascension.opt *: declination.opt *: calibration_role.opt *: user_state.opt *: declared_execution_state.opt *: proposal_status *: too_activation *: too_activation.opt *: cfp_id.opt *: science_band.opt *: user_state.opt)
+      .map:
+        case (pid, tpe, oid, mode, ra, dec, cal, state, ds, ps, too, ceil, cfp, sci, state2) =>
+          ObservationValidationInfo(pid, tpe, oid, mode, None, (ra, dec).mapN(Coordinates.apply), cal, state, ds, ps, too, ceil, cfp, sci, Nil, state2)
+
+    def ProgramAllocations[A <: NonEmptyList[Program.Id]](enc: Encoder[A]): Query[A, (Program.Id, ScienceBand)] =
+      sql"""
+        SELECT DISTINCT
+          c_program_id,
+          c_science_band
+        FROM
+          t_allocation
+        WHERE
+          c_program_id IN ($enc)
+      """.query(program_id *: science_band)
+
+    def CfpInfos[A <: NonEmptyList[CallForProposals.Id]](enc: Encoder[A]): Query[A, (CfpInfo, Option[Instrument])] =
+      sql"""
+        SELECT
+          c.c_cfp_id,
+          c.c_observatory,
+          c.c_north_ra_start,
+          c.c_north_ra_end,
+          c.c_north_dec_start,
+          c.c_north_dec_end,
+          c.c_south_ra_start,
+          c.c_south_ra_end,
+          c.c_south_dec_start,
+          c.c_south_dec_end,
+          c.c_active_start,
+          c.c_active_end,
+          c.c_keck_instruments,
+          c.c_subaru_instruments,
+          i.c_instrument
+        FROM t_cfp c
+        LEFT JOIN t_gemini_cfp_instrument i
+        ON c.c_cfp_id = i.c_cfp_id
+        WHERE c.c_cfp_id in ($enc)
+      """.query(
+          cfp_id                 *:
+          observatory            *:
+          right_ascension        *: // north limits
+          right_ascension        *: // north limits
+          declination            *: // north limits
+          declination            *: // north liits
+          right_ascension.opt    *: // south limits
+          right_ascension.opt    *: // south limits
+          declination.opt        *: // south limits
+          declination.opt        *: // south limits
+          date_interval          *: // active period
+          _keck_instrument.opt   *:
+          _subaru_instrument.opt *:
+          instrument.opt
+        ).map:
+          // The south coordinate limits are null for exchange (keck/subaru) calls,
+          // which use only the northern limits.  Exchange observations have no site
+          // and so never exercise the coordinate-limit validation; we fall back to
+          // the north limits to keep CallCoordinatesLimits total.
+          case (id, obs, n_ra_s, n_ra_e, n_dec_s, n_dec_e, s_ra_s, s_ra_e, s_dec_s, s_dec_e, active, keck, subaru, oinst) =>
+            val north = SiteCoordinatesLimits(n_ra_s, n_ra_e, n_dec_s, n_dec_e)
+            val south = (s_ra_s, s_ra_e, s_dec_s, s_dec_e).mapN(SiteCoordinatesLimits.apply).getOrElse(north)
+            (CfpInfo(id, obs, CallCoordinatesLimits(north, south), active, Nil, keck.orEmpty, subaru.orEmpty), oinst)
+
+  }
+
+}

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidationInfo.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidationInfo.scala
@@ -4,8 +4,11 @@
 package lucuma.odb.service
 package workflow
 
+import cats.*
 import cats.data.NonEmptyList
+import cats.effect.Concurrent
 import cats.implicits.*
+import grackle.Result
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.DeclaredExecutionState
 import lucuma.core.enums.DeclaredExecutionState.given
@@ -13,6 +16,7 @@ import lucuma.core.enums.ExecutionState as CoreExecutionState
 import lucuma.core.enums.Instrument
 import lucuma.core.enums.KeckInstrument
 import lucuma.core.enums.ObservationWorkflowState
+import lucuma.core.enums.Observatory
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.enums.ProgramType
 import lucuma.core.enums.ProposalStatus
@@ -22,29 +26,28 @@ import lucuma.core.enums.SubaruInstrument
 import lucuma.core.enums.TooActivation
 import lucuma.core.enums.VisitorObservingModeType
 import lucuma.core.math.Coordinates
+import lucuma.core.model.CallCoordinatesLimits
 import lucuma.core.model.CallForProposals
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
+import lucuma.core.model.SiteCoordinatesLimits
 import lucuma.core.model.StandardRole.*
 import lucuma.core.model.Target
+import lucuma.core.util.DateInterval
 import lucuma.core.util.Timestamp
 import lucuma.odb.sequence.data.GeneratorParams
 import lucuma.odb.service.ObservationWorkflowService.UserState
 import lucuma.odb.syntax.instrument.*
 import lucuma.odb.syntax.observingModeType.*
-import skunk.Transaction
-import lucuma.core.model.SiteCoordinatesLimits
-import lucuma.core.model.CallCoordinatesLimits
 import lucuma.odb.util.Codecs.*
-import Services.Syntax.*
-import cats.*
-import cats.effect.Concurrent
-import grackle.Result
-import skunk.{ Encoder, Query }
+import skunk.Encoder
+import skunk.Query
+import skunk.Transaction
 import skunk.syntax.all.*
-import lucuma.core.enums.Observatory
-import lucuma.core.util.DateInterval
+
 import java.time.Instant
+
+import Services.Syntax.*
 
 /* Validation Info Record */
 case class ObservationValidationInfo(

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
@@ -15,7 +15,6 @@ import lucuma.core.enums.ConfigurationRequestStatus
 import lucuma.core.enums.ObservationValidationCode
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.ObservingModeType
-import lucuma.core.enums.ScienceBand
 import lucuma.core.enums.TooActivation
 import lucuma.core.model.Observation
 import lucuma.core.model.ObservationValidation
@@ -39,10 +38,6 @@ object ObservationValidator:
 
   /* Validation Messages */
   object Messages {
-
-    def invalidScienceBand(b: ScienceBand): String =
-      s"Science Band ${b.tag.toScreamingSnakeCase} has no time allocation."
-
     def tooActivationExceedsCeiling(obs: TooActivation, ceiling: TooActivation): String =
       s"Target of Opportunity activation ${obs.tag.toScreamingSnakeCase} exceeds the maximum " +
       s"${ceiling.tag.toScreamingSnakeCase} allowed by the proposal."
@@ -81,12 +76,6 @@ object ObservationValidator:
     // Here are our simple validators
     import validator.*
 
-
-
-    val bandValidator: ObservationValidator = info =>
-      (info.scienceBand, info.programAllocations).tupled.foldMap: (b, bs) =>
-        if bs.toList.contains(b) then ObservationValidationMap.empty
-        else ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.invalidScienceBand(b)))
 
     // The Target-of-Opportunity ceiling.  This is an authorization failure
     // rather than a misconfiguration, so it maps to Unapproved -- the
@@ -157,7 +146,7 @@ object ObservationValidator:
       CfpInstrumentValidator     |+|
       ExchangeValidator          |+|
       CfpRaDecValidator          |+|
-      bandValidator              |+|
+      BandValidator              |+|
       ghostVMagnitudeValidator   |+|
       tooActivationValidator     |+|
       opportunityTargetValidator |+|

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
@@ -40,8 +40,6 @@ object ObservationValidator:
   /* Validation Messages */
   object Messages {
 
-    val CoordinatesOutOfRange = "Base coordinates out of Call for Proposals limits."
-
     def invalidScienceBand(b: ScienceBand): String =
       s"Science Band ${b.tag.toScreamingSnakeCase} has no time allocation."
 
@@ -84,14 +82,6 @@ object ObservationValidator:
     import validator.*
 
 
-
-    val cfpRaDecValidator: ObservationValidator = info =>
-      info.cfpInfo.foldMap: cfp =>
-        info.site.foldMap: site =>
-          info.coordinates.foldMap: coords =>
-            val ok = cfp.limits.siteLimits(site).inLimits(coords)
-            if ok then ObservationValidationMap.empty
-            else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.CoordinatesOutOfRange))
 
     val bandValidator: ObservationValidator = info =>
       (info.scienceBand, info.programAllocations).tupled.foldMap: (b, bs) =>
@@ -166,7 +156,7 @@ object ObservationValidator:
       GeneratorValidator         |+|
       CfpInstrumentValidator     |+|
       ExchangeValidator          |+|
-      cfpRaDecValidator          |+|
+      CfpRaDecValidator          |+|
       bandValidator              |+|
       ghostVMagnitudeValidator   |+|
       tooActivationValidator     |+|

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
@@ -25,16 +25,20 @@ import lucuma.core.syntax.string.*
 import lucuma.odb.data.Itc
 import lucuma.odb.data.ItcAcquisition
 import lucuma.odb.data.ObservationValidationMap
-import lucuma.odb.sequence.data.GeneratorParams
-import lucuma.odb.sequence.data.ItcInputDerivation
-import lucuma.odb.sequence.data.MissingParamSet
-import lucuma.odb.service.GeneratorParamsService.Error as GenParamsError
 import ObservationWorkflowState.*
 
 import Services.Syntax.*
 import cats.Applicative
+import cats.Monoid
+
+trait ObservationValidator extends (ObservationValidationInfo => ObservationValidationMap):
+  def apply(info: ObservationValidationInfo): ObservationValidationMap
 
 object ObservationValidator:
+
+  given Monoid[ObservationValidator]:
+    def empty = _ => ObservationValidationMap.empty
+    def combine(x: ObservationValidator, y: ObservationValidator): ObservationValidator = a => x(a) |+| y(a)
 
   /* Validation Messages */
   object Messages {
@@ -66,21 +70,11 @@ object ObservationValidator:
     val MissingVMagnitude = "Please add a V magnitude."
   }
 
-  extension (mp: MissingParamSet)
-    private def toObsValidation: ObservationValidation =
-      ObservationValidation.configuration(s"Missing ${mp.params.map(_.name).toList.intercalate(", ")}")
-
-  extension (ge: GeneratorParamsService.Error)
-    private def toObsValidation: ObservationValidation = ge match
-      case GenParamsError.MissingData(p) => p.toObsValidation
-      case _                             => ObservationValidation.configuration(ge.format)
-
   def validate[F[_]: Applicative](
     infos:  Map[Observation.Id, ObservationValidationInfo],
     itcFor: Observation.Id => Option[Itc]
   )(using Services[F]): ResultT[F, Map[Observation.Id, ObservationValidationMap]] = {
-
-    type Validator = ObservationValidationInfo => ObservationValidationMap
+    import validator.*
 
     val (cals, other)         = infos.partition(_._2.calibrationRole.isDefined)
     val (nonScience, science) = other.partition(!_._2.tpe.hasProposal)
@@ -101,14 +95,7 @@ object ObservationValidator:
 
     // Here are our simple validators
 
-    val generatorValidator: Validator = info =>
-      if info.isVisitor || info.isExchange then ObservationValidationMap.empty
-      else info.generatorParams.foldMap:
-        case Left(error)                                                         => ObservationValidationMap.singleton(error.toObsValidation)
-        case Right(GeneratorParams(itcInput = ItcInputDerivation.Incomplete(m))) => ObservationValidationMap.singleton(m.toObsValidation)
-        case Right(ps)                                                           => ObservationValidationMap.empty
-
-    val cfpInstrumentValidator: Validator = info =>
+    val cfpInstrumentValidator: ObservationValidator = info =>
       info.cfpInfo.foldMap: cfp =>
         if cfp.instruments.isEmpty then ObservationValidationMap.empty // weird but original logic does this
         else info.instrument.foldMap: inst =>
@@ -117,7 +104,7 @@ object ObservationValidator:
 
     // Exchange observations must match the proposal's observatory, and (when
     // the call restricts instruments) use one of its allowed exchange instruments.
-    val exchangeValidator: Validator = info =>
+    val exchangeValidator: ObservationValidator = info =>
       info.observingMode match
         case Some(e: ExchangeObservingModeType) =>
           info.cfpInfo.foldMap: cfp =>
@@ -136,7 +123,7 @@ object ObservationValidator:
                   else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.invalidExchangeInstrument(inst.tag)))
         case _ => ObservationValidationMap.empty
 
-    val cfpRaDecValidator: Validator = info =>
+    val cfpRaDecValidator: ObservationValidator = info =>
       info.cfpInfo.foldMap: cfp =>
         info.site.foldMap: site =>
           info.coordinates.foldMap: coords =>
@@ -144,7 +131,7 @@ object ObservationValidator:
             if ok then ObservationValidationMap.empty
             else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.CoordinatesOutOfRange))
 
-    val bandValidator: Validator = info =>
+    val bandValidator: ObservationValidator = info =>
       (info.scienceBand, info.programAllocations).tupled.foldMap: (b, bs) =>
         if bs.toList.contains(b) then ObservationValidationMap.empty
         else ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.invalidScienceBand(b)))
@@ -153,7 +140,7 @@ object ObservationValidator:
     // rather than a misconfiguration, so it maps to Unapproved -- the
     // observation cannot advance to Ready until the activation is lowered or
     // the proposal's ceiling is raised.
-    val tooActivationValidator: Validator = info =>
+    val tooActivationValidator: ObservationValidator = info =>
       if !info.exceedsTooCeiling then ObservationValidationMap.empty
       else
         ObservationValidationMap.singleton:
@@ -172,7 +159,7 @@ object ObservationValidator:
     // but the asterism can still be edited afterwards (Ready is in
     // preExecutionSet) and a Ready ToO with no coordinates is worse than a
     // loud error.
-    val opportunityTargetValidator: Validator = info =>
+    val opportunityTargetValidator: ObservationValidator = info =>
       if !info.hasTooTarget then ObservationValidationMap.empty
       else if !info.isTooObservation then
         ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.OpportunityTargetRequiresActivation))
@@ -180,7 +167,7 @@ object ObservationValidator:
         ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.OpportunityTargetNotResolved))
       else ObservationValidationMap.empty
 
-    val itcValidator: Validator = info =>
+    val itcValidator: ObservationValidator = info =>
       if itcFor(info.oid).isDefined || info.isVisitor || info.isExchange then ObservationValidationMap.empty
       else ObservationValidationMap.singleton(ObservationValidation.itc("ITC results are not present."))
 
@@ -189,7 +176,7 @@ object ObservationValidator:
     // maps to Undefined and blocks Ready; during execution the frozen snapshot
     // is present and execution-state dominance keeps the observation Ongoing,
     // so it is a non-blocking standing error there.
-    val acquisitionValidator: Validator = info =>
+    val acquisitionValidator: ObservationValidator = info =>
       if info.isVisitor then ObservationValidationMap.empty
       else itcFor(info.oid).foldMap:
         _.acquisition match
@@ -198,23 +185,23 @@ object ObservationValidator:
 
     // V magnitudes are used by Observe to set the GHOST slit viewing
     // camera exposure time, so every target in a GHOST observation needs one.
-    val ghostVMagnitudeValidator: Validator = info =>
+    val ghostVMagnitudeValidator: ObservationValidator = info =>
       if info.observingMode.contains(ObservingModeType.GhostIfu) && info.asterism.exists(!_.sourceProfile.hasBand(Band.V)) then
         ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.MissingVMagnitude))
       else ObservationValidationMap.empty
 
-    val otherConfigErrors: Validator = info =>
+    val otherConfigErrors: ObservationValidator = info =>
       NonEmptyChain.fromSeq(info.otherConfigErrors) match
         case None       => ObservationValidationMap.empty
         case Some(errs) => ObservationValidationMap.singleton(ObservationValidation(ObservationValidationCode.ConfigurationError, errs))
 
     // Here are our composed validators
 
-    val calibrationValidator, engValidator: Validator = _ =>
+    val calibrationValidator, engValidator: ObservationValidator = _ =>
       ObservationValidationMap.empty
 
-    val scienceValidator1: Validator =
-      generatorValidator         |+|
+    val scienceValidator1: ObservationValidator =
+      GeneratorValidator         |+|
       cfpInstrumentValidator     |+|
       exchangeValidator          |+|
       cfpRaDecValidator          |+|
@@ -224,7 +211,7 @@ object ObservationValidator:
       opportunityTargetValidator |+|
       otherConfigErrors
 
-    val scienceValidator2: Validator =
+    val scienceValidator2: ObservationValidator =
       itcValidator |+| acquisitionValidator
 
     // And our validation results

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
@@ -15,11 +15,9 @@ import lucuma.core.enums.ConfigurationRequestStatus
 import lucuma.core.enums.ObservationValidationCode
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.ObservingModeType
-import lucuma.core.enums.TooActivation
 import lucuma.core.model.Observation
 import lucuma.core.model.ObservationValidation
 import lucuma.core.model.StandardRole.*
-import lucuma.core.syntax.string.*
 import lucuma.odb.data.Itc
 import lucuma.odb.data.ItcAcquisition
 import lucuma.odb.data.ObservationValidationMap
@@ -38,9 +36,6 @@ object ObservationValidator:
 
   /* Validation Messages */
   object Messages {
-    def tooActivationExceedsCeiling(obs: TooActivation, ceiling: TooActivation): String =
-      s"Target of Opportunity activation ${obs.tag.toScreamingSnakeCase} exceeds the maximum " +
-      s"${ceiling.tag.toScreamingSnakeCase} allowed by the proposal."
 
     val OpportunityTargetRequiresActivation =
       "An observation with a Target of Opportunity placeholder must set a ToO activation other than NONE."
@@ -77,16 +72,6 @@ object ObservationValidator:
     import validator.*
 
 
-    // The Target-of-Opportunity ceiling.  This is an authorization failure
-    // rather than a misconfiguration, so it maps to Unapproved -- the
-    // observation cannot advance to Ready until the activation is lowered or
-    // the proposal's ceiling is raised.
-    val tooActivationValidator: ObservationValidator = info =>
-      if !info.exceedsTooCeiling then ObservationValidationMap.empty
-      else
-        ObservationValidationMap.singleton:
-          ObservationValidation.tooActivationUnapproved:
-            Messages.tooActivationExceedsCeiling(info.tooActivation, info.tooCeiling.get)
 
     // An opportunity target is a placeholder standing in for a target that
     // has not been found yet, so it makes sense only in an observation that
@@ -148,7 +133,7 @@ object ObservationValidator:
       CfpRaDecValidator          |+|
       BandValidator              |+|
       ghostVMagnitudeValidator   |+|
-      tooActivationValidator     |+|
+      TooActivationValidator     |+|
       opportunityTargetValidator |+|
       otherConfigErrors
 

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
@@ -10,10 +10,8 @@ import cats.data.NonEmptyChain
 import cats.data.NonEmptyList
 import cats.implicits.*
 import grackle.ResultT
-import lucuma.core.enums.Band
 import lucuma.core.enums.ConfigurationRequestStatus
 import lucuma.core.enums.ObservationValidationCode
-import lucuma.core.enums.ObservingModeType
 import lucuma.core.model.Observation
 import lucuma.core.model.ObservationValidation
 import lucuma.core.model.StandardRole.*
@@ -30,13 +28,6 @@ object ObservationValidator:
   given Monoid[ObservationValidator]:
     def empty = _ => ObservationValidationMap.empty
     def combine(x: ObservationValidator, y: ObservationValidator): ObservationValidator = a => x(a) |+| y(a)
-
-  /* Validation Messages */
-  object Messages {
-
-
-    val MissingVMagnitude = "Please add a V magnitude."
-  }
 
   def validate[F[_]: Applicative](
     infos:  Map[Observation.Id, ObservationValidationInfo],
@@ -64,13 +55,6 @@ object ObservationValidator:
     import validator.*
 
 
-    // V magnitudes are used by Observe to set the GHOST slit viewing
-    // camera exposure time, so every target in a GHOST observation needs one.
-    val ghostVMagnitudeValidator: ObservationValidator = info =>
-      if info.observingMode.contains(ObservingModeType.GhostIfu) && info.asterism.exists(!_.sourceProfile.hasBand(Band.V)) then
-        ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.MissingVMagnitude))
-      else ObservationValidationMap.empty
-
     val otherConfigErrors: ObservationValidator = info =>
       NonEmptyChain.fromSeq(info.otherConfigErrors) match
         case None       => ObservationValidationMap.empty
@@ -87,7 +71,7 @@ object ObservationValidator:
       ExchangeValidator          |+|
       CfpRaDecValidator          |+|
       BandValidator              |+|
-      ghostVMagnitudeValidator   |+|
+      GhostVMagnitudeValidator   |+|
       TooActivationValidator     |+|
       OpportunityTargetValidator |+|
       otherConfigErrors

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
@@ -5,8 +5,8 @@ package lucuma.odb.service
 package workflow
 
 import cats.Applicative
+import cats.Functor
 import cats.Monoid
-import cats.data.NonEmptyChain
 import cats.data.NonEmptyList
 import cats.implicits.*
 import grackle.ResultT
@@ -29,6 +29,22 @@ object ObservationValidator:
     def empty = _ => ObservationValidationMap.empty
     def combine(x: ObservationValidator, y: ObservationValidator): ObservationValidator = a => x(a) |+| y(a)
 
+  private def validateConfigurations[F[_]: Functor](
+    infos: NonEmptyList[ObservationValidationInfo]
+  )(using Services[F]): ResultT[F, Map[Observation.Id, ObservationValidationMap]] =
+    ResultT(configurationService.selectRequests(infos.toList.map(i => (i.pid, i.oid)))).map: rs =>
+      rs.view
+        .map:
+          case ((_, oid), lst) =>
+            oid -> {
+              val m = ObservationValidationMap.empty
+              if lst.isEmpty then m.add(ObservationValidation.configurationRequestNotRequested)
+              else if lst.exists(_.status === ConfigurationRequestStatus.Approved) then m
+              else if lst.forall(_.status === ConfigurationRequestStatus.Denied) then m.add(ObservationValidation.configurationRequestDenied)
+              else m.add(ObservationValidation.configurationRequestPending)
+            }
+        .toMap
+
   def validate[F[_]: Applicative](
     infos:  Map[Observation.Id, ObservationValidationInfo],
     itcFor: Observation.Id => Option[Itc]
@@ -37,28 +53,8 @@ object ObservationValidator:
     val (cals, other)         = infos.partition(_._2.calibrationRole.isDefined)
     val (nonScience, science) = other.partition(!_._2.tpe.hasProposal)
 
-    def validateConfigurations(infos: NonEmptyList[ObservationValidationInfo]): ResultT[F, Map[Observation.Id, ObservationValidationMap]] =
-      ResultT(configurationService.selectRequests(infos.toList.map(i => (i.pid, i.oid)))).map: rs =>
-        rs.view
-          .map:
-            case ((_, oid), lst) =>
-              oid -> {
-                val m = ObservationValidationMap.empty
-                if lst.isEmpty then m.add(ObservationValidation.configurationRequestNotRequested)
-                else if lst.exists(_.status === ConfigurationRequestStatus.Approved) then m
-                else if lst.forall(_.status === ConfigurationRequestStatus.Denied) then m.add(ObservationValidation.configurationRequestDenied)
-                else m.add(ObservationValidation.configurationRequestPending)
-              }
-          .toMap
-
     // Here are our simple validators
     import validator.*
-
-
-    val otherConfigErrors: ObservationValidator = info =>
-      NonEmptyChain.fromSeq(info.otherConfigErrors) match
-        case None       => ObservationValidationMap.empty
-        case Some(errs) => ObservationValidationMap.singleton(ObservationValidation(ObservationValidationCode.ConfigurationError, errs))
 
     // Here are our composed validators
 
@@ -74,7 +70,7 @@ object ObservationValidator:
       GhostVMagnitudeValidator   |+|
       TooActivationValidator     |+|
       OpportunityTargetValidator |+|
-      otherConfigErrors
+      OtherConfigErrorValidator
 
     val scienceValidator2: ObservationValidator =
       ItcValidator(itcFor) |+| AcquisitionValidator(itcFor)

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
@@ -18,7 +18,6 @@ import lucuma.core.model.Observation
 import lucuma.core.model.ObservationValidation
 import lucuma.core.model.StandardRole.*
 import lucuma.odb.data.Itc
-import lucuma.odb.data.ItcAcquisition
 import lucuma.odb.data.ObservationValidationMap
 
 import Services.Syntax.*
@@ -65,20 +64,6 @@ object ObservationValidator:
     import validator.*
 
 
-
-
-    // An acquisition-capable mode whose acquisition ITC could not be produced
-    // (a cached deterministic failure) carries an ItcError.  Pre-execution this
-    // maps to Undefined and blocks Ready; during execution the frozen snapshot
-    // is present and execution-state dominance keeps the observation Ongoing,
-    // so it is a non-blocking standing error there.
-    val acquisitionValidator: ObservationValidator = info =>
-      if info.isVisitor then ObservationValidationMap.empty
-      else itcFor(info.oid).foldMap:
-        _.acquisition match
-          case ItcAcquisition.Failed(msg) => ObservationValidationMap.singleton(ObservationValidation.itc(msg))
-          case _                          => ObservationValidationMap.empty
-
     // V magnitudes are used by Observe to set the GHOST slit viewing
     // camera exposure time, so every target in a GHOST observation needs one.
     val ghostVMagnitudeValidator: ObservationValidator = info =>
@@ -108,7 +93,7 @@ object ObservationValidator:
       otherConfigErrors
 
     val scienceValidator2: ObservationValidator =
-      ItcValidator(itcFor) |+| acquisitionValidator
+      ItcValidator(itcFor) |+| AcquisitionValidator(itcFor)
 
     // And our validation results
 

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
@@ -67,10 +67,6 @@ object ObservationValidator:
 
 
 
-    val itcValidator: ObservationValidator = info =>
-      if itcFor(info.oid).isDefined || info.isVisitor || info.isExchange then ObservationValidationMap.empty
-      else ObservationValidationMap.singleton(ObservationValidation.itc("ITC results are not present."))
-
     // An acquisition-capable mode whose acquisition ITC could not be produced
     // (a cached deterministic failure) carries an ItcError.  Pre-execution this
     // maps to Undefined and blocks Ready; during execution the frozen snapshot
@@ -112,7 +108,7 @@ object ObservationValidator:
       otherConfigErrors
 
     val scienceValidator2: ObservationValidator =
-      itcValidator |+| acquisitionValidator
+      ItcValidator(itcFor) |+| acquisitionValidator
 
     // And our validation results
 

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
@@ -13,7 +13,6 @@ import grackle.ResultT
 import lucuma.core.enums.Band
 import lucuma.core.enums.ConfigurationRequestStatus
 import lucuma.core.enums.ObservationValidationCode
-import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.model.Observation
 import lucuma.core.model.ObservationValidation
@@ -22,7 +21,6 @@ import lucuma.odb.data.Itc
 import lucuma.odb.data.ItcAcquisition
 import lucuma.odb.data.ObservationValidationMap
 
-import ObservationWorkflowState.*
 import Services.Syntax.*
 
 trait ObservationValidator extends (ObservationValidationInfo => ObservationValidationMap):
@@ -37,11 +35,6 @@ object ObservationValidator:
   /* Validation Messages */
   object Messages {
 
-    val OpportunityTargetRequiresActivation =
-      "An observation with a Target of Opportunity placeholder must set a ToO activation other than NONE."
-
-    val OpportunityTargetNotResolved =
-      "Replace the Target of Opportunity placeholder with the actual target coordinates."
 
     val MissingVMagnitude = "Please add a V magnitude."
   }
@@ -73,25 +66,6 @@ object ObservationValidator:
 
 
 
-    // An opportunity target is a placeholder standing in for a target that
-    // has not been found yet, so it makes sense only in an observation that
-    // declares itself a Target of Opportunity, and only until the alert
-    // arrives.  Either way the observation is internally inconsistent rather
-    // than merely unapproved, so this is a ConfigurationError -- Undefined,
-    // which also suppresses a stored Ready.
-    //
-    // The second case is a backstop.  A placeholder already blocks the
-    // Defined -> Ready transition, so a trigger cannot be requested for one,
-    // but the asterism can still be edited afterwards (Ready is in
-    // preExecutionSet) and a Ready ToO with no coordinates is worse than a
-    // loud error.
-    val opportunityTargetValidator: ObservationValidator = info =>
-      if !info.hasTooTarget then ObservationValidationMap.empty
-      else if !info.isTooObservation then
-        ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.OpportunityTargetRequiresActivation))
-      else if info.effectiveUserState.contains(Ready) then
-        ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.OpportunityTargetNotResolved))
-      else ObservationValidationMap.empty
 
     val itcValidator: ObservationValidator = info =>
       if itcFor(info.oid).isDefined || info.isVisitor || info.isExchange then ObservationValidationMap.empty
@@ -134,7 +108,7 @@ object ObservationValidator:
       BandValidator              |+|
       ghostVMagnitudeValidator   |+|
       TooActivationValidator     |+|
-      opportunityTargetValidator |+|
+      OpportunityTargetValidator |+|
       otherConfigErrors
 
     val scienceValidator2: ObservationValidator =

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
@@ -1,0 +1,262 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service
+package workflow
+
+import cats.data.NonEmptyChain
+import cats.data.NonEmptyList
+import cats.implicits.*
+import grackle.ResultT
+import lucuma.core.enums.Band
+import lucuma.core.enums.ConfigurationRequestStatus
+import lucuma.core.enums.ExchangeObservingModeType
+import lucuma.core.enums.Instrument
+import lucuma.core.enums.ObservationValidationCode
+import lucuma.core.enums.ObservationWorkflowState
+import lucuma.core.enums.Observatory
+import lucuma.core.enums.ObservingModeType
+import lucuma.core.enums.ScienceBand
+import lucuma.core.enums.TooActivation
+import lucuma.core.model.Observation
+import lucuma.core.model.ObservationValidation
+import lucuma.core.model.StandardRole.*
+import lucuma.core.syntax.string.*
+import lucuma.odb.data.Itc
+import lucuma.odb.data.ItcAcquisition
+import lucuma.odb.data.ObservationValidationMap
+import lucuma.odb.sequence.data.GeneratorParams
+import lucuma.odb.sequence.data.ItcInputDerivation
+import lucuma.odb.sequence.data.MissingParamSet
+import lucuma.odb.service.GeneratorParamsService.Error as GenParamsError
+import ObservationWorkflowState.*
+
+import Services.Syntax.*
+import cats.Applicative
+
+object ObservationValidator:
+
+  /* Validation Messages */
+  object Messages {
+
+    val CoordinatesOutOfRange = "Base coordinates out of Call for Proposals limits."
+
+    def invalidInstrument(instr: Instrument): String =
+      s"Instrument $instr not part of Call for Proposals."
+
+    def invalidScienceBand(b: ScienceBand): String =
+      s"Science Band ${b.tag.toScreamingSnakeCase} has no time allocation."
+
+    def tooActivationExceedsCeiling(obs: TooActivation, ceiling: TooActivation): String =
+      s"Target of Opportunity activation ${obs.tag.toScreamingSnakeCase} exceeds the maximum " +
+      s"${ceiling.tag.toScreamingSnakeCase} allowed by the proposal."
+
+    val OpportunityTargetRequiresActivation =
+      "An observation with a Target of Opportunity placeholder must set a ToO activation other than NONE."
+
+    val OpportunityTargetNotResolved =
+      "Replace the Target of Opportunity placeholder with the actual target coordinates."
+
+    def exchangeObservatoryMismatch(modeObs: Observatory, cfpObs: Observatory): String =
+      s"Exchange observation requires a $modeObs Call for Proposals, but the proposal's observatory is $cfpObs."
+
+    def invalidExchangeInstrument(instr: String): String =
+      s"Instrument $instr is not part of the Call for Proposals."
+
+    val MissingVMagnitude = "Please add a V magnitude."
+  }
+
+  extension (mp: MissingParamSet)
+    private def toObsValidation: ObservationValidation =
+      ObservationValidation.configuration(s"Missing ${mp.params.map(_.name).toList.intercalate(", ")}")
+
+  extension (ge: GeneratorParamsService.Error)
+    private def toObsValidation: ObservationValidation = ge match
+      case GenParamsError.MissingData(p) => p.toObsValidation
+      case _                             => ObservationValidation.configuration(ge.format)
+
+  def validate[F[_]: Applicative](
+    infos:  Map[Observation.Id, ObservationValidationInfo],
+    itcFor: Observation.Id => Option[Itc]
+  )(using Services[F]): ResultT[F, Map[Observation.Id, ObservationValidationMap]] = {
+
+    type Validator = ObservationValidationInfo => ObservationValidationMap
+
+    val (cals, other)         = infos.partition(_._2.calibrationRole.isDefined)
+    val (nonScience, science) = other.partition(!_._2.tpe.hasProposal)
+
+    def validateConfigurations(infos: NonEmptyList[ObservationValidationInfo]): ResultT[F, Map[Observation.Id, ObservationValidationMap]] =
+      ResultT(configurationService.selectRequests(infos.toList.map(i => (i.pid, i.oid)))).map: rs =>
+        rs.view
+          .map:
+            case ((_, oid), lst) =>
+              oid -> {
+                val m = ObservationValidationMap.empty
+                if lst.isEmpty then m.add(ObservationValidation.configurationRequestNotRequested)
+                else if lst.exists(_.status === ConfigurationRequestStatus.Approved) then m
+                else if lst.forall(_.status === ConfigurationRequestStatus.Denied) then m.add(ObservationValidation.configurationRequestDenied)
+                else m.add(ObservationValidation.configurationRequestPending)
+              }
+          .toMap
+
+    // Here are our simple validators
+
+    val generatorValidator: Validator = info =>
+      if info.isVisitor || info.isExchange then ObservationValidationMap.empty
+      else info.generatorParams.foldMap:
+        case Left(error)                                                         => ObservationValidationMap.singleton(error.toObsValidation)
+        case Right(GeneratorParams(itcInput = ItcInputDerivation.Incomplete(m))) => ObservationValidationMap.singleton(m.toObsValidation)
+        case Right(ps)                                                           => ObservationValidationMap.empty
+
+    val cfpInstrumentValidator: Validator = info =>
+      info.cfpInfo.foldMap: cfp =>
+        if cfp.instruments.isEmpty then ObservationValidationMap.empty // weird but original logic does this
+        else info.instrument.foldMap: inst =>
+          if cfp.instruments.contains(inst) then ObservationValidationMap.empty
+          else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.invalidInstrument(inst)))
+
+    // Exchange observations must match the proposal's observatory, and (when
+    // the call restricts instruments) use one of its allowed exchange instruments.
+    val exchangeValidator: Validator = info =>
+      info.observingMode match
+        case Some(e: ExchangeObservingModeType) =>
+          info.cfpInfo.foldMap: cfp =>
+            if cfp.observatory =!= e.observatory then
+              ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.exchangeObservatoryMismatch(e.observatory, cfp.observatory)))
+            else e match
+              case ExchangeObservingModeType.ExchangeKeck =>
+                if cfp.keckInstruments.isEmpty then ObservationValidationMap.empty
+                else info.keckInstrument.foldMap: inst =>
+                  if cfp.keckInstruments.contains(inst) then ObservationValidationMap.empty
+                  else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.invalidExchangeInstrument(inst.tag)))
+              case ExchangeObservingModeType.ExchangeSubaru =>
+                if cfp.subaruInstruments.isEmpty then ObservationValidationMap.empty
+                else info.subaruInstrument.foldMap: inst =>
+                  if cfp.subaruInstruments.contains(inst) then ObservationValidationMap.empty
+                  else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.invalidExchangeInstrument(inst.tag)))
+        case _ => ObservationValidationMap.empty
+
+    val cfpRaDecValidator: Validator = info =>
+      info.cfpInfo.foldMap: cfp =>
+        info.site.foldMap: site =>
+          info.coordinates.foldMap: coords =>
+            val ok = cfp.limits.siteLimits(site).inLimits(coords)
+            if ok then ObservationValidationMap.empty
+            else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.CoordinatesOutOfRange))
+
+    val bandValidator: Validator = info =>
+      (info.scienceBand, info.programAllocations).tupled.foldMap: (b, bs) =>
+        if bs.toList.contains(b) then ObservationValidationMap.empty
+        else ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.invalidScienceBand(b)))
+
+    // The Target-of-Opportunity ceiling.  This is an authorization failure
+    // rather than a misconfiguration, so it maps to Unapproved -- the
+    // observation cannot advance to Ready until the activation is lowered or
+    // the proposal's ceiling is raised.
+    val tooActivationValidator: Validator = info =>
+      if !info.exceedsTooCeiling then ObservationValidationMap.empty
+      else
+        ObservationValidationMap.singleton:
+          ObservationValidation.tooActivationUnapproved:
+            Messages.tooActivationExceedsCeiling(info.tooActivation, info.tooCeiling.get)
+
+    // An opportunity target is a placeholder standing in for a target that
+    // has not been found yet, so it makes sense only in an observation that
+    // declares itself a Target of Opportunity, and only until the alert
+    // arrives.  Either way the observation is internally inconsistent rather
+    // than merely unapproved, so this is a ConfigurationError -- Undefined,
+    // which also suppresses a stored Ready.
+    //
+    // The second case is a backstop.  A placeholder already blocks the
+    // Defined -> Ready transition, so a trigger cannot be requested for one,
+    // but the asterism can still be edited afterwards (Ready is in
+    // preExecutionSet) and a Ready ToO with no coordinates is worse than a
+    // loud error.
+    val opportunityTargetValidator: Validator = info =>
+      if !info.hasTooTarget then ObservationValidationMap.empty
+      else if !info.isTooObservation then
+        ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.OpportunityTargetRequiresActivation))
+      else if info.effectiveUserState.contains(Ready) then
+        ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.OpportunityTargetNotResolved))
+      else ObservationValidationMap.empty
+
+    val itcValidator: Validator = info =>
+      if itcFor(info.oid).isDefined || info.isVisitor || info.isExchange then ObservationValidationMap.empty
+      else ObservationValidationMap.singleton(ObservationValidation.itc("ITC results are not present."))
+
+    // An acquisition-capable mode whose acquisition ITC could not be produced
+    // (a cached deterministic failure) carries an ItcError.  Pre-execution this
+    // maps to Undefined and blocks Ready; during execution the frozen snapshot
+    // is present and execution-state dominance keeps the observation Ongoing,
+    // so it is a non-blocking standing error there.
+    val acquisitionValidator: Validator = info =>
+      if info.isVisitor then ObservationValidationMap.empty
+      else itcFor(info.oid).foldMap:
+        _.acquisition match
+          case ItcAcquisition.Failed(msg) => ObservationValidationMap.singleton(ObservationValidation.itc(msg))
+          case _                          => ObservationValidationMap.empty
+
+    // V magnitudes are used by Observe to set the GHOST slit viewing
+    // camera exposure time, so every target in a GHOST observation needs one.
+    val ghostVMagnitudeValidator: Validator = info =>
+      if info.observingMode.contains(ObservingModeType.GhostIfu) && info.asterism.exists(!_.sourceProfile.hasBand(Band.V)) then
+        ObservationValidationMap.singleton(ObservationValidation.configuration(Messages.MissingVMagnitude))
+      else ObservationValidationMap.empty
+
+    val otherConfigErrors: Validator = info =>
+      NonEmptyChain.fromSeq(info.otherConfigErrors) match
+        case None       => ObservationValidationMap.empty
+        case Some(errs) => ObservationValidationMap.singleton(ObservationValidation(ObservationValidationCode.ConfigurationError, errs))
+
+    // Here are our composed validators
+
+    val calibrationValidator, engValidator: Validator = _ =>
+      ObservationValidationMap.empty
+
+    val scienceValidator1: Validator =
+      generatorValidator         |+|
+      cfpInstrumentValidator     |+|
+      exchangeValidator          |+|
+      cfpRaDecValidator          |+|
+      bandValidator              |+|
+      ghostVMagnitudeValidator   |+|
+      tooActivationValidator     |+|
+      opportunityTargetValidator |+|
+      otherConfigErrors
+
+    val scienceValidator2: Validator =
+      itcValidator |+| acquisitionValidator
+
+    // And our validation results
+
+    val engResults: Map[Observation.Id, ObservationValidationMap] =
+      nonScience.view.mapValues(engValidator).toMap
+
+    val calibrationResults: Map[Observation.Id, ObservationValidationMap] =
+      cals.view.mapValues(calibrationValidator).toMap
+
+    val scienceResults1: Map[Observation.Id, ObservationValidationMap] =
+      science.view.mapValues(scienceValidator1).toMap
+
+    val scienceResults2: Map[Observation.Id, ObservationValidationMap] =
+      science
+        .view
+        .filterKeys(k => scienceResults1.get(k).forall(_.isEmpty)) // ensure there are no warnigs in stage 1
+        .mapValues(scienceValidator2)
+        .toMap
+
+    val prelimV: Map[Observation.Id, ObservationValidationMap] =
+      calibrationResults |+| engResults |+| scienceResults1 |+| scienceResults2
+
+    val toCheck: List[ObservationValidationInfo] =
+      science.values.toList.filter: info =>
+        info.isAccepted && !info.isExchange && prelimV.get(info.oid).forall(_.isEmpty)
+
+    val configValidations: ResultT[F, Map[Observation.Id, ObservationValidationMap]] =
+      NonEmptyList
+        .fromList(toCheck)
+        .fold(ResultT.pure(Map.empty[Observation.Id, ObservationValidationMap]))(validateConfigurations)
+
+    configValidations.map(prelimV |+| _)
+
+  }

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
@@ -12,10 +12,8 @@ import cats.implicits.*
 import grackle.ResultT
 import lucuma.core.enums.Band
 import lucuma.core.enums.ConfigurationRequestStatus
-import lucuma.core.enums.ExchangeObservingModeType
 import lucuma.core.enums.ObservationValidationCode
 import lucuma.core.enums.ObservationWorkflowState
-import lucuma.core.enums.Observatory
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.enums.ScienceBand
 import lucuma.core.enums.TooActivation
@@ -57,12 +55,6 @@ object ObservationValidator:
     val OpportunityTargetNotResolved =
       "Replace the Target of Opportunity placeholder with the actual target coordinates."
 
-    def exchangeObservatoryMismatch(modeObs: Observatory, cfpObs: Observatory): String =
-      s"Exchange observation requires a $modeObs Call for Proposals, but the proposal's observatory is $cfpObs."
-
-    def invalidExchangeInstrument(instr: String): String =
-      s"Instrument $instr is not part of the Call for Proposals."
-
     val MissingVMagnitude = "Please add a V magnitude."
   }
 
@@ -91,26 +83,7 @@ object ObservationValidator:
     // Here are our simple validators
     import validator.*
 
-    // Exchange observations must match the proposal's observatory, and (when
-    // the call restricts instruments) use one of its allowed exchange instruments.
-    val exchangeValidator: ObservationValidator = info =>
-      info.observingMode match
-        case Some(e: ExchangeObservingModeType) =>
-          info.cfpInfo.foldMap: cfp =>
-            if cfp.observatory =!= e.observatory then
-              ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.exchangeObservatoryMismatch(e.observatory, cfp.observatory)))
-            else e match
-              case ExchangeObservingModeType.ExchangeKeck =>
-                if cfp.keckInstruments.isEmpty then ObservationValidationMap.empty
-                else info.keckInstrument.foldMap: inst =>
-                  if cfp.keckInstruments.contains(inst) then ObservationValidationMap.empty
-                  else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.invalidExchangeInstrument(inst.tag)))
-              case ExchangeObservingModeType.ExchangeSubaru =>
-                if cfp.subaruInstruments.isEmpty then ObservationValidationMap.empty
-                else info.subaruInstrument.foldMap: inst =>
-                  if cfp.subaruInstruments.contains(inst) then ObservationValidationMap.empty
-                  else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.invalidExchangeInstrument(inst.tag)))
-        case _ => ObservationValidationMap.empty
+
 
     val cfpRaDecValidator: ObservationValidator = info =>
       info.cfpInfo.foldMap: cfp =>
@@ -192,7 +165,7 @@ object ObservationValidator:
     val scienceValidator1: ObservationValidator =
       GeneratorValidator         |+|
       CfpInstrumentValidator     |+|
-      exchangeValidator          |+|
+      ExchangeValidator          |+|
       cfpRaDecValidator          |+|
       bandValidator              |+|
       ghostVMagnitudeValidator   |+|

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/ObservationValidator.scala
@@ -4,6 +4,8 @@
 package lucuma.odb.service
 package workflow
 
+import cats.Applicative
+import cats.Monoid
 import cats.data.NonEmptyChain
 import cats.data.NonEmptyList
 import cats.implicits.*
@@ -11,7 +13,6 @@ import grackle.ResultT
 import lucuma.core.enums.Band
 import lucuma.core.enums.ConfigurationRequestStatus
 import lucuma.core.enums.ExchangeObservingModeType
-import lucuma.core.enums.Instrument
 import lucuma.core.enums.ObservationValidationCode
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.Observatory
@@ -25,11 +26,9 @@ import lucuma.core.syntax.string.*
 import lucuma.odb.data.Itc
 import lucuma.odb.data.ItcAcquisition
 import lucuma.odb.data.ObservationValidationMap
-import ObservationWorkflowState.*
 
+import ObservationWorkflowState.*
 import Services.Syntax.*
-import cats.Applicative
-import cats.Monoid
 
 trait ObservationValidator extends (ObservationValidationInfo => ObservationValidationMap):
   def apply(info: ObservationValidationInfo): ObservationValidationMap
@@ -44,9 +43,6 @@ object ObservationValidator:
   object Messages {
 
     val CoordinatesOutOfRange = "Base coordinates out of Call for Proposals limits."
-
-    def invalidInstrument(instr: Instrument): String =
-      s"Instrument $instr not part of Call for Proposals."
 
     def invalidScienceBand(b: ScienceBand): String =
       s"Science Band ${b.tag.toScreamingSnakeCase} has no time allocation."
@@ -74,7 +70,6 @@ object ObservationValidator:
     infos:  Map[Observation.Id, ObservationValidationInfo],
     itcFor: Observation.Id => Option[Itc]
   )(using Services[F]): ResultT[F, Map[Observation.Id, ObservationValidationMap]] = {
-    import validator.*
 
     val (cals, other)         = infos.partition(_._2.calibrationRole.isDefined)
     val (nonScience, science) = other.partition(!_._2.tpe.hasProposal)
@@ -94,13 +89,7 @@ object ObservationValidator:
           .toMap
 
     // Here are our simple validators
-
-    val cfpInstrumentValidator: ObservationValidator = info =>
-      info.cfpInfo.foldMap: cfp =>
-        if cfp.instruments.isEmpty then ObservationValidationMap.empty // weird but original logic does this
-        else info.instrument.foldMap: inst =>
-          if cfp.instruments.contains(inst) then ObservationValidationMap.empty
-          else ObservationValidationMap.singleton(ObservationValidation.callForProposals(Messages.invalidInstrument(inst)))
+    import validator.*
 
     // Exchange observations must match the proposal's observatory, and (when
     // the call restricts instruments) use one of its allowed exchange instruments.
@@ -202,7 +191,7 @@ object ObservationValidator:
 
     val scienceValidator1: ObservationValidator =
       GeneratorValidator         |+|
-      cfpInstrumentValidator     |+|
+      CfpInstrumentValidator     |+|
       exchangeValidator          |+|
       cfpRaDecValidator          |+|
       bandValidator              |+|

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/AcquisitionValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/AcquisitionValidator.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service.workflow.validator
+
+import cats.syntax.all.*
+import lucuma.core.model.Observation
+import lucuma.core.model.ObservationValidation
+import lucuma.odb.data.Itc
+import lucuma.odb.data.ItcAcquisition
+import lucuma.odb.data.ObservationValidationMap
+import lucuma.odb.service.workflow.ObservationValidationInfo
+import lucuma.odb.service.workflow.ObservationValidator
+
+// An acquisition-capable mode whose acquisition ITC could not be produced
+// (a cached deterministic failure) carries an ItcError.  Pre-execution this
+// maps to Undefined and blocks Ready; during execution the frozen snapshot
+// is present and execution-state dominance keeps the observation Ongoing,
+// so it is a non-blocking standing error there.
+case class AcquisitionValidator(itcFor: Observation.Id => Option[Itc]) extends ObservationValidator:
+  def apply(info: ObservationValidationInfo): ObservationValidationMap =
+    if info.isVisitor then ObservationValidationMap.empty
+    else itcFor(info.oid).foldMap:
+      _.acquisition match
+        case ItcAcquisition.Failed(msg) => ObservationValidationMap.singleton(ObservationValidation.itc(msg))
+        case _                          => ObservationValidationMap.empty

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/BandValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/BandValidator.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service.workflow
+package validator
+
+import cats.syntax.all.*
+import lucuma.core.enums.ScienceBand
+import lucuma.core.model.ObservationValidation
+import lucuma.core.syntax.string.*
+import lucuma.odb.data.ObservationValidationMap
+
+object BandValidator extends ObservationValidator:
+
+  def invalidScienceBand(b: ScienceBand): String =
+    s"Science Band ${b.tag.toScreamingSnakeCase} has no time allocation."
+
+  def apply(info: ObservationValidationInfo): ObservationValidationMap =
+    (info.scienceBand, info.programAllocations).tupled.foldMap: (b, bs) =>
+      if bs.toList.contains(b) then ObservationValidationMap.empty
+      else ObservationValidationMap.singleton(ObservationValidation.configuration(invalidScienceBand(b)))

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/CfpInstrumentValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/CfpInstrumentValidator.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service.workflow
+package validator
+
+import cats.syntax.all.*
+import lucuma.core.enums.Instrument
+import lucuma.core.model.ObservationValidation
+import lucuma.odb.data.ObservationValidationMap
+
+object CfpInstrumentValidator extends ObservationValidator:
+
+  def invalidInstrument(instr: Instrument): String =
+    s"Instrument $instr not part of Call for Proposals."
+
+  def apply(info: ObservationValidationInfo): ObservationValidationMap =
+    info.cfpInfo.foldMap: cfp =>
+      if cfp.instruments.isEmpty then ObservationValidationMap.empty // weird but original logic does this
+      else info.instrument.foldMap: inst =>
+        if cfp.instruments.contains(inst) then ObservationValidationMap.empty
+        else ObservationValidationMap.singleton(ObservationValidation.callForProposals(invalidInstrument(inst)))
+

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/CfpRaDecValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/CfpRaDecValidator.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service.workflow
+package validator
+
+import cats.syntax.all.*
+import lucuma.core.model.ObservationValidation
+import lucuma.odb.data.ObservationValidationMap
+
+object CfpRaDecValidator extends ObservationValidator:
+
+  val CoordinatesOutOfRange = "Base coordinates out of Call for Proposals limits."
+
+  def apply(info: ObservationValidationInfo): ObservationValidationMap =
+    info.cfpInfo.foldMap: cfp =>
+      info.site.foldMap: site =>
+        info.coordinates.foldMap: coords =>
+          val ok = cfp.limits.siteLimits(site).inLimits(coords)
+          if ok then ObservationValidationMap.empty
+          else ObservationValidationMap.singleton(ObservationValidation.callForProposals(CoordinatesOutOfRange))

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/ExchangeValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/ExchangeValidator.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service.workflow.validator
+
+import cats.syntax.all.*
+import lucuma.core.enums.ExchangeObservingModeType
+import lucuma.core.enums.Observatory
+import lucuma.core.model.ObservationValidation
+import lucuma.odb.data.ObservationValidationMap
+import lucuma.odb.service.workflow.ObservationValidationInfo
+import lucuma.odb.service.workflow.ObservationValidator
+
+// Exchange observations must match the proposal's observatory, and (when
+// the call restricts instruments) use one of its allowed exchange instruments.
+object ExchangeValidator extends ObservationValidator:
+
+  def exchangeObservatoryMismatch(modeObs: Observatory, cfpObs: Observatory): String =
+    s"Exchange observation requires a $modeObs Call for Proposals, but the proposal's observatory is $cfpObs."
+
+  def invalidExchangeInstrument(instr: String): String =
+    s"Instrument $instr is not part of the Call for Proposals."
+
+  def apply(info: ObservationValidationInfo): ObservationValidationMap =
+    info.observingMode match
+      case Some(e: ExchangeObservingModeType) =>
+        info.cfpInfo.foldMap: cfp =>
+          if cfp.observatory =!= e.observatory then
+            ObservationValidationMap.singleton(ObservationValidation.callForProposals(exchangeObservatoryMismatch(e.observatory, cfp.observatory)))
+          else e match
+            case ExchangeObservingModeType.ExchangeKeck =>
+              if cfp.keckInstruments.isEmpty then ObservationValidationMap.empty
+              else info.keckInstrument.foldMap: inst =>
+                if cfp.keckInstruments.contains(inst) then ObservationValidationMap.empty
+                else ObservationValidationMap.singleton(ObservationValidation.callForProposals(invalidExchangeInstrument(inst.tag)))
+            case ExchangeObservingModeType.ExchangeSubaru =>
+              if cfp.subaruInstruments.isEmpty then ObservationValidationMap.empty
+              else info.subaruInstrument.foldMap: inst =>
+                if cfp.subaruInstruments.contains(inst) then ObservationValidationMap.empty
+                else ObservationValidationMap.singleton(ObservationValidation.callForProposals(invalidExchangeInstrument(inst.tag)))
+      case _ => ObservationValidationMap.empty

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/GeneratorValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/GeneratorValidator.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service.workflow
+package validator
+
+import cats.syntax.all.*
+import lucuma.core.model.ObservationValidation
+import lucuma.odb.data.ObservationValidationMap
+import lucuma.odb.sequence.data.GeneratorParams
+import lucuma.odb.sequence.data.ItcInputDerivation
+import lucuma.odb.sequence.data.MissingParamSet
+import lucuma.odb.service.GeneratorParamsService
+import lucuma.odb.service.GeneratorParamsService.Error as GenParamsError
+import lucuma.odb.service.workflow.ObservationValidator
+
+extension (mp: MissingParamSet)
+  def toObsValidation: ObservationValidation =
+    ObservationValidation.configuration(s"Missing ${mp.params.map(_.name).toList.intercalate(", ")}")
+
+extension (ge: GeneratorParamsService.Error)
+  def toObsValidation: ObservationValidation = ge match
+    case GenParamsError.MissingData(p) => p.toObsValidation
+    case _                             => ObservationValidation.configuration(ge.format)
+
+val GeneratorValidator: ObservationValidator = info =>
+  if info.isVisitor || info.isExchange then ObservationValidationMap.empty
+  else info.generatorParams.foldMap:
+    case Left(error)                                                         => ObservationValidationMap.singleton(error.toObsValidation)
+    case Right(GeneratorParams(itcInput = ItcInputDerivation.Incomplete(m))) => ObservationValidationMap.singleton(m.toObsValidation)
+    case Right(ps)                                                           => ObservationValidationMap.empty
+

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/GhostVMagnitudeValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/GhostVMagnitudeValidator.scala
@@ -5,10 +5,10 @@ package lucuma.odb.service
 package workflow
 package validator
 
+import lucuma.core.enums.Band
 import lucuma.core.enums.ObservingModeType
 import lucuma.core.model.ObservationValidation
 import lucuma.odb.data.ObservationValidationMap
-import lucuma.core.enums.Band
 
 // V magnitudes are used by Observe to set the GHOST slit viewing
 // camera exposure time, so every target in a GHOST observation needs one.

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/GhostVMagnitudeValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/GhostVMagnitudeValidator.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service
+package workflow
+package validator
+
+import lucuma.core.enums.ObservingModeType
+import lucuma.core.model.ObservationValidation
+import lucuma.odb.data.ObservationValidationMap
+import lucuma.core.enums.Band
+
+// V magnitudes are used by Observe to set the GHOST slit viewing
+// camera exposure time, so every target in a GHOST observation needs one.
+object GhostVMagnitudeValidator extends ObservationValidator:
+
+  val MissingVMagnitude = "Please add a V magnitude."
+
+  def apply(info: ObservationValidationInfo): ObservationValidationMap =
+    if info.observingMode.contains(ObservingModeType.GhostIfu) && info.asterism.exists(!_.sourceProfile.hasBand(Band.V)) then
+      ObservationValidationMap.singleton(ObservationValidation.configuration(MissingVMagnitude))
+    else ObservationValidationMap.empty

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/ItcValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/ItcValidator.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service.workflow
+package validator
+
+import lucuma.core.model.Observation
+import lucuma.core.model.ObservationValidation
+import lucuma.odb.data.Itc
+import lucuma.odb.data.ObservationValidationMap
+
+class ItcValidator(itcFor: Observation.Id => Option[Itc]) extends ObservationValidator:
+  def apply(info: ObservationValidationInfo): ObservationValidationMap =
+    if itcFor(info.oid).isDefined || info.isVisitor || info.isExchange then ObservationValidationMap.empty
+    else ObservationValidationMap.singleton(ObservationValidation.itc("ITC results are not present."))
+
+object ItcValidator:
+  def apply(itcFor: Observation.Id => Option[Itc]): ObservationValidator =
+    new ItcValidator(itcFor)

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/OpportunityTargetValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/OpportunityTargetValidator.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service.workflow
+package validator
+
+import lucuma.core.enums.ObservationWorkflowState.Ready
+import lucuma.core.model.ObservationValidation
+import lucuma.odb.data.ObservationValidationMap
+
+object OpportunityTargetValidator extends ObservationValidator:
+  
+  val OpportunityTargetRequiresActivation =
+    "An observation with a Target of Opportunity placeholder must set a ToO activation other than NONE."
+
+  val OpportunityTargetNotResolved =
+    "Replace the Target of Opportunity placeholder with the actual target coordinates."
+
+  // An opportunity target is a placeholder standing in for a target that
+  // has not been found yet, so it makes sense only in an observation that
+  // declares itself a Target of Opportunity, and only until the alert
+  // arrives.  Either way the observation is internally inconsistent rather
+  // than merely unapproved, so this is a ConfigurationError -- Undefined,
+  // which also suppresses a stored Ready.
+  //
+  // The second case is a backstop.  A placeholder already blocks the
+  // Defined -> Ready transition, so a trigger cannot be requested for one,
+  // but the asterism can still be edited afterwards (Ready is in
+  // preExecutionSet) and a Ready ToO with no coordinates is worse than a
+  // loud error.
+  def apply(info: ObservationValidationInfo): ObservationValidationMap =
+    if !info.hasTooTarget then ObservationValidationMap.empty
+    else if !info.isTooObservation then
+      ObservationValidationMap.singleton(ObservationValidation.configuration(OpportunityTargetRequiresActivation))
+    else if info.effectiveUserState.contains(Ready) then
+      ObservationValidationMap.singleton(ObservationValidation.configuration(OpportunityTargetNotResolved))
+    else ObservationValidationMap.empty

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/OtherConfigErrorValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/OtherConfigErrorValidator.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service.workflow
+package validator
+
+import cats.data.NonEmptyChainImpl
+import lucuma.core.enums.ObservationValidationCode
+import lucuma.core.model.ObservationValidation
+import lucuma.odb.data.ObservationValidationMap
+
+val OtherConfigErrorValidator: ObservationValidator = info =>
+  NonEmptyChainImpl.fromSeq(info.otherConfigErrors) match
+    case None       => ObservationValidationMap.empty
+    case Some(errs) => ObservationValidationMap.singleton(ObservationValidation(ObservationValidationCode.ConfigurationError, errs))

--- a/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/TooActivationValidator.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/workflow/validator/TooActivationValidator.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.service.workflow
+package validator
+
+import lucuma.core.enums.TooActivation
+import lucuma.core.model.ObservationValidation
+import lucuma.core.syntax.string.*
+import lucuma.odb.data.ObservationValidationMap
+
+// The Target-of-Opportunity ceiling.  This is an authorization failure
+// rather than a misconfiguration, so it maps to Unapproved -- the
+// observation cannot advance to Ready until the activation is lowered or
+// the proposal's ceiling is raised.
+object TooActivationValidator extends ObservationValidator:
+
+  def tooActivationExceedsCeiling(obs: TooActivation, ceiling: TooActivation): String =
+    s"Target of Opportunity activation ${obs.tag.toScreamingSnakeCase} exceeds the maximum " +
+    s"${ceiling.tag.toScreamingSnakeCase} allowed by the proposal."
+
+  def apply(info: ObservationValidationInfo): ObservationValidationMap =
+    if !info.exceedsTooCeiling then ObservationValidationMap.empty
+    else
+      ObservationValidationMap.singleton:
+        ObservationValidation.tooActivationUnapproved:
+          tooActivationExceedsCeiling(info.tooActivation, info.tooCeiling.get)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow.scala
@@ -33,6 +33,7 @@ import lucuma.odb.graphql.input.AllocationInput
 import lucuma.odb.graphql.mutation.UpdateObservationsOps
 import lucuma.odb.service.ObservationService
 import lucuma.odb.service.ObservationWorkflowService
+import lucuma.odb.service.workflow.validator.CfpRaDecValidator
 
 class observation_workflow
   extends ExecutionTestSupportForGmos
@@ -504,7 +505,7 @@ class observation_workflow
                 ObservationWorkflow(
                   ObservationWorkflowState.Undefined,
                   List(ObservationWorkflowState.Inactive),
-                  List(ObservationValidation.callForProposals(ObservationWorkflowService.Messages.CoordinatesOutOfRange))
+                  List(ObservationValidation.callForProposals(CfpRaDecValidator.CoordinatesOutOfRange))
                 )
               )
             ).asRight
@@ -533,7 +534,7 @@ class observation_workflow
                 ObservationWorkflow(
                   ObservationWorkflowState.Undefined,
                   List(ObservationWorkflowState.Inactive),
-                  List(ObservationValidation.callForProposals(ObservationWorkflowService.Messages.CoordinatesOutOfRange))
+                  List(ObservationValidation.callForProposals(CfpRaDecValidator.CoordinatesOutOfRange))
                 )
               )
             ).asRight
@@ -591,7 +592,7 @@ class observation_workflow
             ObservationWorkflow(
               ObservationWorkflowState.Undefined,
               List(ObservationWorkflowState.Inactive),
-              List(ObservationValidation.callForProposals(ObservationWorkflowService.Messages.CoordinatesOutOfRange))
+              List(ObservationValidation.callForProposals(CfpRaDecValidator.CoordinatesOutOfRange))
             )
           )
         ).asRight
@@ -622,7 +623,7 @@ class observation_workflow
               List(
                 ObservationValidation.callForProposals(
                   ObservationService.InvalidInstrumentMsg(Instrument.GmosSouth),
-                  ObservationWorkflowService.Messages.CoordinatesOutOfRange
+                  CfpRaDecValidator.CoordinatesOutOfRange
                 )
               )
             )
@@ -900,7 +901,7 @@ class observation_workflow
               List(
                 ObservationValidation.callForProposals(
                   ObservationService.InvalidInstrumentMsg(Instrument.GmosSouth),
-                  ObservationWorkflowService.Messages.CoordinatesOutOfRange
+                  CfpRaDecValidator.CoordinatesOutOfRange
                 ),
               )
             )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow.scala
@@ -32,8 +32,8 @@ import lucuma.core.util.CalculationState
 import lucuma.odb.graphql.input.AllocationInput
 import lucuma.odb.graphql.mutation.UpdateObservationsOps
 import lucuma.odb.service.ObservationService
-import lucuma.odb.service.ObservationWorkflowService
 import lucuma.odb.service.workflow.validator.CfpRaDecValidator
+import lucuma.odb.service.workflow.validator.OpportunityTargetValidator
 
 class observation_workflow
   extends ExecutionTestSupportForGmos
@@ -218,7 +218,7 @@ class observation_workflow
     // problem rather than something the fixture can set up around.
     val moreMessages: List[String] =
       tt match
-        case TargetType.Opportunity => List(ObservationWorkflowService.Messages.OpportunityTargetRequiresActivation)
+        case TargetType.Opportunity => List(OpportunityTargetValidator.OpportunityTargetRequiresActivation)
         case _                      => Nil
 
     setup.flatMap: oid =>

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow_exchange.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/observation_workflow_exchange.scala
@@ -15,7 +15,7 @@ import lucuma.core.model.Observation
 import lucuma.core.model.ObservationValidation
 import lucuma.core.model.Program
 import lucuma.core.model.User
-import lucuma.odb.service.ObservationWorkflowService.Messages
+import lucuma.odb.service.workflow.validator.ExchangeValidator
 
 class observation_workflow_exchange extends OdbSuite with DatabaseOperations:
 
@@ -87,7 +87,7 @@ class observation_workflow_exchange extends OdbSuite with DatabaseOperations:
       _   <- runObscalcUpdateAs(serviceUser, pid, oid)
       ves <- validationErrors(oid)
       _   <- IO(assert(
-               ves.contains_(ObservationValidation.callForProposals(Messages.exchangeObservatoryMismatch(Observatory.Keck, Observatory.Subaru))),
+               ves.contains_(ObservationValidation.callForProposals(ExchangeValidator.exchangeObservatoryMismatch(Observatory.Keck, Observatory.Subaru))),
                s"Expected observatory-mismatch validation, got: $ves"
              ))
     yield ()
@@ -101,7 +101,7 @@ class observation_workflow_exchange extends OdbSuite with DatabaseOperations:
       _   <- runObscalcUpdateAs(serviceUser, pid, oid)
       ves <- validationErrors(oid)
       _   <- IO(assert(
-               ves.contains_(ObservationValidation.callForProposals(Messages.invalidExchangeInstrument(KeckInstrument.Hires.tag))),
+               ves.contains_(ObservationValidation.callForProposals(ExchangeValidator.invalidExchangeInstrument(KeckInstrument.Hires.tag))),
                s"Expected invalid-instrument validation, got: $ves"
              ))
     yield ()


### PR DESCRIPTION
This factors out the validation code from ObservationWorkflowService and moves each validator into its own source file. It's completely mechanical. I did a while back but I got too out of sync with main so I did it again. Fingers crossed.
