### PR TITLE
Fix SSO users query filtered by orcidId

### DIFF
--- a/modules/binding/src/main/scala/lucuma/odb/graphql/binding/WhereOptionString.scala
+++ b/modules/binding/src/main/scala/lucuma/odb/graphql/binding/WhereOptionString.scala
@@ -5,6 +5,7 @@ package lucuma.odb.graphql
 
 package binding
 
+import cats.Eq
 import cats.syntax.all.*
 import eu.timepit.refined.cats.*
 import grackle.Path
@@ -17,13 +18,23 @@ import lucuma.odb.graphql.binding.*
 object WhereOptionString {
 
   def binding(path: Path): Matcher[Predicate] =
+    bindingAs(path, NonEmptyStringBinding)
+
+  /**
+   * As `binding`, but parses the equality-style values (EQ, NEQ, IN, NIN) with the
+   * given matcher. Use this when the mapped column's Scala type is not `String`,
+   * since the constants are bound into the query with the column's own codec.
+   * LIKE and NLIKE remain string comparisons, which is always correct because
+   * Grackle encodes them with a string encoder regardless of the column codec.
+   */
+  def bindingAs[A: Eq](path: Path, value: Matcher[A]): Matcher[Predicate] =
     ObjectFieldsBinding.rmap {
       case List(
         BooleanBinding.Option("IS_NULL", rIsNull),
-        NonEmptyStringBinding.Option("EQ", rEq),
-        NonEmptyStringBinding.Option("NEQ", rNeq),
-        NonEmptyStringBinding.List.Option("IN", rIn),
-        NonEmptyStringBinding.List.Option("NIN", rNin),
+        value.Option("EQ", rEq),
+        value.Option("NEQ", rNeq),
+        value.List.Option("IN", rIn),
+        value.List.Option("NIN", rNin),
         NonEmptyStringBinding.Option("LIKE", rLike),
         NonEmptyStringBinding.Option("NLIKE", rNlike),
         BooleanBinding.Option("MATCH_CASE", rMatchCase)

--- a/modules/sso-service/src/main/scala/graphql/input/WhereUser.scala
+++ b/modules/sso-service/src/main/scala/graphql/input/WhereUser.scala
@@ -18,7 +18,7 @@ object WhereUser:
   def binding(path: Path): Matcher[Predicate] =
     val WhereUserId  = WhereOrder.binding[User.Id](path / "id", UserIdBinding)
     val WhereType    = WhereEq.binding[UserType](path / "type", UserTypeBinding)
-    val WhereOrcidId = WhereOptionString.binding(path / "orcidId")
+    val WhereOrcidId = WhereOptionString.bindingAs(path / "orcidId", OrcidIdBinding)
     val WhereProfile = WhereUserProfile.binding(path / "profile")
 
     lazy val WhereUserBinding = binding(path)

--- a/modules/sso-service/src/test/scala/graphql/query/users.scala
+++ b/modules/sso-service/src/test/scala/graphql/query/users.scala
@@ -154,6 +154,196 @@ class users extends GraphQLSuite with SsoSuite with Fixture with OrcidIdGenerato
         """
     )
 
+  test("Staff can see many users (filter for orcid id)."):
+    setup >>
+    AsBob.withRoleRequest(RoleRequest.Staff).expectQuery(
+      query =
+        s"""
+          query {
+            users(
+              WHERE: {
+                orcidId: {
+                  EQ: "${BobOrcidId.value}"
+                }
+              }
+            ) {
+              matches {
+                id
+                orcidId
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "data" : {
+              "users" : {
+                "matches" : [
+                  {
+                    "id" : "u-103",
+                    "orcidId" : ${BobOrcidId}
+                  }
+                ]
+              }
+            }
+          }
+        """
+    )
+
+  test("Staff can see many users (filter for orcid id in uri form)."):
+    setup >>
+    AsBob.withRoleRequest(RoleRequest.Staff).expectQuery(
+      query =
+        s"""
+          query {
+            users(
+              WHERE: {
+                orcidId: {
+                  EQ: "${BobOrcidId.uri}"
+                }
+              }
+            ) {
+              matches {
+                id
+                orcidId
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "data" : {
+              "users" : {
+                "matches" : [
+                  {
+                    "id" : "u-103",
+                    "orcidId" : ${BobOrcidId}
+                  }
+                ]
+              }
+            }
+          }
+        """
+    )
+
+  test("Staff can see many users (filter for orcid id in a list)."):
+    setup >>
+    AsBob.withRoleRequest(RoleRequest.Staff).expectQuery(
+      query =
+        s"""
+          query {
+            users(
+              WHERE: {
+                orcidId: {
+                  IN: ["${AliceOrcidId.value}", "${BobOrcidId.value}"]
+                }
+              }
+            ) {
+              matches {
+                id
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "data" : {
+              "users" : {
+                "matches" : [
+                  { "id" : "u-101" },
+                  { "id" : "u-103" }
+                ]
+              }
+            }
+          }
+        """
+    )
+
+  test("Staff can see many users (filter for missing orcid id)."):
+    setup >>
+    AsBob.withRoleRequest(RoleRequest.Staff).expectQuery(
+      query =
+        """
+          query {
+            users(
+              WHERE: {
+                orcidId: {
+                  IS_NULL: true
+                }
+              }
+            ) {
+              matches {
+                id
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "data" : {
+              "users" : {
+                "matches" : [
+                  { "id" : "u-100" }
+                ]
+              }
+            }
+          }
+        """
+    )
+
+  test("Staff can see many users (filter for orcid id with LIKE)."):
+    setup >>
+    AsBob.withRoleRequest(RoleRequest.Staff).expectQuery(
+      query =
+        s"""
+          query {
+            users(
+              WHERE: {
+                orcidId: {
+                  LIKE: "%${BobOrcidId.value.takeRight(4)}"
+                }
+              }
+            ) {
+              matches {
+                id
+              }
+            }
+          }
+        """,
+        expected = json"""
+          {
+            "data" : {
+              "users" : {
+                "matches" : [
+                  { "id" : "u-103" }
+                ]
+              }
+            }
+          }
+        """
+    )
+
+  test("An invalid orcid id filter is rejected."):
+    setup >>
+    AsBob.withRoleRequest(RoleRequest.Staff).query(
+      """
+        query {
+          users(
+            WHERE: {
+              orcidId: {
+                EQ: "not-an-orcid-id"
+              }
+            }
+          ) {
+            matches {
+              id
+            }
+          }
+        }
+      """
+    ).map: json =>
+      assert(json.hcursor.downField("errors").focus.exists(_.spaces2.contains("Invalid ORCID id")), json.spaces2)
+
   test("Andy issue ('exceeded maximum input value depth')."):
     setup >>
     AsBob.withRoleRequest(RoleRequest.Staff).expectQuery(


### PR DESCRIPTION
WhereUser.orcidId is declared as WhereOptionString, so the predicate bound a String constant. Grackle binds Const values with the column's own encoder, and the SSO's orcid_id column is typed as OrcidId, so EQ/NEQ/IN/NIN threw a ClassCastException at execution time, producing a 500 with an empty body.

Add WhereOptionString.bindingAs, which parses the equality-style values with a supplied matcher, and use it with OrcidIdBinding in the SSO. LIKE/NLIKE remain string comparisons, which Grackle always encodes as strings.