### PR TITLE
Derive the mask name from the ODF file name convention

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -7769,9 +7769,12 @@ type Attachment {
   fileName: NonEmptyString!
 
   """
-  The identifier of the physical mask plate this attachment describes, derived
-  from the attachment itself and not settable.  Null when the attachment is not
-  a MOS_MASK, always present when it is.
+  The identifier of the physical mask plate this attachment describes.  It is
+  derived from the file name by dropping the `_ODF.fits` suffix.
+  The file name must follow the standard ODF naming convention, either
+  `G(N|S)YYYY(A|B)<type>PPP-XX_ODF.fits` or
+  `GYYYY(A|B)PPPP<type>-XX_ODF.fits`.  
+  Not settable.  Null when the attachment is not a MOS_MASK, always present when it is.
   """
   maskName: NonEmptyString
   description: NonEmptyString

--- a/modules/service/src/main/resources/db/migration/V1251__mask_name_odf_convention.sql
+++ b/modules/service/src/main/resources/db/migration/V1251__mask_name_odf_convention.sql
@@ -1,0 +1,23 @@
+-- Mask names follow the standard ODF naming convention, in either the OCS form
+--
+--   G(N|S)YYYY(A|B)<type>PPP-XX_ODF.fits, e.g. GS2015AQ023-01_ODF.fits
+--
+-- or the GPP form built from the program reference with its dashes removed
+--
+--   GYYYY(A|B)PPPP<type>-XX_ODF.fits, e.g. G2027A1234Q-42_ODF.fits
+--
+-- In both the mask name is the file name with the '_ODF.fits' suffix removed.
+-- V1247 stripped only the extension, which left the '_ODF' in place.
+--
+-- The shape is validated on upload rather than by the domain, so that the
+-- convention can evolve without a migration.
+
+DROP INDEX unique_mask_name_index;
+
+UPDATE t_attachment
+  SET c_mask_name = upper(regexp_replace(c_file_name, '_ODF\.fits$', '', 'i'))
+  WHERE c_attachment_type = 'mos_mask';
+
+CREATE UNIQUE INDEX unique_mask_name_index
+  ON t_attachment (c_program_id, c_mask_name)
+  WHERE c_attachment_type = 'mos_mask';

--- a/modules/service/src/main/scala/lucuma/odb/service/AttachmentFileService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/AttachmentFileService.scala
@@ -106,11 +106,6 @@ object AttachmentFileService {
       // does not contain the dot.
       def extName: Option[NonEmptyString] =
         NonEmptyString.from(Path(fileName.value.value).extName.drop(1).toLowerCase).toOption
-
-      // the whole name when there is no extension to strip.
-      def baseName: NonEmptyString =
-        val name = fileName.value.value
-        NonEmptyString.from(name.stripSuffix(Path(name).extName)).getOrElse(fileName.value)
   }
 
   extension [F[_], A](fe: F[Either[AttachmentException, A]])
@@ -151,14 +146,35 @@ object AttachmentFileService {
   }
 
   /**
-   * The mask name will be derived now from the file, removing the extension.
-   * In the future we should parse the fits file and read the name directly.
+   * MOS mask files follow the standard ODF naming convention in either the OCS
+   * form, `G(N|S)YYYY(A|B)<type>PPP-XX_ODF.fits`, or the GPP form built from
+   * the program reference with its dashes removed,
+   * `GYYYY(A|B)PPPP<type>-XX_ODF.fits`.
+   *
+   * The mask name is the file name with the `_ODF.fits` suffix removed.
+   * Names are matched case-insensitively but stored upper case, so the identifier
+   * handed to observe is canonical however the file was named.
    */
+  private val OcsMaskFileName =
+    raw"(?i)(G[NS]\d{4}[AB](?:ENG|CAL|COM|DD|DS|SV|LP|FT|Q|C)\d{3}-\d{2})_ODF\.fits".r
+  private val GppMaskFileName = raw"(?i)(G\d{4}[AB]\d{4}[CDFLPQSV]-\d{2})_ODF\.fits".r
+
+  val InvalidMaskFileNameMsg =
+    "Invalid MOS mask file name. Must follow the ODF naming convention, e.g. 'GS2015AQ023-01_ODF.fits' or 'G2027A1234Q-42_ODF.fits'."
+
   def deriveMaskName(
     attachmentType: AttachmentType,
     fileName:       FileName
-  ): Option[NonEmptyString] =
-    Option.when(attachmentType === AttachmentType.MosMask)(fileName.baseName)
+  ): Either[AttachmentException, Option[NonEmptyString]] =
+    def maskName(root: String): Either[AttachmentException, Option[NonEmptyString]] =
+      NonEmptyString.from(root.toUpperCase).bimap(_ => InvalidRequest(InvalidMaskFileNameMsg), _.some)
+
+    if (attachmentType =!= AttachmentType.MosMask) none.asRight
+    else
+      fileName.value.value match
+        case OcsMaskFileName(root) => maskName(root)
+        case GppMaskFileName(root) => maskName(root)
+        case _                     => InvalidRequest(InvalidMaskFileNameMsg).asLeft
 
   def checkForEmptyFile(fileSize: Long): Either[AttachmentException, Unit] =
     if (fileSize <= 0) InvalidRequest("File cannot be empty").asLeft
@@ -375,13 +391,15 @@ object AttachmentFileService {
           (
             for {
               fn     <- FileName.fromString(fileName).liftF
-              mn      = deriveMaskName(attachmentType, fn)
-              _      <- services.transactionallyEitherT:
-                          checkAccess(user, programId, AccessRequired.Write, Forbidden) >>
-                            validateFileExtensionByType(attachmentType, fn).liftF >>
-                            checkForDuplicateType(programId, attachmentType).asEitherT >>
-                            checkForDuplicateName(programId, fn, none).asEitherT >>
-                            checkForDuplicateMaskName(programId, mn, none).asEitherT
+              mn     <- services.transactionallyEitherT:
+                          for {
+                            _  <- checkAccess(user, programId, AccessRequired.Write, Forbidden)
+                            _  <- validateFileExtensionByType(attachmentType, fn).liftF
+                            mn <- deriveMaskName(attachmentType, fn).liftF
+                            _  <- checkForDuplicateType(programId, attachmentType).asEitherT
+                            _  <- checkForDuplicateName(programId, fn, none).asEitherT
+                            _  <- checkForDuplicateMaskName(programId, mn, none).asEitherT
+                          } yield mn
               uuid   <- UUIDGen[F].randomUUID.right
               path    = Services.asSuperUser(filePath(programId, uuid, fn.value))
             } yield (fn, mn, path)
@@ -426,7 +444,7 @@ object AttachmentFileService {
                 for {
                   (pid, oldPath) <- getAttachmentInfoAndCheckAccess(user, attachmentId, AccessRequired.Write)
                   at             <- validateFileExtensionById(attachmentId, fn).asEitherT
-                  mn              = deriveMaskName(at, fn)
+                  mn             <- deriveMaskName(at, fn).liftF
                   _              <- checkForDuplicateName(pid, fn, attachmentId.some).asEitherT
                   _              <- checkForDuplicateMaskName(pid, mn, attachmentId.some).asEitherT
                 } yield (pid, mn, oldPath)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachments.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/attachments.scala
@@ -91,10 +91,10 @@ class attachments extends AttachmentsSuite {
   }
 
   // TODO: science, team and custom_sed file tests
-  val mosMask1A         = TestAttachment("file1.fits", "mos_mask", "A description".some, "Hopeful", maskName = "file1".some)
-  val mosMask1B         = TestAttachment("file1.fits", "mos_mask", None, "New contents", maskName = "file1".some)
-  val mosMask1Upper     = TestAttachment("file1.FITS", "mos_mask", "Shouty".some, "Also hopeful", maskName = "file1".some)
-  val mosMask2          = TestAttachment("file2.fits", "mos_mask", "Masked".some, "Zorro", maskName = "file2".some)
+  val mosMask1A         = TestAttachment("GS2015AQ023-01_ODF.fits", "mos_mask", "A description".some, "Hopeful", maskName = "GS2015AQ023-01".some)
+  val mosMask1B         = TestAttachment("GS2015AQ023-01_ODF.fits", "mos_mask", None, "New contents", maskName = "GS2015AQ023-01".some)
+  val mosMask1Lower     = TestAttachment("gs2015aq023-01_odf.FITS", "mos_mask", "Shouty".some, "Also hopeful", maskName = "GS2015AQ023-01".some)
+  val mosMask2          = TestAttachment("GS2015AQ023-02_ODF.fits", "mos_mask", "Masked".some, "Zorro", maskName = "GS2015AQ023-02".some)
   val finderPNG         = TestAttachment("different.png", "finder", "Unmatching file name".some, "Something different")
   val finderJPG         = TestAttachment("finder.jpg", "finder", "jpg file".some, "A finder JPG file")
   val preImaging        = TestAttachment("pi.fits", "pre_imaging", none, "A pre imaging file")
@@ -106,7 +106,7 @@ class attachments extends AttachmentsSuite {
   val customSedSED      = TestAttachment("sed.sed", "custom_sed", "It's custom".some, "A custom SED file")
   val customSedTXT      = TestAttachment("sed.TXT", "custom_sed", "It's custom".some, "Another custom SED file")
   val customSedDAT      = TestAttachment("sed.dat", "custom_sed", "It's custom".some, "A third custom SED file")
-  val emptyFile         = TestAttachment("file1.fits", "mos_mask", "Thing".some, "")
+  val emptyFile         = TestAttachment("GS2015AQ023-01_ODF.fits", "mos_mask", "Thing".some, "")
   val missingType       = TestAttachment("file1.fits", "", "Whatever".some, "It'll never make it")
   val invalidType       = TestAttachment("file1.fits", "NotAType", none, "It'll never make it")
   val missingFileName   = TestAttachment("", "finder", none, "Doesn't matter")
@@ -115,6 +115,15 @@ class attachments extends AttachmentsSuite {
   val emptyMosMaskExt   = TestAttachment("file.", "mos_mask", none, "Doesn't matter")
   val invalidFinderExt  = TestAttachment("file.fits", "finder", none, "Doesn't matter")
   val invalidMosMaskExt = TestAttachment("file.png", "mos_mask", none, "Doesn't matter")
+  val engMask           = TestAttachment("GN2026AENG051-10_ODF.fits", "mos_mask", "Engineering".some, "Three letter type", maskName = "GN2026AENG051-10".some)
+  val svMask            = TestAttachment("GN2026ASV051-10_ODF.fits", "mos_mask", "System verification".some, "Two letter type", maskName = "GN2026ASV051-10".some)
+  val gppMask           = TestAttachment("G2027A1234Q-42_ODF.fits", "mos_mask", "GPP style".some, "From a program reference", maskName = "G2027A1234Q-42".some)
+  val gppMaskLower      = TestAttachment("g2027a1234q-42_odf.fits", "mos_mask", "GPP style".some, "Shouty", maskName = "G2027A1234Q-42".some)
+  val badMaskName       = TestAttachment("mask.fits", "mos_mask", none, "Doesn't matter")
+  val unpaddedMaskName  = TestAttachment("GS2015AQ23-01_ODF.fits", "mos_mask", none, "Doesn't matter")
+  val noOdfMaskName     = TestAttachment("GS2015AQ023-01.fits", "mos_mask", none, "Doesn't matter")
+  val gppShortProgram   = TestAttachment("G2027A123Q-42_ODF.fits", "mos_mask", none, "Doesn't matter")
+  val gppBadSubtype     = TestAttachment("G2027A1234Z-42_ODF.fits", "mos_mask", none, "Doesn't matter")
   val invalidPreImgExt  = TestAttachment("file.jpg", "pre_imaging", none, "Doesn't matter")
 
   val invalidFitsMsg = "Invalid file. Must be a FITS file."
@@ -741,7 +750,7 @@ class attachments extends AttachmentsSuite {
       newTa1  = mosMask1A.copy(description = newDesc.some)
       newTa2  = mosMask2.copy(description = newDesc.some)
       _      <- updateAttachmentsGql(pi,
-                                     WHERE = s"""{ fileName: { LIKE: "file%"}, program: { id: { EQ: "$pid" } } }""",
+                                     WHERE = s"""{ fileName: { LIKE: "GS2015AQ023%"}, program: { id: { EQ: "$pid" } } }""",
                                      SET = s"""{ description: "$newDesc" }""",
                                      (aid1, newTa1),
                                      (aid2, newTa2)
@@ -847,19 +856,38 @@ class attachments extends AttachmentsSuite {
     } yield ()
   }
 
-  test("mask name ignores the case of the extension"):
+  List(mosMask1A, mosMask1Lower, engMask, svMask, gppMask, gppMaskLower).foreach: ta =>
+    test(s"mask name of '${ta.fileName}' is '${ta.maskName.orEmpty}'"):
+      for {
+        pid <- createProgramAs(pi)
+        aid <- insertAttachment(pi, pid, ta).toAttachmentId
+        _   <- assertAttachmentsGql(pi, pid, (aid, ta))
+      } yield ()
+
+  List(badMaskName, unpaddedMaskName, noOdfMaskName, gppShortProgram, gppBadSubtype).foreach: ta =>
+    test(s"insert of mask '${ta.fileName}' is a BadRequest"):
+      for {
+        pid <- createProgramAs(pi)
+        _   <- insertAttachment(pi, pid, ta)
+                 .withExpectation(Status.BadRequest, AttachmentFileService.InvalidMaskFileNameMsg)
+        _   <- assertAttachmentsGql(pi, pid)
+      } yield ()
+
+  test("update to a mask name not following the convention is a BadRequest"):
     for {
       pid <- createProgramAs(pi)
-      aid <- insertAttachment(pi, pid, mosMask1Upper).toAttachmentId
-      _   <- assertAttachmentsGql(pi, pid, (aid, mosMask1Upper))
+      aid <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
+      _   <- updateAttachment(pi, aid, badMaskName)
+               .withExpectation(Status.BadRequest, AttachmentFileService.InvalidMaskFileNameMsg)
+      _   <- assertAttachmentsGql(pi, pid, (aid, mosMask1A))
     } yield ()
 
   test("insert with duplicate mask name is a BadRequest"):
     for {
       pid <- createProgramAs(pi)
       aid <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
-      _   <- insertAttachment(pi, pid, mosMask1Upper)
-               .withExpectation(Status.BadRequest, AttachmentFileService.duplicateMaskNameMsg(NonEmptyString.unsafeFrom("file1")))
+      _   <- insertAttachment(pi, pid, mosMask1Lower)
+               .withExpectation(Status.BadRequest, AttachmentFileService.duplicateMaskNameMsg(NonEmptyString.unsafeFrom("GS2015AQ023-01")))
       _   <- assertAttachmentsGql(pi, pid, (aid, mosMask1A))
     } yield ()
 
@@ -878,8 +906,8 @@ class attachments extends AttachmentsSuite {
       pid  <- createProgramAs(pi)
       aid1 <- insertAttachment(pi, pid, mosMask1A).toAttachmentId
       aid2 <- insertAttachment(pi, pid, mosMask2).toAttachmentId
-      _    <- updateAttachment(pi, aid2, mosMask1Upper)
-                .withExpectation(Status.BadRequest, AttachmentFileService.duplicateMaskNameMsg(NonEmptyString.unsafeFrom("file1")))
+      _    <- updateAttachment(pi, aid2, mosMask1Lower)
+                .withExpectation(Status.BadRequest, AttachmentFileService.duplicateMaskNameMsg(NonEmptyString.unsafeFrom("GS2015AQ023-01")))
       _    <- assertAttachmentsGql(pi, pid, (aid1, mosMask1A), (aid2, mosMask2))
       _    <- getAttachment(pi, aid2).expectBody(mosMask2.content)
     } yield ()
@@ -892,7 +920,7 @@ class attachments extends AttachmentsSuite {
       _     <- insertAttachment(pi, pid, finderPNG).toAttachmentId
       newTa2 = mosMask2.copy(description = "Found".some)
       _     <- updateAttachmentsGql(pi,
-                                    WHERE = s"""{ maskName: { EQ: "file2" }, program: { id: { EQ: "$pid" } } }""",
+                                    WHERE = s"""{ maskName: { EQ: "GS2015AQ023-02" }, program: { id: { EQ: "$pid" } } }""",
                                     SET = """{ description: "Found" }""",
                                     (aid2, newTa2)
                )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/attachments/obsAttachmentsAssignments.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/attachments/obsAttachmentsAssignments.scala
@@ -209,7 +209,7 @@ class obsAttachmentsAssignments extends AttachmentsSuite {
       expected = List(error).asLeft
     )
 
-  val mosMask = TestAttachment("file1.fits", "mos_mask", "A description".some, "Hopeful", maskName = "file1".some)
+  val mosMask = TestAttachment("GS2015AQ023-01_ODF.fits", "mos_mask", "A description".some, "Hopeful", maskName = "GS2015AQ023-01".some)
   val finder  = TestAttachment("file2.jpg", "finder", "jpg file".some, "A finder JPG file")
   val preImaging  = TestAttachment("preImaging.fits", "pre_imaging", none, "A pre imaging file")
   val science = TestAttachment("science.pdf", "science", none, "science file")

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/cloneObservation.scala
@@ -2686,7 +2686,7 @@ class cloneObservation extends OdbSuite with ObservingModeSetupOperations {
         VALUES ($program_id, 'mos_mask', $text, 42, 'unused', $text)
         RETURNING c_attachment_id
       """.query(attachment_id)
-    withSession(_.unique(q)(pid, fileName, fileName.stripSuffix(".fits")))
+    withSession(_.unique(q)(pid, fileName, fileName.stripSuffix("_ODF.fits").toUpperCase))
 
   private def readMaskColumns(
     table: String,
@@ -2704,7 +2704,7 @@ class cloneObservation extends OdbSuite with ObservingModeSetupOperations {
     for
       pid  <- createProgramAs(pi)
       tid  <- createTargetAs(pi, pid)
-      aid  <- insertMosMaskAttachment(pid, "mask.fits")
+      aid  <- insertMosMaskAttachment(pid, "GN2025AQ001-01_ODF.fits")
       mode  = s"""
         gmosNorthMos: {
           grating: R831_G5302

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GmosMos.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GmosMos.scala
@@ -44,7 +44,7 @@ class createObservation_GmosMos extends OdbSuite:
         VALUES ($program_id, 'mos_mask', $text, 42, 'unused', $text)
         RETURNING c_attachment_id
       """.query(attachment_id)
-    withSession(_.unique(q)(pid, fileName, fileName.stripSuffix(".fits")))
+    withSession(_.unique(q)(pid, fileName, fileName.stripSuffix("_ODF.fits").toUpperCase))
 
   private def scienceRequirements: String =
     """
@@ -203,7 +203,7 @@ class createObservation_GmosMos extends OdbSuite:
     for
       pid <- createProgramAs(pi)
       tid <- createTargetAs(pi, pid)
-      aid <- insertMosMaskAttachment(pid, "mask.fits")
+      aid <- insertMosMaskAttachment(pid, "GN2025AQ001-01_ODF.fits")
       oid <- create(pid, tid, s"""
                gmosNorthMos: {
                  grating: R831_G5302

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/customMask.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/customMask.scala
@@ -42,7 +42,7 @@ trait CustomMaskOps extends ReplaceSequenceOps:
         VALUES ($program_id, 'mos_mask', $text, 42, 'unused', $text)
         RETURNING c_attachment_id
       """.query(attachment_id)
-    withSession(_.unique(q)(pid, fileName, fileName.stripSuffix(".fits")))
+    withSession(_.unique(q)(pid, fileName, fileName.stripSuffix("_ODF.fits").toUpperCase))
 
   protected def gmosStep(customMask: String): String =
     s"""
@@ -136,7 +136,7 @@ class customMask extends query.ExecutionTestSupportForGmos with CustomMaskOps:
         p   <- createProgram
         t   <- createTargetWithProfileAs(pi, p)
         o   <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
-        a   <- Option.when(defined)(insertMosMaskAttachment(p, "mask.fits")).sequence
+        a   <- Option.when(defined)(insertMosMaskAttachment(p, "GN2025AQ001-01_ODF.fits")).sequence
         // Pending simply omits the attachment id; the slit width alone marks
         // the custom mask as present.
         cm   = a.fold(s"""{ slitWidth: $SlitWidth }""")(id => s"""{ attachmentId: "$id", slitWidth: $SlitWidth }""")

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/customMaskInUse.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/customMaskInUse.scala
@@ -43,7 +43,7 @@ class customMaskInUse
       p <- createProgram
       t <- createTargetWithProfileAs(pi, p)
       o <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
-      a <- insertMosMaskAttachment(p, "in-use.fits")
+      a <- insertMosMaskAttachment(p, "GN2025AQ001-02_ODF.fits")
       m  = s"""{ attachmentId: "$a", slitWidth: $SlitWidth }"""
       i  = input(o, SequenceType.Science, atomInput("Masked", gmosStep(m)))
       _ <- query(pi, mutation(Instrument.GmosNorth, i))

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations_GmosMos.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations_GmosMos.scala
@@ -44,7 +44,7 @@ class updateObservations_GmosMos extends OdbSuite:
         VALUES ($program_id, $text::e_attachment_type, $text, 42, 'unused', ${text.opt})
         RETURNING c_attachment_id
       """.query(attachment_id)
-    val maskName = Option.when(tpe === "mos_mask")(fileName.stripSuffix(".fits"))
+    val maskName = Option.when(tpe === "mos_mask")(fileName.stripSuffix("_ODF.fits").toUpperCase)
     withSession(_.unique(q)(pid, tpe, fileName, maskName))
 
   // The mask attachment is stored as two columns (id + type) pinned together
@@ -139,7 +139,7 @@ class updateObservations_GmosMos extends OdbSuite:
   test("attach a mask to a maskless observation"):
     for
       (pid, oid) <- setupNorth("slitWidth: CUSTOM_WIDTH_1_00")
-      aid        <- insertAttachment(pid, "mos_mask", "mask.fits")
+      aid        <- insertAttachment(pid, "mos_mask", "GN2025AQ001-01_ODF.fits")
       _          <- expect(pi, updateMutation(
                       oid,
                       s"""gmosNorthMos: { customMask: { slitWidth: CUSTOM_WIDTH_1_00, attachmentId: "$aid" } }""",
@@ -168,7 +168,7 @@ class updateObservations_GmosMos extends OdbSuite:
     for
       pid <- createProgramAs(pi)
       tid <- createTargetAs(pi, pid)
-      aid <- insertAttachment(pid, "mos_mask", "mask.fits")
+      aid <- insertAttachment(pid, "mos_mask", "GN2025AQ001-01_ODF.fits")
       oid <- create(pid, tid, northMode(s"""slitWidth: CUSTOM_WIDTH_1_00, attachmentId: "$aid""""))
       _   <- expect(pi, updateMutation(
                oid,
@@ -201,7 +201,7 @@ class updateObservations_GmosMos extends OdbSuite:
     for
       pid <- createProgramAs(pi)
       tid <- createTargetAs(pi, pid)
-      aid <- insertAttachment(pid, "mos_mask", "mask.fits")
+      aid <- insertAttachment(pid, "mos_mask", "GN2025AQ001-01_ODF.fits")
       oid <- create(pid, tid, northMode(s"""slitWidth: CUSTOM_WIDTH_1_00, attachmentId: "$aid""""))
       _   <- expect(pi, updateMutation(
                oid,
@@ -233,7 +233,7 @@ class updateObservations_GmosMos extends OdbSuite:
     for
       pid <- createProgramAs(pi)
       tid <- createTargetAs(pi, pid)
-      aid <- insertAttachment(pid, "mos_mask", "mask.fits")
+      aid <- insertAttachment(pid, "mos_mask", "GN2025AQ001-01_ODF.fits")
       oid <- create(pid, tid, northMode(s"""slitWidth: CUSTOM_WIDTH_1_00, attachmentId: "$aid""""))
       _   <- expect(pi, updateMutation(
                oid,
@@ -311,7 +311,7 @@ class updateObservations_GmosMos extends OdbSuite:
     for
       pid <- createProgramAs(pi)
       tid <- createTargetAs(pi, pid)
-      aid <- insertAttachment(pid, "mos_mask", "mask.fits")
+      aid <- insertAttachment(pid, "mos_mask", "GN2025AQ001-01_ODF.fits")
       oid <- create(pid, tid, southMode("slitWidth: CUSTOM_WIDTH_1_00"))
       _   <- expect(pi, updateMutation(
                oid,
@@ -393,7 +393,7 @@ class updateObservations_GmosMos extends OdbSuite:
     for
       (_, oid) <- setupNorth("slitWidth: CUSTOM_WIDTH_1_00")
       other    <- createProgramAs(pi)
-      aid      <- insertAttachment(other, "mos_mask", "mask.fits")
+      aid      <- insertAttachment(other, "mos_mask", "GN2025AQ001-01_ODF.fits")
       _        <- expect(
                     user     = pi,
                     query    = updateMutation(
@@ -410,7 +410,7 @@ class updateObservations_GmosMos extends OdbSuite:
       pid   <- createProgramAs(pi)
       tid   <- createTargetAs(pi, pid)
       other <- createProgramAs(pi)
-      aid   <- insertAttachment(other, "mos_mask", "mask.fits")
+      aid   <- insertAttachment(other, "mos_mask", "GN2025AQ001-01_ODF.fits")
       _     <- expect(
                  user     = pi,
                  query    = s"""


### PR DESCRIPTION
This PR updates how we derive mask names from the files and also requires filenames to follow either ocs or gpp conventions

We need ocs ones to do testing in the interim period