### PR TITLE
Move GNIRS imaging coadds into the per-filter list

### DIFF
--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -11163,6 +11163,12 @@ type GnirsImagingFilter {
   """
   exposureTimeMode: ExposureTimeMode!
 
+  """
+  Coadds per exposure for this filter.  Always 1 when the exposure time mode is
+  signal-to-noise, which does not support coadds.
+  """
+  coadds: PosInt!
+
 }
 
 """
@@ -11180,6 +11186,13 @@ input GnirsImagingFilterInput {
   If not specified, it is taken from the observation's requirements.
   """
   exposureTimeMode: ExposureTimeModeInput
+
+  """
+  Coadds per exposure for this filter.  If not specified, defaults to 1.
+  Forced to 1 when the exposure time mode is signal-to-noise, which does not
+  support coadds.
+  """
+  coadds: PosInt
 
 }
 
@@ -11230,11 +11243,6 @@ type GnirsImaging {
   The camera (determines the pixel scale).
   """
   camera: GnirsCamera!
-
-  """
-  Coadds per exposure.
-  """
-  coadds: PosInt!
 
   """
   Optional explicitly specified read mode.  If not set, the read mode is
@@ -11298,11 +11306,6 @@ input GnirsImagingInput {
   The camera (determines the pixel scale).  Required on creation.
   """
   camera: GnirsCamera
-
-  """
-  Coadds per exposure.  On creation, if not specified, defaults to 1.
-  """
-  coadds: PosInt
 
   """
   The explicitReadMode field may be unset by assigning a null value, or ignored by skipping it altogether

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/imaging/Config.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/imaging/Config.scala
@@ -6,9 +6,9 @@ package lucuma.odb.sequence.gnirs.imaging
 import cats.Eq
 import cats.data.NonEmptyList
 import cats.derived.*
-import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.GnirsCamera
+import lucuma.core.enums.GnirsFilter
 import lucuma.core.enums.GnirsReadMode
 import lucuma.core.enums.GnirsWellDepth
 import lucuma.core.model.sequence.gnirs.GnirsStaticConfig
@@ -28,7 +28,6 @@ case class Config(
   variant:           Variant,
   filters:           NonEmptyList[Filter],
   camera:            GnirsCamera,
-  coadds:            PosInt,
   explicitReadMode:  Option[GnirsReadMode],
   defaultWellDepth:  GnirsWellDepth,
   explicitWellDepth: Option[GnirsWellDepth],
@@ -38,6 +37,16 @@ case class Config(
   def wellDepth: GnirsWellDepth =
     explicitWellDepth.getOrElse(defaultWellDepth)
 
+  private lazy val coaddsByFilter: Map[GnirsFilter, PosInt] =
+    filters.toList.map(f => f.filter -> f.coadds).toMap
+
+  /**
+   * Coadds for the given filter.  Falls back to 1 for a filter that isn't part
+   * of this configuration, which the sequence never asks for.
+   */
+  def coaddsFor(filter: GnirsFilter): PosInt =
+    coaddsByFilter.getOrElse(filter, PosInt.unsafeFrom(1))
+
   def staticConfig: GnirsStaticConfig =
     GnirsStaticConfig(wellDepth)
 
@@ -46,10 +55,13 @@ case class Config(
     val out: DataOutputStream      = new DataOutputStream(bao)
 
     out.write(variant.hashBytes)
-    out.write(filters.hashBytes)
+    // Length-prefixed: the element count is user-controlled, so without it two
+    // different filter lists could hash to the same bytes.
+    out.writeInt(filters.length)
+    filters.toList.foreach: f =>
+      out.write(f.hashBytes)
 
     out.writeChars(camera.tag)
-    out.write(coadds.value.hashBytes)
     out.writeChars(explicitReadMode.fold("")(_.tag))
     out.writeChars(wellDepth.tag)
 

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/imaging/Filter.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/imaging/Filter.scala
@@ -5,16 +5,29 @@ package lucuma.odb.sequence.gnirs.imaging
 
 import cats.Eq
 import cats.derived.*
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.model.ExposureTimeMode
+import lucuma.odb.sequence.syntax.all.*
 import lucuma.odb.sequence.util.HashBytes
 
+/**
+ * One GNIRS imaging science configuration: a filter together with the exposure
+ * time mode and coadds that apply to it.  Each is a separate ITC calculation.
+ */
 case class Filter(
   filter:           GnirsFilter,
-  exposureTimeMode: ExposureTimeMode
+  exposureTimeMode: ExposureTimeMode,
+  coadds:           PosInt
 ) derives Eq
 
 object Filter:
 
-  given HashBytes[Filter] =
-    HashBytes.by2(_.filter, _.exposureTimeMode)
+  given HashBytes[Filter] with
+    def hashBytes(a: Filter): Array[Byte] =
+      Array.concat(
+        a.filter.hashBytes,
+        a.exposureTimeMode.hashBytes,
+        a.coadds.value.hashBytes
+      )

--- a/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/imaging/Science.scala
+++ b/modules/sequence/src/main/scala/lucuma/odb/sequence/gnirs/imaging/Science.scala
@@ -49,10 +49,9 @@ object Science:
       for
         // The initial dynamic config already has the acquisition decker,
         // acquisition mirror in, and best focus; only the acquisition FPU and the
-        // mode's camera and coadds need setting.
+        // mode's camera need setting.  Coadds come with the filter.
         _ <- GnirsDynamicConfig.fpu    := GnirsFpu.Other(Acquisition)
         _ <- GnirsDynamicConfig.camera := config.camera
-        _ <- GnirsDynamicConfig.coadds := config.coadds
       yield ()
 
     def runSetup(config: Config): GnirsDynamicConfig =
@@ -63,6 +62,7 @@ object Science:
       for
         _ <- GnirsDynamicConfig.filter   := filter
         _ <- GnirsDynamicConfig.exposure := time
+        _ <- GnirsDynamicConfig.coadds   := config.coaddsFor(filter)
         _ <- GnirsDynamicConfig.readMode := config.explicitReadMode.getOrElse(GnirsReadMode.forExposureTime(time))
       yield ()
 

--- a/modules/sequence/src/test/scala/lucuma/odb/sequence/gnirs/imaging/ConfigSuite.scala
+++ b/modules/sequence/src/test/scala/lucuma/odb/sequence/gnirs/imaging/ConfigSuite.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.sequence.gnirs.imaging
+
+import cats.data.NonEmptyList
+import eu.timepit.refined.types.numeric.PosInt
+import lucuma.core.enums.GnirsCamera
+import lucuma.core.enums.GnirsFilter
+import lucuma.core.enums.GnirsWellDepth
+import lucuma.core.math.Wavelength
+import lucuma.core.model.ExposureTimeMode
+import lucuma.core.util.TimeSpan
+import lucuma.odb.sequence.gnirs.AcquisitionConfig
+import lucuma.odb.sequence.imaging.Variant
+import munit.FunSuite
+
+class ConfigSuite extends FunSuite:
+
+  private def etm(seconds: Double): ExposureTimeMode =
+    ExposureTimeMode.TimeAndCountMode(
+      TimeSpan.FromSeconds.unsafeGet(BigDecimal(seconds)),
+      PosInt.unsafeFrom(3),
+      Wavelength.decimalNanometers.unsafeGet(1250.0)
+    )
+
+  private def config(filters: NonEmptyList[Filter]): Config =
+    Config(
+      variant           = Variant.Interleaved.Default,
+      filters           = filters,
+      camera            = GnirsCamera.ShortBlue,
+      explicitReadMode  = None,
+      defaultWellDepth  = GnirsWellDepth.Shallow,
+      explicitWellDepth = None,
+      acquisition       = AcquisitionConfig(None, None, etm(10.0), PosInt.unsafeFrom(1))
+    )
+
+  private val j      = Filter(GnirsFilter.J, etm(10.0), PosInt.unsafeFrom(2))
+  private val order4 = Filter(GnirsFilter.Order4, etm(25.0), PosInt.unsafeFrom(5))
+
+  test("coaddsFor picks up each filter's own value"):
+    val c = config(NonEmptyList.of(j, order4))
+    assertEquals(c.coaddsFor(GnirsFilter.J), PosInt.unsafeFrom(2))
+    assertEquals(c.coaddsFor(GnirsFilter.Order4), PosInt.unsafeFrom(5))
+
+  test("coaddsFor defaults to 1 for a filter not in the configuration"):
+    assertEquals(config(NonEmptyList.one(j)).coaddsFor(GnirsFilter.K), PosInt.unsafeFrom(1))
+
+  test("changing a filter's coadds changes the hash"):
+    val a = config(NonEmptyList.of(j, order4))
+    val b = config(NonEmptyList.of(j.copy(coadds = PosInt.unsafeFrom(3)), order4))
+    assert(!java.util.Arrays.equals(a.hashBytes, b.hashBytes))
+
+  test("dropping a filter changes the hash"):
+    val a = config(NonEmptyList.of(j, order4))
+    val b = config(NonEmptyList.one(j))
+    assert(!java.util.Arrays.equals(a.hashBytes, b.hashBytes))

--- a/modules/service/src/main/resources/db/migration/V1252__gnirs_imaging_filter_coadds.sql
+++ b/modules/service/src/main/resources/db/migration/V1252__gnirs_imaging_filter_coadds.sql
@@ -1,0 +1,67 @@
+-- Coadds move from the GNIRS imaging mode to the individual filters, so that
+-- each filter's coadds can accompany its own exposure time mode.  This mirrors
+-- the GNIRS spectroscopy central wavelength configurations, where the coadds
+-- live with the wavelength's exposure time mode.
+
+ALTER TABLE t_gnirs_imaging_filter
+  ADD COLUMN c_coadds int4 NOT NULL DEFAULT 1 CHECK (c_coadds > 0);
+
+COMMENT ON COLUMN t_gnirs_imaging_filter.c_coadds IS
+  'Coadds per exposure for this filter.  Always 1 for a signal-to-noise exposure time mode, which does not support coadds.';
+
+-- Existing observations keep the mode-level value, in both row versions.
+UPDATE t_gnirs_imaging_filter f
+   SET c_coadds = i.c_coadds
+  FROM t_gnirs_imaging i
+ WHERE i.c_observation_id = f.c_observation_id;
+
+-- ... except where the exposure time mode is signal-to-noise, which does not
+-- support coadds.
+UPDATE t_gnirs_imaging_filter f
+   SET c_coadds = 1
+  FROM t_exposure_time_mode m
+ WHERE m.c_exposure_time_mode_id = f.c_exposure_time_mode_id
+   AND m.c_exposure_time_mode = 'signal_to_noise';
+
+-- v_gnirs_imaging selects i.*, so the column cannot be dropped beneath it.
+DROP VIEW v_gnirs_imaging;
+
+ALTER TABLE t_gnirs_imaging
+  DROP COLUMN c_coadds;
+
+CREATE VIEW v_gnirs_imaging AS
+  SELECT
+    i.*,
+    -- well depth default: mirrors GnirsWellDepth.forCamera
+    -- ATTENTION: This logic is duplicated from lucuma-core GnirsWellDepth. Modify in sync.
+    (CASE
+      WHEN i.c_camera IN ('ShortBlue', 'LongBlue') THEN 'Shallow'
+      WHEN i.c_camera IN ('ShortRed',  'LongRed')  THEN 'Deep'
+    END)::e_gnirs_well_depth AS c_well_depth_default,
+    f.c_filters,
+    CASE WHEN i.c_variant = 'grouped'      THEN i.c_observation_id END AS c_grouped_observation_id,
+    CASE WHEN i.c_variant = 'interleaved'  THEN i.c_observation_id END AS c_interleaved_observation_id,
+    CASE WHEN i.c_variant = 'pre_imaging'  THEN i.c_observation_id END AS c_pre_imaging_observation_id
+  FROM
+    t_gnirs_imaging i
+  LEFT JOIN (
+    SELECT
+      c_observation_id,
+      array_remove(array_agg(c_filter ORDER BY c_filter), NULL) AS c_filters
+    FROM t_gnirs_imaging_filter
+    WHERE c_version = 'current'
+    GROUP BY c_observation_id
+  ) AS f USING (c_observation_id);
+
+-- Coadds are part of the per-filter ITC input, so where the backfill above forced
+-- a signal-to-noise filter to 1 the observation's ITC input hash changes and its
+-- cached result can never be matched again.  The stored result shape is unchanged,
+-- so only GNIRS imaging observations are affected.
+DELETE FROM t_itc_result r
+ WHERE NOT r.c_is_frozen
+   AND EXISTS (
+     SELECT 1
+       FROM t_observation o
+      WHERE o.c_observation_id = r.c_observation_id
+        AND o.c_observing_mode_type = 'gnirs_imaging'
+   );

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsImagingFilterInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsImagingFilterInput.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.graphql.input
 
 import cats.syntax.parallel.*
+import eu.timepit.refined.types.numeric.PosInt
 import grackle.Result
 import lucuma.core.enums.GnirsFilter
 import lucuma.core.model.ExposureTimeMode
@@ -11,7 +12,8 @@ import lucuma.odb.graphql.binding.*
 
 case class GnirsImagingFilterInput(
   filter:           GnirsFilter,
-  exposureTimeMode: Option[ExposureTimeMode]
+  exposureTimeMode: Option[ExposureTimeMode],
+  coadds:           Option[PosInt]
 )
 
 object GnirsImagingFilterInput:
@@ -20,6 +22,21 @@ object GnirsImagingFilterInput:
     ObjectFieldsBinding.rmap:
       case List(
         GnirsFilterBinding("filter", rFilter),
-        ExposureTimeModeInput.Binding.Option("exposureTimeMode", rEtm)
+        ExposureTimeModeInput.Binding.Option("exposureTimeMode", rEtm),
+        PosIntBinding.Option("coadds", rCoadds)
       ) =>
-        (rFilter, rEtm).parMapN(apply)
+        (rFilter, rEtm, rCoadds).parMapN: (filter, etm, coadds) =>
+          GnirsImagingFilterInput(filter, etm, coaddsForEtm(etm, coadds))
+
+  /**
+   * Signal-to-noise exposure time mode does not support coadds.  When the ETM is
+   * set to signal-to-noise, force coadds to 1 so a previously-set value doesn't
+   * linger.
+   */
+  private def coaddsForEtm(
+    etm:    Option[ExposureTimeMode],
+    coadds: Option[PosInt]
+  ): Option[PosInt] =
+    etm match
+      case Some(ExposureTimeMode.SignalToNoiseMode(_, _)) => PosInt.from(1).toOption
+      case _                                              => coadds

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsImagingInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/GnirsImagingInput.scala
@@ -50,7 +50,6 @@ object GnirsImagingInput extends ImagingFilterCheck:
   case class Create(
     filters:           NonEmptyList[GnirsImagingFilterInput],
     camera:            GnirsCamera,
-    coadds:            PosInt                   = DefaultCoadds,
     explicitReadMode:  Option[GnirsReadMode]    = None,
     explicitWellDepth: Option[GnirsWellDepth]   = None,
     variant:           ImagingVariantInput      = DefaultVariant,
@@ -67,7 +66,6 @@ object GnirsImagingInput extends ImagingFilterCheck:
           ImagingVariantInput.Binding.Option("variant", rVariant),
           GnirsImagingFilterInput.Binding.List("filters", rFilters),
           GnirsCameraBinding.Option("camera", rCamera),
-          PosIntBinding.Option("coadds", rCoadds),
           GnirsReadModeBinding.Option("explicitReadMode", rReadMode),
           GnirsWellDepthBinding.Option("explicitWellDepth", rWellDepth),
           AcquisitionInput.Binding.Option("acquisition", rAcq)
@@ -76,20 +74,18 @@ object GnirsImagingInput extends ImagingFilterCheck:
             rVariant,
             notEmpty("GNIRS", rFilters),
             rCamera,
-            rCoadds,
             rReadMode,
             rWellDepth,
             rAcq
-          ).parTupled.flatMap: (variant, filters, camera, coadds, readMode, wellDepth, acq) =>
+          ).parTupled.flatMap: (variant, filters, camera, readMode, wellDepth, acq) =>
             camera.fold(OdbError.InvalidArgument("A 'camera' is required on creation.".some).asFailure): c =>
-              Create(filters, c, coadds.getOrElse(DefaultCoadds), readMode, wellDepth, variant.getOrElse(DefaultVariant), acq).success
+              Create(filters, c, readMode, wellDepth, variant.getOrElse(DefaultVariant), acq).success
 
   end Create
 
   case class Edit(
     filters:           Option[NonEmptyList[GnirsImagingFilterInput]],
     camera:            Option[GnirsCamera],
-    coadds:            Option[PosInt],
     explicitReadMode:  Nullable[GnirsReadMode],
     explicitWellDepth: Nullable[GnirsWellDepth],
     variant:           Option[ImagingVariantInput],
@@ -108,7 +104,6 @@ object GnirsImagingInput extends ImagingFilterCheck:
         Create(
           fs,
           c,
-          coadds.getOrElse(DefaultCoadds),
           explicitReadMode.toOption,
           explicitWellDepth.toOption,
           variant.getOrElse(DefaultVariant),
@@ -123,7 +118,6 @@ object GnirsImagingInput extends ImagingFilterCheck:
           ImagingVariantInput.Binding.Option("variant", rVariant),
           GnirsImagingFilterInput.Binding.List.Option("filters", rFilters),
           GnirsCameraBinding.Option("camera", rCamera),
-          PosIntBinding.Option("coadds", rCoadds),
           GnirsReadModeBinding.Nullable("explicitReadMode", rReadMode),
           GnirsWellDepthBinding.Nullable("explicitWellDepth", rWellDepth),
           AcquisitionInput.Binding.Option("acquisition", rAcq)
@@ -132,12 +126,11 @@ object GnirsImagingInput extends ImagingFilterCheck:
             rVariant,
             notEmptyIfPresent("GNIRS", rFilters),
             rCamera,
-            rCoadds,
             rReadMode,
             rWellDepth,
             rAcq
-          ).parMapN: (variant, filters, camera, coadds, readMode, wellDepth, acq) =>
-            Edit(filters, camera, coadds, readMode, wellDepth, variant, acq)
+          ).parMapN: (variant, filters, camera, readMode, wellDepth, acq) =>
+            Edit(filters, camera, readMode, wellDepth, variant, acq)
 
   end Edit
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GnirsImagingMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/GnirsImagingMapping.scala
@@ -38,6 +38,7 @@ trait GnirsImagingMapping[F[_]]
       SqlField("observationId",     GnirsImagingFilterTable.ObservationId, key = true, hidden = true),
       SqlField("filter",            GnirsImagingFilterTable.Filter, key = true),
       SqlField("version",           GnirsImagingFilterTable.Version, key = true, hidden = true),
+      SqlField("coadds",            GnirsImagingFilterTable.Coadds),
       SqlObject("exposureTimeMode", Join(GnirsImagingFilterTable.ExposureTimeModeId, ExposureTimeModeView.Id))
     )
 
@@ -116,7 +117,6 @@ trait GnirsImagingMapping[F[_]]
       SqlObject("initialFilters", Join(GnirsImagingView.ObservationId, GnirsImagingFilterTable.ObservationId)),
 
       SqlField("camera", GnirsImagingView.Camera),
-      SqlField("coadds", GnirsImagingView.Coadds),
 
       SqlField("explicitReadMode", GnirsImagingView.ReadMode),
 

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/GnirsImagingView.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/GnirsImagingView.scala
@@ -13,6 +13,7 @@ trait GnirsImagingView[F[_]] extends BaseMapping[F]:
     val ObservationId: ColumnRef = col("c_observation_id", observation_id)
     val Filter: ColumnRef        = col("c_filter", gnirs_filter)
     val Version: ColumnRef       = col("c_version", observing_mode_row_version)
+    val Coadds: ColumnRef        = col("c_coadds", int4_pos)
     val ExposureTimeModeId       = col("c_exposure_time_mode_id", exposure_time_mode_id)
     val Role: ColumnRef          = col("c_role", exposure_time_mode_role)
 
@@ -24,7 +25,6 @@ trait GnirsImagingView[F[_]] extends BaseMapping[F]:
     val Filters: ColumnRef          = col("c_filters", _gnirs_filter)
 
     val Camera: ColumnRef           = col("c_camera", gnirs_camera)
-    val Coadds: ColumnRef           = col("c_coadds", int4_pos)
 
     val ReadMode: ColumnRef         = col("c_read_mode", gnirs_read_mode.opt)
 

--- a/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GeneratorParamsService.scala
@@ -397,7 +397,7 @@ object GeneratorParamsService {
                   camera           = gnm.camera,
                   readMode         = readMode,
                   wellDepth        = gnm.wellDepth,
-                  coadds           = gnm.coadds
+                  coadds           = f.coadds
                 )
               )
 

--- a/modules/service/src/main/scala/lucuma/odb/service/GnirsImagingService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/GnirsImagingService.scala
@@ -27,6 +27,7 @@ import lucuma.odb.data.ExposureTimeModeRole
 import lucuma.odb.data.Nullable
 import lucuma.odb.data.ObservingModeRowVersion
 import lucuma.odb.data.TelescopeConfigGeneratorRole
+import lucuma.odb.graphql.input.GnirsImagingFilterInput
 import lucuma.odb.graphql.input.GnirsImagingInput
 import lucuma.odb.graphql.input.ImagingVariantInput
 import lucuma.odb.graphql.input.TelescopeConfigGeneratorInput
@@ -95,7 +96,15 @@ object GnirsImagingService:
                   pq.stream(af.argument, chunkSize = 1024)
                     .compile
                     .toList
-                    .map(_.map((oid, fs, vf, mf) => oid -> (fs, vf, mf)).toMap)
+                    .map: rows =>
+                      // One row per filter, ordered by filter.  `groupBy` preserves
+                      // that order within each group.
+                      rows
+                        .groupBy(_._1)
+                        .flatMap: (oid, group) =>
+                          NonEmptyList.fromList(group.map(_._2)).map: fs =>
+                            oid -> (fs, group.head._3, group.head._4)
+                        .toMap
 
             for
               c <- precursorMap
@@ -108,7 +117,6 @@ object GnirsImagingService:
                 vf.toVariant(og, sg),
                 fs,
                 mf.camera,
-                mf.coadds,
                 mf.explicitReadMode,
                 mf.defaultWellDepth,
                 mf.explicitWellDepth,
@@ -121,17 +129,24 @@ object GnirsImagingService:
       ): Map[Observation.Id, NonEmptyList[(GnirsFilter, E)]] =
         m.view.mapValues(_._2).toMap
 
+      /**
+       * Writes the filter rows for one row version.  The ETM resolution carries
+       * only the filter, so the coadds are re-attached here from the input.
+       */
       private def insertFilters(
+        input:   NonEmptyList[GnirsImagingFilterInput],
         etms:    Map[Observation.Id, NonEmptyList[(GnirsFilter, ExposureTimeModeId)]],
         version: ObservingModeRowVersion
       ): F[Unit] =
+        val coaddsFor: Map[GnirsFilter, PosInt] =
+          input.toList.map(f => f.filter -> f.coadds.getOrElse(GnirsImagingInput.DefaultCoadds)).toMap
         NonEmptyList
           .fromList:
             etms.toList.flatMap: (oid, fs) =>
               fs.toList.map: (filter, eid) =>
-                (oid, filter, eid)
+                (oid, filter, coaddsFor.getOrElse(filter, GnirsImagingInput.DefaultCoadds), eid)
           .traverse_ : rs =>
-            session.exec(ImagingStatements.insertFilters(GnirsImagingService.FilterTableName, gnirs_filter, rs, version))
+            session.exec(Statements.insertFilters(rs, version))
 
       override def insert(
         input:  GnirsImagingInput.Create,
@@ -159,11 +174,11 @@ object GnirsImagingService:
 
               ids <- ResultT.liftF(services.exposureTimeModeService.insertResolvedAcquisitionAndScience(r))
               ini  = stripAcquisition(ids)
-              _   <- ResultT.liftF(insertFilters(ini, ObservingModeRowVersion.Initial))
+              _   <- ResultT.liftF(insertFilters(input.filters, ini, ObservingModeRowVersion.Initial))
 
               // Insert the science filters
               cur <- ResultT.liftF(services.exposureTimeModeService.insertResolvedScienceOnly(stripAcquisition(r)))
-              _   <- ResultT.liftF(insertFilters(cur, ObservingModeRowVersion.Current))
+              _   <- ResultT.liftF(insertFilters(input.filters, cur, ObservingModeRowVersion.Current))
 
               // Insert the offset generators
               _   <- ResultT.liftF(services.telescopeConfigGeneratorService.insert(oids, offsets, TelescopeConfigGeneratorRole.Object))
@@ -205,7 +220,7 @@ object GnirsImagingService:
                 // Insert the science filters (current / mutable version)
                 r   <- ResultT(services.exposureTimeModeService.resolve("GNIRS Imaging", none, fs.map(f => (f.filter, f.exposureTimeMode)), none, which))
                 cur <- ResultT.liftF(services.exposureTimeModeService.insertResolvedScienceOnly(stripAcquisition(r)))
-                _   <- ResultT.liftF(insertFilters(cur, ObservingModeRowVersion.Current))
+                _   <- ResultT.liftF(insertFilters(fs, cur, ObservingModeRowVersion.Current))
               yield ()
 
           val acqEtmUpdate =
@@ -250,9 +265,8 @@ object GnirsImagingService:
         newObservationId: Observation.Id,
         etms:             List[(ExposureTimeModeId, ExposureTimeModeId)]
       )(using Transaction[F]): F[Unit] =
-        session.exec(Statements.clone(observationId, newObservationId))                                                        *>
-          session.exec(
-            ImagingStatements.cloneFiltersAndEtms(GnirsImagingService.FilterTableName, observationId, newObservationId, etms)) *>
+        session.exec(Statements.clone(observationId, newObservationId))                                *>
+          session.exec(Statements.cloneFiltersAndEtms(observationId, newObservationId, etms))          *>
           services.telescopeConfigGeneratorService.clone(observationId, newObservationId)
 
   object Statements:
@@ -260,7 +274,6 @@ object GnirsImagingService:
     // GNIRS imaging properties including overrides
     case class ModeFields(
       camera:            GnirsCamera,
-      coadds:            PosInt,
       explicitReadMode:  Option[GnirsReadMode],
       defaultWellDepth:  GnirsWellDepth,
       explicitWellDepth: Option[GnirsWellDepth],
@@ -289,55 +302,40 @@ object GnirsImagingService:
 
     val modeFields: Decoder[ModeFields] =
       (gnirs_camera         *:
-       int4_pos             *:
        gnirs_read_mode.opt  *:
        gnirs_well_depth     *:
        gnirs_well_depth.opt *:
        acquisition
       ).to[ModeFields]
 
-    val configFields: Decoder[(NonEmptyList[Filter], Variant.Fields, ModeFields)] =
-      (GmosImagingService.Statements.filter_list(gnirs_filter) *:
-       GmosImagingService.Statements.variant_fields            *:
+    /**
+     * Decodes one (observation, filter) row.  `select` groups the rows per
+     * observation to recover the full filter list.
+     */
+    val configFields: Decoder[(Filter, Variant.Fields, ModeFields)] =
+      (gnirs_filter                                *: // c_filter
+       exposure_time_mode                          *: // the filter's science ETM
+       int4_pos                                    *: // c_coadds
+       GmosImagingService.Statements.variant_fields *:
        modeFields
-      ).map: (filters, variantFields, mode) =>
-        (filters.map(f => Filter(f.filter, f.exposureTimeMode)), variantFields, mode)
+      ).map: (filter, etm, coadds, variantFields, mode) =>
+        (Filter(filter, etm, coadds), variantFields, mode)
 
     def select(
       oids: NonEmptyList[Observation.Id]
     ): AppliedFragment =
       sql"""
-        WITH selected_observations AS (
-          SELECT t.c_observation_id
-          FROM #${GnirsImagingService.ModeTableName} t
-          WHERE """(Void) |+| observationIdIn(oids) |+| sql"""
-        ),
-        aggregated_filters AS (
-          SELECT
-            f.c_observation_id,
-            array_agg(
-              ROW(
-                f.c_filter,
-                e.c_exposure_time_mode,
-                e.c_signal_to_noise_at,
-                e.c_signal_to_noise,
-                e.c_exposure_time,
-                e.c_exposure_count
-              )::s_filter_exposure_time_mode
-              ORDER BY f.c_filter
-            ) AS c_filters
-          FROM #${GnirsImagingService.FilterTableName} f
-          JOIN t_exposure_time_mode e ON e.c_exposure_time_mode_id = f.c_exposure_time_mode_id
-          JOIN selected_observations s ON s.c_observation_id = f.c_observation_id
-          WHERE f.c_version = 'current'
-          GROUP BY f.c_observation_id
-        )
         SELECT
           v.c_observation_id,
-          af.c_filters,
+          f.c_filter,
+          sci.c_exposure_time_mode,
+          sci.c_signal_to_noise_at,
+          sci.c_signal_to_noise,
+          sci.c_exposure_time,
+          sci.c_exposure_count,
+          f.c_coadds,
           #${ImagingStatements.variantColumns("v.")},
           v.c_camera,
-          v.c_coadds,
           v.c_read_mode,
           v.c_well_depth_default,
           v.c_well_depth,
@@ -352,10 +350,14 @@ object GnirsImagingService:
           acq.c_exposure_time,
           acq.c_exposure_count
         FROM v_gnirs_imaging v
-        JOIN aggregated_filters af ON af.c_observation_id = v.c_observation_id
+        JOIN #${GnirsImagingService.FilterTableName} f
+          ON f.c_observation_id = v.c_observation_id AND f.c_version = 'current'
+        JOIN t_exposure_time_mode sci
+          ON sci.c_exposure_time_mode_id = f.c_exposure_time_mode_id
         JOIN t_exposure_time_mode acq
           ON acq.c_observation_id = v.c_observation_id AND acq.c_role = 'acquisition'
-      """(Void)
+        WHERE """(Void) |+| observationIdIn(oids, "v".some) |+|
+      void" ORDER BY v.c_observation_id, f.c_filter"
 
     def insert(
       input: GnirsImagingInput.Create,
@@ -371,7 +373,6 @@ object GnirsImagingService:
             $observation_id,
             (SELECT c_program_id FROM t_observation WHERE c_observation_id = $observation_id),
             $gnirs_camera,
-            $int4,
             ${gnirs_read_mode.opt},
             ${gnirs_well_depth.opt},
             ${gnirs_acquisition_type.opt},
@@ -390,7 +391,6 @@ object GnirsImagingService:
             oid,
             oid,
             input.camera,
-            input.coadds.value,
             input.explicitReadMode,
             input.explicitWellDepth,
             input.acquisition.flatMap(_.explicitAcqType.toOption),
@@ -412,7 +412,6 @@ object GnirsImagingService:
           c_observation_id,
           c_program_id,
           c_camera,
-          c_coadds,
           c_read_mode,
           c_well_depth,
           c_acq_type,
@@ -423,6 +422,75 @@ object GnirsImagingService:
           #${ImagingStatements.variantColumns()}
         ) VALUES
       """(Void) |+| modeEntries.intercalate(void", ")
+
+    /**
+     * Inserts the filter rows for one row version.  Unlike the other imaging
+     * modes, GNIRS carries coadds per filter, so this doesn't use the shared
+     * `ImagingStatements.insertFilters`.
+     */
+    def insertFilters(
+      rows:    NonEmptyList[(Observation.Id, GnirsFilter, PosInt, ExposureTimeModeId)],
+      version: ObservingModeRowVersion
+    ): AppliedFragment =
+      val insertInto: AppliedFragment =
+        void"""
+          INSERT INTO t_gnirs_imaging_filter (
+            c_observation_id,
+            c_filter,
+            c_version,
+            c_coadds,
+            c_exposure_time_mode_id
+          ) VALUES
+        """
+
+      val values =
+        rows.map: (oid, filter, coadds, eid) =>
+          sql"($observation_id, $gnirs_filter, $observing_mode_row_version, $int4_pos, $exposure_time_mode_id)"(
+            oid, filter, version, coadds, eid
+          )
+
+      insertInto |+| values.intercalate(void", ")
+
+    /**
+     * Copies the filter rows to a cloned observation, remapping each to its
+     * cloned exposure time mode row.  Carries the coadds that the shared
+     * `ImagingStatements.cloneFiltersAndEtms` doesn't know about.
+     */
+    def cloneFiltersAndEtms(
+      originalId: Observation.Id,
+      newId:      Observation.Id,
+      etms:       List[(ExposureTimeModeId, ExposureTimeModeId)]
+    ): AppliedFragment =
+      sql"""
+        WITH etm_map AS (
+          SELECT
+            old_exposure_time_mode_id,
+            new_exposure_time_mode_id
+          FROM
+            unnest(
+              ARRAY[${exposure_time_mode_id.list(etms.length)}],
+              ARRAY[${exposure_time_mode_id.list(etms.length)}]
+            ) AS map(old_exposure_time_mode_id, new_exposure_time_mode_id)
+        )
+        INSERT INTO t_gnirs_imaging_filter (
+          c_observation_id,
+          c_exposure_time_mode_id,
+          c_filter,
+          c_version,
+          c_coadds,
+          c_role
+        )
+        SELECT
+          $observation_id,
+          e.new_exposure_time_mode_id,
+          f.c_filter,
+          f.c_version,
+          f.c_coadds,
+          f.c_role
+        FROM t_gnirs_imaging_filter f
+        JOIN etm_map e ON f.c_exposure_time_mode_id = e.old_exposure_time_mode_id
+        WHERE f.c_observation_id = $observation_id
+      """.apply(etms.map(_._1), etms.map(_._2), newId, originalId)
 
     def delete(
       which: List[Observation.Id]
@@ -437,7 +505,6 @@ object GnirsImagingService:
       input: GnirsImagingInput.Edit
     ): List[AppliedFragment] =
       val upCamera    = sql"c_camera     = $gnirs_camera"
-      val upCoadds    = sql"c_coadds     = $int4"
       val upReadMode  = sql"c_read_mode  = ${gnirs_read_mode.opt}"
       val upWellDepth = sql"c_well_depth = ${gnirs_well_depth.opt}"
 
@@ -471,7 +538,6 @@ object GnirsImagingService:
 
       List(
         input.camera.map(upCamera),
-        input.coadds.map(c => upCoadds(c.value)),
         input.explicitReadMode.toOptionOption.map(upReadMode),
         input.explicitWellDepth.toOptionOption.map(upWellDepth)
       ).flatten ++ acqUpdates
@@ -485,7 +551,6 @@ object GnirsImagingService:
           c_observation_id,
           c_program_id,
           c_camera,
-          c_coadds,
           c_read_mode,
           c_well_depth,
           c_acq_type,
@@ -499,7 +564,6 @@ object GnirsImagingService:
           $observation_id,
           (SELECT c_program_id FROM t_observation WHERE c_observation_id = $observation_id),
           c_camera,
-          c_coadds,
           c_read_mode,
           c_well_depth,
           c_acq_type,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GnirsImaging.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/createObservation_GnirsImaging.scala
@@ -51,10 +51,9 @@ class createObservation_GnirsImaging extends OdbSuite:
                 observingMode {
                   mode
                   gnirsImaging {
-                    filters { filter }
-                    initialFilters { filter }
+                    filters { filter coadds }
+                    initialFilters { filter coadds }
                     camera
-                    coadds
                     explicitReadMode
                     wellDepth
                     defaultWellDepth
@@ -84,15 +83,14 @@ class createObservation_GnirsImaging extends OdbSuite:
                   "mode": "GNIRS_IMAGING",
                   "gnirsImaging": {
                     "filters": [
-                      { "filter": "ORDER4" },
-                      { "filter": "J" }
+                      { "filter": "ORDER4", "coadds": 1 },
+                      { "filter": "J", "coadds": 1 }
                     ],
                     "initialFilters": [
-                      { "filter": "ORDER4" },
-                      { "filter": "J" }
+                      { "filter": "ORDER4", "coadds": 1 },
+                      { "filter": "J", "coadds": 1 }
                     ],
                     "camera": "SHORT_BLUE",
-                    "coadds": 1,
                     "explicitReadMode": "BRIGHT",
                     "wellDepth": "SHALLOW",
                     "defaultWellDepth": "SHALLOW",
@@ -116,6 +114,104 @@ class createObservation_GnirsImaging extends OdbSuite:
             }
           }
         """.asRight)
+
+  test("create GNIRS imaging with per-filter coadds"):
+    createProgramAs(pi).flatMap: pid =>
+      createTargetAs(pi, pid).flatMap: tid =>
+        expect(pi,
+          s"""
+            mutation {
+              createObservation(input: {
+                programId: ${pid.asJson}
+                SET: {
+                  targetEnvironment: {
+                    asterism: [${tid.asJson}]
+                  }
+                  scienceRequirements: {
+                    exposureTimeMode: {
+                      signalToNoise: {
+                        value: 100.0
+                        at: { nanometers: 1250.0 }
+                      }
+                    }
+                  }
+                  observingMode: {
+                    gnirsImaging: {
+                      camera: SHORT_BLUE
+                      filters: [
+                        {
+                          filter: J
+                          exposureTimeMode: {
+                            timeAndCount: { time: { seconds: 30.0 }, count: 6, at: { nanometers: 1250.0 } }
+                          }
+                          coadds: 4
+                        },
+                        {
+                          filter: ORDER4
+                          exposureTimeMode: {
+                            signalToNoise: { value: 50.0, at: { nanometers: 1250.0 } }
+                          }
+                          coadds: 7
+                        }
+                      ]
+                    }
+                  }
+                }
+              }) {
+                observation {
+                  observingMode {
+                    gnirsImaging {
+                      filters {
+                        filter
+                        coadds
+                        exposureTimeMode {
+                          signalToNoise { value at { nanometers } }
+                          timeAndCount { time { seconds } count at { nanometers } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          """,
+          json"""
+            {
+              "createObservation": {
+                "observation": {
+                  "observingMode": {
+                    "gnirsImaging": {
+                      "filters": [
+                        {
+                          "filter": "ORDER4",
+                          "coadds": 1,
+                          "exposureTimeMode": {
+                            "signalToNoise": {
+                              "value": 50.000,
+                              "at": { "nanometers": 1250.000 }
+                            },
+                            "timeAndCount": null
+                          }
+                        },
+                        {
+                          "filter": "J",
+                          "coadds": 4,
+                          "exposureTimeMode": {
+                            "signalToNoise": null,
+                            "timeAndCount": {
+                              "time": { "seconds": 30.000000 },
+                              "count": 6,
+                              "at": { "nanometers": 1250.000 }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          """.asRight)
 
   /** Creates a GNIRS imaging observation with the given acquisition input block. */
   private def createWithAcquisition(acquisition: String, selection: String) =

--- a/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations_GnirsImaging.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/mutation/updateObservations_GnirsImaging.scala
@@ -42,10 +42,9 @@ class updateObservations_GnirsImaging extends OdbSuite with UpdateObservationsOp
         observingMode {
           mode
           gnirsImaging {
-            filters { filter }
-            initialFilters { filter }
+            filters { filter coadds }
+            initialFilters { filter coadds }
             camera
-            coadds
             explicitReadMode
             wellDepth
             defaultWellDepth
@@ -65,15 +64,14 @@ class updateObservations_GnirsImaging extends OdbSuite with UpdateObservationsOp
                 "mode": "GNIRS_IMAGING",
                 "gnirsImaging": {
                   "filters": [
-                    { "filter": "ORDER4" },
-                    { "filter": "J" }
+                    { "filter": "ORDER4", "coadds": 1 },
+                    { "filter": "J", "coadds": 1 }
                   ],
                   "initialFilters": [
-                    { "filter": "ORDER4" },
-                    { "filter": "J" }
+                    { "filter": "ORDER4", "coadds": 1 },
+                    { "filter": "J", "coadds": 1 }
                   ],
                   "camera": "SHORT_BLUE",
-                  "coadds": 1,
                   "explicitReadMode": "BRIGHT",
                   "wellDepth": "SHALLOW",
                   "defaultWellDepth": "SHALLOW",
@@ -362,6 +360,70 @@ class updateObservations_GnirsImaging extends OdbSuite with UpdateObservationsOp
       List(
         (setWithAcqEtm, query, expected(json"""[ { "filter": "J" } ]""")),
         (editFilters, query, expected(json"""[ { "filter": "ORDER4" }, { "filter": "K" } ]"""))
+      )
+    )
+
+  test("observing mode: update GNIRS imaging per-filter coadds"):
+    // The initial filters keep the coadds they were created with, and a
+    // signal-to-noise filter is forced to 1 coadd.
+    val update = """
+      observingMode: {
+        gnirsImaging: {
+          filters: [
+            {
+              filter: J
+              exposureTimeMode: {
+                timeAndCount: { time: { seconds: 30.0 }, count: 6, at: { nanometers: 1250.0 } }
+              }
+              coadds: 5
+            },
+            {
+              filter: ORDER4
+              exposureTimeMode: {
+                signalToNoise: { value: 50.0, at: { nanometers: 1250.0 } }
+              }
+              coadds: 5
+            }
+          ]
+        }
+      }
+    """
+
+    val query = """
+      observations {
+        observingMode {
+          gnirsImaging {
+            filters { filter coadds }
+            initialFilters { filter coadds }
+          }
+        }
+      }
+    """
+
+    def expected(filters: io.circe.Json) =
+      json"""
+        {
+          "updateObservations": {
+            "observations": [
+              {
+                "observingMode": {
+                  "gnirsImaging": {
+                    "filters": $filters,
+                    "initialFilters": [ { "filter": "J", "coadds": 1 } ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      """.asRight
+
+    multiUpdateTest(pi,
+      List(
+        (setGnirsImaging, query, expected(json"""[ { "filter": "J", "coadds": 1 } ]""")),
+        (update, query, expected(json"""
+          [ { "filter": "ORDER4", "coadds": 1 }, { "filter": "J", "coadds": 5 } ]
+        """))
       )
     )
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsImaging.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/executionSciGnirsImaging.scala
@@ -41,13 +41,14 @@ class executionSciGnirsImaging extends ExecutionTestSupportForGnirs:
     exposureTime: TimeSpan,
     p:            Int            = 0,
     q:            Int            = 0,
-    guiding:      StepGuideState = StepGuideState.Enabled
+    guiding:      StepGuideState = StepGuideState.Enabled,
+    coadds:       Int            = 1
   ): Json =
     json"""
       {
         "instrumentConfig": {
           "exposure":             { "seconds": ${exposureTime.toSeconds} },
-          "coadds":               1,
+          "coadds":               $coadds,
           "centralWavelength":    { "nanometers": ${filter.centralWavelength.toNanometers.value.value} },
           "filter":               ${filter.tag.toScreamingSnakeCase.asJson},
           "decker":               "ACQUISITION",
@@ -114,6 +115,48 @@ class executionSciGnirsImaging extends ExecutionTestSupportForGnirs:
     val atoms =
       List.fill(2)(sciAtom(GnirsFilter.J, 10.secondTimeSpan)) ++
       List.fill(3)(sciAtom(GnirsFilter.Order4, 25.secondTimeSpan))
+
+    setup.flatMap: oid =>
+      expect(pi, gnirsScienceQuery(oid, 100.some), expectedScience(atoms).asRight)
+
+  test("grouped, per-filter coadds"):
+    // Coadds live with the filter's exposure time mode, so each filter's steps
+    // carry its own value.  Signal-to-noise doesn't support coadds, so the
+    // ORDER4 filter is forced back to 1.
+    val mode =
+      s"""
+        gnirsImaging: {
+          camera: SHORT_BLUE
+          variant: { grouped: { skyCount: 0 } }
+          filters: [
+            {
+              filter: J
+              exposureTimeMode: {
+                timeAndCount: { time: { seconds: 10.0 }, count: 2, at: { nanometers: 1250.0 } }
+              }
+              coadds: 4
+            },
+            {
+              filter: ORDER4
+              exposureTimeMode: {
+                signalToNoise: { value: 100.0, at: { nanometers: 1650.0 } }
+              }
+              coadds: 4
+            }
+          ]
+        }
+      """
+
+    val setup: IO[Observation.Id] =
+      for
+        p <- createProgram
+        t <- createTargetWithProfileAs(pi, p)
+        o <- createObservationWithModeAs(pi, p, List(t), mode)
+      yield o
+
+    val atoms =
+      List.fill(2)(sciAtomOf(sciStep(GnirsFilter.J, 10.secondTimeSpan, coadds = 4))) ++
+      List.fill(3)(sciAtomOf(sciStep(GnirsFilter.Order4, 25.secondTimeSpan)))
 
     setup.flatMap: oid =>
       expect(pi, gnirsScienceQuery(oid, 100.some), expectedScience(atoms).asRight)


### PR DESCRIPTION
Coadds were a single mode-level field applied to every filter, while each filter already carried its own exposure time mode.  That is wrong in two ways: the legacy OCS ITC discards the caller's coadds entirely under a signal-to-noise ETM (ImagingMethodExptime hardcodes 1 and GnirsRecipe recomputes its own), and one value cannot serve a filter list whose members mix ETMs.

So coadds now live on GnirsImagingFilter, forced to 1 when that filter's ETM is signal-to-noise, and the mode-level field is gone.  This mirrors the GNIRS spectroscopy central wavelength configurations.

The read path moves off the shared s_filter_exposure_time_mode composite type (which has no coadds slot and is shared with GMOS/Flamingos-2) to the row-per-key join used by GNIRS spectroscopy.