### PR TITLE
Expose itc max adu result

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ val spireVersion                 = "0.18.0"
 val slf4jVersion                 = "2.0.18"
 val testcontainersScalaVersion   = "0.44.1" // check test output if you attempt to update this
 
-ThisBuild / tlBaseVersion      := "0.91"
+ThisBuild / tlBaseVersion      := "0.92"
 ThisBuild / scalaVersion       := "3.8.4"
 ThisBuild / crossScalaVersions := Seq("3.8.4")
 ThisBuild / scalacOptions     ++= Seq("-Xmax-inlines", "50") // Hash derivation fails with default of 32

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -14528,6 +14528,16 @@ type ItcResult {
   the exposure time reported alongside it.
   """
   peakPixelFlux: Float
+
+  """
+  The maximum, across the CCDs, of each CCD's peak pixel flux converted to ADU
+  using that CCD's own amplifier gain.  Because the gain differs per CCD this
+  is not in general `peakPixelFlux` divided by a single gain; the per-CCD
+  maximum is what matters for saturation.  Null under exactly the same
+  conditions as `peakPixelFlux`, and likewise computed for the unclamped
+  acquisition exposure time.
+  """
+  peakPixelAdu: Int
 }
 
 """

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -14518,26 +14518,30 @@ type ItcResult {
   signalToNoiseAt: SignalToNoiseAt
 
   """
-  The maximum, across the CCDs, of each CCD's peak pixel flux: the highest
-  electron count in any single pixel, as computed by the ITC for a single
-  exposure.  Null when the ITC reported no CCD data (GHOST, which has no ITC
-  calculation at all, and sources too bright to calculate), and for results
-  that were cached or frozen before this field existed.  For an acquisition
-  whose exposure time was clamped to the instrument's acquisition limits, this
-  is the flux the ITC computed for the unclamped time, so it may disagree with
-  the exposure time reported alongside it.
+  The brightest pixel the ITC found, as computed for a single exposure.  Null
+  when the ITC reported no CCD data or a frozen row.
+  For an acquisition whose exposure time was clamped to the instrument's acquisition
+  limits, this is what the ITC computed for the unclamped time, so it may disagree
+  with the exposure time reported alongside it.
   """
-  peakPixelFlux: Float
+  peakPixel: ItcPeakPixel
+}
+
+"""
+The brightest pixel found by the ITC, taken across the CCDs it reported.
+"""
+type ItcPeakPixel {
+  """
+  The maximum, across the CCDs, of each CCD's peak pixel flux: the highest
+  electron count in any single pixel.
+  """
+  flux: Float!
 
   """
   The maximum, across the CCDs, of each CCD's peak pixel flux converted to ADU
-  using that CCD's own amplifier gain.  Because the gain differs per CCD this
-  is not in general `peakPixelFlux` divided by a single gain; the per-CCD
-  maximum is what matters for saturation.  Null under exactly the same
-  conditions as `peakPixelFlux`, and likewise computed for the unclamped
-  acquisition exposure time.
+  using that CCD's own amplifier gain.
   """
-  peakPixelAdu: Int
+  adu: Int!
 }
 
 """

--- a/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
@@ -33,12 +33,16 @@ import monocle.macros.GenPrism
  *
  * `peakPixelFlux` is the maximum, across the CCDs the ITC reported, of each
  * CCD's peak pixel flux.  It is absent wherever no CCD data reaches us: GHOST
+ *
+ * `peakPixelAdu` is the maximum, across the same CCDs, of each CCD's flux
+ * converted to ADU by its own amplifier gain.
  */
 case class ItcResult(
   targetId:      Target.Id,
   value:         IntegrationTime,
   signalToNoise: Option[SignalToNoiseAt],
-  peakPixelFlux: Option[Double]
+  peakPixelFlux: Option[Double],
+  peakPixelAdu:  Option[Int]
 ):
   def totalTime: Option[TimeSpan] =
     val total = BigInt(value.exposureTime.toMicroseconds) * value.exposureCount.value

--- a/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/data/Itc.scala
@@ -26,23 +26,28 @@ import monocle.Prism
 import monocle.macros.GenPrism
 
 /**
+ * The brightest pixel the ITC found, taken across the CCDs it reported.  `flux`
+ * is the maximum of the per-CCD peak pixel fluxes; `adu` is the maximum of the
+ * per-CCD ADU values, each converted with its own CCD's amplifier gain.
+ */
+case class ItcPeakPixel(
+  flux: Double,
+  adu:  Int
+) derives Eq
+
+/**
  * A single ITC result for one target: the integration time (exposure time and
  * count) and, when available, the achieved signal-to-noise.  Shared by both the
  * science ([[ItcScience]]) and acquisition ([[ItcAcquisition]]) results.
  * Corresponds to `ItcResult` in the GraphQL schema.
  *
- * `peakPixelFlux` is the maximum, across the CCDs the ITC reported, of each
- * CCD's peak pixel flux.  It is absent wherever no CCD data reaches us: GHOST
- *
- * `peakPixelAdu` is the maximum, across the same CCDs, of each CCD's flux
- * converted to ADU by its own amplifier gain.
+ * `peakPixel` is absent wherever no CCD data reaches us: GHOST
  */
 case class ItcResult(
   targetId:      Target.Id,
   value:         IntegrationTime,
   signalToNoise: Option[SignalToNoiseAt],
-  peakPixelFlux: Option[Double],
-  peakPixelAdu:  Option[Int]
+  peakPixel:     Option[ItcPeakPixel]
 ):
   def totalTime: Option[TimeSpan] =
     val total = BigInt(value.exposureTime.toMicroseconds) * value.exposureCount.value

--- a/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
@@ -31,6 +31,7 @@ import lucuma.itc.IntegrationTime
 import lucuma.itc.SignalToNoiseAt
 import lucuma.odb.data.Itc
 import lucuma.odb.data.ItcAcquisition
+import lucuma.odb.data.ItcPeakPixel
 import lucuma.odb.data.ItcResult
 import lucuma.odb.data.ItcScience
 
@@ -50,6 +51,20 @@ trait ItcCodec:
   // N.B. lucuma.itc.SignalToNoiseAt defines its own encoder consistent with
   // this decoder.  Perhaps we should move the decoder there as well.
 
+  given Decoder[ItcPeakPixel] =
+    Decoder.instance: c =>
+      for
+        flux <- c.downField("flux").as[Double]
+        adu  <- c.downField("adu").as[Int]
+      yield ItcPeakPixel(flux, adu)
+
+  given Encoder[ItcPeakPixel] =
+    Encoder.instance: a =>
+      Json.obj(
+        "flux" -> a.flux.asJson,
+        "adu"  -> a.adu.asJson
+      )
+
   given Decoder[ItcResult] =
     Decoder.instance: c =>
       for
@@ -57,9 +72,8 @@ trait ItcCodec:
         exposureTime    <- c.downField("exposureTime").as[TimeSpan]
         exposureCount   <- c.downField("exposureCount").as[PosInt]
         signalToNoiseAt <- c.downField("signalToNoiseAt").as[Option[SignalToNoiseAt]]
-        peakPixelFlux   <- c.downField("peakPixelFlux").as[Option[Double]]
-        peakPixelAdu    <- c.downField("peakPixelAdu").as[Option[Int]]
-      yield ItcResult(targetId, IntegrationTime(exposureTime, exposureCount), signalToNoiseAt, peakPixelFlux, peakPixelAdu)
+        peakPixel       <- c.downField("peakPixel").as[Option[ItcPeakPixel]]
+      yield ItcResult(targetId, IntegrationTime(exposureTime, exposureCount), signalToNoiseAt, peakPixel)
 
   given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[ItcResult] =
     Encoder.instance: a =>
@@ -68,8 +82,7 @@ trait ItcCodec:
         "exposureTime"    -> a.value.exposureTime.asJson,
         "exposureCount"   -> a.value.exposureCount.value.asJson,
         "signalToNoiseAt" -> a.signalToNoise.asJson,
-        "peakPixelFlux"   -> a.peakPixelFlux.asJson,
-        "peakPixelAdu"    -> a.peakPixelAdu.asJson
+        "peakPixel"       -> a.peakPixel.asJson
       )
 
   // GnirsAcquisitionType is a plain Enumerated; encode by tag.  Round-trips

--- a/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
+++ b/modules/schema/src/main/scala/lucuma/odb/json/itc.scala
@@ -58,7 +58,8 @@ trait ItcCodec:
         exposureCount   <- c.downField("exposureCount").as[PosInt]
         signalToNoiseAt <- c.downField("signalToNoiseAt").as[Option[SignalToNoiseAt]]
         peakPixelFlux   <- c.downField("peakPixelFlux").as[Option[Double]]
-      yield ItcResult(targetId, IntegrationTime(exposureTime, exposureCount), signalToNoiseAt, peakPixelFlux)
+        peakPixelAdu    <- c.downField("peakPixelAdu").as[Option[Int]]
+      yield ItcResult(targetId, IntegrationTime(exposureTime, exposureCount), signalToNoiseAt, peakPixelFlux, peakPixelAdu)
 
   given (using Encoder[TimeSpan], Encoder[Wavelength]): Encoder[ItcResult] =
     Encoder.instance: a =>
@@ -67,7 +68,8 @@ trait ItcCodec:
         "exposureTime"    -> a.value.exposureTime.asJson,
         "exposureCount"   -> a.value.exposureCount.value.asJson,
         "signalToNoiseAt" -> a.signalToNoise.asJson,
-        "peakPixelFlux"   -> a.peakPixelFlux.asJson
+        "peakPixelFlux"   -> a.peakPixelFlux.asJson,
+        "peakPixelAdu"    -> a.peakPixelAdu.asJson
       )
 
   // GnirsAcquisitionType is a plain Enumerated; encode by tag.  Round-trips

--- a/modules/schema/src/test/scala/lucuma/odb/data/arb/ArbItc.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/data/arb/ArbItc.scala
@@ -64,11 +64,15 @@ trait ArbItc:
     Cogen[(Wavelength, SignalToNoise, SignalToNoise)].contramap: a =>
       (a.wavelength, a.single.value, a.total.value)
 
-  private val genPeakPixelFlux: Gen[Double] =
-    Gen.chooseNum(0.0, 1.0e7)
+  given Arbitrary[ItcPeakPixel] =
+    Arbitrary:
+      for
+        f <- Gen.chooseNum(0.0, 1.0e7)
+        a <- Gen.chooseNum(0, 10000000)
+      yield ItcPeakPixel(f, a)
 
-  private val genPeakPixelAdu: Gen[Int] =
-    Gen.chooseNum(0, 10000000)
+  given Cogen[ItcPeakPixel] =
+    Cogen[(Double, Int)].contramap(a => (a.flux, a.adu))
 
   given Arbitrary[ItcResult] =
     Arbitrary:
@@ -76,13 +80,12 @@ trait ArbItc:
         t <- arbitrary[Target.Id]
         v <- arbitrary[IntegrationTime]
         s <- arbitrary[Option[SignalToNoiseAt]]
-        p <- Gen.option(genPeakPixelFlux)
-        d <- Gen.option(genPeakPixelAdu)
-      yield ItcResult(t, v, s, p, d)
+        p <- arbitrary[Option[ItcPeakPixel]]
+      yield ItcResult(t, v, s, p)
 
   given Cogen[ItcResult] =
-    Cogen[(Target.Id, IntegrationTime, Option[SignalToNoiseAt], Option[Double], Option[Int])].contramap: a =>
-      (a.targetId, a.value, a.signalToNoise, a.peakPixelFlux, a.peakPixelAdu)
+    Cogen[(Target.Id, IntegrationTime, Option[SignalToNoiseAt], Option[ItcPeakPixel])].contramap: a =>
+      (a.targetId, a.value, a.signalToNoise, a.peakPixel)
 
   given Arbitrary[ItcScience.Flamingos2Imaging] =
     Arbitrary:

--- a/modules/schema/src/test/scala/lucuma/odb/data/arb/ArbItc.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/data/arb/ArbItc.scala
@@ -67,6 +67,9 @@ trait ArbItc:
   private val genPeakPixelFlux: Gen[Double] =
     Gen.chooseNum(0.0, 1.0e7)
 
+  private val genPeakPixelAdu: Gen[Int] =
+    Gen.chooseNum(0, 10000000)
+
   given Arbitrary[ItcResult] =
     Arbitrary:
       for
@@ -74,11 +77,12 @@ trait ArbItc:
         v <- arbitrary[IntegrationTime]
         s <- arbitrary[Option[SignalToNoiseAt]]
         p <- Gen.option(genPeakPixelFlux)
-      yield ItcResult(t, v, s, p)
+        d <- Gen.option(genPeakPixelAdu)
+      yield ItcResult(t, v, s, p, d)
 
   given Cogen[ItcResult] =
-    Cogen[(Target.Id, IntegrationTime, Option[SignalToNoiseAt], Option[Double])].contramap: a =>
-      (a.targetId, a.value, a.signalToNoise, a.peakPixelFlux)
+    Cogen[(Target.Id, IntegrationTime, Option[SignalToNoiseAt], Option[Double], Option[Int])].contramap: a =>
+      (a.targetId, a.value, a.signalToNoise, a.peakPixelFlux, a.peakPixelAdu)
 
   given Arbitrary[ItcScience.Flamingos2Imaging] =
     Arbitrary:

--- a/modules/schema/src/test/scala/lucuma/odb/json/ItcSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/json/ItcSuite.scala
@@ -34,8 +34,15 @@ class ItcSuite extends DisciplineSuite with ArbitraryInstances:
         Right(r.peakPixelFlux)
       )
 
-  // Rows cached before the field existed must still decode.
-  test("peakPixelFlux is absent from legacy JSON"):
+  property("peakPixelAdu survives a round trip"):
+    forAll: (r: ItcResult) =>
+      assertEquals(
+        decode[ItcResult](r.asJson.spaces2).map(_.peakPixelAdu),
+        Right(r.peakPixelAdu)
+      )
+
+  // Rows cached before the fields existed must still decode.
+  test("peakPixelFlux and peakPixelAdu are absent from legacy JSON"):
     val legacy =
       """
         {
@@ -46,3 +53,4 @@ class ItcSuite extends DisciplineSuite with ArbitraryInstances:
         }
       """
     assertEquals(decode[ItcResult](legacy).map(_.peakPixelFlux), Right(None))
+    assertEquals(decode[ItcResult](legacy).map(_.peakPixelAdu), Right(None))

--- a/modules/schema/src/test/scala/lucuma/odb/json/ItcSuite.scala
+++ b/modules/schema/src/test/scala/lucuma/odb/json/ItcSuite.scala
@@ -27,22 +27,15 @@ class ItcSuite extends DisciplineSuite with ArbitraryInstances:
   checkAll("ItcScienceCodec", CodecTests[ItcScience].codec)
   checkAll("ItcAcquisitionAvailableCodec", CodecTests[ItcAcquisition.Available].codec)
 
-  property("peakPixelFlux survives a round trip"):
+  property("peakPixel survives a round trip"):
     forAll: (r: ItcResult) =>
       assertEquals(
-        decode[ItcResult](r.asJson.spaces2).map(_.peakPixelFlux),
-        Right(r.peakPixelFlux)
+        decode[ItcResult](r.asJson.spaces2).map(_.peakPixel),
+        Right(r.peakPixel)
       )
 
-  property("peakPixelAdu survives a round trip"):
-    forAll: (r: ItcResult) =>
-      assertEquals(
-        decode[ItcResult](r.asJson.spaces2).map(_.peakPixelAdu),
-        Right(r.peakPixelAdu)
-      )
-
-  // Rows cached before the fields existed must still decode.
-  test("peakPixelFlux and peakPixelAdu are absent from legacy JSON"):
+  // Rows cached before the field existed must still decode.
+  test("peakPixel is absent from legacy JSON"):
     val legacy =
       """
         {
@@ -52,5 +45,17 @@ class ItcSuite extends DisciplineSuite with ArbitraryInstances:
           "signalToNoiseAt": null
         }
       """
-    assertEquals(decode[ItcResult](legacy).map(_.peakPixelFlux), Right(None))
-    assertEquals(decode[ItcResult](legacy).map(_.peakPixelAdu), Right(None))
+    assertEquals(decode[ItcResult](legacy).map(_.peakPixel), Right(None))
+
+  test("peakPixel is absent from flat peakPixelFlux JSON"):
+    val flat =
+      """
+        {
+          "targetId": "t-100",
+          "exposureTime": { "microseconds": 1000000 },
+          "exposureCount": 3,
+          "signalToNoiseAt": null,
+          "peakPixelFlux": 2500.0
+        }
+      """
+    assertEquals(decode[ItcResult](flat).map(_.peakPixel), Right(None))

--- a/modules/service/src/main/resources/db/migration/V1256__itc_peak_pixel_adu.sql
+++ b/modules/service/src/main/resources/db/migration/V1256__itc_peak_pixel_adu.sql
@@ -1,4 +1,5 @@
--- ItcResult gained a peakPixelAdu field.  We need to invalidate the cache to recalculate adu
+-- ItcResult replaced peakPixelFlux with peakPixel { flux, adu }.  We need to
+-- invalidate the cache to recalculate adu; the old flat field is ignored on read.
 --
 -- Frozen rows are spared.
 DELETE FROM t_itc_result WHERE NOT c_is_frozen;

--- a/modules/service/src/main/resources/db/migration/V1256__itc_peak_pixel_adu.sql
+++ b/modules/service/src/main/resources/db/migration/V1256__itc_peak_pixel_adu.sql
@@ -1,0 +1,16 @@
+-- ItcResult gained a peakPixelAdu field.  We need to invalidate the cache to recalculate adu
+--
+-- Frozen rows are spared.
+DELETE FROM t_itc_result WHERE NOT c_is_frozen;
+
+UPDATE t_obscalc SET
+  c_last_invalidation = NOW(),
+  c_failure_count     = 0,
+  c_retry_at          = NULL,
+  c_obscalc_state     = 'pending'
+WHERE c_obscalc_state IN ('ready', 'retry')
+  AND c_workflow_state NOT IN ('inactive', 'ongoing', 'completed')
+  AND (
+        c_workflow_state = 'ready'
+        OR c_workflow_validations @> '[{"code": "ITC_ERROR"}]'::jsonb
+      );

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -22,6 +22,7 @@ import cats.syntax.functor.*
 import cats.syntax.option.*
 import cats.syntax.order.*
 import cats.syntax.parallel.*
+import cats.syntax.reducible.*
 import cats.syntax.traverse.*
 import clue.ResponseException
 import fs2.Stream
@@ -54,6 +55,7 @@ import lucuma.itc.client.SpectroscopyInput
 import lucuma.itc.client.SpectroscopyParameters
 import lucuma.odb.data.Itc
 import lucuma.odb.data.ItcAcquisition
+import lucuma.odb.data.ItcPeakPixel
 import lucuma.odb.data.ItcResult
 import lucuma.odb.data.ItcScience
 import lucuma.odb.data.Md5Hash
@@ -524,11 +526,12 @@ object ItcService {
            .map: a =>
              val z = a.value.zipWithIndex.map { case (intTime, index) =>
                val t = targets.get(index).get
-               // we keep the largest of the per-CCD peak pixel fluxes.
-               val peak = intTime.ccds.map(_.peakPixelFlux).maxOption
-               // The ADU maximum is taken over the per-CCD ADU value
-               val adu  = intTime.ccds.map(_.adu).maxOption
-               ItcResult(t.targetId, intTime.times.focus, intTime.signalToNoiseAt, peak, adu)
+               // We keep the largest of the per-CCD peak pixel fluxes.  The ADU
+               // maximum is taken over the per-CCD ADU values rather than
+               // derived from the winning flux, since the gain differs per CCD.
+               val peak = NonEmptyList.fromList(intTime.ccds).map: ccds =>
+                 ItcPeakPixel(ccds.map(_.peakPixelFlux).maximum, ccds.map(_.adu).maximum)
+               ItcResult(t.targetId, intTime.times.focus, intTime.signalToNoiseAt, peak)
              }
              // Pin the "selected" result to the user's signal-to-noise target,
              // if one is set and present; otherwise keep the automatic
@@ -654,7 +657,7 @@ object ItcService {
             Zipper.fromNel:
               targets.map: t =>
                 val it = IntegrationTime(d.timeAndCount.time, d.timeAndCount.count)
-                ItcResult(t.targetId, it, none, none, none)
+                ItcResult(t.targetId, it, none, none)
 
           EitherT.pure:
             Itc(

--- a/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ItcService.scala
@@ -526,7 +526,9 @@ object ItcService {
                val t = targets.get(index).get
                // we keep the largest of the per-CCD peak pixel fluxes.
                val peak = intTime.ccds.map(_.peakPixelFlux).maxOption
-               ItcResult(t.targetId, intTime.times.focus, intTime.signalToNoiseAt, peak)
+               // The ADU maximum is taken over the per-CCD ADU value
+               val adu  = intTime.ccds.map(_.adu).maxOption
+               ItcResult(t.targetId, intTime.times.focus, intTime.signalToNoiseAt, peak, adu)
              }
              // Pin the "selected" result to the user's signal-to-noise target,
              // if one is set and present; otherwise keep the automatic
@@ -652,7 +654,7 @@ object ItcService {
             Zipper.fromNel:
               targets.map: t =>
                 val it = IntegrationTime(d.timeAndCount.time, d.timeAndCount.count)
-                ItcResult(t.targetId, it, none, none)
+                ItcResult(t.targetId, it, none, none, none)
 
           EitherT.pure:
             Itc(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -76,6 +76,7 @@ import lucuma.itc.client.ItcClient
 import lucuma.itc.client.SpectroscopyInput
 import lucuma.odb.Config
 import lucuma.odb.FMain
+import lucuma.odb.data.ItcPeakPixel
 import lucuma.odb.data.OdbError
 import lucuma.odb.data.OdbErrorExtensions.*
 import lucuma.odb.graphql.enums.Enums
@@ -288,11 +289,8 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
         warnings                      = Nil
       )
 
-  val FakeItcPeakPixelFlux: Double =
-    FakeItcCcds.map(_.peakPixelFlux).max
-
-  val FakeItcPeakPixelAdu: Int =
-    FakeItcCcds.map(_.adu).max
+  val FakeItcPeakPixel: ItcPeakPixel =
+    ItcPeakPixel(FakeItcCcds.map(_.peakPixelFlux).max, FakeItcCcds.map(_.adu).max)
 
   def fakeSignalToNoiseAt(w: Wavelength): SignalToNoiseAt =
     SignalToNoiseAt(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/OdbSuite.scala
@@ -291,6 +291,9 @@ abstract class OdbSuite(debug: Boolean = false) extends CatsEffectSuite with Tes
   val FakeItcPeakPixelFlux: Double =
     FakeItcCcds.map(_.peakPixelFlux).max
 
+  val FakeItcPeakPixelAdu: Int =
+    FakeItcCcds.map(_.adu).max
+
   def fakeSignalToNoiseAt(w: Wavelength): SignalToNoiseAt =
     SignalToNoiseAt(
       w,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -68,6 +68,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                     total
                   }
                   peakPixelFlux
+                  peakPixelAdu
                 }
                 all {
                   targetId
@@ -88,6 +89,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                     total
                   }
                   peakPixelFlux
+                  peakPixelAdu
                 }
                 all {
                   targetId
@@ -114,7 +116,8 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                 },
                 "exposureCount": ${FakeItcResult.exposureCount.value},
                 "signalToNoiseAt": ${fakeSignalToNoiseAt(Wavelength.fromIntNanometers(500).get).asJson},
-                "peakPixelFlux": $FakeItcPeakPixelFlux
+                "peakPixelFlux": $FakeItcPeakPixelFlux,
+                "peakPixelAdu": $FakeItcPeakPixelAdu
               },
               "all": [
                 {
@@ -130,7 +133,8 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                 },
                 "exposureCount": ${FakeItcResult.exposureCount.value},
                 "signalToNoiseAt": null,
-                "peakPixelFlux": $FakeItcPeakPixelFlux
+                "peakPixelFlux": $FakeItcPeakPixelFlux,
+                "peakPixelAdu": $FakeItcPeakPixelAdu
               },
               "all": [
                 {
@@ -586,6 +590,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                     total
                   }
                   peakPixelFlux
+                  peakPixelAdu
                 }
                 all {
                   targetId
@@ -606,6 +611,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                     total
                   }
                   peakPixelFlux
+                  peakPixelAdu
                 }
                 all {
                   targetId
@@ -630,7 +636,8 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                 },
                 "exposureCount" : 1,
                 "signalToNoiseAt" : null,
-                "peakPixelFlux" : null
+                "peakPixelFlux" : null,
+                "peakPixelAdu" : null
               },
               "all" : [
                 {
@@ -646,7 +653,8 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                 },
                 "exposureCount" : 2,
                 "signalToNoiseAt" : null,
-                "peakPixelFlux" : null
+                "peakPixelFlux" : null,
+                "peakPixelAdu" : null
               },
               "all" : [
                 {

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/itc.scala
@@ -67,8 +67,10 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                     single
                     total
                   }
-                  peakPixelFlux
-                  peakPixelAdu
+                  peakPixel {
+                    flux
+                    adu
+                  }
                 }
                 all {
                   targetId
@@ -88,8 +90,10 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                     single
                     total
                   }
-                  peakPixelFlux
-                  peakPixelAdu
+                  peakPixel {
+                    flux
+                    adu
+                  }
                 }
                 all {
                   targetId
@@ -116,8 +120,10 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                 },
                 "exposureCount": ${FakeItcResult.exposureCount.value},
                 "signalToNoiseAt": ${fakeSignalToNoiseAt(Wavelength.fromIntNanometers(500).get).asJson},
-                "peakPixelFlux": $FakeItcPeakPixelFlux,
-                "peakPixelAdu": $FakeItcPeakPixelAdu
+                "peakPixel": {
+                  "flux": ${FakeItcPeakPixel.flux},
+                  "adu": ${FakeItcPeakPixel.adu}
+                }
               },
               "all": [
                 {
@@ -133,8 +139,10 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                 },
                 "exposureCount": ${FakeItcResult.exposureCount.value},
                 "signalToNoiseAt": null,
-                "peakPixelFlux": $FakeItcPeakPixelFlux,
-                "peakPixelAdu": $FakeItcPeakPixelAdu
+                "peakPixel": {
+                  "flux": ${FakeItcPeakPixel.flux},
+                  "adu": ${FakeItcPeakPixel.adu}
+                }
               },
               "all": [
                 {
@@ -589,8 +597,10 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                     single
                     total
                   }
-                  peakPixelFlux
-                  peakPixelAdu
+                  peakPixel {
+                    flux
+                    adu
+                  }
                 }
                 all {
                   targetId
@@ -610,8 +620,10 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                     single
                     total
                   }
-                  peakPixelFlux
-                  peakPixelAdu
+                  peakPixel {
+                    flux
+                    adu
+                  }
                 }
                 all {
                   targetId
@@ -636,8 +648,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                 },
                 "exposureCount" : 1,
                 "signalToNoiseAt" : null,
-                "peakPixelFlux" : null,
-                "peakPixelAdu" : null
+                "peakPixel" : null
               },
               "all" : [
                 {
@@ -653,8 +664,7 @@ class itc extends OdbSuite with ObservingModeSetupOperations {
                 },
                 "exposureCount" : 2,
                 "signalToNoiseAt" : null,
-                "peakPixelFlux" : null,
-                "peakPixelAdu" : null
+                "peakPixel" : null
               },
               "all" : [
                 {


### PR DESCRIPTION
We can calculate the ADU after getting the results from ITC and expose them in the schema. Explore wants to display adu values.