### PR TITLE
Assign bands to all callibrations

### DIFF
--- a/modules/service/src/main/scala/lucuma/odb/service/CalibrationsUtils.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/CalibrationsUtils.scala
@@ -311,6 +311,17 @@ trait CalibrationObservations {
   def toConfigForCalibration(all: List[ObsExtract[ObservingMode]]): List[ObsExtract[CalibrationConfigSubset]] =
     all.map(_.map(_.toConfigSubset))
 
+  // The props are keyed by science configuration, which the calibration's own
+  // configuration only matches modulo the role's normalization (e.g. spec photo
+  // ignores the ROI), hence the search rather than a direct lookup.
+  private def propsForConfig(
+    props:  Map[CalibrationConfigSubset, CalObsProps],
+    role:   CalibrationRole,
+    config: CalibrationConfigSubset
+  ): Option[CalObsProps] =
+    props.collectFirst:
+      case (sciConfig, p) if CalibrationConfigMatcher.matcherFor(sciConfig, role).configsMatch(sciConfig, config) => p
+
   def gmosLongSlitSpecPhotObs[F[_]: MonadThrow: Services: Transaction, G, L, U](
     pid:    Program.Id,
     gid:    Group.Id,
@@ -318,14 +329,9 @@ trait CalibrationObservations {
     props:  Map[CalibrationConfigSubset, CalObsProps],
     config: CalibrationConfigSubset.Gmos[G, L, U]
   ): F[Observation.Id] =
-    val matchingProps = props.find { case (originalConfig, _) =>
-      // Check if this original config could have produced the transformed config using SpectroPhotometric strategy
-      CalibrationConfigMatcher
-        .matcherFor(originalConfig, CalibrationRole.SpectroPhotometric)
-        .configsMatch(originalConfig, config)
-    }.map(_._2)
-    val wavelengthAt = matchingProps.flatMap(_.wavelengthAt)
-    val band         = matchingProps.flatMap(_.band)
+    val matchingProps: Option[CalObsProps] = propsForConfig(props, CalibrationRole.SpectroPhotometric, config)
+    val wavelengthAt: Option[Wavelength]   = matchingProps.flatMap(_.wavelengthAt)
+    val band: Option[ScienceBand]          = matchingProps.flatMap(_.band)
     specPhotoObservation(pid, gid, tid, wavelengthAt, band, config.toLongSlitInput)
 
   def roleConstraints(role: CalibrationRole) =
@@ -381,15 +387,18 @@ trait CalibrationObservations {
     pid:    Program.Id,
     gid:    Group.Id,
     tid:    Target.Id,
+    props:  Map[CalibrationConfigSubset, CalObsProps],
     config: CalibrationConfigSubset.Gmos[G, L, U]
   ): F[Observation.Id] =
-    twilightObservation(pid, gid, tid, config.centralWavelength, config.toLongSlitInput)
+    val band: Option[ScienceBand] = propsForConfig(props, CalibrationRole.Twilight, config).flatMap(_.band)
+    twilightObservation(pid, gid, tid, band, config.centralWavelength, config.toLongSlitInput)
 
-  private def twilightObservation[F[_]: Services: MonadThrow: Transaction](pid: Program.Id, gid: Group.Id, tid: Target.Id, cw: Wavelength, obsMode: ObservingModeInput.Create): F[Observation.Id] =
+  private def twilightObservation[F[_]: Services: MonadThrow: Transaction](pid: Program.Id, gid: Group.Id, tid: Target.Id, band: Option[ScienceBand], cw: Wavelength, obsMode: ObservingModeInput.Create): F[Observation.Id] =
       observationService.createObservation(
         Services.asSuperUser:
           AccessControl.unchecked(
             ObservationPropertiesInput.Create.Default.copy(
+              scienceBand = band,
               targetEnvironment = TargetEnvironmentInput.Create(
                 none,
                 List(tid).some,

--- a/modules/service/src/main/scala/lucuma/odb/service/PerProgramPerConfigCalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/PerProgramPerConfigCalibrationsService.scala
@@ -79,7 +79,11 @@ object PerProgramPerConfigCalibrationsService:
             case ws  =>
               val pm = ws.map(_.toPicometers.value.value).combineAll / ws.size
               PosInt.from(pm).map(Wavelength(_)).toOption
-          k -> CalObsProps(w, v.map(_.band).min)
+          // Highest priority band (band 1 beats band 2, …) among the science
+          // observations sharing the configuration.  Observations with no band
+          // assigned are ignored rather than dragging the result to "no band",
+          // which would leave the calibration unschedulable.
+          k -> CalObsProps(w, v.flatMap(_.band).minOption)
 
       private def uniqueConfiguration(
         all: List[ObsExtract[ObservingMode]]
@@ -169,9 +173,9 @@ object PerProgramPerConfigCalibrationsService:
           case (Site.GS, CalibrationRole.SpectroPhotometric, c: GmosSConfigs) =>
             gmosLongSlitSpecPhotObs(pid, gid, tid, props, c).some
           case (Site.GN, CalibrationRole.Twilight, c: GmosNConfigs)           =>
-            gmosLongSlitTwilightObs(pid, gid, tid, c).some
+            gmosLongSlitTwilightObs(pid, gid, tid, props, c).some
           case (Site.GS, CalibrationRole.Twilight, c: GmosSConfigs)           =>
-            gmosLongSlitTwilightObs(pid, gid, tid, c).some
+            gmosLongSlitTwilightObs(pid, gid, tid, props, c).some
           case _                                                              =>
             none
 

--- a/modules/service/src/main/scala/lucuma/odb/service/PerScienceObservationCalibrationsService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/PerScienceObservationCalibrationsService.scala
@@ -621,6 +621,7 @@ object PerScienceObservationCalibrationsService:
           sql"""
             UPDATE t_observation target
             SET
+              c_science_band             = source.c_science_band,
               c_cloud_extinction         = source.c_cloud_extinction,
               c_image_quality            = source.c_image_quality,
               c_sky_background           = source.c_sky_background,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/TelluricCalibrationsTestSupport.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/TelluricCalibrationsTestSupport.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import cats.syntax.all.*
 import io.circe.Decoder
 import lucuma.core.enums.CalibrationRole
+import lucuma.core.enums.ScienceBand
 import lucuma.core.model.Group
 import lucuma.core.model.Observation
 import lucuma.odb.graphql.query.ExecutionTestSupport
@@ -59,6 +60,19 @@ trait TelluricCalibrationsTestSupport:
         .leftMap(f => new RuntimeException(f.message))
         .liftTo[IO]
     }
+
+  protected def queryScienceBand(oid: Observation.Id): IO[Option[ScienceBand]] =
+    query(
+      serviceUser,
+      s"""query {
+            observation(observationId: "$oid") {
+              scienceBand
+            }
+          }"""
+    ).flatMap: c =>
+      c.hcursor.downFields("observation", "scienceBand").as[Option[ScienceBand]]
+        .leftMap(f => new RuntimeException(f.message))
+        .liftTo[IO]
 
   protected def queryObservationExists(oid: Observation.Id): IO[Boolean] =
     query(

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/perProgramPerConfigCalibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/perProgramPerConfigCalibrations.scala
@@ -20,7 +20,9 @@ import lucuma.core.enums.GmosAmpReadMode
 import lucuma.core.enums.GmosRoi
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.ObservingModeType
+import lucuma.core.enums.ScienceBand
 import lucuma.core.enums.Site
+import lucuma.core.enums.TimeAccountingCategory
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Wavelength
 import lucuma.core.model.CloudExtinction
@@ -31,9 +33,11 @@ import lucuma.core.model.ProgramReference.Description
 import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.core.syntax.string.*
+import lucuma.core.syntax.timespan.*
 import lucuma.odb.data.EditType
 import lucuma.odb.graphql.OdbSuite
 import lucuma.odb.graphql.TestUsers
+import lucuma.odb.graphql.input.AllocationInput
 import lucuma.odb.graphql.input.ProgramPropertiesInput
 import lucuma.odb.graphql.query.ExecutionQuerySetupOperations
 import lucuma.odb.graphql.query.ExecutionTestSupportForGmos
@@ -63,7 +67,7 @@ class perProgramPerConfigCalibrations
 
   val DefaultSnAt: Wavelength = Wavelength.fromIntNanometers(510).get
 
-  override val validUsers = List(pi, service)
+  override val validUsers = List(pi, service, staff)
 
   def scienceRequirements(pi: User, oid: Observation.Id, snAt: Wavelength = DefaultSnAt): IO[Json] =
     query(
@@ -174,6 +178,26 @@ class perProgramPerConfigCalibrations
         .leftMap(f => new RuntimeException(f.message))
         .liftTo[IO]
      }
+
+  case class CalibBand(calibrationRole: Option[CalibrationRole], scienceBand: Option[ScienceBand]) derives Decoder
+
+  // Bands of the program's calibration observations, ordered by calibration role.
+  private def queryCalibrationBands(pid: Program.Id): IO[List[Option[ScienceBand]]] =
+    query(
+      service,
+      s"""query {
+            observations(WHERE: { program: { id: { EQ: "$pid" } } }) {
+              matches {
+                calibrationRole
+                scienceBand
+              }
+            }
+          }"""
+    ).flatMap { c =>
+      c.hcursor.downFields("observations", "matches").as[List[CalibBand]]
+        .leftMap(f => new RuntimeException(f.message))
+        .liftTo[IO]
+    }.map(_.collect { case CalibBand(Some(r), b) => (r, b) }.sortBy(_._1.tag).map(_._2))
 
   private def queryObservations(pid: Program.Id): IO[List[CalibObs]] =
     query(
@@ -301,6 +325,39 @@ class perProgramPerConfigCalibrations
       assert(obsGids.forall(g => cgid.exists(_ == g)))
       assertEquals(cCount, 4)
       assertEquals(oids.size, 2)
+    }
+  }
+
+  test("calibrations take the highest priority band of the science observations") {
+    // More than one allocated band, so no band is assigned program-wide on allocation.
+    val allocations = List(
+      AllocationInput(TimeAccountingCategory.US, ScienceBand.Band1, 1.hourTimeSpan),
+      AllocationInput(TimeAccountingCategory.US, ScienceBand.Band2, 2.hourTimeSpan),
+      AllocationInput(TimeAccountingCategory.US, ScienceBand.Band3, 4.hourTimeSpan)
+    )
+    for {
+      pid    <- createProgramAs(pi)
+      _      <- setAllocationsAs(staff, pid, allocations)
+      tid    <- createTargetAs(pi, pid, "One")
+      oid1   <- createObservationAs(pi, pid, ObservingModeType.GmosNorthLongSlit.some, tid)
+      oid2   <- createObservationAs(pi, pid, ObservingModeType.GmosNorthLongSlit.some, tid)
+      // Same configuration, hence the same calibrations, but no band assigned.
+      oid3   <- createObservationAs(pi, pid, ObservingModeType.GmosNorthLongSlit.some, tid)
+      _      <- setScienceBandAs(pi, oid1, ScienceBand.Band3.some)
+      _      <- setScienceBandAs(pi, oid2, ScienceBand.Band2.some)
+      _      <- prepareObservation(pi, pid, oid1, tid)
+      _      <- prepareObservation(pi, pid, oid2, tid)
+      _      <- prepareObservation(pi, pid, oid3, tid)
+      _      <- recalculateCalibrations(pid, when, oid1)
+      bands1 <- queryCalibrationBands(pid)
+      // A higher priority band on any of them moves the existing calibrations
+      _      <- setScienceBandAs(pi, oid1, ScienceBand.Band1.some)
+      _      <- runObscalcUpdate(pid, oid1)
+      _      <- recalculateCalibrations(pid, when, oid1)
+      bands2 <- queryCalibrationBands(pid)
+    } yield {
+      assertEquals(bands1, List(ScienceBand.Band2.some, ScienceBand.Band2.some))
+      assertEquals(bands2, List(ScienceBand.Band1.some, ScienceBand.Band1.some))
     }
   }
 

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/perProgramPerConfigCalibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/perProgramPerConfigCalibrations.scala
@@ -329,7 +329,10 @@ class perProgramPerConfigCalibrations
   }
 
   test("calibrations take the highest priority band of the science observations") {
-    // More than one allocated band, so no band is assigned program-wide on allocation.
+    // With a single allocated band, setAllocations back-fills it onto every
+    // observation with no band, which would hide the case under test. More
+    // than one band skips that back-fill, so the bands here are only the ones
+    // set explicitly below.
     val allocations = List(
       AllocationInput(TimeAccountingCategory.US, ScienceBand.Band1, 1.hourTimeSpan),
       AllocationInput(TimeAccountingCategory.US, ScienceBand.Band2, 2.hourTimeSpan),

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/perScienceObservationCalibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/perScienceObservationCalibrations.scala
@@ -1232,7 +1232,10 @@ class perScienceObservationCalibrations
     }
 
   test("telluric observation takes the science band of its science observation"):
-    // Two allocated bands, so the band isn't assigned program-wide on allocation.
+    // With a single allocated band, setAllocations back-fills it onto every
+    // observation with no band, which would hide the case under test.  More
+    // than one band skips that back-fill, so the bands here are only the ones
+    // set explicitly below.
     val allocations = List(
       AllocationInput(TimeAccountingCategory.US, ScienceBand.Band1, 1.hourTimeSpan),
       AllocationInput(TimeAccountingCategory.US, ScienceBand.Band2, 4.hourTimeSpan)

--- a/modules/service/src/test/scala/lucuma/odb/graphql/feature/perScienceObservationCalibrations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/feature/perScienceObservationCalibrations.scala
@@ -26,8 +26,10 @@ import lucuma.core.enums.GnirsPrism
 import lucuma.core.enums.GnirsWellDepth
 import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.ObservingModeType
+import lucuma.core.enums.ScienceBand
 import lucuma.core.enums.SequenceCommand
 import lucuma.core.enums.TelluricCalibrationOrder
+import lucuma.core.enums.TimeAccountingCategory
 import lucuma.core.math.BoundedInterval
 import lucuma.core.math.BrightnessUnits.BrightnessMeasure
 import lucuma.core.math.BrightnessUnits.Integrated
@@ -53,6 +55,7 @@ import lucuma.itc.IntegrationTime
 import lucuma.itc.client.SpectroscopyInput
 import lucuma.odb.TestCoordinates.coords
 import lucuma.odb.data.OdbError
+import lucuma.odb.graphql.input.AllocationInput
 import lucuma.odb.graphql.query.ExecutionTestSupportForFlamingos2
 import lucuma.odb.graphql.query.ExecutionTestSupportForGnirs
 import lucuma.odb.graphql.query.ExecutionTestSupportForIgrins2
@@ -1226,6 +1229,33 @@ class perScienceObservationCalibrations
       assertEquals(telluricFpu1, Flamingos2Fpu.LongSlit1.some)
       assertEquals(scienceFpu2, Flamingos2Fpu.LongSlit2.some)
       assertEquals(telluricFpu2, Flamingos2Fpu.LongSlit2.some)
+    }
+
+  test("telluric observation takes the science band of its science observation"):
+    // Two allocated bands, so the band isn't assigned program-wide on allocation.
+    val allocations = List(
+      AllocationInput(TimeAccountingCategory.US, ScienceBand.Band1, 1.hourTimeSpan),
+      AllocationInput(TimeAccountingCategory.US, ScienceBand.Band2, 4.hourTimeSpan)
+    )
+    for {
+      pid         <- createProgramAs(pi)
+      _           <- setAllocationsAs(staff, pid, allocations)
+      tid         <- createTargetWithProfileAs(pi, pid)
+      oid         <- createFlamingos2LongSlitObservationAs(pi, pid, List(tid))
+      _           <- setScienceBandAs(pi, oid, ScienceBand.Band2.some)
+      _           <- runObscalcUpdate(pid, oid)
+      _           <- recalculateCalibrations(pid, when, oid)
+      obs         <- queryObservation(oid)
+      obsInGroup  <- queryObservationsInGroup(obs.groupId.get)
+      telluricOid =  obsInGroup.find(_.calibrationRole.contains(CalibrationRole.Telluric)).get.id
+      band1       <- queryScienceBand(telluricOid)
+      _           <- setScienceBandAs(pi, oid, ScienceBand.Band1.some)
+      _           <- runObscalcUpdate(pid, oid)
+      _           <- sleep >> recalculateCalibrations(pid, when, oid)
+      band2       <- queryScienceBand(telluricOid)
+    } yield {
+      assertEquals(band1, ScienceBand.Band2.some)
+      assertEquals(band2, ScienceBand.Band1.some)
     }
 
   test("Don't generate for inactive"):


### PR DESCRIPTION
## Assign a science band to calibration observations

Fixes [sc-7684]. Calibration observations must get the highest priority band of
the science observations they serve. Today a program with time in two or more
bands often ends up with no band on its calibrations, and the scheduler skips
them.

### Why it happened

When a program has time in only one band, `setAllocations` copies that band onto
every observation, so calibrations got a band by accident. With two or more
bands nothing does that, and three gaps showed up:

1. The band for GMOS calibrations was picked with `min` over `Option[ScienceBand]`.
   In that ordering "no band" sorts before every real band, so a single science
   observation without a band pulled the calibration down to no band at all.
2. Twilight observations were never given a band when created. They only picked
   one up later, on the next recalculation.
3. Tellurics and daytime pinhole flats were created with no band and never
   updated.

### Changes

- `PerProgramPerConfigCalibrationsService`: pick the lowest band among the
  science observations that actually have one, ignoring the rest. Band 1 wins
  over Band 2, which wins over Band 3, so a configuration shared by Band 2 and
  Band 3 gives a Band 2 calibration.
- `CalibrationsUtils`: twilight observations now get their band at creation,
  the same way spectrophotometric ones already did. The lookup that finds the
  science properties for a calibration configuration is now shared by both
  (`propsForConfig`), since it has to match configurations the way the role
  does, not by exact key.
- `PerScienceObservationCalibrationsService`: `syncObservationConfiguration`
  now copies `c_science_band` from the science observation. That covers
  tellurics and daytime pinhole flats, and because the sync runs on every
  recalculation, a later band change on the science observation follows through.

### Tests

- `perProgramPerConfigCalibrations`: three GMOS-N observations sharing one
  configuration, with Band 3, Band 2, and no band at all. Both calibrations
  (spectrophotometric and twilight) come out as Band 2. Moving one science
  observation to Band 1 then moves both calibrations to Band 1.
- `perScienceObservationCalibrations`: an F2 telluric takes its science
  observation's band, and follows it when the band changes.


Note on the daytime pinhole flat: it now inherits a band too, since it goes through the same sync. It's a DayCal and non-chargeable so the band should not affect time accounting. If anyone suspects this is an issue, we can special-case it to leave it unassigned.
