### PR TITLE
Shortcut 9747: Trigger update

### DIFF
--- a/modules/binding/src/main/scala/lucuma/odb/graphql/binding/WhereOrder.scala
+++ b/modules/binding/src/main/scala/lucuma/odb/graphql/binding/WhereOrder.scala
@@ -5,11 +5,40 @@ package lucuma.odb.graphql
 package binding
 
 import cats.Order
+import cats.syntax.order.*
 import cats.syntax.parallel.*
 import grackle.Path
 import grackle.Predicate
 import grackle.Predicate.*
 import lucuma.odb.graphql.binding.*
+
+/**
+ * The same criteria `binding` compiles into a Grackle predicate, kept as data so
+ * they can be evaluated in memory instead.  Subscriptions filter events as they
+ * arrive, with no query to push a predicate into, so a filter that wants ordering
+ * ("at least RAPID") has to be applied here rather than in SQL.
+ *
+ * All supplied criteria must match, though usually only one is given.
+ */
+final case class WhereOrder[A: Order](
+  eq:  Option[A],
+  neq: Option[A],
+  in:  Option[List[A]],
+  nin: Option[List[A]],
+  gt:  Option[A],
+  lt:  Option[A],
+  gte: Option[A],
+  lte: Option[A]
+):
+  def matches(a: A): Boolean =
+    eq.forall(_ === a)        &&
+    neq.forall(_ =!= a)       &&
+    in.forall(_.contains(a))  &&
+    nin.forall(!_.contains(a)) &&
+    gt.forall(a > _)          &&
+    lt.forall(a < _)          &&
+    gte.forall(a >= _)        &&
+    lte.forall(a <= _)
 
 object WhereOrder {
 
@@ -38,6 +67,22 @@ object WhereOrder {
               LTE.map(a => LtEql(path, Const(a)))
             ).flatten)
         }
+    }
+
+  /** Like `binding`, but yields the criteria themselves for in-memory matching. */
+  def inputBinding[A: Order](binding: Matcher[A]): Matcher[WhereOrder[A]] =
+    ObjectFieldsBinding.rmap {
+      case List(
+        binding.Option("EQ", rEQ),
+        binding.Option("NEQ", rNEQ),
+        binding.List.Option("IN", rIN),
+        binding.List.Option("NIN", rNIN),
+        binding.Option("GT", rGT),
+        binding.Option("LT", rLT),
+        binding.Option("GTE", rGTE),
+        binding.Option("LTE", rLTE)
+      ) =>
+        (rEQ, rNEQ, rIN, rNIN, rGT, rLT, rGTE, rLTE).parMapN(WhereOrder.apply)
     }
 
 }

--- a/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
+++ b/modules/schema/src/main/resources/lucuma/odb/graphql/OdbSchema.graphql
@@ -15715,17 +15715,53 @@ enum ConfigurationRequestStatus {
 scalar TooTriggerId
 
 """
-Lifecycle status of a Target-of-Opportunity trigger.  A trigger is REQUESTED
-while its observation carries the READY workflow state, and WITHDRAWN when that
-state is cleared; DECLINED records that an observer saw it and chose not to
-observe.  Both terminal statuses are equivalent to never having been triggered:
-setting the observation READY again produces a new trigger, never a transition
-out of a terminal state.
+Lifecycle status of a Target-of-Opportunity trigger.
+
+A trigger is not requested directly.  It comes into being when a ToO observation
+is set to the READY workflow state with a resolved opportunity target, and the
+database keeps the two in step, so the status can never disagree with the
+observation.  REQUESTED is the only non-terminal status.
+
+DECLINED, WITHDRAWN and SUPERSEDED are terminal, and for the purpose of
+triggering again all three are equivalent to never having been triggered: setting
+the observation READY once more produces a new trigger rather than transitioning
+out of a terminal status.  They are kept distinct because they answer different
+questions about what became of the request.
 """
 enum TooTriggerStatus {
+
+  """
+  Live: the observation is ready to be observed and the observatory has it under
+  consideration.  The only non-terminal status, and the only one an outstanding
+  request can hold -- at most one trigger per observation is REQUESTED at a time.
+  A trigger stays REQUESTED while its observation executes; that execution has
+  begun is reported by the execution events, not here.
+  """
   REQUESTED
+
+  """
+  An observer saw the request and chose not to act on it, with a reason in
+  `resolutionReason`.  Distinct from a request simply sitting there: DECLINED says
+  somebody looked, where REQUESTED says nothing about whether anyone has.
+  Declining also returns the observation to DEFINED.
+  """
   DECLINED
+
+  """
+  The request was taken back before it was acted on -- the PI cleared the READY
+  workflow state, cleared the target's resolution, or the observation stopped
+  being a Target of Opportunity.  Nobody at the observatory need have seen it.
+  """
   WITHDRAWN
+
+  """
+  Replaced by a request at a different `tooActivation`.  A trigger's activation is
+  fixed when it is created, so a change of activation on an outstanding request
+  closes it out and creates a successor rather than amending it in place -- the
+  successor's `supersedes` points back here.  Unlike WITHDRAWN, nothing was taken
+  back: the observation is still live, under the successor.
+  """
+  SUPERSEDED
 }
 
 """
@@ -15769,6 +15805,16 @@ input TooTriggerEditInput {
   If provided, only edits for this specific trigger are delivered.
   """
   tooTriggerId: TooTriggerId
+
+  """
+  If provided, only edits for triggers requested at a matching activation are
+  delivered.  Ordered, so `EQ: INTERRRUPTING` follows just the requests that
+  cannot wait for the ordinary queue.  Matched against the activation the
+  trigger carries, which is fixed when it is created -- so a supersession
+  reports the predecessor's own activation on its closing event, not the
+  successor's.
+  """
+  tooActivation: WhereOrderTooActivation
 }
 
 """
@@ -15784,6 +15830,23 @@ type TooTrigger {
 
   "The trigger's lifecycle status."
   status: TooTriggerStatus!
+
+  """
+  The ToO activation this request was made at.  Fixed when the trigger is created
+  and never changed: a request at a different activation is a different request,
+  since who is notified, how fast, and what they are expected to drop all differ.
+  If the observation's activation moves while this request is outstanding, this
+  trigger becomes SUPERSEDED and a successor carries the new value.  Never NONE.
+  """
+  tooActivation: TooActivation!
+
+  """
+  The request this one replaced, null for a first request.  Following the chain
+  back gives the moment the observation first went live at any activation, which
+  `requestedAt` deliberately does not -- it is the age of this request, at this
+  activation.
+  """
+  supersedes: TooTrigger
 
   "Reason accompanying a terminal transition (e.g. a denial or withdrawal), if any."
   resolutionReason: NonEmptyString
@@ -15854,8 +15917,8 @@ input WhereOrderTooTriggerId {
 
 """
 Filters on equality or order comparisons of the TooTriggerStatus property.  Order
-follows the lifecycle declaration: REQUESTED < ACCEPTED < DENIED < WITHDRAWN, so
-`GTE: REQUESTED` matches every status.
+follows the lifecycle declaration: REQUESTED < DECLINED < WITHDRAWN < SUPERSEDED,
+so `GTE: REQUESTED` matches every status.
 """
 input WhereOrderTooTriggerStatus {
   "Matches if the property is exactly the supplied value."
@@ -15883,6 +15946,39 @@ input WhereOrderTooTriggerStatus {
   LTE: TooTriggerStatus
 }
 
+"""
+Filters on equality or order comparisons of the TooActivation property.  Order
+follows the declaration NONE < STANDARD < RAPID < INTERRUPTING, so `GTE: RAPID`
+matches the activations that cannot wait for the ordinary queue.  Note that only
+INTERRUPTING may displace work already under way; RAPID is observed as soon as
+possible but takes its turn.
+"""
+input WhereOrderTooActivation {
+  "Matches if the property is exactly the supplied value."
+  EQ: TooActivation
+
+  "Matches if the property is not the supplied value."
+  NEQ: TooActivation
+
+  "Matches if the property value is any of the supplied options."
+  IN: [TooActivation!]
+
+  "Matches if the property value is none of the supplied values."
+  NIN: [TooActivation!]
+
+  "Matches if the property is ordered after (>) the supplied value."
+  GT: TooActivation
+
+  "Matches if the property is ordered before (<) the supplied value."
+  LT: TooActivation
+
+  "Matches if the property is ordered after or equal (>=) the supplied value."
+  GTE: TooActivation
+
+  "Matches if the property is ordered before or equal (<=) the supplied value."
+  LTE: TooActivation
+}
+
 input WhereTooTrigger {
   "A list of nested trigger filters that all must match."
   AND: [WhereTooTrigger!]
@@ -15904,6 +16000,12 @@ input WhereTooTrigger {
 
   "Matches the trigger status."
   status: WhereOrderTooTriggerStatus
+
+  """
+  Matches the activation the trigger was requested at.  Ordered, so
+  `EQ: INTERRUPTING` selects the requests that cannot wait for the ordinary queue.
+  """
+  tooActivation: WhereOrderTooActivation
 
   "Matches the request (creation) time."
   requestedAt: WhereOrderTimestamp
@@ -15940,10 +16042,21 @@ type TooTriggerChronicleEntry {
   modStatus: Boolean!
   modResolutionReason: Boolean!
 
+  """
+  Always false on an update -- a trigger's activation never changes -- so this is
+  true exactly on the row that recorded the trigger's creation.
+  """
+  modTooActivation: Boolean!
+
+  "As `modTooActivation`: only ever true on a creation."
+  modSupersedes: Boolean!
+
   newObservationId: ObservationId
   newProgramId: ProgramId
   newStatus: TooTriggerStatus
   newResolutionReason: NonEmptyString
+  newTooActivation: TooActivation
+  newSupersedes: TooTriggerId
 }
 
 """
@@ -15979,6 +16092,8 @@ input WhereTooTriggerChronicleEntry {
   modProgramId: WhereBoolean
   modStatus: WhereBoolean
   modResolutionReason: WhereBoolean
+  modTooActivation: WhereBoolean
+  modSupersedes: WhereBoolean
 }
 
 """

--- a/modules/service/src/main/resources/db/migration/V1266__too_trigger_superseded.sql
+++ b/modules/service/src/main/resources/db/migration/V1266__too_trigger_superseded.sql
@@ -1,0 +1,16 @@
+-- Adds the 'superseded' trigger status, in a migration of its own.
+--
+-- A trigger records the ToO activation it was requested at (V1267), and that
+-- value never changes: an activation at a different level is a different request,
+-- because who is notified, how fast, and what they are expected to drop all
+-- differ.  So when the observation's activation moves while a request is
+-- outstanding, the outstanding row is closed out and replaced rather than
+-- amended, and 'superseded' is what it is closed out as.
+--
+ALTER TYPE e_too_trigger_status ADD VALUE 'superseded';
+
+COMMENT ON TYPE e_too_trigger_status IS
+  'ToO trigger lifecycle. requested is the only non-terminal status; declined '
+  '(observer said no), withdrawn (PI took it back) and superseded (replaced by a '
+  'request at a different activation) are terminal, and all three are equivalent '
+  'to never having been triggered.';

--- a/modules/service/src/main/resources/db/migration/V1267__too_trigger_activation.sql
+++ b/modules/service/src/main/resources/db/migration/V1267__too_trigger_activation.sql
@@ -1,0 +1,240 @@
+-- Records, on the trigger itself, the ToO activation it was requested at.
+--
+-- The UI needs trigger events to carry the activation and to be filterable on
+-- it, and needs a change of activation on an outstanding request to produce an
+-- event of its own.  All three fall out of putting the activation on the row.
+--
+-- A CHANGE OF ACTIVATION IS A NEW REQUEST
+--
+-- Triggering a standard ToO, a rapid one and an interrupting one provoke very
+-- distinct notification behaviour downstream: who is told, how fast, and what
+-- they are expected to drop.  They are effectively different things, so a
+-- request's identity does not survive a change in its character.  The
+-- outstanding row is superseded and a successor takes its place, with a new id
+-- and a new c_requested_at -- which is correct rather than lossy, since the clock
+-- that matters is how long *this* request, at *this* activation, has been
+-- outstanding.  c_supersedes chains them, so the root of a chain still answers
+-- "when did this observation first go live at any activation".
+
+-------------------------------------------------------------------------------
+-- Columns.
+-------------------------------------------------------------------------------
+
+ALTER TABLE t_too_trigger
+  -- Nullable for now; backfilled and tightened below.
+  ADD COLUMN c_too_activation e_too_activation NULL,
+
+  -- The request this one replaced, null for a first request.  Points backwards,
+  -- so the chain walks both ways, and UNIQUE because a request is superseded at
+  -- most once -- the successor is the only row that may point at it.
+  ADD COLUMN c_supersedes d_too_trigger_id NULL
+    REFERENCES t_too_trigger(c_too_trigger_id),
+  ADD CONSTRAINT too_trigger_supersedes_unique UNIQUE (c_supersedes);
+
+-------------------------------------------------------------------------------
+-- Backfill.
+-------------------------------------------------------------------------------
+
+ALTER TABLE t_too_trigger DISABLE TRIGGER USER;
+
+UPDATE t_too_trigger t
+   SET c_too_activation = GREATEST(o.c_too_activation, 'standard'::e_too_activation)
+  FROM t_observation o
+ WHERE o.c_observation_id = t.c_observation_id;
+
+ALTER TABLE t_too_trigger ENABLE TRIGGER USER;
+
+ALTER TABLE t_too_trigger
+  ALTER COLUMN c_too_activation SET NOT NULL,
+
+  -- Every trigger is for a ToO, so this column cannot take 'none'.  The
+  -- observation's column must admit it; this one must not.
+  ADD CONSTRAINT too_trigger_activation_not_none
+    CHECK (c_too_activation <> 'none'::e_too_activation);
+
+-------------------------------------------------------------------------------
+-- Chronicle.
+-------------------------------------------------------------------------------
+
+ALTER TABLE t_chron_too_trigger_update
+  ADD COLUMN c_mod_too_activation bool NOT NULL DEFAULT false,
+  ADD COLUMN c_mod_supersedes     bool NOT NULL DEFAULT false,
+  ADD COLUMN c_new_too_activation e_too_activation,
+  ADD COLUMN c_new_supersedes     d_too_trigger_id;
+
+ALTER TABLE t_chron_too_trigger_update
+  ALTER COLUMN c_mod_too_activation DROP DEFAULT,
+  ALTER COLUMN c_mod_supersedes     DROP DEFAULT;
+
+-- Body as V1242, with the two new columns threaded through.  Neither ever
+-- changes on an existing row, so on an UPDATE both flags are always false; what
+-- makes them worth carrying is the INSERT branch, where OLD is null and every
+-- `NEW.x IS DISTINCT FROM OLD.x` is true -- so the creation row records the
+-- activation and the predecessor link, and the chronicle can reconstruct a whole
+-- supersession chain.
+CREATE OR REPLACE FUNCTION chron_too_trigger_update()
+  RETURNS TRIGGER AS $$
+DECLARE
+  mod_observation_id    bool := NEW.c_observation_id    IS DISTINCT FROM OLD.c_observation_id;
+  mod_program_id        bool := NEW.c_program_id        IS DISTINCT FROM OLD.c_program_id;
+  mod_status            bool := NEW.c_status            IS DISTINCT FROM OLD.c_status;
+  mod_resolution_reason bool := NEW.c_resolution_reason IS DISTINCT FROM OLD.c_resolution_reason;
+  mod_too_activation    bool := NEW.c_too_activation    IS DISTINCT FROM OLD.c_too_activation;
+  mod_supersedes        bool := NEW.c_supersedes        IS DISTINCT FROM OLD.c_supersedes;
+BEGIN
+  INSERT INTO t_chron_too_trigger_update AS chron (
+    c_operation,
+    c_too_trigger_id,
+    c_mod_observation_id,
+    c_mod_program_id,
+    c_mod_status,
+    c_mod_resolution_reason,
+    c_mod_too_activation,
+    c_mod_supersedes,
+    c_new_observation_id,
+    c_new_program_id,
+    c_new_status,
+    c_new_resolution_reason,
+    c_new_too_activation,
+    c_new_supersedes
+  ) VALUES (
+    TG_OP::e_tg_op,
+    coalesce(OLD.c_too_trigger_id, NEW.c_too_trigger_id),
+    mod_observation_id,
+    mod_program_id,
+    mod_status,
+    mod_resolution_reason,
+    mod_too_activation,
+    mod_supersedes,
+    CASE WHEN mod_observation_id    THEN NEW.c_observation_id    END,
+    CASE WHEN mod_program_id        THEN NEW.c_program_id        END,
+    CASE WHEN mod_status            THEN NEW.c_status            END,
+    CASE WHEN mod_resolution_reason THEN NEW.c_resolution_reason END,
+    CASE WHEN mod_too_activation    THEN NEW.c_too_activation    END,
+    CASE WHEN mod_supersedes        THEN NEW.c_supersedes        END
+  ) ON CONFLICT ON CONSTRAINT t_chron_too_trigger_update_unique DO UPDATE SET
+    c_mod_observation_id    = chron.c_mod_observation_id    OR mod_observation_id,
+    c_mod_program_id        = chron.c_mod_program_id        OR mod_program_id,
+    c_mod_status            = chron.c_mod_status            OR mod_status,
+    c_mod_resolution_reason = chron.c_mod_resolution_reason OR mod_resolution_reason,
+    c_mod_too_activation    = chron.c_mod_too_activation    OR mod_too_activation,
+    c_mod_supersedes        = chron.c_mod_supersedes        OR mod_supersedes,
+    c_new_observation_id    = CASE WHEN chron.c_mod_observation_id    OR mod_observation_id    THEN NEW.c_observation_id    END,
+    c_new_program_id        = CASE WHEN chron.c_mod_program_id        OR mod_program_id        THEN NEW.c_program_id        END,
+    c_new_status            = CASE WHEN chron.c_mod_status            OR mod_status            THEN NEW.c_status            END,
+    c_new_resolution_reason = CASE WHEN chron.c_mod_resolution_reason OR mod_resolution_reason THEN NEW.c_resolution_reason END,
+    c_new_too_activation    = CASE WHEN chron.c_mod_too_activation    OR mod_too_activation    THEN NEW.c_too_activation    END,
+    c_new_supersedes        = CASE WHEN chron.c_mod_supersedes        OR mod_supersedes        THEN NEW.c_supersedes        END;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-------------------------------------------------------------------------------
+-- Supersession.
+-------------------------------------------------------------------------------
+
+-- Body as V1261, plus a third branch and the activation on the insert.
+--
+-- The two predicates read: the PI has asked for this observation, it is a Target
+-- of Opportunity, and its target is resolved.  Note that `c_too_activation <>
+-- 'none'` is the test for *being* a ToO -- too_activation() returns 'none'
+-- whenever c_has_too_target is false, so an ordinary observation never gets past
+-- it whatever its scheduling mode.  The c_has_unresolved_too_target clause is
+-- therefore only ever excluding a genuine ToO whose target has no coordinates
+-- yet; on its own it would be satisfied by an observation with no ToO target at
+-- all.
+CREATE OR REPLACE FUNCTION too_trigger_track_ready()
+  RETURNS trigger AS $$
+DECLARE
+  was_triggered bool := TG_OP = 'UPDATE'
+                    AND OLD.c_workflow_user_state IS NOT DISTINCT FROM 'ready'::e_workflow_user_state
+                    AND OLD.c_too_activation <> 'none'::e_too_activation
+                    AND NOT OLD.c_has_unresolved_too_target;
+  is_triggered  bool := NEW.c_workflow_user_state IS NOT DISTINCT FROM 'ready'::e_workflow_user_state
+                    AND NEW.c_too_activation <> 'none'::e_too_activation
+                    AND NOT NEW.c_has_unresolved_too_target;
+
+  -- Guarded on TG_OP exactly as was_triggered is, so OLD is only read on UPDATE.
+  activation_changed bool := TG_OP = 'UPDATE'
+                         AND NEW.c_too_activation IS DISTINCT FROM OLD.c_too_activation;
+
+  superseded_id d_too_trigger_id;
+BEGIN
+  -- A new trigger.
+  IF is_triggered AND NOT was_triggered THEN
+    INSERT INTO t_too_trigger (c_observation_id, c_program_id, c_too_activation)
+    VALUES (NEW.c_observation_id, NEW.c_program_id, NEW.c_too_activation)
+    ON CONFLICT DO NOTHING;
+
+  -- A trigger withdrawal
+  ELSIF was_triggered AND NOT is_triggered THEN
+    UPDATE t_too_trigger
+       SET c_status = 'withdrawn'
+     WHERE c_observation_id = NEW.c_observation_id
+       AND c_status = 'requested';
+
+  -- Update the ToO activation by superseding the existing request.
+  ELSIF was_triggered AND is_triggered AND activation_changed THEN
+    UPDATE t_too_trigger
+       SET c_status = 'superseded'
+     WHERE c_observation_id = NEW.c_observation_id
+       AND c_status = 'requested'
+    RETURNING c_too_trigger_id INTO superseded_id;
+
+    -- superseded_id is null if no row was updated, which was_triggered says
+    -- should not happen.  Not worth an exception: the successor is then simply a
+    -- request with no predecessor, and the invariant self-heals.
+    INSERT INTO t_too_trigger (c_observation_id, c_program_id, c_too_activation, c_supersedes)
+    VALUES (NEW.c_observation_id, NEW.c_program_id, NEW.c_too_activation, superseded_id)
+    ON CONFLICT DO NOTHING;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-------------------------------------------------------------------------------
+-- Notification.
+-------------------------------------------------------------------------------
+
+-- ch_too_trigger_edit payload:
+--   trigger_id, observation_id, program_id, status, too_activation, TG_OP
+--
+-- Subscription filtering happens in memory over the topic element, not in the
+-- database, so anything a subscriber filters on has to be in this payload.
+CREATE OR REPLACE FUNCTION ch_too_trigger_edit()
+  RETURNS trigger AS $$
+BEGIN
+  PERFORM pg_notify(
+    'ch_too_trigger_edit',
+    NEW.c_too_trigger_id       || ',' ||
+    NEW.c_observation_id       || ',' ||
+    NEW.c_program_id           || ',' ||
+    NEW.c_status::text         || ',' ||
+    NEW.c_too_activation::text || ',' ||
+    TG_OP
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-------------------------------------------------------------------------------
+-- Documentation.
+-------------------------------------------------------------------------------
+
+COMMENT ON COLUMN t_too_trigger.c_too_activation IS
+  'The ToO activation this request was made at, written at creation and never '
+  'changed. A change of activation supersedes the request rather than amending '
+  'it. Never ''none'': every trigger is for a Target of Opportunity.';
+
+COMMENT ON COLUMN t_too_trigger.c_supersedes IS
+  'The request this one replaced, null for a first request. The root of the chain '
+  'is when the observation first went live at any activation.';
+
+COMMENT ON TABLE t_too_trigger IS
+  'One row per attempt to activate a ToO observation, maintained by '
+  'too_trigger_track_ready() from the observation user state and its derived '
+  'activation. At most one row per observation is requested at a time '
+  '(i_too_trigger_active); declined, withdrawn and superseded attempts accumulate '
+  'as history.';

--- a/modules/service/src/main/resources/db/migration/V1268__too_trigger_ceiling_withdraw.sql
+++ b/modules/service/src/main/resources/db/migration/V1268__too_trigger_ceiling_withdraw.sql
@@ -1,0 +1,37 @@
+-- Withdraws outstanding ToO trigger requests that a newly lowered ceiling no
+-- longer authorizes.
+--
+-- The proposal's ToO activation ceiling is what the TAC granted.  Until now it
+-- was enforced only on the observation's side: a request already outstanding when
+-- the ceiling moved beneath it simply stayed outstanding, so an observer could be
+-- looking at a live request for a disruption the program is no longer permitted
+-- to cause.  The observation does go 'unapproved' and cannot execute, but that is
+-- computed asynchronously by obscalc and does nothing to the trigger row.
+--
+CREATE FUNCTION too_trigger_ceiling_withdraw()
+  RETURNS trigger AS $$
+BEGIN
+  UPDATE t_too_trigger
+     SET c_status = 'withdrawn'
+   WHERE c_program_id     = NEW.c_program_id
+     AND c_status         = 'requested'
+     AND c_too_activation > NEW.c_too_activation;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- UPDATE only.  A proposal is created before its program has observations worth
+-- triggering, and the two writers that matter -- the TAC editing the ceiling and
+-- the freeze at acceptance -- are both updates.
+CREATE TRIGGER too_trigger_ceiling_withdraw_trigger
+  AFTER UPDATE OF c_too_activation ON t_proposal
+  FOR EACH ROW
+  WHEN (NEW.c_too_activation IS NOT NULL
+        AND NEW.c_too_activation IS DISTINCT FROM OLD.c_too_activation)
+  EXECUTE FUNCTION too_trigger_ceiling_withdraw();
+
+COMMENT ON FUNCTION too_trigger_ceiling_withdraw() IS
+  'Withdraws outstanding ToO trigger requests above a newly lowered explicit '
+  'ceiling. Compares against the activation each request was made at, which for '
+  'a live request is the observation''s current activation.';

--- a/modules/service/src/main/scala/lucuma/odb/data/TooTriggerStatus.scala
+++ b/modules/service/src/main/scala/lucuma/odb/data/TooTriggerStatus.scala
@@ -15,9 +15,20 @@ import lucuma.core.util.Enumerated
  * that a trigger was seen and passed over, with a reason, and clears the
  * observation's user state so the observation returns to `Defined`.
  *
- * `Declined` and `Withdrawn` are terminal, and for the purpose of triggering
- * again are equivalent to never having been triggered: setting the observation
- * `Ready` once more produces a new trigger rather than reviving an old one.
+ * `Superseded` is the one status nobody sets deliberately.  A trigger records
+ * the ToO activation it was requested at, and that value never changes: an
+ * activation at a different level is a different request, because who is
+ * notified, how fast, and what they are expected to drop all differ.  So when the
+ * observation's activation moves while a request is outstanding, the outstanding
+ * row is closed out as `Superseded` and a successor takes its place, linked back
+ * to it by `supersedes`.
+ *
+ * `Declined`, `Withdrawn` and `Superseded` are terminal, and for the purpose of
+ * triggering again are equivalent to never having been triggered: setting the
+ * observation `Ready` once more produces a new trigger rather than reviving an
+ * old one.  They are kept distinct because they answer different questions --
+ * `Withdrawn` means the PI took it back, `Superseded` means the same request
+ * came back wearing a different activation.
  *
  * There is deliberately no status meaning "approved".  The proposal's ToO
  * activation ceiling, frozen at acceptance, is the authorization; a second
@@ -30,6 +41,7 @@ import lucuma.core.util.Enumerated
  * settles.
  */
 enum TooTriggerStatus(val tag: String) derives Enumerated:
-  case Requested extends TooTriggerStatus("requested")
-  case Declined  extends TooTriggerStatus("declined")
-  case Withdrawn extends TooTriggerStatus("withdrawn")
+  case Requested  extends TooTriggerStatus("requested")
+  case Declined   extends TooTriggerStatus("declined")
+  case Withdrawn  extends TooTriggerStatus("withdrawn")
+  case Superseded extends TooTriggerStatus("superseded")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/TooTriggerEditInput.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/TooTriggerEditInput.scala
@@ -6,6 +6,7 @@ package lucuma.odb.graphql
 package input
 
 import cats.syntax.parallel.*
+import lucuma.core.enums.TooActivation
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.odb.data.TooTrigger
@@ -14,17 +15,23 @@ import lucuma.odb.graphql.binding.*
 case class TooTriggerEditInput(
   programId:     Option[Program.Id],
   observationId: Option[Observation.Id],
-  tooTriggerId:  Option[TooTrigger.Id]
+  tooTriggerId:  Option[TooTrigger.Id],
+  tooActivation: Option[WhereOrder[TooActivation]]
 )
 
 object TooTriggerEditInput:
 
   private val TooTriggerIdBinding = gidBinding[TooTrigger.Id]("too trigger")
 
+  // Evaluated in memory against each event rather than compiled into SQL: a
+  // subscription has no query to push a predicate into.
+  private val WhereOrderTooActivation = WhereOrder.inputBinding(TooActivationBinding)
+
   val Binding = ObjectFieldsBinding.rmap:
     case List(
       ProgramIdBinding.Option("programId", rProgramId),
       ObservationIdBinding.Option("observationId", rObservationId),
-      TooTriggerIdBinding.Option("tooTriggerId", rTooTriggerId)
+      TooTriggerIdBinding.Option("tooTriggerId", rTooTriggerId),
+      WhereOrderTooActivation.Option("tooActivation", rTooActivation)
     ) =>
-      (rProgramId, rObservationId, rTooTriggerId).parMapN(apply)
+      (rProgramId, rObservationId, rTooTriggerId, rTooActivation).parMapN(apply)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereTooTrigger.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereTooTrigger.scala
@@ -7,6 +7,7 @@ import cats.syntax.all.*
 import grackle.Path
 import grackle.Predicate
 import grackle.Predicate.*
+import lucuma.core.enums.TooActivation
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.util.Timestamp
@@ -21,6 +22,7 @@ object WhereTooTrigger:
     val WhereObservationIdBinding  = WhereOrder.binding[Observation.Id](path / "observation" / "id", ObservationIdBinding)
     val WhereProgramIdBinding      = WhereOrder.binding[Program.Id](path / "programId", ProgramIdBinding)
     val WhereStatusBinding         = WhereOrder.binding[TooTriggerStatus](path / "status", enumeratedBinding[TooTriggerStatus])
+    val WhereActivationBinding     = WhereOrder.binding[TooActivation](path / "tooActivation", enumeratedBinding[TooActivation])
     val WhereRequestedAtBinding    = WhereOrder.binding[Timestamp](path / "requestedAt", TimestampBinding)
     val WhereRequestedByBinding    = WhereUser.binding(path / "requestedBy")
     val WhereUpdatedAtBinding      = WhereOrder.binding[Timestamp](path / "updatedAt", TimestampBinding)
@@ -36,12 +38,13 @@ object WhereTooTrigger:
         WhereObservationIdBinding.Option("observationId", rObs),
         WhereProgramIdBinding.Option("programId", rProgram),
         WhereStatusBinding.Option("status", rStatus),
+        WhereActivationBinding.Option("tooActivation", rActivation),
         WhereRequestedAtBinding.Option("requestedAt", rRequestedAt),
         WhereRequestedByBinding.Option("requestedBy", rRequestedBy),
         WhereUpdatedAtBinding.Option("updatedAt", rUpdatedAt)
       ) =>
-        (rAND, rOR, rNOT, rId, rObs, rProgram, rStatus, rRequestedAt, rRequestedBy, rUpdatedAt).parMapN:
-          (AND, OR, NOT, id, obs, program, status, requestedAt, requestedBy, updatedAt) =>
+        (rAND, rOR, rNOT, rId, rObs, rProgram, rStatus, rActivation, rRequestedAt, rRequestedBy, rUpdatedAt).parMapN:
+          (AND, OR, NOT, id, obs, program, status, activation, requestedAt, requestedBy, updatedAt) =>
             and(List(
               AND.map(and),
               OR.map(or),
@@ -50,6 +53,7 @@ object WhereTooTrigger:
               obs,
               program,
               status,
+              activation,
               requestedAt,
               requestedBy,
               updatedAt

--- a/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereTooTriggerChronicleEntry.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/input/WhereTooTriggerChronicleEntry.scala
@@ -26,6 +26,8 @@ object WhereTooTriggerChronicleEntry:
     val WhereModProgramId        = WhereBoolean.binding(path / "modProgramId", BooleanBinding)
     val WhereModStatus           = WhereBoolean.binding(path / "modStatus", BooleanBinding)
     val WhereModResolutionReason = WhereBoolean.binding(path / "modResolutionReason", BooleanBinding)
+    val WhereModTooActivation    = WhereBoolean.binding(path / "modTooActivation", BooleanBinding)
+    val WhereModSupersedes       = WhereBoolean.binding(path / "modSupersedes", BooleanBinding)
 
     lazy val WhereTooTriggerChronicleEntryBinding = binding(path)
 
@@ -44,10 +46,12 @@ object WhereTooTriggerChronicleEntry:
         WhereModObservationId.Option("modObservationId", rModObservationId),
         WhereModProgramId.Option("modProgramId", rModProgramId),
         WhereModStatus.Option("modStatus", rModStatus),
-        WhereModResolutionReason.Option("modResolutionReason", rModResolutionReason)
+        WhereModResolutionReason.Option("modResolutionReason", rModResolutionReason),
+        WhereModTooActivation.Option("modTooActivation", rModTooActivation),
+        WhereModSupersedes.Option("modSupersedes", rModSupersedes)
       ) =>
-        (rAND, rOR, rNOT, rId, rUser, rOp, rTimestamp, rTooTriggerId, rModObservationId, rModProgramId, rModStatus, rModResolutionReason).parMapN:
-          (AND, OR, NOT, id, user, op, timestamp, tooTriggerId, modObservationId, modProgramId, modStatus, modResolutionReason) =>
+        (rAND, rOR, rNOT, rId, rUser, rOp, rTimestamp, rTooTriggerId, rModObservationId, rModProgramId, rModStatus, rModResolutionReason, rModTooActivation, rModSupersedes).parMapN:
+          (AND, OR, NOT, id, user, op, timestamp, tooTriggerId, modObservationId, modProgramId, modStatus, modResolutionReason, modTooActivation, modSupersedes) =>
             and(List(
               AND.map(and),
               OR.map(or),
@@ -60,5 +64,7 @@ object WhereTooTriggerChronicleEntry:
               modObservationId,
               modProgramId,
               modStatus,
-              modResolutionReason
+              modResolutionReason,
+              modTooActivation,
+              modSupersedes
             ).flatten)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/QueryMapping.scala
@@ -107,14 +107,14 @@ trait QueryMapping[F[_]] extends Predicates[F] {
       SqlObject("programNote"),
       SqlObject("programNotes"),
       SqlObject("programUsers"),
-      SqlObject("tooTrigger"),
-      SqlObject("tooTriggers"),
-      SqlObject("tooTriggerChronicleEntries"),
       SqlObject("spectroscopyConfigOptions"),
       SqlObject("imagingConfigOptions"),
       SqlObject("target"),
       SqlObject("targetGroup"),
       SqlObject("targets"),
+      SqlObject("tooTrigger"),
+      SqlObject("tooTriggers"),
+      SqlObject("tooTriggerChronicleEntries")
     )
 
   lazy val QueryElaborator: PartialFunction[(TypeRef, String, List[Binding]), Elab[Unit]] =
@@ -140,13 +140,13 @@ trait QueryMapping[F[_]] extends Predicates[F] {
       ProgramNote,
       ProgramNotes,
       ProgramUsers,
-      TooTrigger_,
-      TooTriggers,
-      TooTriggerChronicleEntries,
       SpectroscopyConfigOptions,
       Target,
       TargetGroup,
       Targets,
+      TooTrigger_,
+      TooTriggers,
+      TooTriggerChronicleEntries
     ).combineAll
 
   import Services.Syntax.*

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/SubscriptionMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/SubscriptionMapping.scala
@@ -263,7 +263,12 @@ trait SubscriptionMapping[F[_]] extends Predicates[F] {
           e.canRead(user) &&
           input.flatMap(_.programId).forall(_ === e.programId) &&
           input.flatMap(_.observationId).forall(_ === e.observationId) &&
-          input.flatMap(_.tooTriggerId).forall(_ === e.triggerId)
+          input.flatMap(_.tooTriggerId).forall(_ === e.triggerId) &&
+          // Matched in memory, as obscalcUpdate matches its calculation states.
+          // The activation the event carries is the trigger's own, fixed at
+          // creation -- so a supersession is matched by the predecessor's
+          // activation on the way out and the successor's on the way in.
+          input.flatMap(_.tooActivation).forall(_.matches(e.activation))
         }
         .map { e =>
           Result(

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TooTriggerChronicleEntryMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TooTriggerChronicleEntryMapping.scala
@@ -26,9 +26,13 @@ trait TooTriggerChronicleEntryMapping[F[_]] extends ChronTooTriggerUpdateTable[F
       SqlField("modProgramId",        ChronTooTriggerUpdateTable.Mod.ProgramId),
       SqlField("modStatus",           ChronTooTriggerUpdateTable.Mod.Status),
       SqlField("modResolutionReason", ChronTooTriggerUpdateTable.Mod.ResolutionReason),
+      SqlField("modTooActivation",    ChronTooTriggerUpdateTable.Mod.TooActivation),
+      SqlField("modSupersedes",       ChronTooTriggerUpdateTable.Mod.Supersedes),
 
       SqlField("newObservationId",    ChronTooTriggerUpdateTable.New.ObservationId),
       SqlField("newProgramId",        ChronTooTriggerUpdateTable.New.ProgramId),
       SqlField("newStatus",           ChronTooTriggerUpdateTable.New.Status),
-      SqlField("newResolutionReason", ChronTooTriggerUpdateTable.New.ResolutionReason)
+      SqlField("newResolutionReason", ChronTooTriggerUpdateTable.New.ResolutionReason),
+      SqlField("newTooActivation",    ChronTooTriggerUpdateTable.New.TooActivation),
+      SqlField("newSupersedes",       ChronTooTriggerUpdateTable.New.Supersedes)
     )

--- a/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TooTriggerMapping.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/mapping/TooTriggerMapping.scala
@@ -16,6 +16,11 @@ trait TooTriggerMapping[F[_]] extends TooTriggerTable[F] with ObservationView[F]
       SqlField("programId", TooTriggerTable.ProgramId, hidden = true),
       SqlObject("observation", Join(TooTriggerTable.ObservationId, ObservationView.Id)),
       SqlField("status", TooTriggerTable.Status),
+      SqlField("tooActivation", TooTriggerTable.TooActivation),
+      // Self-join: the request this one replaced.  Null for a first request, and
+      // the chain is finite -- a superseded row is terminal, so it is never itself
+      // superseded again.
+      SqlObject("supersedes", Join(TooTriggerTable.Supersedes, TooTriggerTable.Id)),
       SqlField("resolutionReason", TooTriggerTable.ResolutionReason),
       SqlField("requestedAt", TooTriggerTable.RequestedAt),
       SqlObject("requestedBy", Join(TooTriggerTable.RequestedBy, UserTable.UserId)),

--- a/modules/service/src/main/scala/lucuma/odb/graphql/predicate/TooTriggerPredicates.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/predicate/TooTriggerPredicates.scala
@@ -4,6 +4,7 @@
 package lucuma.odb.graphql.predicate
 
 import grackle.Path
+import lucuma.core.enums.TooActivation
 import lucuma.core.model.Program
 import lucuma.core.util.Timestamp
 import lucuma.odb.data.TooTrigger
@@ -14,5 +15,6 @@ class TooTriggerPredicates(path: Path):
   val programId   = LeafPredicates[Program.Id](path / "programId")
   val observation = ObservationPredicates(path / "observation")
   val status      = LeafPredicates[TooTriggerStatus](path / "status")
+  val activation  = LeafPredicates[TooActivation](path / "tooActivation")
   val requestedAt = LeafPredicates[Timestamp](path / "requestedAt")
   val updatedAt   = LeafPredicates[Timestamp](path / "updatedAt")

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/ChronTooTriggerUpdateTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/ChronTooTriggerUpdateTable.scala
@@ -23,9 +23,13 @@ trait ChronTooTriggerUpdateTable[F[_]] extends BaseMapping[F]:
       val ProgramId        = col("c_mod_program_id",        bool)
       val Status           = col("c_mod_status",            bool)
       val ResolutionReason = col("c_mod_resolution_reason", bool)
+      val TooActivation    = col("c_mod_too_activation",    bool)
+      val Supersedes       = col("c_mod_supersedes",        bool)
 
     object New:
       val ObservationId    = col("c_new_observation_id",    observation_id.opt)
       val ProgramId        = col("c_new_program_id",        program_id.opt)
       val Status           = col("c_new_status",            too_trigger_status.opt)
       val ResolutionReason = col("c_new_resolution_reason", text_nonempty.opt)
+      val TooActivation    = col("c_new_too_activation",    too_activation.opt)
+      val Supersedes       = col("c_new_supersedes",        too_trigger_id.opt)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/table/TooTriggerTable.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/table/TooTriggerTable.scala
@@ -13,6 +13,8 @@ trait TooTriggerTable[F[_]] extends BaseMapping[F]:
     val ObservationId    = col("c_observation_id",    observation_id)
     val ProgramId        = col("c_program_id",        program_id)
     val Status           = col("c_status",            too_trigger_status)
+    val TooActivation    = col("c_too_activation",    too_activation)
+    val Supersedes       = col("c_supersedes",        too_trigger_id.opt)
     val ResolutionReason = col("c_resolution_reason", text_nonempty.opt)
     val RequestedAt      = col("c_requested_at",      core_timestamp)
     val RequestedBy      = col("c_requested_by",      user_id.opt)

--- a/modules/service/src/main/scala/lucuma/odb/graphql/topic/TooTriggerTopic.scala
+++ b/modules/service/src/main/scala/lucuma/odb/graphql/topic/TooTriggerTopic.scala
@@ -7,6 +7,7 @@ import cats.effect.*
 import cats.effect.std.Supervisor
 import cats.implicits.*
 import fs2.concurrent.Topic
+import lucuma.core.enums.TooActivation
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.User
@@ -29,6 +30,11 @@ object TooTriggerTopic:
    * @param observationId the observation the trigger is for
    * @param programId     the observation's program's id
    * @param status        the trigger's status after the edit
+   * @param activation    the ToO activation this request was made at.  Immutable,
+   *                      so this is both the activation at the instant of the
+   *                      event and the one the row will carry forever -- a
+   *                      supersession reports the predecessor's own activation on
+   *                      its closing event, not the successor's.
    * @param editType      creation vs update
    * @param users         users associated with the program (audience for scoping)
    */
@@ -37,23 +43,25 @@ object TooTriggerTopic:
     observationId: Observation.Id,
     programId:     Program.Id,
     status:        TooTriggerStatus,
+    activation:    TooActivation,
     editType:      EditType,
     users:         List[User.Id]
   ) extends TopicElement
 
   private val topic =
-    OdbTopic.define[(TooTrigger.Id, Observation.Id, Program.Id, TooTriggerStatus, EditType), Element](
+    OdbTopic.define[(TooTrigger.Id, Observation.Id, Program.Id, TooTriggerStatus, TooActivation, EditType), Element](
       "TooTrigger",
       id"ch_too_trigger_edit",
       _._3, // program id -> audience is anyone who can read the program
-      (u, users) => Element(u._1, u._2, u._3, u._4, u._5, users)
+      (u, users) => Element(u._1, u._2, u._3, u._4, u._5, u._6, users)
     ) {
-      case Array(_tid, _oid, _pid, _status, _tg_op) =>
+      case Array(_tid, _oid, _pid, _status, _activation, _tg_op) =>
         (
           TooTrigger.Id.parse(_tid),
           Gid[Observation.Id].fromString.getOption(_oid),
           Gid[Program.Id].fromString.getOption(_pid),
           Enumerated[TooTriggerStatus].fromTag(_status),
+          Enumerated[TooActivation].fromTag(_activation),
           EditType.fromTgOp(_tg_op)
         ).tupled
     }

--- a/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
+++ b/modules/service/src/main/scala/lucuma/odb/service/ObservationService.scala
@@ -509,6 +509,34 @@ object ObservationService {
                       .combineAllOption
                       .getOrElse(Result.unit)
 
+            // Checks that no observation is left deriving a ToO activation above
+            // the ceiling its proposal was granted.  Runs after the update, like
+            // the unsplittable check above, so it reads the activation the edit
+            // actually produced rather than predicting it; a failure rolls the
+            // transaction back.
+            //
+            // Only the explicit ceiling is enforced.  The derived default is the
+            // maximum activation among the program's own observations, so nothing
+            // can exceed it and a check against it would reject a PI raising the
+            // first observation's mode before the proposal is even submitted.
+            val validateTooActivationCeiling: ResultT[F, Unit] =
+              ResultT:
+                val af = Statements.validateTooActivationCeiling(which)
+                session
+                  .prepareR(af.fragment.query(observation_id *: too_activation *: too_activation))
+                  .use: p =>
+                    p.stream(af.argument, chunkSize = 1024)
+                     .compile
+                     .toList
+                  .map: problems =>
+                    problems
+                      .map: (oid, activation, ceiling) =>
+                        OdbError.InvalidArgument(
+                          s"Cannot set the scheduling mode for observation $oid: Target of Opportunity activation ${activation.tag.toScreamingSnakeCase} exceeds the maximum ${ceiling.tag.toScreamingSnakeCase} allowed by the proposal.".some
+                        ).asFailure.void
+                      .combineAllOption
+                      .getOrElse(Result.unit)
+
             // Observations in system groups (telluric, etc.) cannot be moved
             // by non-service callers.
             // doing so may introduce orphan groups, at least for tellurics.
@@ -557,6 +585,13 @@ object ObservationService {
                 // then ensure that any existing materialized sequence is compatible.
                 isSplittable = !SET.scheduling.toOption.exists(_.makesUnsplittable)
                 _ <- if isSplittable then ResultT.unit else validateUnsplittableStoredSequence
+
+                // A mode edit is the one path that can raise an observation over
+                // its program's ceiling in a single step, and the one worth
+                // refusing outright: allowing it would put a live request in front
+                // of an observer at an activation the TAC never granted.
+                setsMode = SET.scheduling.toOption.flatMap(_.schedulingMode).isDefined
+                _ <- if setsMode then validateTooActivationCeiling else ResultT.unit
 
                 _ <- ResultT(u.map(u => Services.asSuperUser(updateObservingModes(SET.observingMode, u, e.toOption))).getOrElse(Result.unit.pure[F]))
                 _ <- ResultT(Services.asSuperUser(setTimingWindows(u.foldMap(_.toList), SET.scheduling.flatMap(_.timingWindows).foldPresent(_.orEmpty))))
@@ -1374,6 +1409,24 @@ object ObservationService {
           FROM v_observation
          WHERE c_observation_id = $observation_id
       """.query(bool)
+
+    // Observations whose derived ToO activation exceeds their proposal's explicit
+    // ceiling.  No join to the proposal's derived default is needed, and none to
+    // the asterism: c_too_activation is a generated column on t_observation.
+    def validateTooActivationCeiling(
+      which: AppliedFragment
+    ): AppliedFragment =
+      void"""
+        SELECT
+          o.c_observation_id,
+          o.c_too_activation,
+          p.c_too_activation
+        FROM t_observation o
+        JOIN t_proposal p ON p.c_program_id = o.c_program_id
+        WHERE o.c_observation_id IN (""" |+| which |+| void""")
+          AND p.c_too_activation IS NOT NULL
+          AND o.c_too_activation > p.c_too_activation
+      """
 
     def validateUnsplittableSequence(
       which: AppliedFragment,

--- a/modules/service/src/test/scala/lucuma/odb/graphql/TooTriggerSetupOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/TooTriggerSetupOperations.scala
@@ -5,13 +5,20 @@ package lucuma.odb.graphql
 
 import cats.effect.IO
 import cats.syntax.all.*
+import io.circe.Decoder
+import io.circe.Json
 import io.circe.syntax.*
 import lucuma.core.enums.ConfigurationRequestStatus
 import lucuma.core.enums.ObservationWorkflowState
+import lucuma.core.enums.SchedulingMode
+import lucuma.core.enums.TooActivation
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.model.User
+import lucuma.core.syntax.string.*
+import lucuma.odb.data.TooTrigger
+import lucuma.odb.data.TooTriggerStatus
 import lucuma.odb.graphql.query.ObservingModeSetupOperations
 
 /**
@@ -26,13 +33,13 @@ trait TooTriggerSetupOperations extends ObservingModeSetupOperations { this: Odb
   /** The service user used to drive obscalc; not a GraphQL caller. */
   val tooObscalcUser = TestUsers.service(97)
 
-  def setSchedulingModeAs(user: User, oid: Observation.Id, mode: String): IO[Unit] =
+  def setSchedulingModeAs(user: User, oid: Observation.Id, mode: SchedulingMode): IO[Unit] =
     query(
       user,
       s"""
         mutation {
           updateObservations(input: {
-            SET: { schedulingConstraints: { schedulingMode: $mode } }
+            SET: { schedulingConstraints: { schedulingMode: ${mode.tag.toScreamingSnakeCase} } }
             WHERE: { id: { EQ: ${oid.asJson} } }
           }) {
             observations { id }
@@ -102,7 +109,7 @@ trait TooTriggerSetupOperations extends ObservingModeSetupOperations { this: Odb
     ).void
 
   /** Reads the observation's workflow state together with the transitions it is offered. */
-  def tooWorkflowStateAndTransitions(pid: Program.Id, oid: Observation.Id, user: User): IO[(String, List[String])] =
+  def tooWorkflowStateAndTransitions(pid: Program.Id, oid: Observation.Id, user: User): IO[(ObservationWorkflowState, List[ObservationWorkflowState])] =
     runObscalcUpdateAs(tooObscalcUser, pid, oid) *>
     query(
       user,
@@ -115,10 +122,13 @@ trait TooTriggerSetupOperations extends ObservingModeSetupOperations { this: Odb
       """
     ).map: js =>
       val c = js.hcursor.downFields("observation", "workflow", "value")
-      (c.downField("state").require[String], c.downField("validTransitions").require[List[String]])
+      (
+        c.downField("state").require[ObservationWorkflowState],
+        c.downField("validTransitions").require[List[ObservationWorkflowState]]
+      )
 
   /** Recomputes obscalc, then reads the cached workflow state back. */
-  def tooWorkflowState(pid: Program.Id, oid: Observation.Id, user: User): IO[String] =
+  def tooWorkflowState(pid: Program.Id, oid: Observation.Id, user: User): IO[ObservationWorkflowState] =
     runObscalcUpdateAs(tooObscalcUser, pid, oid) *>
     query(
       user,
@@ -129,7 +139,7 @@ trait TooTriggerSetupOperations extends ObservingModeSetupOperations { this: Odb
           }
         }
       """
-    ).map(_.hcursor.downFields("observation", "workflow", "value", "state").require[String])
+    ).map(_.hcursor.downFields("observation", "workflow", "value", "state").require[ObservationWorkflowState])
 
   /**
    * A program with an accepted proposal and one valid *ordinary* observation,
@@ -138,19 +148,19 @@ trait TooTriggerSetupOperations extends ObservingModeSetupOperations { this: Odb
    * activation and setting it `Ready` records no trigger.
    */
   def createTriggerableObservationAs(
-    pi:    User,
+    user:  User,
     staff: User
   ): IO[(Program.Id, Observation.Id)] =
     for
       cfp <- createGeminiCallForProposalsAs(staff)
-      pid <- createProgramWithNonPartnerPi(pi, "ToO")
-      _   <- addProposal(pi, pid, cfp.some, None)
-      tid <- createTargetWithProfileAs(pi, pid)
-      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
-      _   <- createConfigurationRequestAs(pi, oid).flatMap(setConfigurationRequestStatusAs(staff, _, ConfigurationRequestStatus.Approved))
-      _   <- computeItcResultAs(pi, oid)
-      _   <- addPartnerSplits(pi, pid)
-      _   <- addCoisAs(pi, pid)
+      pid <- createProgramWithNonPartnerPi(user, "ToO")
+      _   <- addProposal(user, pid, cfp.some, None)
+      tid <- createTargetWithProfileAs(user, pid)
+      oid <- createGmosNorthLongSlitObservationAs(user, pid, List(tid))
+      _   <- createConfigurationRequestAs(user, oid).flatMap(setConfigurationRequestStatusAs(staff, _, ConfigurationRequestStatus.Approved))
+      _   <- computeItcResultAs(user, oid)
+      _   <- addPartnerSplits(user, pid)
+      _   <- addCoisAs(user, pid)
       _   <- setProposalStatus(staff, pid, "ACCEPTED")
       _   <- runObscalcUpdateAs(tooObscalcUser, pid, oid)
     yield (pid, oid)
@@ -170,25 +180,102 @@ trait TooTriggerSetupOperations extends ObservingModeSetupOperations { this: Odb
    * `Unapproved`.
    */
   def createTooObservationAs(
-    pi:       User,
+    user:     User,
     staff:    User,
     resolved: Boolean = true,
-    mode:     String  = "UNINTERRUPTIBLE"
+    mode:     SchedulingMode = SchedulingMode.Uninterruptible
   ): IO[(Program.Id, Observation.Id, Target.Id)] =
     for
       cfp <- createGeminiCallForProposalsAs(staff)
-      pid <- createProgramWithNonPartnerPi(pi, "ToO")
-      _   <- addProposal(pi, pid, cfp.some, None)
-      tid <- createOpportunityTargetAs(pi, pid)
-      _   <- resolveOpportunityTargetAs(pi, tid).whenA(resolved)
-      oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
-      _   <- createConfigurationRequestAs(pi, oid).flatMap(setConfigurationRequestStatusAs(staff, _, ConfigurationRequestStatus.Approved))
-      _   <- computeItcResultAs(pi, oid)
-      _   <- setSchedulingModeAs(pi, oid, mode)
-      _   <- addPartnerSplits(pi, pid)
-      _   <- addCoisAs(pi, pid)
+      pid <- createProgramWithNonPartnerPi(user, "ToO")
+      _   <- addProposal(user, pid, cfp.some, None)
+      tid <- createOpportunityTargetAs(user, pid)
+      _   <- resolveOpportunityTargetAs(user, tid).whenA(resolved)
+      oid <- createGmosNorthLongSlitObservationAs(user, pid, List(tid))
+      _   <- createConfigurationRequestAs(user, oid).flatMap(setConfigurationRequestStatusAs(staff, _, ConfigurationRequestStatus.Approved))
+      _   <- computeItcResultAs(user, oid)
+      _   <- setSchedulingModeAs(user, oid, mode)
+      _   <- addPartnerSplits(user, pid)
+      _   <- addCoisAs(user, pid)
       _   <- setProposalStatus(staff, pid, "ACCEPTED")
       _   <- runObscalcUpdateAs(tooObscalcUser, pid, oid)
     yield (pid, oid, tid)
 
+  case class Trigger(
+    id:         TooTrigger.Id,
+    status:     TooTriggerStatus,
+    activation: TooActivation,
+    supersedes: Option[TooTrigger.Id],
+    resolution: Option[String]
+  )
+
+  object Trigger:
+    given Decoder[Trigger] =
+      Decoder.instance: c =>
+        for
+          id         <- c.downField("id").as[TooTrigger.Id]
+          status     <- c.downField("status").as[TooTriggerStatus]
+          activation <- c.downField("tooActivation").as[TooActivation]
+          s          <- c.downField("supersedes").as[Option[Json]]
+          supersedes <- s.traverse(_.hcursor.downField("id").as[TooTrigger.Id])
+          reason     <- c.downField("resolutionReason").as[Option[String]]
+        yield Trigger(id, status, activation, supersedes, reason)
+
+  def getTooTriggersAs(user: User, oid: Observation.Id): IO[List[Trigger]] =
+    query(
+      user,
+      s"""
+        query {
+          tooTriggers(WHERE: { observationId: { EQ: ${oid.asJson} } }) {
+            matches {
+              id
+              status
+              tooActivation
+              supersedes { id }
+              resolutionReason
+            }
+          }
+        }
+      """
+    ).map:
+      _.hcursor.downFields("tooTriggers", "matches").require[List[Json]].map: j =>
+        j.hcursor.require[Trigger]
+
+  /** The live request. */
+  def getRequestedTooTriggerAs(user: User, oid: Observation.Id): IO[Trigger] =
+    query(
+      user,
+      s"""
+        query {
+          tooTriggers(WHERE: { observationId: { EQ: ${oid.asJson} }, status: { EQ: REQUESTED } }) {
+            matches {
+              id
+              status
+              tooActivation
+              supersedes { id }
+              resolutionReason
+            }
+          }
+        }
+      """
+    ).map: js =>
+      js.hcursor.downFields("tooTriggers", "matches").require[List[Json]].head.hcursor.require[Trigger]
+
+  def declineQuery(rid: TooTrigger.Id, reason: Option[String] = None): String =
+    s"""
+      mutation {
+        declineTooTrigger(input: {
+          tooTriggerId: "$rid"
+          ${reason.fold("")(r => s"""reason: "$r"""")}
+        }) {
+          tooTrigger { status resolutionReason }
+        }
+      }
+    """
+
+  def declineTooTrigger(user: User, rid: TooTrigger.Id, reason: Option[String] = None): IO[Unit] =
+    query(
+      user  = user,
+      query = declineQuery(rid, reason)
+    ).void
 }

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/ObservingModeSetupOperations.scala
@@ -231,6 +231,12 @@ trait ObservingModeSetupOperations extends DatabaseOperations { this: OdbSuite =
    * program's observations and frozen when the proposal is accepted, and several
    * fixtures accept the proposal before the observation exists, which would
    * freeze it at NONE.
+   *
+   * It goes to the *top* of the ladder rather than a middle rung.  This used to
+   * write 'rapid', which is one short: an observation whose mode is INTERRUPTING
+   * derives INTERRUPTING, exceeds the ceiling, and lands `Unapproved` -- so it can
+   * never be offered `Ready`, and any fixture built at that mode is untriggerable
+   * for a reason that has nothing to do with what the test is about.
    */
   private def raiseTooCeilingForOpportunityTargets(
     oid:  Observation.Id,
@@ -253,7 +259,7 @@ trait ObservingModeSetupOperations extends DatabaseOperations { this: OdbSuite =
         s.prepareR(
           sql"""
             UPDATE t_proposal
-            SET c_too_activation = 'rapid'
+            SET c_too_activation = 'interrupting'
             WHERE c_program_id = (
               SELECT c_program_id FROM t_observation WHERE c_observation_id = $observation_id
             )

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/tooActivationCeiling.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/tooActivationCeiling.scala
@@ -5,6 +5,7 @@ package lucuma.odb.graphql
 package query
 
 import cats.effect.IO
+import cats.syntax.either.*
 import cats.syntax.option.*
 import io.circe.syntax.*
 import lucuma.core.enums.GeminiCallForProposalsType.RegularSemester
@@ -75,6 +76,46 @@ class tooActivationCeiling extends OdbSuite with TooTriggerSetupOperations:
         }
       """
     ).void
+
+  /** Sets the explicit ceiling, which after acceptance is what enforcement uses. */
+  private def setExplicitCeiling(pid: Program.Id, ceiling: String): IO[Unit] =
+    query(
+      staff,
+      s"""
+        mutation {
+          updateProposal(input: {
+            programId: "$pid"
+            SET: { gemini: { queue: { explicitTooActivationCeiling: $ceiling } } }
+          }) {
+            proposal { gemini { ... on Queue { explicitTooActivationCeiling } } }
+          }
+        }
+      """
+    ).void
+
+  private def setSchedulingModeQuery(oid: Observation.Id, mode: String): String =
+    s"""
+      mutation {
+        updateObservations(input: {
+          SET: { schedulingConstraints: { schedulingMode: $mode } }
+          WHERE: { id: { EQ: ${oid.asJson} } }
+        }) {
+          observations { id }
+        }
+      }
+    """
+
+  private def schedulingMode(oid: Observation.Id): IO[String] =
+    query(
+      pi,
+      s"""
+        query {
+          observation(observationId: ${oid.asJson}) {
+            schedulingConstraints { schedulingMode }
+          }
+        }
+      """
+    ).map(_.hcursor.downFields("observation", "schedulingConstraints", "schedulingMode").require[String])
 
   private def proposalCeiling(pid: Program.Id): IO[String] =
     query(
@@ -184,17 +225,28 @@ class tooActivationCeiling extends OdbSuite with TooTriggerSetupOperations:
       before <- proposalCeiling(p)
       t      <- createTargetWithProfileAs(pi, p)
       o2     <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
-      _      <- deriveTooActivation(p, o2, "INTERRUPTING")
+      // The mode goes first, while the asterism is still ordinary: the activation
+      // derives NONE, so the ceiling guard has nothing to object to.  Setting the
+      // mode after the opportunity target were added would be refused outright --
+      // which is the point of the guard, and why this reaches INTERRUPTING through
+      // the asterism instead.
+      _      <- setSchedulingMode(o2, "INTERRUPTING")
+      tid    <- createOpportunityTargetAs(pi, p)
+      _      <- resolveOpportunityTargetAs(pi, tid)
+      _      <- addOpportunityTargetToAsterism(o2, tid)
       after  <- proposalCeiling(p)
     yield
       assertEquals(before, "RAPID")
       assertEquals(after,  "RAPID") // frozen: the new observation does not raise its own ceiling
 
+  // Raising the mode over the ceiling is refused outright now, so the only way
+  // to reach this state is for the ceiling to move beneath a settled observation.
+  // The validator still matters: the ceiling is not the only thing that can move.
   test("an observation exceeding the frozen ceiling is flagged and cannot become ready"):
     for
       (p, o) <- setup("RAPID")
       _      <- acceptProposal(staff, p)
-      _      <- setSchedulingMode(o, "INTERRUPTING")
+      _      <- setExplicitCeiling(p, "STANDARD")
       _      <- runObscalcUpdateAs(service, p, o)
       codes  <- validationCodes(o)
       state  <- workflowState(o)
@@ -210,3 +262,87 @@ class tooActivationCeiling extends OdbSuite with TooTriggerSetupOperations:
       _      <- runObscalcUpdateAs(service, p, o)
       codes  <- validationCodes(o)
     yield assert(!codes.contains("TOO_ACTIVATION_UNAPPROVED"), s"unexpected ceiling violation: $codes")
+
+  test("a PI may lower the mode after the ceiling moves beneath them, recovering the observation"):
+    for
+      (p, o)  <- setup("RAPID")
+      _       <- acceptProposal(staff, p)
+      _       <- setExplicitCeiling(p, "STANDARD")
+      _       <- runObscalcUpdateAs(service, p, o)
+      before  <- validationCodes(o)
+      state   <- workflowState(o)
+      // UNAPPROVED is a pre-execution state, so the observation is still editable
+      // and the PI is not stranded above a ceiling they cannot come back under.
+      // It has to come all the way down to a compliant mode: while the derived
+      // activation is over the ceiling, any mode leaving it over is refused.
+      _       <- setSchedulingMode(o, "UNCONSTRAINED")
+      _       <- runObscalcUpdateAs(service, p, o)
+      after   <- validationCodes(o)
+    yield
+      assertEquals(state, "UNAPPROVED")
+      assert(before.contains("TOO_ACTIVATION_UNAPPROVED"), s"expected ceiling violation, got $before")
+      // The ceiling violation clears.  This fixture has no approved configuration,
+      // so the observation stays UNAPPROVED for that unrelated reason -- what is
+      // being pinned is that the ceiling no longer contributes.
+      assert(!after.contains("TOO_ACTIVATION_UNAPPROVED"), s"expected recovery, got $after")
+
+  // -- The guard on direct mode edits ---------------------------------------
+
+  private def ceilingRefusal(oid: Observation.Id, activation: String, ceiling: String) =
+    List(
+      s"Cannot set the scheduling mode for observation $oid: Target of Opportunity activation $activation exceeds the maximum $ceiling allowed by the proposal."
+    ).asLeft
+
+  test("raising the mode above the frozen ceiling is refused"):
+    for
+      (p, o) <- setup("RAPID")
+      _      <- acceptProposal(staff, p)
+      _      <- expect(pi, setSchedulingModeQuery(o, "INTERRUPTING"), ceilingRefusal(o, "INTERRUPTING", "RAPID"))
+    yield ()
+
+  test("the refusal leaves the observation untouched"):
+    for
+      (p, o) <- setup("RAPID")
+      _      <- acceptProposal(staff, p)
+      before <- schedulingMode(o)
+      _      <- expect(pi, setSchedulingModeQuery(o, "INTERRUPTING"), ceilingRefusal(o, "INTERRUPTING", "RAPID"))
+      after  <- schedulingMode(o)
+    yield
+      // The check runs after the update inside the transaction, so a violation
+      // has to roll the whole thing back rather than leave it half applied.
+      assertEquals(before, "UNINTERRUPTIBLE")
+      assertEquals(after, before)
+
+  test("a mode at or below the frozen ceiling is accepted"):
+    for
+      (p, o) <- setup("RAPID")
+      _      <- acceptProposal(staff, p)
+      _      <- setSchedulingMode(o, "UNCONSTRAINED")
+      mode   <- schedulingMode(o)
+    yield assertEquals(mode, "UNCONSTRAINED")
+
+  test("the ceiling does not constrain the mode before it is frozen"):
+    for
+      (p, o) <- setup("RAPID")
+      // No acceptance, so no explicit ceiling.  The derived one is the maximum
+      // over the program's own observations, which this edit is raising -- checking
+      // against it would refuse a PI for describing their own proposal.
+      _      <- setSchedulingMode(o, "INTERRUPTING")
+      mode   <- schedulingMode(o)
+      too    <- proposalCeiling(p)
+    yield
+      assertEquals(mode, "INTERRUPTING")
+      assertEquals(too, "INTERRUPTING")
+
+  test("a non-ToO observation may take any mode, whatever the ceiling"):
+    for
+      (p, o) <- setup("RAPID")
+      _      <- acceptProposal(staff, p)
+      t      <- createTargetWithProfileAs(pi, p)
+      o2     <- createGmosNorthLongSlitObservationAs(pi, p, List(t))
+      // No opportunity target, so the activation derives NONE whatever the mode.
+      // INTERRUPTING is invalid for a different reason -- it needs a ToO target --
+      // but that is the workflow's business, not the ceiling's.
+      _      <- setSchedulingMode(o2, "UNINTERRUPTIBLE")
+      mode   <- schedulingMode(o2)
+    yield assertEquals(mode, "UNINTERRUPTIBLE")

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/tooTriggerActivation.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/tooTriggerActivation.scala
@@ -1,0 +1,318 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package lucuma.odb.graphql
+package query
+
+import cats.effect.IO
+import cats.syntax.either.*
+import io.circe.Json
+import io.circe.syntax.*
+import lucuma.core.enums.ObservationWorkflowState
+import lucuma.core.enums.SchedulingMode
+import lucuma.core.enums.TooActivation
+import lucuma.core.enums.TooActivation.Interrupting
+import lucuma.core.enums.TooActivation.Rapid
+import lucuma.core.enums.TooActivation.Standard
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.syntax.string.*
+import lucuma.odb.data.TooTrigger
+import lucuma.odb.data.TooTriggerStatus
+import lucuma.odb.data.TooTriggerStatus.*
+
+/**
+ * The activation a trigger was requested at, and what happens when the
+ * observation's activation moves while the request is outstanding.
+ *
+ * The activation is written when the trigger is created and never changes: a
+ * request at a different activation is a different request, since who is
+ * notified and how fast both differ.  So a change supersedes the outstanding row
+ * and creates a successor linked back to it, rather than amending it in place.
+ *
+ * All three ToO activations are reachable here because the fixture raises the
+ * proposal's ceiling to the top of the ladder; the ceiling rule itself is covered
+ * by tooActivationCeiling, not here.
+ */
+class tooTriggerActivation extends ExecutionTestSupportForGmos with TooTriggerSetupOperations:
+
+  private def setState(oid: Observation.Id, s: ObservationWorkflowState): IO[Unit] =
+    setTooWorkflowState(pi, oid, s)
+
+  private def setMode(oid: Observation.Id, mode: SchedulingMode): IO[Unit] =
+    setSchedulingModeAs(pi, oid, mode)
+
+  private def requestedTrigger(oid: Observation.Id): IO[(TooTrigger.Id, TooActivation, Option[TooTrigger.Id])] =
+    getRequestedTooTriggerAs(pi, oid).map: t =>
+      (t.id, t.activation, t.supersedes)
+
+  private def allTriggers(oid: Observation.Id): IO[List[(TooTriggerStatus, TooActivation)]] =
+    getTooTriggersAs(pi, oid).map: ts =>
+      ts.map(t => (t.status, t.activation))
+
+  private def schedulingModeQuery(oid: Observation.Id, mode: SchedulingMode): String =
+    s"""
+      mutation {
+        updateObservations(input: {
+          SET: { schedulingConstraints: { schedulingMode: ${mode.tag.toScreamingSnakeCase} } }
+          WHERE: { id: { EQ: ${oid.asJson} } }
+        }) {
+          observations { id }
+        }
+      }
+    """
+
+  test("a trigger records the activation it was requested at"):
+    for
+      (_, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _           <- setState(oid, ObservationWorkflowState.Ready)
+      ts          <- allTriggers(oid)
+    yield assertEquals(ts, List(Requested -> Rapid))
+
+  test("an interrupting ToO records a trigger at the top of the ladder"):
+    for
+      (_, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Interrupting)
+      _           <- setState(oid, ObservationWorkflowState.Ready)
+      ts          <- allTriggers(oid)
+    yield assertEquals(ts, List(Requested -> Interrupting))
+
+  test("changing the activation supersedes the request and creates a successor"):
+    for
+      (_, oid, _)       <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _                 <- setState(oid, ObservationWorkflowState.Ready)
+      (first, _, _)     <- requestedTrigger(oid)
+      _                 <- setMode(oid, SchedulingMode.Unconstrained)
+      ts                <- allTriggers(oid)
+      (_, act, prevOpt) <- requestedTrigger(oid)
+    yield
+      assertEquals(ts, List(Superseded -> Rapid, Requested -> Standard))
+      // The successor carries the new activation and points back at the row it replaced.
+      assertEquals(act, Standard)
+      assertEquals(prevOpt, Some(first))
+
+  // The case that motivated the whole activation-on-the-trigger design: a live
+  // rapid request is escalated to interrupting.
+  test("escalating a rapid ToO to interrupting supersedes it and requests a new one"):
+    for
+      (_, oid, _)    <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _              <- setState(oid, ObservationWorkflowState.Ready)
+      (first, _, _)  <- requestedTrigger(oid)
+      _              <- setMode(oid, SchedulingMode.Interrupting)
+      ts             <- allTriggers(oid)
+      (_, act, prev) <- requestedTrigger(oid)
+    yield
+      assertEquals(ts, List(Superseded -> Rapid, Requested -> Interrupting))
+      // The new request carries the escalated activation and points back at the
+      // one it replaced; the closed-out row still says RAPID, which is what was
+      // actually asked for at the time.
+      assertEquals(act, Interrupting)
+      assertEquals(prev, Some(first))
+
+  test("a superseded request keeps the activation it was made at"):
+    for
+      (_, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _           <- setState(oid, ObservationWorkflowState.Ready)
+      _           <- setMode(oid, SchedulingMode.Unconstrained)
+      _           <- setMode(oid, SchedulingMode.Uninterruptible)
+      ts          <- allTriggers(oid)
+    yield
+      // Each closed-out row still says what it was requested at; they are records
+      // of what was asked for, not views of what the observation is now.
+      assertEquals(
+        ts,
+        List(Superseded -> Rapid, Superseded -> Standard, Requested -> Rapid)
+      )
+
+  test("exactly one request is live through a chain of changes"):
+    for
+      (_, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _           <- setState(oid, ObservationWorkflowState.Ready)
+      _           <- setMode(oid, SchedulingMode.Unconstrained)
+      _           <- setMode(oid, SchedulingMode.Uninterruptible)
+      _           <- setMode(oid, SchedulingMode.Unconstrained)
+      ts          <- allTriggers(oid)
+    yield
+      assertEquals(ts.count(_._1 == Requested), 1)
+      assertEquals(ts.count(_._1 == Superseded), 3)
+
+  test("the chain walks back to the first request"):
+    for
+      (_, oid, _)    <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _              <- setState(oid, ObservationWorkflowState.Ready)
+      (first, _, _)  <- requestedTrigger(oid)
+      _              <- setMode(oid, SchedulingMode.Unconstrained)
+      (second, _, _) <- requestedTrigger(oid)
+      _              <- setMode(oid, SchedulingMode.Interrupting)
+      js             <- query(
+                          pi,
+                          s"""
+                            query {
+                              tooTriggers(WHERE: { observationId: { EQ: ${oid.asJson} }, status: { EQ: REQUESTED } }) {
+                                matches {
+                                  id
+                                  tooActivation
+                                  supersedes {
+                                    id
+                                    tooActivation
+                                    supersedes { id tooActivation supersedes { id } }
+                                  }
+                                }
+                              }
+                            }
+                          """
+                        )
+    yield
+      val c = js.hcursor.downFields("tooTriggers", "matches").require[List[Json]].head.hcursor
+      assertEquals(c.downField("tooActivation").require[TooActivation], Interrupting)
+      assertEquals(c.downFields("supersedes", "id").require[TooTrigger.Id], second)
+      assertEquals(c.downFields("supersedes", "tooActivation").require[TooActivation], Standard)
+      assertEquals(c.downFields("supersedes", "supersedes", "id").require[TooTrigger.Id], first)
+      assertEquals(c.downFields("supersedes", "supersedes", "tooActivation").require[TooActivation], Rapid)
+      // The root of the chain is the first request, which replaced nothing.
+      assertEquals(c.downFields("supersedes", "supersedes", "supersedes").require[Option[Json]], None)
+
+  test("a mode change that does not move the activation supersedes nothing"):
+    for
+      (_, oid, _)    <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _              <- setState(oid, ObservationWorkflowState.Ready)
+      _              <- setMode(oid, SchedulingMode.Unconstrained)
+      (before, _, _) <- requestedTrigger(oid)
+      // Both UNCONSTRAINED and NO_SPLITTING derive STANDARD, so nothing changes.
+      _              <- setMode(oid, SchedulingMode.NoSplitting)
+      ts             <- allTriggers(oid)
+      (after, _, _)  <- requestedTrigger(oid)
+    yield
+      assertEquals(ts.count(_._1 == Superseded), 1)
+      assertEquals(after, before)
+
+  test("clearing Ready withdraws rather than supersedes"):
+    for
+      (_, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _           <- setState(oid, ObservationWorkflowState.Ready)
+      _           <- setState(oid, ObservationWorkflowState.Defined)
+      ts          <- allTriggers(oid)
+    yield assertEquals(ts, List(Withdrawn -> Rapid))
+
+  test("a request made afresh after a withdrawal supersedes nothing"):
+    for
+      (_, oid, _)    <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _              <- setState(oid, ObservationWorkflowState.Ready)
+      _              <- setState(oid, ObservationWorkflowState.Defined)
+      _              <- setMode(oid, SchedulingMode.Unconstrained)
+      _              <- setState(oid, ObservationWorkflowState.Ready)
+      (_, act, prev) <- requestedTrigger(oid)
+    yield
+      // The activation moved while nothing was outstanding, so this is a first
+      // request at STANDARD, not a successor to the withdrawn one.
+      assertEquals(act, Standard)
+      assertEquals(prev, None)
+
+  test("changing the activation while not triggered records nothing"):
+    for
+      (_, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _           <- setMode(oid, SchedulingMode.Unconstrained)
+      ts          <- allTriggers(oid)
+    yield assertEquals(ts, Nil)
+
+  test("filtering on activation selects the requests that cannot wait for the queue"):
+    for
+      (_, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _           <- setState(oid, ObservationWorkflowState.Ready)
+      _           <- setMode(oid, SchedulingMode.Unconstrained)
+      _           <- setMode(oid, SchedulingMode.Interrupting)
+      js          <- query(
+                       pi,
+                       s"""
+                         query {
+                           tooTriggers(WHERE: {
+                             observationId: { EQ: ${oid.asJson} }
+                             tooActivation: { GTE: RAPID }
+                           }) {
+                             matches { tooActivation }
+                           }
+                         }
+                       """
+                     )
+    yield
+      val acts = js.hcursor.downFields("tooTriggers", "matches").require[List[Json]]
+        .map(_.hcursor.downField("tooActivation").require[String]).sorted
+      // The STANDARD request is excluded.  The ordering is what makes this
+      // expressible on the query side, where the filter is real SQL.  RAPID does
+      // not displace work already under way -- only INTERRUPTING does -- but both
+      // are wanted sooner than the queue would get to them.
+      assertEquals(acts, List("INTERRUPTING", "RAPID"))
+
+  test("an executing observation's mode cannot be changed, so its trigger cannot be superseded"):
+    for
+      (pid, oid, _)  <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _              <- setState(oid, ObservationWorkflowState.Ready)
+      (before, _, _) <- requestedTrigger(oid)
+      // One completed step is enough to be under way without finishing.
+      v              <- recordVisitAs(serviceUser, oid)
+      s              <- firstScienceAtomStepIds(serviceUser, oid)
+      _              <- addEndStepEvent(s.head, v)
+      state          <- tooWorkflowState(pid, oid, pi)
+      // Scheduling edits are limited to the pre-execution states, and the refusal
+      // is explicit rather than a silently empty update.
+      _              <- expect(
+                          pi,
+                          schedulingModeQuery(oid, SchedulingMode.Unconstrained),
+                          expected = List(
+                            s"Observation $oid is ineligible for this operation due to its workflow state (Ongoing with allowed transition to Completed)."
+                          ).asLeft
+                        )
+      ts             <- allTriggers(oid)
+      (after, _, _)  <- requestedTrigger(oid)
+    yield
+      assertEquals(state, ObservationWorkflowState.Ongoing)
+      // The live request survives, at the activation it was made at: a running
+      // observation cannot have its trigger replaced out from under it.
+      assertEquals(ts, List(Requested -> Rapid))
+      assertEquals(after, before)
+
+  /** Lowers (or raises) the proposal's explicit ceiling, which only staff may do. */
+  private def setCeiling(pid: Program.Id, ceiling: String): IO[Unit] =
+    query(
+      staff,
+      s"""
+        mutation {
+          updateProposal(input: {
+            programId: "$pid"
+            SET: { gemini: { queue: { explicitTooActivationCeiling: $ceiling } } }
+          }) {
+            proposal { gemini { ... on Queue { explicitTooActivationCeiling } } }
+          }
+        }
+      """
+    ).void
+
+  test("lowering the ceiling withdraws a request it no longer authorizes"):
+    for
+      (pid, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _             <- setState(oid, ObservationWorkflowState.Ready)
+      before        <- allTriggers(oid)
+      // The TAC takes back what it granted.  Nothing about the observation
+      // changes, so only the proposal-side trigger can act on this.
+      _             <- setCeiling(pid, "STANDARD")
+      after         <- allTriggers(oid)
+    yield
+      assertEquals(before, List(Requested -> Rapid))
+      assertEquals(after, List(Withdrawn -> Rapid))
+
+  test("lowering the ceiling leaves a request it still authorizes alone"):
+    for
+      (pid, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Unconstrained)
+      _             <- setState(oid, ObservationWorkflowState.Ready)
+      _             <- setCeiling(pid, "STANDARD")
+      ts            <- allTriggers(oid)
+    yield
+      // STANDARD is at the ceiling, not above it.
+      assertEquals(ts, List(Requested -> Standard))
+
+  test("raising the ceiling withdraws nothing"):
+    for
+      (pid, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+      _             <- setState(oid, ObservationWorkflowState.Ready)
+      _             <- setCeiling(pid, "INTERRUPTING")
+      ts            <- allTriggers(oid)
+    yield assertEquals(ts, List(Requested -> Rapid))

--- a/modules/service/src/test/scala/lucuma/odb/graphql/query/tooTriggerWorkflow.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/query/tooTriggerWorkflow.scala
@@ -10,8 +10,12 @@ import cats.syntax.option.*
 import io.circe.literal.*
 import io.circe.syntax.*
 import lucuma.core.enums.ObservationWorkflowState
+import lucuma.core.enums.SchedulingMode
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
+import lucuma.odb.data.TooTrigger
+import lucuma.odb.data.TooTriggerStatus
+import lucuma.odb.data.TooTriggerStatus.*
 
 /**
  * The Target-of-Opportunity trigger, derived from the observation's workflow
@@ -21,105 +25,71 @@ import lucuma.core.model.Program
  */
 class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetupOperations:
 
-  private def triggers(oid: Observation.Id): IO[List[(String, Option[String])]] =
-    query(
-      pi,
-      s"""
-        query {
-          tooTriggers(WHERE: { observationId: { EQ: ${oid.asJson} } }) {
-            matches { status resolutionReason }
-          }
-        }
-      """
-    ).map:
-      _.hcursor.downFields("tooTriggers", "matches").require[List[io.circe.Json]].map: j =>
-        (
-          j.hcursor.downField("status").require[String],
-          j.hcursor.downField("resolutionReason").require[Option[String]]
-        )
+  private def triggers(oid: Observation.Id): IO[List[(TooTriggerStatus, Option[String])]] =
+    getTooTriggersAs(pi, oid).map: ts =>
+      ts.map(t => (t.status, t.resolution))
 
-  private def triggerId(oid: Observation.Id): IO[String] =
-    query(
-      pi,
-      s"""
-        query {
-          tooTriggers(WHERE: { observationId: { EQ: ${oid.asJson} }, status: { EQ: REQUESTED } }) {
-            matches { id }
-          }
-        }
-      """
-    ).map(_.hcursor.downFields("tooTriggers", "matches").require[List[io.circe.Json]].head.hcursor.downField("id").require[String])
+  private def triggerId(oid: Observation.Id): IO[TooTrigger.Id] =
+    getRequestedTooTriggerAs(pi, oid).map(_._1)
 
-  private def declineQuery(rid: String, reason: Option[String] = None): String =
-    s"""
-      mutation {
-        declineTooTrigger(input: {
-          tooTriggerId: "$rid"
-          ${reason.fold("")(r => s"""reason: "$r"""")}
-        }) {
-          tooTrigger { status resolutionReason }
-        }
-      }
-    """
-
-  private def state(pid: Program.Id, oid: Observation.Id): IO[String] =
+  private def getWorkflowState(pid: Program.Id, oid: Observation.Id): IO[ObservationWorkflowState] =
     tooWorkflowState(pid, oid, pi)
 
-  private def setState(oid: Observation.Id, s: ObservationWorkflowState): IO[Unit] =
+  private def setWorkflowState(oid: Observation.Id, s: ObservationWorkflowState): IO[Unit] =
     setTooWorkflowState(pi, oid, s)
 
   test("setting a ToO observation Ready requests a trigger"):
     for
       (pid, oid, _) <- createTooObservationAs(pi, staff)
       before     <- triggers(oid)
-      _          <- setState(oid, ObservationWorkflowState.Ready)
+      _          <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       after      <- triggers(oid)
-      s          <- state(pid, oid)
+      s          <- getWorkflowState(pid, oid)
     yield
       assertEquals(before, Nil)
-      assertEquals(after, List(("REQUESTED", None)))
-      assertEquals(s, "READY")
+      assertEquals(after, List((Requested, None)))
+      assertEquals(s, ObservationWorkflowState.Ready)
 
   test("clearing Ready withdraws the trigger"):
     for
       (pid, oid, _) <- createTooObservationAs(pi, staff)
-      _          <- setState(oid, ObservationWorkflowState.Ready)
-      _          <- setState(oid, ObservationWorkflowState.Defined)
+      _          <- setWorkflowState(oid, ObservationWorkflowState.Ready)
+      _          <- setWorkflowState(oid, ObservationWorkflowState.Defined)
       ts         <- triggers(oid)
-      s          <- state(pid, oid)
+      s          <- getWorkflowState(pid, oid)
     yield
-      assertEquals(ts, List(("WITHDRAWN", None)))
-      assertEquals(s, "DEFINED")
+      assertEquals(ts, List((Withdrawn, None)))
+      assertEquals(s, ObservationWorkflowState.Defined)
 
   test("marking a triggered observation Inactive withdraws the trigger"):
     for
       (pid, oid, _) <- createTooObservationAs(pi, staff)
-      _          <- setState(oid, ObservationWorkflowState.Ready)
-      _          <- setState(oid, ObservationWorkflowState.Inactive)
+      _          <- setWorkflowState(oid, ObservationWorkflowState.Ready)
+      _          <- setWorkflowState(oid, ObservationWorkflowState.Inactive)
       ts         <- triggers(oid)
-      s          <- state(pid, oid)
+      s          <- getWorkflowState(pid, oid)
     yield
-      assertEquals(ts, List(("WITHDRAWN", None)))
-      assertEquals(s, "INACTIVE")
+      assertEquals(ts, List((Withdrawn, None)))
+      assertEquals(s, ObservationWorkflowState.Inactive)
 
   test("re-triggering after a withdrawal creates a second trigger, keeping the first as history"):
     for
       (_, oid, _) <- createTooObservationAs(pi, staff)
-      _        <- setState(oid, ObservationWorkflowState.Ready)
-      _        <- setState(oid, ObservationWorkflowState.Defined)
-      _        <- setState(oid, ObservationWorkflowState.Ready)
+      _        <- setWorkflowState(oid, ObservationWorkflowState.Ready)
+      _        <- setWorkflowState(oid, ObservationWorkflowState.Defined)
+      _        <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       ts       <- triggers(oid)
-    yield assertEquals(ts.map(_._1).sorted, List("REQUESTED", "WITHDRAWN"))
+    yield assertEquals(ts.map(_._1), List(Withdrawn, Requested))
 
   test("a non-ToO observation set Ready records no trigger"):
     for
       (pid, oid) <- createTriggerableObservationAs(pi, staff)
-      _          <- setState(oid, ObservationWorkflowState.Ready)
+      _          <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       ts         <- triggers(oid)
-      s          <- state(pid, oid)
+      s          <- getWorkflowState(pid, oid)
     yield
       assertEquals(ts, Nil)
-      assertEquals(s, "READY")
+      assertEquals(s, ObservationWorkflowState.Ready)
 
   // The activation is derived from the asterism now, so what used to be
   // "lower the activation" is "remove the opportunity target" -- the
@@ -127,25 +97,25 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
   test("removing the opportunity target while Ready withdraws the trigger"):
     for
       (_, oid, tid) <- createTooObservationAs(pi, staff)
-      _             <- setState(oid, ObservationWorkflowState.Ready)
+      _             <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       _             <- editAsterismAs(pi, oid, add = Nil, del = List(tid))
       ts            <- triggers(oid)
-    yield assertEquals(ts, List(("WITHDRAWN", None)))
+    yield assertEquals(ts, List((Withdrawn, None)))
 
   test("adding a resolved opportunity target while Ready requests a trigger"):
     for
       (pid, oid) <- createTriggerableObservationAs(pi, staff)
       tid        <- createOpportunityTargetAs(pi, pid)
       _          <- resolveOpportunityTargetAs(pi, tid)
-      _          <- setState(oid, ObservationWorkflowState.Ready)
+      _          <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       _          <- editAsterismAs(pi, oid, add = List(tid), del = Nil)
       ts         <- triggers(oid)
-    yield assertEquals(ts, List(("REQUESTED", None)))
+    yield assertEquals(ts, List((Requested, None)))
 
   test("declining records the reason and returns the observation to Defined"):
     for
       (pid, oid, _) <- createTooObservationAs(pi, staff)
-      _          <- setState(oid, ObservationWorkflowState.Ready)
+      _          <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       rid        <- triggerId(oid)
       _          <- expect(
                       staff,
@@ -162,26 +132,26 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
                       """.asRight
                     )
       ts         <- triggers(oid)
-      s          <- state(pid, oid)
+      s          <- getWorkflowState(pid, oid)
     yield
       // Declined, not withdrawn: the reason survives the user-state clear.
-      assertEquals(ts, List(("DECLINED", Some("weathered out"))))
-      assertEquals(s, "DEFINED")
+      assertEquals(ts, List((Declined, Some("weathered out"))))
+      assertEquals(s, ObservationWorkflowState.Defined)
 
   test("a declined trigger does not block a fresh request"):
     for
       (_, oid, _) <- createTooObservationAs(pi, staff)
-      _        <- setState(oid, ObservationWorkflowState.Ready)
+      _        <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       rid      <- triggerId(oid)
       _        <- query(staff, declineQuery(rid))
-      _        <- setState(oid, ObservationWorkflowState.Ready)
+      _        <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       ts       <- triggers(oid)
-    yield assertEquals(ts.map(_._1).sorted, List("DECLINED", "REQUESTED"))
+    yield assertEquals(ts.map(_._1), List(Declined, Requested))
 
   test("a PI cannot decline"):
     for
       (_, oid, _) <- createTooObservationAs(pi, staff)
-      _        <- setState(oid, ObservationWorkflowState.Ready)
+      _        <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       rid      <- triggerId(oid)
       _        <- expect(
                     pi,
@@ -193,7 +163,7 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
   test("an already-declined trigger cannot be declined again"):
     for
       (_, oid, _) <- createTooObservationAs(pi, staff)
-      _        <- setState(oid, ObservationWorkflowState.Ready)
+      _        <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       rid      <- triggerId(oid)
       _        <- query(staff, declineQuery(rid))
       _        <- expect(
@@ -214,8 +184,8 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
       _   <- addProposal(pi, pid, cfp.some, None)
       tid <- createTargetWithProfileAs(pi, pid)
       oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
-      _   <- setSchedulingModeAs(pi, oid, "INTERRUPTING")
-      s   <- state(pid, oid)
+      _   <- setSchedulingModeAs(pi, oid, SchedulingMode.Interrupting)
+      s   <- getWorkflowState(pid, oid)
       ms  <- query(
                pi,
                s"""
@@ -229,7 +199,7 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
                      .require[List[io.circe.Json]]
                      .flatMap(_.hcursor.downField("messages").require[List[String]]))
     yield
-      assertEquals(s, "UNDEFINED")
+      assertEquals(s, ObservationWorkflowState.Undefined)
       assert(ms.exists(_.contains("may only interrupt executing science")), s"expected the interrupting message, got $ms")
 
   test("an observation still holding an unresolved opportunity target cannot be triggered"):
@@ -239,7 +209,7 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
       _   <- addProposal(pi, pid, cfp.some, None)
       tid <- createOpportunityTargetAs(pi, pid)
       oid <- createGmosNorthLongSlitObservationAs(pi, pid, List(tid))
-      _   <- state(pid, oid)
+      _   <- getWorkflowState(pid, oid)
       // Defined -> Ready excludes an unresolved opportunity target, so there is
       // no way to request a trigger while it is still waiting on the alert.
       r   <- setObservationWorkflowState(pi, oid, ObservationWorkflowState.Ready).attempt
@@ -259,24 +229,24 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
       (pid, oid, _) <- createTooObservationAs(pi, staff, resolved = true)
       (s, ts)       <- tooWorkflowStateAndTransitions(pid, oid, pi)
     yield
-      assertEquals(s, "DEFINED")
-      assert(ts.contains("READY"), s"expected READY among the transitions, got $ts")
+      assertEquals(s, ObservationWorkflowState.Defined)
+      assert(ts.contains(ObservationWorkflowState.Ready), s"expected READY among the transitions, got $ts")
 
   test("an unresolved opportunity target is not offered Ready"):
     for
       (pid, oid, _) <- createTooObservationAs(pi, staff, resolved = false)
       (_, ts)       <- tooWorkflowStateAndTransitions(pid, oid, pi)
-    yield assert(!ts.contains("READY"), s"expected READY to be withheld, got $ts")
+    yield assert(!ts.contains(ObservationWorkflowState.Ready), s"expected READY to be withheld, got $ts")
 
   test("setting a resolved opportunity ToO Ready requests a trigger"):
     for
       (_, oid, _) <- createTooObservationAs(pi, staff, resolved = true)
       before      <- triggers(oid)
-      _           <- setState(oid, ObservationWorkflowState.Ready)
+      _           <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       after       <- triggers(oid)
     yield
       assertEquals(before, Nil)
-      assertEquals(after, List(("REQUESTED", None)))
+      assertEquals(after, List((Requested, None)))
 
   test("resolving an opportunity target unblocks triggering"):
     for
@@ -286,12 +256,12 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
       // resolving inside that region leaves the approval covering it.
       _               <- resolveOpportunityTargetAs(pi, tid)
       (_, after)      <- tooWorkflowStateAndTransitions(pid, oid, pi)
-      _               <- setState(oid, ObservationWorkflowState.Ready)
+      _               <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       ts              <- triggers(oid)
     yield
-      assert(!before.contains("READY"), s"expected READY to be withheld, got $before")
-      assert(after.contains("READY"), s"expected READY once resolved, got $after")
-      assertEquals(ts, List(("REQUESTED", None)))
+      assert(!before.contains(ObservationWorkflowState.Ready), s"expected READY to be withheld, got $before")
+      assert(after.contains(ObservationWorkflowState.Ready), s"expected READY once resolved, got $after")
+      assertEquals(ts, List((Requested, None)))
 
   // The approval is against the region, so the resolution has to land inside it.  This is the
   // one place a ToO's region is enforced today, and it enforces it through the approval rather
@@ -301,7 +271,7 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
       (pid, oid, tid) <- createTooObservationAs(pi, staff, resolved = false)
       _               <- resolveOpportunityTargetAs(pi, tid, "30:00:00.00")
       state           <- tooWorkflowState(pid, oid, pi)
-    yield assertEquals(state, "DEFINED")
+    yield assertEquals(state, ObservationWorkflowState.Defined)
 
   test("resolving outside the approved region unapproves the observation"):
     for
@@ -310,8 +280,8 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
       _               <- resolveOpportunityTargetAs(pi, tid, "-00:06:04.89")
       (state, trans)  <- tooWorkflowStateAndTransitions(pid, oid, pi)
     yield
-      assertEquals(state, "UNAPPROVED")
-      assert(!trans.contains("READY"), s"expected READY to be withheld, got $trans")
+      assertEquals(state, ObservationWorkflowState.Unapproved)
+      assert(!trans.contains(ObservationWorkflowState.Ready), s"expected READY to be withheld, got $trans")
 
   // The region outlives resolution, so the approval keeps being checked against it: moving a
   // resolved target out of its region later is caught exactly as resolving outside it would be.
@@ -325,9 +295,9 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
       _               <- resolveOpportunityTargetAs(pi, tid, "45:00:00.00")
       back            <- tooWorkflowState(pid, oid, pi)
     yield
-      assertEquals(inside,  "DEFINED")
-      assertEquals(outside, "UNAPPROVED")
-      assertEquals(back,    "DEFINED")
+      assertEquals(inside,  ObservationWorkflowState.Defined)
+      assertEquals(outside, ObservationWorkflowState.Unapproved)
+      assertEquals(back,    ObservationWorkflowState.Defined)
 
   private def unresolveTargetAs(tid: lucuma.core.model.Target.Id): IO[Unit] =
     query(pi,
@@ -349,7 +319,7 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
     for
       (pid, oid) <- createTriggerableObservationAs(pi, staff)
       tid        <- createOpportunityTargetAs(pi, pid)
-      _          <- setState(oid, ObservationWorkflowState.Ready)
+      _          <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       _          <- editAsterismAs(pi, oid, add = List(tid), del = Nil)
       ts         <- triggers(oid)
     yield assertEquals(ts, Nil)
@@ -357,20 +327,20 @@ class tooTriggerWorkflow extends ExecutionTestSupportForGmos with TooTriggerSetu
   test("clearing the resolution of a triggered ToO withdraws the trigger"):
     for
       (_, oid, tid) <- createTooObservationAs(pi, staff, resolved = true)
-      _             <- setState(oid, ObservationWorkflowState.Ready)
+      _             <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       before        <- triggers(oid)
       _             <- unresolveTargetAs(tid)
       after         <- triggers(oid)
     yield
-      assertEquals(before, List(("REQUESTED", None)))
-      assertEquals(after,  List(("WITHDRAWN", None)))
+      assertEquals(before, List((Requested, None)))
+      assertEquals(after,  List((Withdrawn, None)))
 
   // ... and resolving it again asks afresh, so the round trip is not one-way.
   test("re-resolving a withdrawn trigger requests it again"):
     for
       (_, oid, tid) <- createTooObservationAs(pi, staff, resolved = true)
-      _             <- setState(oid, ObservationWorkflowState.Ready)
+      _             <- setWorkflowState(oid, ObservationWorkflowState.Ready)
       _             <- unresolveTargetAs(tid)
       _             <- resolveOpportunityTargetAs(pi, tid)
       ts            <- triggers(oid)
-    yield assertEquals(ts.map(_._1).sorted, List("REQUESTED", "WITHDRAWN"))
+    yield assertEquals(ts.map(_._1), List(Withdrawn, Requested))

--- a/modules/service/src/test/scala/lucuma/odb/graphql/subscription/tooTriggerEdit.scala
+++ b/modules/service/src/test/scala/lucuma/odb/graphql/subscription/tooTriggerEdit.scala
@@ -9,11 +9,18 @@ import cats.effect.kernel.Deferred
 import cats.syntax.all.*
 import io.circe.Json
 import io.circe.literal.*
-import io.circe.syntax.*
 import lucuma.core.enums.ObservationWorkflowState
+import lucuma.core.enums.SchedulingMode
+import lucuma.core.enums.TooActivation
+import lucuma.core.enums.TooActivation.Interrupting
+import lucuma.core.enums.TooActivation.Rapid
+import lucuma.core.enums.TooActivation.Standard
 import lucuma.core.model.Observation
-import lucuma.core.model.User
+import lucuma.core.syntax.string.*
 import lucuma.odb.data.EditType
+import lucuma.odb.data.TooTrigger
+import lucuma.odb.data.TooTriggerStatus
+import lucuma.odb.data.TooTriggerStatus.*
 
 import scala.concurrent.duration.*
 
@@ -30,50 +37,38 @@ class tooTriggerEdit extends OdbSuite with SubscriptionUtils with TooTriggerSetu
         tooTriggerEdit {
           editType
           tooTriggerId
-          value { status }
+          value { status tooActivation }
           observation { id }
         }
       }
     """
 
-  private def liveTriggerId(oid: Observation.Id): IO[String] =
-    query(
-      pi,
-      s"""
-        query {
-          tooTriggers(WHERE: { observationId: { EQ: ${oid.asJson} }, status: { EQ: REQUESTED } }) {
-            matches { id }
-          }
-        }
-      """
-    ).map(_.hcursor.downFields("tooTriggers", "matches").require[List[Json]].head.hcursor.downField("id").require[String])
+  private def liveTriggerId(oid: Observation.Id): IO[TooTrigger.Id] =
+   getRequestedTooTriggerAs(pi, oid).map(_.id)
 
-  private def declineTooTrigger(user: User, rid: String): IO[Unit] =
-    query(
-      user  = user,
-      query = s"""
-        mutation {
-          declineTooTrigger(input: { tooTriggerId: "$rid" }) {
-            tooTrigger { id }
-          }
-        }
-      """
-    ).void
-
-  private def tooTriggerEdit(editType: EditType, status: String, rid: String, oid: Observation.Id): Json =
+  private def tooTriggerEdit(
+    editType:   EditType,
+    status:     TooTriggerStatus,
+    rid:        TooTrigger.Id,
+    oid:        Observation.Id,
+    activation: TooActivation = TooActivation.Rapid
+  ): Json =
     json"""
       {
         "tooTriggerEdit": {
           "editType":     ${editType.tag.toUpperCase},
           "tooTriggerId": $rid,
-          "value":        { "status": $status },
+          "value":        {
+            "status": ${status.tag.toScreamingSnakeCase},
+            "tooActivation": ${activation.tag.toScreamingSnakeCase}
+          },
           "observation":  { "id": $oid }
         }
       }
     """
 
   test("triggering then declining emits creation and update events"):
-    (Deferred[IO, Observation.Id], Deferred[IO, String]).tupled.flatMap: (oidRef, ridRef) =>
+    (Deferred[IO, Observation.Id], Deferred[IO, TooTrigger.Id]).tupled.flatMap: (oidRef, ridRef) =>
       subscriptionExpectF(
         user      = pi,
         query     = subscription,
@@ -92,7 +87,111 @@ class tooTriggerEdit extends OdbSuite with SubscriptionUtils with TooTriggerSetu
         expectedF =
           (oidRef.get, ridRef.get).mapN: (oid, rid) =>
             List(
-              tooTriggerEdit(EditType.Created, "REQUESTED", rid, oid),
-              tooTriggerEdit(EditType.Updated, "DECLINED",  rid, oid)
+              tooTriggerEdit(EditType.Created, Requested, rid, oid),
+              tooTriggerEdit(EditType.Updated, Declined,  rid, oid)
+            )
+      )
+
+  private def subscriptionWith(where: String): String =
+    s"""
+      subscription {
+        tooTriggerEdit(input: { tooActivation: $where }) {
+          editType
+          tooTriggerId
+          value { status tooActivation }
+          observation { id }
+        }
+      }
+    """
+
+  test("a supersession arrives as a closing update and a fresh creation"):
+    (Deferred[IO, Observation.Id], Deferred[IO, TooTrigger.Id], Deferred[IO, TooTrigger.Id]).tupled.flatMap: (oidRef, firstRef, secondRef) =>
+      subscriptionExpectF(
+        user      = pi,
+        query     = subscription,
+        mutations =
+          Right(
+            for
+              (_, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+              _           <- oidRef.complete(oid)
+              _           <- setTooWorkflowState(pi, oid, ObservationWorkflowState.Ready)
+              first       <- liveTriggerId(oid)
+              _           <- firstRef.complete(first)
+              _           <- IO.sleep(2.seconds) // give the client time to receive the creation
+              _           <- setSchedulingModeAs(pi, oid, SchedulingMode.Unconstrained)
+              second      <- liveTriggerId(oid)
+              _           <- secondRef.complete(second)
+            yield ()
+          ),
+        expectedF =
+          (oidRef.get, firstRef.get, secondRef.get).mapN: (oid, first, second) =>
+            List(
+              tooTriggerEdit(EditType.Created, Requested,  first,  oid, Rapid),
+              // The predecessor closes out reporting its *own* activation, not the
+              // successor's -- the value is fixed at creation.
+              tooTriggerEdit(EditType.Updated, Superseded, first,  oid, Rapid),
+              tooTriggerEdit(EditType.Created, Requested,  second, oid, Standard)
+            )
+      )
+
+  test("the activation filter selects which events arrive"):
+    (Deferred[IO, Observation.Id], Deferred[IO, TooTrigger.Id]).tupled.flatMap: (oidRef, ridRef) =>
+      subscriptionExpectF(
+        user      = pi,
+        query     = subscriptionWith("{ EQ: STANDARD }"),
+        mutations =
+          Right(
+            for
+              (_, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+              _           <- oidRef.complete(oid)
+              // Both of these events carry RAPID, so neither is delivered.
+              _           <- setTooWorkflowState(pi, oid, ObservationWorkflowState.Ready)
+              _           <- IO.sleep(2.seconds)
+              _           <- setSchedulingModeAs(pi, oid, SchedulingMode.Unconstrained)
+              rid         <- liveTriggerId(oid)
+              _           <- ridRef.complete(rid)
+            yield ()
+          ),
+        expectedF =
+          (oidRef.get, ridRef.get).mapN: (oid, rid) =>
+            List(
+              // Only the successor matches: it is the one requested at STANDARD.
+              tooTriggerEdit(EditType.Created, Requested, rid, oid, Standard)
+            )
+      )
+
+  test("an ordered activation filter follows only the disruptive requests"):
+    (Deferred[IO, Observation.Id], Deferred[IO, TooTrigger.Id], Deferred[IO, TooTrigger.Id]).tupled.flatMap: (oidRef, firstRef, thirdRef) =>
+      subscriptionExpectF(
+        user      = pi,
+        // The whole point of matching in memory rather than in SQL: a subscription
+        // can ask an ordered question.
+        query     = subscriptionWith("{ GTE: RAPID }"),
+        mutations =
+          Right(
+            for
+              (_, oid, _) <- createTooObservationAs(pi, staff, mode = SchedulingMode.Uninterruptible)
+              _           <- oidRef.complete(oid)
+              _           <- setTooWorkflowState(pi, oid, ObservationWorkflowState.Ready)
+              first       <- liveTriggerId(oid)
+              _           <- firstRef.complete(first)
+              _           <- IO.sleep(2.seconds)
+              // Down to STANDARD: the predecessor's closing event still carries
+              // RAPID and is delivered, but the successor's creation is not.
+              _           <- setSchedulingModeAs(pi, oid, SchedulingMode.Unconstrained)
+              _           <- IO.sleep(2.seconds)
+              // Back up to INTERRUPTING: the STANDARD row closes out below the
+              // threshold and is filtered, while its successor is delivered.
+              _           <- setSchedulingModeAs(pi, oid, SchedulingMode.Interrupting)
+              third       <- liveTriggerId(oid)
+              _           <- thirdRef.complete(third)
+            yield ()
+          ),
+        expectedF =
+          (oidRef.get, firstRef.get, thirdRef.get).mapN: (oid, first, third) =>
+            List(
+              tooTriggerEdit(EditType.Created, Requested,  first, oid, Rapid),
+              tooTriggerEdit(EditType.Updated, Superseded, first, oid, Rapid),
+              tooTriggerEdit(EditType.Created, Requested,  third, oid, Interrupting)
             )
       )

--- a/notes/too-scheduling-overview.md
+++ b/notes/too-scheduling-overview.md
@@ -166,8 +166,19 @@ without filling in a second form.
 
 At **acceptance the ceiling is frozen**. From that point it is an authorization rather
 than a description — the TAC saying in advance how much disruption this program may
-cause. An observation that exceeds it is flagged as *unapproved* and cannot reach
-`Ready` until either the mode comes down or the ceiling goes up.
+cause.
+
+Once frozen, it is enforced in two places. **A scheduling mode that would take an
+observation over the ceiling is refused outright**, so a PI cannot deliberately step over
+the line and discover the problem later. And **if the ceiling is lowered beneath an
+observation that already has an outstanding trigger, that request is withdrawn** — the
+observatory should not be looking at a live request for a disruption the program is no
+longer permitted to cause.
+
+An observation can still end up over the ceiling by a less direct route — gaining a Target
+of Opportunity target while its mode is already high, for instance. Those are flagged as
+*unapproved* and cannot reach `Ready` until either the mode comes down or the ceiling goes
+up.
 
 This is the only approval step. There is no second, per-trigger sign-off: requiring one
 would add latency to exactly the observations where latency is the whole point.
@@ -198,12 +209,26 @@ came with its own timing windows keeps them.
 ```mermaid
 stateDiagram-v2
     [*] --> Requested: observation is Ready with a resolved target
-    Requested --> Withdrawn: PI clears Ready, clears the resolution,<br/>or lowers the mode
+    Requested --> Withdrawn: PI clears Ready, clears the resolution,<br/>or stops it being a ToO
     Requested --> Declined: observer says no, with a reason
+    Requested --> Superseded: activation changes, replaced by a new request
     Requested --> [*]: observation executes
     Withdrawn --> [*]
     Declined --> [*]
+    Superseded --> [*]
 ```
+
+**A trigger is a prompt, not a promise that the observation can run right now.** If the
+observation is later edited into a state where it cannot be executed — a configuration
+falls out of approval, something required goes missing — the request stays outstanding.
+Nothing bad follows from that: the scheduler weighs the observation when it picks one up,
+and an observation that cannot execute does not execute. Clients that care can read the
+observation's workflow state alongside the trigger.
+
+The reasoning is that a request stops being a request when the PI takes it back, or when
+the observatory revokes what it granted — not when the observation is temporarily broken.
+A broken observation still has a PI waiting on it, and the request records when *they*
+asked, which is the number that matters when the point is promptness.
 
 `Requested` is the only non-terminal state, and a requested trigger simply stays
 requested while the observation executes. Nothing here records "execution has begun" —
@@ -214,18 +239,38 @@ Every attempt is its own record, so the full history accumulates: a PI who sets 
 again after a decline gets a fresh trigger, and the earlier one remains as a record of
 what happened. Every transition is attributed and timestamped.
 
+**A trigger records the activation it was requested at, and that never changes.**
+Triggering a standard ToO, a rapid one and an interrupting one are effectively different
+requests — who is told, how fast, and what they are expected to drop all differ. So if
+the observation's activation moves while a request is outstanding, the request is
+**superseded**: it closes out, and a successor takes its place carrying the new
+activation. The successor's `supersedes` points back at what it replaced, so the chain is
+walkable and the root of it answers "when did this observation first go live at any
+activation" — which the successor's own `requestedAt` deliberately does not, being the
+age of *this* request at *this* activation.
+
 ---
 
 ## 6. What clients can do
 
 **Watch for triggers as they happen.** The `tooTriggerEdit` subscription delivers every
-creation and lifecycle transition, filterable by program, observation, or a single
-trigger. This is what an observer's dashboard would sit on — a ToO appearing mid-night
-shows up without polling.
+creation and lifecycle transition, filterable by program, observation, a single trigger,
+or the activation the request was made at. The activation filter is ordered, so a
+dashboard that only cares about the ones that cannot wait can subscribe with
+`tooActivation: { GTE: RAPID }` and be told about nothing else. This is what an observer's
+dashboard would sit on — a ToO appearing mid-night shows up without polling.
+
+A supersession arrives as two ordinary events: the predecessor closing out, then the
+successor appearing. The closing event reports the predecessor's *own* activation rather
+than the new one, since that is what the record says — so a client filtered to one
+activation sees a request leave its view and, if it moved into scope, arrive again under
+its new identity.
 
 **Query them.** `tooTrigger(tooTriggerId:)` for one, `tooTriggers(WHERE:)` for many,
-filtered by status among other things. Each carries its observation, status, the time
-and user of the request, and the reason accompanying any terminal transition.
+filtered by status and by activation among other things — the activation filter is
+ordered, so "at least rapid" is expressible. Each carries its observation, status,
+activation, the request it superseded if any, the time and user of the request, and the
+reason accompanying any terminal transition.
 
 **Decline one.** `declineTooTrigger(tooTriggerId:, reason:)` records that an observer
 saw a trigger and chose not to act on it, with a reason, and returns the observation to
@@ -283,6 +328,9 @@ That earlier design was dropped rather than extended.
 | Opportunity target survives resolution, resolvable to sidereal or nonsidereal | built |
 | `SchedulingMode` replacing the two earlier observation-level fields | built |
 | Derived ToO activation | built |
+| Trigger records its activation; a change supersedes it | built |
+| Ceiling enforced on mode edits; lowering it withdraws over-ceiling triggers | built |
+| Trigger withdrawn when an observation becomes invalid for any other reason | **not done** — deliberately; see [§5](#5-triggering) |
 | Region enforced at the resolved position, via configuration approval | built |
 | Default scheduling window applied at trigger time | designed, not yet built |
 | Region enforced over a path, and who may edit a region | **deferred** — needs science staff input, see [§2](#2-the-target-of-opportunity-target) |


### PR DESCRIPTION
This PR makes two updates to ToO triggers.

## Superseded

Updates ToO triggers with a new status: `SUPERSEDED`.  This allows the scheduling mode of an observation to change after a trigger, resulting in superseding an existing trigger.  In particular, a `Rapid` ToO can turn into an `Interrupting` ToO by changing the observation's `SchedulingMode` to `Interrupting`.  When the scheduling mode of an already triggered observation is changed, an outstanding ToO request is superseded by the new request.  Old requests are not deleted but are no longer considered live.  A full audit trail of past triggers is available by following the `supersedes` reference on `TooTrigger`.

From the ToO documentation:

> The interrupt occurs when an observation/group with the interrupt flag selected is set to Ready, or when an observation that is Ready has its interrupt flag set.  An interrupt will cause the system to prompt the observer to abort the current observation and slew immediately to the new observation/group (see the Inception document). A new observing plan is then generated.

Here setting the "interrupt flag" is changing the `SchedulingMode` to `Interrupting`.  ToO triggers generate events which subscribers may respond to (e.g., to "slew immediately").

## Withdrawn  

Plugs a hole in which the ToO ceiling for a program could be reset by staff and yet leave outstanding triggers at a higher activation value.  When the ceiling is changed, existing triggers for the program that violate the ceiling are now withdrawn.